### PR TITLE
[feat] Add AES-XTS streaming encryption/decryption support

### DIFF
--- a/api/cpp/aes_tests.cpp
+++ b/api/cpp/aes_tests.cpp
@@ -5169,3 +5169,809 @@ TEST_F(AESTest, AesXtsDataUnitLenNone)
 
     std::cout << "AES XTS data_unit_len=0 (default) test passed" << std::endl;
 }
+
+// ================================================================================
+// AES XTS Streaming Tests
+// ================================================================================
+
+TEST_F(AESTest, AesXtsStreamingEncryptDecrypt512)
+{
+    // Generate AES XTS key
+    azihsm_handle key_handle = 0;
+    azihsm_algo key_gen_algo = {
+        .id = AZIHSM_ALGO_ID_AES_XTS_KEY_GEN,
+        .params = nullptr,
+        .len = 0};
+
+    uint32_t bit_len = 512;
+    bool encrypt_prop = true;
+    bool decrypt_prop = true;
+    azihsm_key_prop props[] = {
+        {.id = AZIHSM_KEY_PROP_ID_BIT_LEN, .val = &bit_len, .len = sizeof(bit_len)},
+        {.id = AZIHSM_KEY_PROP_ID_ENCRYPT, .val = &encrypt_prop, .len = sizeof(encrypt_prop)},
+        {.id = AZIHSM_KEY_PROP_ID_DECRYPT, .val = &decrypt_prop, .len = sizeof(decrypt_prop)}};
+
+    azihsm_key_prop_list prop_list = {.props = props, .count = 3};
+
+    auto err = azihsm_key_gen(session_handle, &key_gen_algo, &prop_list, &key_handle);
+    EXPECT_EQ(err, AZIHSM_ERROR_SUCCESS) << "Failed to generate AES XTS key";
+
+    auto key_guard = scope_guard::make_scope_exit([&]
+                                                  { azihsm_key_delete(session_handle, key_handle); });
+
+    // Test data - 2048 bytes (4 data units of 512 bytes each)
+    std::vector<uint8_t> plaintext(2048, 0xAB);
+
+    // Setup XTS parameters with data_unit_len = 512
+    azihsm_algo_aes_xts_params xts_params = {
+        .sector_num = {0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01,
+                       0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01},
+        .data_unit_len = 512};
+
+    azihsm_algo encrypt_algo = {
+        .id = AZIHSM_ALGO_ID_AES_XTS,
+        .params = &xts_params,
+        .len = sizeof(xts_params)};
+
+    // Initialize encryption stream
+    azihsm_handle encrypt_ctx_handle = 0;
+    err = azihsm_crypt_encrypt_init(session_handle, &encrypt_algo, key_handle, &encrypt_ctx_handle);
+    EXPECT_EQ(err, AZIHSM_ERROR_SUCCESS) << "Failed to initialize encrypt stream";
+    EXPECT_NE(encrypt_ctx_handle, 0) << "Encrypt context handle should be valid";
+
+    auto encrypt_ctx_guard = scope_guard::make_scope_exit([&]
+                                                          {
+        if (encrypt_ctx_handle != 0) {
+            std::vector<uint8_t> final_output(512);
+            azihsm_buffer final_buffer = {.buf = final_output.data(), .len = static_cast<uint32_t>(final_output.size())};
+            azihsm_crypt_encrypt_final(session_handle, encrypt_ctx_handle, &final_buffer);
+        } });
+
+    // Encrypt in 512-byte chunks (one data unit at a time)
+    std::vector<uint8_t> ciphertext(plaintext.size());
+    size_t total_encrypted = 0;
+
+    for (size_t offset = 0; offset < plaintext.size(); offset += 512)
+    {
+        azihsm_buffer pt_chunk = {
+            .buf = plaintext.data() + offset,
+            .len = 512};
+
+        azihsm_buffer ct_chunk = {
+            .buf = ciphertext.data() + total_encrypted,
+            .len = static_cast<uint32_t>(ciphertext.size() - total_encrypted)};
+
+        err = azihsm_crypt_encrypt_update(session_handle, encrypt_ctx_handle, &pt_chunk, &ct_chunk);
+        EXPECT_EQ(err, AZIHSM_ERROR_SUCCESS) << "Failed to encrypt chunk at offset " << offset;
+        total_encrypted += ct_chunk.len;
+    }
+
+    // Finalize encryption
+    std::vector<uint8_t> final_ct(512);
+    azihsm_buffer final_ct_buffer = {.buf = final_ct.data(), .len = static_cast<uint32_t>(final_ct.size())};
+    err = azihsm_crypt_encrypt_final(session_handle, encrypt_ctx_handle, &final_ct_buffer);
+    EXPECT_EQ(err, AZIHSM_ERROR_SUCCESS) << "Failed to finalize encryption";
+    encrypt_ctx_handle = 0; // Context is consumed
+
+    EXPECT_EQ(total_encrypted, plaintext.size()) << "Total encrypted should match plaintext size";
+    EXPECT_NE(memcmp(plaintext.data(), ciphertext.data(), plaintext.size()), 0)
+        << "Ciphertext should differ from plaintext";
+
+    // Now decrypt using streaming
+    azihsm_algo decrypt_algo = {
+        .id = AZIHSM_ALGO_ID_AES_XTS,
+        .params = &xts_params,
+        .len = sizeof(xts_params)};
+
+    azihsm_handle decrypt_ctx_handle = 0;
+    err = azihsm_crypt_decrypt_init(session_handle, &decrypt_algo, key_handle, &decrypt_ctx_handle);
+    EXPECT_EQ(err, AZIHSM_ERROR_SUCCESS) << "Failed to initialize decrypt stream";
+    EXPECT_NE(decrypt_ctx_handle, 0) << "Decrypt context handle should be valid";
+
+    auto decrypt_ctx_guard = scope_guard::make_scope_exit([&]
+                                                          {
+        if (decrypt_ctx_handle != 0) {
+            std::vector<uint8_t> final_output(512);
+            azihsm_buffer final_buffer = {.buf = final_output.data(), .len = static_cast<uint32_t>(final_output.size())};
+            azihsm_crypt_decrypt_final(session_handle, decrypt_ctx_handle, &final_buffer);
+        } });
+
+    // Decrypt in 512-byte chunks
+    std::vector<uint8_t> decrypted(ciphertext.size());
+    size_t total_decrypted = 0;
+
+    for (size_t offset = 0; offset < ciphertext.size(); offset += 512)
+    {
+        azihsm_buffer ct_chunk = {
+            .buf = ciphertext.data() + offset,
+            .len = 512};
+
+        azihsm_buffer pt_chunk = {
+            .buf = decrypted.data() + total_decrypted,
+            .len = static_cast<uint32_t>(decrypted.size() - total_decrypted)};
+
+        err = azihsm_crypt_decrypt_update(session_handle, decrypt_ctx_handle, &ct_chunk, &pt_chunk);
+        EXPECT_EQ(err, AZIHSM_ERROR_SUCCESS) << "Failed to decrypt chunk at offset " << offset;
+        total_decrypted += pt_chunk.len;
+    }
+
+    // Finalize decryption
+    std::vector<uint8_t> final_pt(512);
+    azihsm_buffer final_pt_buffer = {.buf = final_pt.data(), .len = static_cast<uint32_t>(final_pt.size())};
+    err = azihsm_crypt_decrypt_final(session_handle, decrypt_ctx_handle, &final_pt_buffer);
+    EXPECT_EQ(err, AZIHSM_ERROR_SUCCESS) << "Failed to finalize decryption";
+    decrypt_ctx_handle = 0; // Context is consumed
+
+    EXPECT_EQ(total_decrypted, plaintext.size()) << "Total decrypted should match plaintext size";
+    EXPECT_EQ(memcmp(plaintext.data(), decrypted.data(), plaintext.size()), 0)
+        << "Decrypted data should match original plaintext";
+
+    std::cout << "AES XTS streaming encrypt/decrypt test passed (data_unit_len=512)" << std::endl;
+}
+
+TEST_F(AESTest, AesXtsStreamingDataUnitLen4096)
+{
+    // Generate AES XTS key
+    azihsm_handle key_handle = 0;
+    azihsm_algo key_gen_algo = {
+        .id = AZIHSM_ALGO_ID_AES_XTS_KEY_GEN,
+        .params = nullptr,
+        .len = 0};
+
+    uint32_t bit_len = 512;
+    bool encrypt_prop = true;
+    bool decrypt_prop = true;
+    azihsm_key_prop props[] = {
+        {.id = AZIHSM_KEY_PROP_ID_BIT_LEN, .val = &bit_len, .len = sizeof(bit_len)},
+        {.id = AZIHSM_KEY_PROP_ID_ENCRYPT, .val = &encrypt_prop, .len = sizeof(encrypt_prop)},
+        {.id = AZIHSM_KEY_PROP_ID_DECRYPT, .val = &decrypt_prop, .len = sizeof(decrypt_prop)}};
+
+    azihsm_key_prop_list prop_list = {.props = props, .count = 3};
+
+    auto err = azihsm_key_gen(session_handle, &key_gen_algo, &prop_list, &key_handle);
+    EXPECT_EQ(err, AZIHSM_ERROR_SUCCESS);
+
+    auto key_guard = scope_guard::make_scope_exit([&]
+                                                  { azihsm_key_delete(session_handle, key_handle); });
+
+    // Test data - 12288 bytes (3 data units of 4096 bytes each)
+    std::vector<uint8_t> plaintext(12288, 0xCD);
+
+    azihsm_algo_aes_xts_params xts_params = {
+        .sector_num = {0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02,
+                       0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02},
+        .data_unit_len = 4096};
+
+    azihsm_algo encrypt_algo = {
+        .id = AZIHSM_ALGO_ID_AES_XTS,
+        .params = &xts_params,
+        .len = sizeof(xts_params)};
+
+    // Initialize encryption stream
+    azihsm_handle encrypt_ctx_handle = 0;
+    err = azihsm_crypt_encrypt_init(session_handle, &encrypt_algo, key_handle, &encrypt_ctx_handle);
+    EXPECT_EQ(err, AZIHSM_ERROR_SUCCESS);
+
+    // Encrypt in 4096-byte chunks
+    std::vector<uint8_t> ciphertext(plaintext.size());
+    size_t total_encrypted = 0;
+
+    for (size_t offset = 0; offset < plaintext.size(); offset += 4096)
+    {
+        azihsm_buffer pt_chunk = {.buf = plaintext.data() + offset, .len = 4096};
+        azihsm_buffer ct_chunk = {
+            .buf = ciphertext.data() + total_encrypted,
+            .len = static_cast<uint32_t>(ciphertext.size() - total_encrypted)};
+
+        err = azihsm_crypt_encrypt_update(session_handle, encrypt_ctx_handle, &pt_chunk, &ct_chunk);
+        EXPECT_EQ(err, AZIHSM_ERROR_SUCCESS);
+        total_encrypted += ct_chunk.len;
+    }
+
+    // Finalize
+    std::vector<uint8_t> final_ct(4096);
+    azihsm_buffer final_ct_buffer = {.buf = final_ct.data(), .len = static_cast<uint32_t>(final_ct.size())};
+    err = azihsm_crypt_encrypt_final(session_handle, encrypt_ctx_handle, &final_ct_buffer);
+    EXPECT_EQ(err, AZIHSM_ERROR_SUCCESS);
+
+    // Decrypt using streaming
+    azihsm_algo decrypt_algo = {
+        .id = AZIHSM_ALGO_ID_AES_XTS,
+        .params = &xts_params,
+        .len = sizeof(xts_params)};
+
+    azihsm_handle decrypt_ctx_handle = 0;
+    err = azihsm_crypt_decrypt_init(session_handle, &decrypt_algo, key_handle, &decrypt_ctx_handle);
+    EXPECT_EQ(err, AZIHSM_ERROR_SUCCESS);
+
+    std::vector<uint8_t> decrypted(ciphertext.size());
+    size_t total_decrypted = 0;
+
+    for (size_t offset = 0; offset < ciphertext.size(); offset += 4096)
+    {
+        azihsm_buffer ct_chunk = {.buf = ciphertext.data() + offset, .len = 4096};
+        azihsm_buffer pt_chunk = {
+            .buf = decrypted.data() + total_decrypted,
+            .len = static_cast<uint32_t>(decrypted.size() - total_decrypted)};
+
+        err = azihsm_crypt_decrypt_update(session_handle, decrypt_ctx_handle, &ct_chunk, &pt_chunk);
+        EXPECT_EQ(err, AZIHSM_ERROR_SUCCESS);
+        total_decrypted += pt_chunk.len;
+    }
+
+    std::vector<uint8_t> final_pt(4096);
+    azihsm_buffer final_pt_buffer = {.buf = final_pt.data(), .len = static_cast<uint32_t>(final_pt.size())};
+    err = azihsm_crypt_decrypt_final(session_handle, decrypt_ctx_handle, &final_pt_buffer);
+    EXPECT_EQ(err, AZIHSM_ERROR_SUCCESS);
+
+    EXPECT_EQ(memcmp(plaintext.data(), decrypted.data(), plaintext.size()), 0)
+        << "Decrypted data should match original plaintext";
+
+    std::cout << "AES XTS streaming test passed (data_unit_len=4096)" << std::endl;
+}
+
+TEST_F(AESTest, AesXtsStreamingDataUnitLen8192)
+{
+    // Generate AES XTS key
+    azihsm_handle key_handle = 0;
+    azihsm_algo key_gen_algo = {
+        .id = AZIHSM_ALGO_ID_AES_XTS_KEY_GEN,
+        .params = nullptr,
+        .len = 0};
+
+    uint32_t bit_len = 512;
+    bool encrypt_prop = true;
+    bool decrypt_prop = true;
+    azihsm_key_prop props[] = {
+        {.id = AZIHSM_KEY_PROP_ID_BIT_LEN, .val = &bit_len, .len = sizeof(bit_len)},
+        {.id = AZIHSM_KEY_PROP_ID_ENCRYPT, .val = &encrypt_prop, .len = sizeof(encrypt_prop)},
+        {.id = AZIHSM_KEY_PROP_ID_DECRYPT, .val = &decrypt_prop, .len = sizeof(decrypt_prop)}};
+
+    azihsm_key_prop_list prop_list = {.props = props, .count = 3};
+
+    auto err = azihsm_key_gen(session_handle, &key_gen_algo, &prop_list, &key_handle);
+    EXPECT_EQ(err, AZIHSM_ERROR_SUCCESS);
+
+    auto key_guard = scope_guard::make_scope_exit([&]
+                                                  { azihsm_key_delete(session_handle, key_handle); });
+
+    // Test data - 24576 bytes (3 data units of 8192 bytes each)
+    std::vector<uint8_t> plaintext(24576, 0xEF);
+
+    azihsm_algo_aes_xts_params xts_params = {
+        .sector_num = {0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03,
+                       0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03},
+        .data_unit_len = 8192};
+
+    azihsm_algo encrypt_algo = {
+        .id = AZIHSM_ALGO_ID_AES_XTS,
+        .params = &xts_params,
+        .len = sizeof(xts_params)};
+
+    // Initialize encryption stream
+    azihsm_handle encrypt_ctx_handle = 0;
+    err = azihsm_crypt_encrypt_init(session_handle, &encrypt_algo, key_handle, &encrypt_ctx_handle);
+    EXPECT_EQ(err, AZIHSM_ERROR_SUCCESS);
+
+    // Encrypt in 8192-byte chunks
+    std::vector<uint8_t> ciphertext(plaintext.size());
+    size_t total_encrypted = 0;
+
+    for (size_t offset = 0; offset < plaintext.size(); offset += 8192)
+    {
+        azihsm_buffer pt_chunk = {.buf = plaintext.data() + offset, .len = 8192};
+        azihsm_buffer ct_chunk = {
+            .buf = ciphertext.data() + total_encrypted,
+            .len = static_cast<uint32_t>(ciphertext.size() - total_encrypted)};
+
+        err = azihsm_crypt_encrypt_update(session_handle, encrypt_ctx_handle, &pt_chunk, &ct_chunk);
+        EXPECT_EQ(err, AZIHSM_ERROR_SUCCESS);
+        total_encrypted += ct_chunk.len;
+    }
+
+    // Finalize
+    std::vector<uint8_t> final_ct(8192);
+    azihsm_buffer final_ct_buffer = {.buf = final_ct.data(), .len = static_cast<uint32_t>(final_ct.size())};
+    err = azihsm_crypt_encrypt_final(session_handle, encrypt_ctx_handle, &final_ct_buffer);
+    EXPECT_EQ(err, AZIHSM_ERROR_SUCCESS);
+
+    // Decrypt using streaming
+    azihsm_algo decrypt_algo = {
+        .id = AZIHSM_ALGO_ID_AES_XTS,
+        .params = &xts_params,
+        .len = sizeof(xts_params)};
+
+    azihsm_handle decrypt_ctx_handle = 0;
+    err = azihsm_crypt_decrypt_init(session_handle, &decrypt_algo, key_handle, &decrypt_ctx_handle);
+    EXPECT_EQ(err, AZIHSM_ERROR_SUCCESS);
+
+    std::vector<uint8_t> decrypted(ciphertext.size());
+    size_t total_decrypted = 0;
+
+    for (size_t offset = 0; offset < ciphertext.size(); offset += 8192)
+    {
+        azihsm_buffer ct_chunk = {.buf = ciphertext.data() + offset, .len = 8192};
+        azihsm_buffer pt_chunk = {
+            .buf = decrypted.data() + total_decrypted,
+            .len = static_cast<uint32_t>(decrypted.size() - total_decrypted)};
+
+        err = azihsm_crypt_decrypt_update(session_handle, decrypt_ctx_handle, &ct_chunk, &pt_chunk);
+        EXPECT_EQ(err, AZIHSM_ERROR_SUCCESS);
+        total_decrypted += pt_chunk.len;
+    }
+
+    std::vector<uint8_t> final_pt(8192);
+    azihsm_buffer final_pt_buffer = {.buf = final_pt.data(), .len = static_cast<uint32_t>(final_pt.size())};
+    err = azihsm_crypt_decrypt_final(session_handle, decrypt_ctx_handle, &final_pt_buffer);
+    EXPECT_EQ(err, AZIHSM_ERROR_SUCCESS);
+
+    EXPECT_EQ(memcmp(plaintext.data(), decrypted.data(), plaintext.size()), 0)
+        << "Decrypted data should match original plaintext";
+
+    std::cout << "AES XTS streaming test passed (data_unit_len=8192)" << std::endl;
+}
+
+TEST_F(AESTest, AesXtsOneshotEncryptStreamingDecrypt)
+{
+    // Generate AES XTS key
+    azihsm_handle key_handle = 0;
+    azihsm_algo key_gen_algo = {
+        .id = AZIHSM_ALGO_ID_AES_XTS_KEY_GEN,
+        .params = nullptr,
+        .len = 0};
+
+    uint32_t bit_len = 512;
+    bool encrypt_prop = true;
+    bool decrypt_prop = true;
+    azihsm_key_prop props[] = {
+        {.id = AZIHSM_KEY_PROP_ID_BIT_LEN, .val = &bit_len, .len = sizeof(bit_len)},
+        {.id = AZIHSM_KEY_PROP_ID_ENCRYPT, .val = &encrypt_prop, .len = sizeof(encrypt_prop)},
+        {.id = AZIHSM_KEY_PROP_ID_DECRYPT, .val = &decrypt_prop, .len = sizeof(decrypt_prop)}};
+
+    azihsm_key_prop_list prop_list = {.props = props, .count = 3};
+
+    auto err = azihsm_key_gen(session_handle, &key_gen_algo, &prop_list, &key_handle);
+    EXPECT_EQ(err, AZIHSM_ERROR_SUCCESS);
+
+    auto key_guard = scope_guard::make_scope_exit([&]
+                                                  { azihsm_key_delete(session_handle, key_handle); });
+
+    // Test data - 2048 bytes (4 data units of 512 bytes each)
+    std::vector<uint8_t> plaintext(2048, 0xAB);
+
+    azihsm_algo_aes_xts_params xts_params = {
+        .sector_num = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+                       0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
+        .data_unit_len = 512};
+
+    azihsm_algo encrypt_algo = {
+        .id = AZIHSM_ALGO_ID_AES_XTS,
+        .params = &xts_params,
+        .len = sizeof(xts_params)};
+
+    // One-shot encryption
+    azihsm_buffer pt_buffer = {.buf = plaintext.data(), .len = static_cast<uint32_t>(plaintext.size())};
+    std::vector<uint8_t> ciphertext(plaintext.size());
+    azihsm_buffer ct_buffer = {.buf = ciphertext.data(), .len = static_cast<uint32_t>(ciphertext.size())};
+
+    err = azihsm_crypt_encrypt(session_handle, &encrypt_algo, key_handle, &pt_buffer, &ct_buffer);
+    EXPECT_EQ(err, AZIHSM_ERROR_SUCCESS);
+
+    // Streaming decryption
+    azihsm_algo decrypt_algo = {
+        .id = AZIHSM_ALGO_ID_AES_XTS,
+        .params = &xts_params,
+        .len = sizeof(xts_params)};
+
+    azihsm_handle decrypt_ctx_handle = 0;
+    err = azihsm_crypt_decrypt_init(session_handle, &decrypt_algo, key_handle, &decrypt_ctx_handle);
+    EXPECT_EQ(err, AZIHSM_ERROR_SUCCESS);
+
+    std::vector<uint8_t> decrypted(ciphertext.size());
+    size_t total_decrypted = 0;
+
+    for (size_t offset = 0; offset < ciphertext.size(); offset += 512)
+    {
+        azihsm_buffer ct_chunk = {.buf = ciphertext.data() + offset, .len = 512};
+        azihsm_buffer pt_chunk = {
+            .buf = decrypted.data() + total_decrypted,
+            .len = static_cast<uint32_t>(decrypted.size() - total_decrypted)};
+
+        err = azihsm_crypt_decrypt_update(session_handle, decrypt_ctx_handle, &ct_chunk, &pt_chunk);
+        EXPECT_EQ(err, AZIHSM_ERROR_SUCCESS);
+        total_decrypted += pt_chunk.len;
+    }
+
+    std::vector<uint8_t> final_pt(512);
+    azihsm_buffer final_pt_buffer = {.buf = final_pt.data(), .len = static_cast<uint32_t>(final_pt.size())};
+    err = azihsm_crypt_decrypt_final(session_handle, decrypt_ctx_handle, &final_pt_buffer);
+    EXPECT_EQ(err, AZIHSM_ERROR_SUCCESS);
+
+    EXPECT_EQ(memcmp(plaintext.data(), decrypted.data(), plaintext.size()), 0)
+        << "Decrypted data should match original plaintext";
+
+    std::cout << "AES XTS one-shot encrypt + streaming decrypt test passed" << std::endl;
+}
+
+TEST_F(AESTest, AesXtsStreamingEncryptOneshotDecrypt)
+{
+    // Generate AES XTS key
+    azihsm_handle key_handle = 0;
+    azihsm_algo key_gen_algo = {
+        .id = AZIHSM_ALGO_ID_AES_XTS_KEY_GEN,
+        .params = nullptr,
+        .len = 0};
+
+    uint32_t bit_len = 512;
+    bool encrypt_prop = true;
+    bool decrypt_prop = true;
+    azihsm_key_prop props[] = {
+        {.id = AZIHSM_KEY_PROP_ID_BIT_LEN, .val = &bit_len, .len = sizeof(bit_len)},
+        {.id = AZIHSM_KEY_PROP_ID_ENCRYPT, .val = &encrypt_prop, .len = sizeof(encrypt_prop)},
+        {.id = AZIHSM_KEY_PROP_ID_DECRYPT, .val = &decrypt_prop, .len = sizeof(decrypt_prop)}};
+
+    azihsm_key_prop_list prop_list = {.props = props, .count = 3};
+
+    auto err = azihsm_key_gen(session_handle, &key_gen_algo, &prop_list, &key_handle);
+    EXPECT_EQ(err, AZIHSM_ERROR_SUCCESS);
+
+    auto key_guard = scope_guard::make_scope_exit([&]
+                                                  { azihsm_key_delete(session_handle, key_handle); });
+
+    // Test data - 2048 bytes (4 data units of 512 bytes each)
+    std::vector<uint8_t> plaintext(2048, 0xAB);
+
+    azihsm_algo_aes_xts_params xts_params = {
+        .sector_num = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+                       0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
+        .data_unit_len = 512};
+
+    azihsm_algo encrypt_algo = {
+        .id = AZIHSM_ALGO_ID_AES_XTS,
+        .params = &xts_params,
+        .len = sizeof(xts_params)};
+
+    // Streaming encryption
+    azihsm_handle encrypt_ctx_handle = 0;
+    err = azihsm_crypt_encrypt_init(session_handle, &encrypt_algo, key_handle, &encrypt_ctx_handle);
+    EXPECT_EQ(err, AZIHSM_ERROR_SUCCESS);
+
+    std::vector<uint8_t> ciphertext(plaintext.size());
+    size_t total_encrypted = 0;
+
+    for (size_t offset = 0; offset < plaintext.size(); offset += 512)
+    {
+        azihsm_buffer pt_chunk = {.buf = plaintext.data() + offset, .len = 512};
+        azihsm_buffer ct_chunk = {
+            .buf = ciphertext.data() + total_encrypted,
+            .len = static_cast<uint32_t>(ciphertext.size() - total_encrypted)};
+
+        err = azihsm_crypt_encrypt_update(session_handle, encrypt_ctx_handle, &pt_chunk, &ct_chunk);
+        EXPECT_EQ(err, AZIHSM_ERROR_SUCCESS);
+        total_encrypted += ct_chunk.len;
+    }
+
+    std::vector<uint8_t> final_ct(512);
+    azihsm_buffer final_ct_buffer = {.buf = final_ct.data(), .len = static_cast<uint32_t>(final_ct.size())};
+    err = azihsm_crypt_encrypt_final(session_handle, encrypt_ctx_handle, &final_ct_buffer);
+    EXPECT_EQ(err, AZIHSM_ERROR_SUCCESS);
+
+    // One-shot decryption
+    azihsm_algo decrypt_algo = {
+        .id = AZIHSM_ALGO_ID_AES_XTS,
+        .params = &xts_params,
+        .len = sizeof(xts_params)};
+
+    azihsm_buffer ct_buffer = {.buf = ciphertext.data(), .len = static_cast<uint32_t>(ciphertext.size())};
+    std::vector<uint8_t> decrypted(ciphertext.size());
+    azihsm_buffer pt_buffer = {.buf = decrypted.data(), .len = static_cast<uint32_t>(decrypted.size())};
+
+    err = azihsm_crypt_decrypt(session_handle, &decrypt_algo, key_handle, &ct_buffer, &pt_buffer);
+    EXPECT_EQ(err, AZIHSM_ERROR_SUCCESS);
+
+    EXPECT_EQ(memcmp(plaintext.data(), decrypted.data(), plaintext.size()), 0)
+        << "Decrypted data should match original plaintext";
+
+    std::cout << "AES XTS streaming encrypt + one-shot decrypt test passed" << std::endl;
+}
+
+TEST_F(AESTest, AesXtsStreamingInvalidDataUnitLen)
+{
+    // Generate AES XTS key
+    azihsm_handle key_handle = 0;
+    azihsm_algo key_gen_algo = {
+        .id = AZIHSM_ALGO_ID_AES_XTS_KEY_GEN,
+        .params = nullptr,
+        .len = 0};
+
+    uint32_t bit_len = 512;
+    bool encrypt_prop = true;
+    bool decrypt_prop = true;
+    azihsm_key_prop props[] = {
+        {.id = AZIHSM_KEY_PROP_ID_BIT_LEN, .val = &bit_len, .len = sizeof(bit_len)},
+        {.id = AZIHSM_KEY_PROP_ID_ENCRYPT, .val = &encrypt_prop, .len = sizeof(encrypt_prop)},
+        {.id = AZIHSM_KEY_PROP_ID_DECRYPT, .val = &decrypt_prop, .len = sizeof(decrypt_prop)}};
+
+    azihsm_key_prop_list prop_list = {.props = props, .count = 3};
+
+    auto err = azihsm_key_gen(session_handle, &key_gen_algo, &prop_list, &key_handle);
+    EXPECT_EQ(err, AZIHSM_ERROR_SUCCESS);
+
+    auto key_guard = scope_guard::make_scope_exit([&]
+                                                  { azihsm_key_delete(session_handle, key_handle); });
+
+    // Test with invalid data_unit_len (2048 - not 512/4096/8192)
+    azihsm_algo_aes_xts_params xts_params = {
+        .sector_num = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+                       0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
+        .data_unit_len = 2048};
+
+    azihsm_algo encrypt_algo = {
+        .id = AZIHSM_ALGO_ID_AES_XTS,
+        .params = &xts_params,
+        .len = sizeof(xts_params)};
+
+    azihsm_handle encrypt_ctx_handle = 0;
+    err = azihsm_crypt_encrypt_init(session_handle, &encrypt_algo, key_handle, &encrypt_ctx_handle);
+    EXPECT_EQ(err, AZIHSM_AES_UNSUPPORTED_DATA_UNIT_LENGTH)
+        << "encrypt_init should fail with invalid data_unit_len";
+    EXPECT_EQ(encrypt_ctx_handle, 0) << "Context handle should be 0 on failure";
+
+    // Test decrypt_init with same invalid data_unit_len
+    azihsm_algo decrypt_algo = {
+        .id = AZIHSM_ALGO_ID_AES_XTS,
+        .params = &xts_params,
+        .len = sizeof(xts_params)};
+
+    azihsm_handle decrypt_ctx_handle = 0;
+    err = azihsm_crypt_decrypt_init(session_handle, &decrypt_algo, key_handle, &decrypt_ctx_handle);
+    EXPECT_EQ(err, AZIHSM_AES_UNSUPPORTED_DATA_UNIT_LENGTH)
+        << "decrypt_init should fail with invalid data_unit_len";
+    EXPECT_EQ(decrypt_ctx_handle, 0) << "Context handle should be 0 on failure";
+
+    std::cout << "AES XTS streaming invalid data_unit_len test passed" << std::endl;
+}
+
+TEST_F(AESTest, AesXtsStreamingInvalidHandle)
+{
+    // Test operations with invalid handle
+    azihsm_handle invalid_handle = 0xDEADBEEF;
+
+    std::vector<uint8_t> data(512, 0xAA);
+    azihsm_buffer data_buf = {.buf = data.data(), .len = 512};
+    std::vector<uint8_t> output(512);
+    azihsm_buffer output_buf = {.buf = output.data(), .len = 512};
+
+    // Test encrypt_update with invalid handle
+    auto err = azihsm_crypt_encrypt_update(session_handle, invalid_handle, &data_buf, &output_buf);
+    EXPECT_EQ(err, AZIHSM_ERROR_INVALID_HANDLE)
+        << "encrypt_update should fail with invalid handle";
+
+    // Test encrypt_final with invalid handle
+    err = azihsm_crypt_encrypt_final(session_handle, invalid_handle, &output_buf);
+    EXPECT_EQ(err, AZIHSM_ERROR_INVALID_HANDLE)
+        << "encrypt_final should fail with invalid handle";
+
+    // Test decrypt_update with invalid handle
+    err = azihsm_crypt_decrypt_update(session_handle, invalid_handle, &data_buf, &output_buf);
+    EXPECT_EQ(err, AZIHSM_ERROR_INVALID_HANDLE)
+        << "decrypt_update should fail with invalid handle";
+
+    // Test decrypt_final with invalid handle
+    err = azihsm_crypt_decrypt_final(session_handle, invalid_handle, &output_buf);
+    EXPECT_EQ(err, AZIHSM_ERROR_INVALID_HANDLE)
+        << "decrypt_final should fail with invalid handle";
+
+    std::cout << "AES XTS streaming invalid handle test passed" << std::endl;
+}
+
+TEST_F(AESTest, AesXtsStreamingPartialDataUnit)
+{
+    // Generate AES XTS key
+    azihsm_handle key_handle = 0;
+    azihsm_algo key_gen_algo = {
+        .id = AZIHSM_ALGO_ID_AES_XTS_KEY_GEN,
+        .params = nullptr,
+        .len = 0};
+
+    uint32_t bit_len = 512;
+    bool encrypt_prop = true;
+    bool decrypt_prop = true;
+    azihsm_key_prop props[] = {
+        {.id = AZIHSM_KEY_PROP_ID_BIT_LEN, .val = &bit_len, .len = sizeof(bit_len)},
+        {.id = AZIHSM_KEY_PROP_ID_ENCRYPT, .val = &encrypt_prop, .len = sizeof(encrypt_prop)},
+        {.id = AZIHSM_KEY_PROP_ID_DECRYPT, .val = &decrypt_prop, .len = sizeof(decrypt_prop)}};
+
+    azihsm_key_prop_list prop_list = {.props = props, .count = 3};
+
+    auto err = azihsm_key_gen(session_handle, &key_gen_algo, &prop_list, &key_handle);
+    EXPECT_EQ(err, AZIHSM_ERROR_SUCCESS);
+
+    auto key_guard = scope_guard::make_scope_exit([&]
+                                                  { azihsm_key_delete(session_handle, key_handle); });
+
+    azihsm_algo_aes_xts_params xts_params = {
+        .sector_num = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+                       0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
+        .data_unit_len = 512};
+
+    azihsm_algo encrypt_algo = {
+        .id = AZIHSM_ALGO_ID_AES_XTS,
+        .params = &xts_params,
+        .len = sizeof(xts_params)};
+
+    // Initialize streaming encryption
+    azihsm_handle encrypt_ctx_handle = 0;
+    err = azihsm_crypt_encrypt_init(session_handle, &encrypt_algo, key_handle, &encrypt_ctx_handle);
+    EXPECT_EQ(err, AZIHSM_ERROR_SUCCESS);
+
+    auto enc_ctx_guard = scope_guard::make_scope_exit([&]
+                                                      {
+        if (encrypt_ctx_handle != 0)
+        {
+            azihsm_buffer final_buf = {.buf = nullptr, .len = 0};
+            azihsm_crypt_encrypt_final(session_handle, encrypt_ctx_handle, &final_buf);
+        } });
+
+    // Update with partial data unit (256 bytes, but data_unit_len is 512)
+    std::vector<uint8_t> partial_data(256, 0xBB);
+    azihsm_buffer pt_buf = {.buf = partial_data.data(), .len = 256};
+    std::vector<uint8_t> ciphertext(512);
+    azihsm_buffer ct_buf = {.buf = ciphertext.data(), .len = 512};
+
+    err = azihsm_crypt_encrypt_update(session_handle, encrypt_ctx_handle, &pt_buf, &ct_buf);
+    EXPECT_EQ(err, AZIHSM_ERROR_SUCCESS);
+    EXPECT_EQ(ct_buf.len, 0) << "Should buffer partial data unit without output";
+
+    // Finalize should fail because we have incomplete data unit
+    azihsm_buffer final_buf = {.buf = ciphertext.data(), .len = 512};
+    err = azihsm_crypt_encrypt_final(session_handle, encrypt_ctx_handle, &final_buf);
+    EXPECT_NE(err, AZIHSM_ERROR_SUCCESS)
+        << "encrypt_final should fail with incomplete data unit";
+
+    encrypt_ctx_handle = 0; // Mark as cleaned up
+
+    std::cout << "AES XTS streaming partial data unit test passed" << std::endl;
+}
+
+TEST_F(AESTest, AesXtsStreamingWrongChunkSize)
+{
+    // Generate AES XTS key
+    azihsm_handle key_handle = 0;
+    azihsm_algo key_gen_algo = {
+        .id = AZIHSM_ALGO_ID_AES_XTS_KEY_GEN,
+        .params = nullptr,
+        .len = 0};
+
+    uint32_t bit_len = 512;
+    bool encrypt_prop = true;
+    bool decrypt_prop = true;
+    azihsm_key_prop props[] = {
+        {.id = AZIHSM_KEY_PROP_ID_BIT_LEN, .val = &bit_len, .len = sizeof(bit_len)},
+        {.id = AZIHSM_KEY_PROP_ID_ENCRYPT, .val = &encrypt_prop, .len = sizeof(encrypt_prop)},
+        {.id = AZIHSM_KEY_PROP_ID_DECRYPT, .val = &decrypt_prop, .len = sizeof(decrypt_prop)}};
+
+    azihsm_key_prop_list prop_list = {.props = props, .count = 3};
+
+    auto err = azihsm_key_gen(session_handle, &key_gen_algo, &prop_list, &key_handle);
+    EXPECT_EQ(err, AZIHSM_ERROR_SUCCESS);
+
+    auto key_guard = scope_guard::make_scope_exit([&]
+                                                  { azihsm_key_delete(session_handle, key_handle); });
+
+    azihsm_algo_aes_xts_params xts_params = {
+        .sector_num = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+                       0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
+        .data_unit_len = 512};
+
+    azihsm_algo encrypt_algo = {
+        .id = AZIHSM_ALGO_ID_AES_XTS,
+        .params = &xts_params,
+        .len = sizeof(xts_params)};
+
+    // Initialize streaming encryption
+    azihsm_handle encrypt_ctx_handle = 0;
+    err = azihsm_crypt_encrypt_init(session_handle, &encrypt_algo, key_handle, &encrypt_ctx_handle);
+    EXPECT_EQ(err, AZIHSM_ERROR_SUCCESS);
+
+    auto enc_ctx_guard = scope_guard::make_scope_exit([&]
+                                                      {
+        if (encrypt_ctx_handle != 0)
+        {
+            azihsm_buffer final_buf = {.buf = nullptr, .len = 0};
+            azihsm_crypt_encrypt_final(session_handle, encrypt_ctx_handle, &final_buf);
+        } });
+
+    // First update with correct size (512 bytes)
+    std::vector<uint8_t> plaintext1(512, 0xAA);
+    azihsm_buffer pt_buf1 = {.buf = plaintext1.data(), .len = 512};
+    std::vector<uint8_t> ciphertext(1024);
+    azihsm_buffer ct_buf1 = {.buf = ciphertext.data(), .len = 512};
+
+    err = azihsm_crypt_encrypt_update(session_handle, encrypt_ctx_handle, &pt_buf1, &ct_buf1);
+    EXPECT_EQ(err, AZIHSM_ERROR_SUCCESS);
+    EXPECT_EQ(ct_buf1.len, 512);
+
+    // Second update with wrong size (768 bytes - not a multiple of data_unit_len)
+    std::vector<uint8_t> plaintext2(768, 0xBB);
+    azihsm_buffer pt_buf2 = {.buf = plaintext2.data(), .len = 768};
+    azihsm_buffer ct_buf2 = {.buf = ciphertext.data() + 512, .len = 512};
+
+    err = azihsm_crypt_encrypt_update(session_handle, encrypt_ctx_handle, &pt_buf2, &ct_buf2);
+    EXPECT_EQ(err, AZIHSM_ERROR_SUCCESS);
+    // 768 = 512 + 256, so 512 gets processed, 256 gets buffered
+    EXPECT_EQ(ct_buf2.len, 512) << "Should process one complete 512-byte unit";
+
+    // Finalize should fail because of remaining 256 bytes
+    azihsm_buffer final_buf = {.buf = ciphertext.data(), .len = 512};
+    err = azihsm_crypt_encrypt_final(session_handle, encrypt_ctx_handle, &final_buf);
+    EXPECT_NE(err, AZIHSM_ERROR_SUCCESS)
+        << "encrypt_final should fail with incomplete final data unit";
+
+    encrypt_ctx_handle = 0; // Mark as cleaned up
+
+    std::cout << "AES XTS streaming wrong chunk size test passed" << std::endl;
+}
+
+TEST_F(AESTest, AesXtsStreamingInsufficientOutputBuffer)
+{
+    // Generate AES XTS key
+    azihsm_handle key_handle = 0;
+    azihsm_algo key_gen_algo = {
+        .id = AZIHSM_ALGO_ID_AES_XTS_KEY_GEN,
+        .params = nullptr,
+        .len = 0};
+
+    uint32_t bit_len = 512;
+    bool encrypt_prop = true;
+    bool decrypt_prop = true;
+    azihsm_key_prop props[] = {
+        {.id = AZIHSM_KEY_PROP_ID_BIT_LEN, .val = &bit_len, .len = sizeof(bit_len)},
+        {.id = AZIHSM_KEY_PROP_ID_ENCRYPT, .val = &encrypt_prop, .len = sizeof(encrypt_prop)},
+        {.id = AZIHSM_KEY_PROP_ID_DECRYPT, .val = &decrypt_prop, .len = sizeof(decrypt_prop)}};
+
+    azihsm_key_prop_list prop_list = {.props = props, .count = 3};
+
+    auto err = azihsm_key_gen(session_handle, &key_gen_algo, &prop_list, &key_handle);
+    EXPECT_EQ(err, AZIHSM_ERROR_SUCCESS);
+
+    auto key_guard = scope_guard::make_scope_exit([&]
+                                                  { azihsm_key_delete(session_handle, key_handle); });
+
+    azihsm_algo_aes_xts_params xts_params = {
+        .sector_num = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+                       0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
+        .data_unit_len = 512};
+
+    azihsm_algo encrypt_algo = {
+        .id = AZIHSM_ALGO_ID_AES_XTS,
+        .params = &xts_params,
+        .len = sizeof(xts_params)};
+
+    // Initialize streaming encryption
+    azihsm_handle encrypt_ctx_handle = 0;
+    err = azihsm_crypt_encrypt_init(session_handle, &encrypt_algo, key_handle, &encrypt_ctx_handle);
+    EXPECT_EQ(err, AZIHSM_ERROR_SUCCESS);
+
+    auto enc_ctx_guard = scope_guard::make_scope_exit([&]
+                                                      {
+        if (encrypt_ctx_handle != 0)
+        {
+            azihsm_buffer final_buf = {.buf = nullptr, .len = 0};
+            azihsm_crypt_encrypt_final(session_handle, encrypt_ctx_handle, &final_buf);
+        } });
+
+    // Update with 512 bytes but provide insufficient output buffer
+    std::vector<uint8_t> plaintext(512, 0xCC);
+    azihsm_buffer pt_buf = {.buf = plaintext.data(), .len = 512};
+    std::vector<uint8_t> small_buffer(256); // Only 256 bytes, need 512
+    azihsm_buffer ct_buf = {.buf = small_buffer.data(), .len = 256};
+
+    err = azihsm_crypt_encrypt_update(session_handle, encrypt_ctx_handle, &pt_buf, &ct_buf);
+    EXPECT_NE(err, AZIHSM_ERROR_SUCCESS)
+        << "encrypt_update should fail with insufficient output buffer";
+
+    encrypt_ctx_handle = 0; // Mark as cleaned up
+
+    std::cout << "AES XTS streaming insufficient output buffer test passed" << std::endl;
+}

--- a/api/lib/src/bindings/handle_table.rs
+++ b/api/lib/src/bindings/handle_table.rs
@@ -21,6 +21,7 @@ pub(crate) enum HandleType {
     SecretKey,
     HmacKey,
     AesCbcStreamingContext,
+    AesXtsStreamingContext,
     EcSignStreamingContext,
     EcVerifyStreamingContext,
     ShaStreamingContext,

--- a/api/lib/src/crypto/mod.rs
+++ b/api/lib/src/crypto/mod.rs
@@ -173,7 +173,7 @@ pub trait StreamingDecryptOp {
 
 /// Trait for algorithms that support streaming operations
 #[allow(unused)]
-pub trait StreamingEncDecAlgo<'a, K: Key> {
+pub(crate) trait StreamingEncDecAlgo<'a, K: Key> {
     type EncryptStream: StreamingEncryptOp;
     type DecryptStream: StreamingDecryptOp;
 
@@ -241,7 +241,7 @@ pub trait StreamingVerifyOp {
 
 /// Trait for algorithms that support streaming sign/verify operations
 #[allow(unused)]
-pub trait StreamingSignVerifyAlgo<'a, K: Key> {
+pub(crate) trait StreamingSignVerifyAlgo<'a, K: Key> {
     type SignStream: StreamingSignOp;
     type VerifyStream: StreamingVerifyOp;
 
@@ -280,7 +280,7 @@ pub trait StreamingDigestOp {
 
 #[allow(unused)]
 /// Trait for algorithms that support streaming digest operations
-pub trait StreamingDigestAlgo<'a> {
+pub(crate) trait StreamingDigestAlgo<'a> {
     type DigestStream: StreamingDigestOp;
 
     /// Create a streaming digest object

--- a/api/lib/src/crypto/tests/aes_tests.rs
+++ b/api/lib/src/crypto/tests/aes_tests.rs
@@ -10,7 +10,6 @@ mod tests {
         use crate::crypto::aes::AesCbcKey;
         use crate::crypto::aes::AES_CBC_BLOCK_IV_LENGTH;
         use crate::crypto::DecryptOp;
-        use crate::crypto::EncryptOp;
         use crate::test_helpers::create_test_session;
         use crate::types::KeyProps;
         use crate::AZIHSM_ERROR_INSUFFICIENT_BUFFER;
@@ -142,8 +141,8 @@ mod tests {
             let mut aes_cbc = AesCbcAlgo::new(iv, false);
 
             // Encrypt the plaintext
-            aes_cbc
-                .encrypt(&session, &aes_key, plaintext, &mut ciphertext)
+            session
+                .encrypt(&mut aes_cbc, &aes_key, plaintext, &mut ciphertext)
                 .expect("Failed to encrypt data");
 
             // Verify that ciphertext is different from plaintext
@@ -160,8 +159,8 @@ mod tests {
             ];
 
             // Decrypt the ciphertext
-            aes_cbc
-                .decrypt(&session, &aes_key, &ciphertext, &mut decrypted)
+            session
+                .decrypt(&mut aes_cbc, &aes_key, &ciphertext, &mut decrypted)
                 .expect("Failed to decrypt data");
 
             // Verify that decrypted data matches original plaintext
@@ -203,8 +202,12 @@ mod tests {
             let mut small_ciphertext = vec![0u8; 8]; // 8 bytes - too small for 16 byte plaintext
             let mut aes_cbc_encrypt1 = AesCbcAlgo::new(iv, false);
 
-            let result =
-                aes_cbc_encrypt1.encrypt(&session, &aes_key, plaintext, &mut small_ciphertext);
+            let result = session.encrypt(
+                &mut aes_cbc_encrypt1,
+                &aes_key,
+                plaintext,
+                &mut small_ciphertext,
+            );
             assert!(
                 result.is_err(),
                 "Encrypt should fail with insufficient buffer"
@@ -215,8 +218,12 @@ mod tests {
             let mut exact_ciphertext = vec![0u8; 16]; // 16 bytes - exact match
             let mut aes_cbc_encrypt2 = AesCbcAlgo::new(iv, false);
 
-            let result =
-                aes_cbc_encrypt2.encrypt(&session, &aes_key, plaintext, &mut exact_ciphertext);
+            let result = session.encrypt(
+                &mut aes_cbc_encrypt2,
+                &aes_key,
+                plaintext,
+                &mut exact_ciphertext,
+            );
             assert!(
                 result.is_ok(),
                 "Encrypt should succeed with exact buffer size"
@@ -229,8 +236,13 @@ mod tests {
             let mut large_ciphertext = vec![0u8; 32]; // 32 bytes - larger than needed
             let mut aes_cbc_encrypt3 = AesCbcAlgo::new(iv, false);
 
-            let encrypted_len = aes_cbc_encrypt3
-                .encrypt(&session, &aes_key, plaintext, &mut large_ciphertext)
+            let encrypted_len = session
+                .encrypt(
+                    &mut aes_cbc_encrypt3,
+                    &aes_key,
+                    plaintext,
+                    &mut large_ciphertext,
+                )
                 .expect("Encrypt should succeed with larger buffer");
 
             // Verify that only the first 16 bytes contain the encrypted data
@@ -249,8 +261,8 @@ mod tests {
             let mut unaligned_ciphertext = vec![0u8; 16];
             let mut aes_cbc_encrypt4 = AesCbcAlgo::new(iv, false);
 
-            let result = aes_cbc_encrypt4.encrypt(
-                &session,
+            let result = session.encrypt(
+                &mut aes_cbc_encrypt4,
                 &aes_key,
                 unaligned_plaintext,
                 &mut unaligned_ciphertext,
@@ -292,9 +304,9 @@ mod tests {
             let iv = [0u8; 16];
             let mut aes_cbc_encrypt = AesCbcAlgo::new(iv, false);
 
-            aes_cbc_encrypt
+            session
                 .encrypt(
-                    &session,
+                    &mut aes_cbc_encrypt,
                     &aes_key,
                     original_plaintext,
                     &mut valid_ciphertext,
@@ -321,8 +333,8 @@ mod tests {
             let mut exact_plaintext = vec![0u8; 16]; // 16 bytes - exact match
             let mut aes_cbc_decrypt2 = AesCbcAlgo::new(iv, false);
 
-            let result = aes_cbc_decrypt2.decrypt(
-                &session,
+            let result = session.decrypt(
+                &mut aes_cbc_decrypt2,
                 &aes_key,
                 &valid_ciphertext,
                 &mut exact_plaintext,
@@ -337,8 +349,13 @@ mod tests {
             let mut large_plaintext = vec![0u8; 32]; // 32 bytes - larger than needed
             let mut aes_cbc_decrypt3 = AesCbcAlgo::new(iv, false);
 
-            let decrypted_len = aes_cbc_decrypt3
-                .decrypt(&session, &aes_key, &valid_ciphertext, &mut large_plaintext)
+            let decrypted_len = session
+                .decrypt(
+                    &mut aes_cbc_decrypt3,
+                    &aes_key,
+                    &valid_ciphertext,
+                    &mut large_plaintext,
+                )
                 .expect("Decrypt should succeed with larger buffer");
 
             // Verify that only the first 16 bytes contain the decrypted data
@@ -389,8 +406,8 @@ mod tests {
             let mut aes_cbc = AesCbcAlgo::new(iv, false);
 
             // Encrypt multiple blocks
-            aes_cbc
-                .encrypt(&session, &aes_key, plaintext, &mut ciphertext)
+            session
+                .encrypt(&mut aes_cbc, &aes_key, plaintext, &mut ciphertext)
                 .expect("Failed to encrypt multiple blocks");
 
             // Verify encryption changed the data
@@ -403,8 +420,8 @@ mod tests {
             ];
 
             // Decrypt multiple blocks
-            aes_cbc
-                .decrypt(&session, &aes_key, &ciphertext, &mut decrypted)
+            session
+                .decrypt(&mut aes_cbc, &aes_key, &ciphertext, &mut decrypted)
                 .expect("Failed to decrypt multiple blocks");
 
             // Verify round-trip success
@@ -442,7 +459,7 @@ mod tests {
             let mut aes_cbc = AesCbcAlgo::new(iv, false); // No padding
 
             // Should fail because input is not block-aligned
-            let result = aes_cbc.encrypt(&session, &aes_key, plaintext, &mut ciphertext);
+            let result = session.encrypt(&mut aes_cbc, &aes_key, plaintext, &mut ciphertext);
             assert!(
                 result.is_err(),
                 "Should fail with non-block-aligned input in unpadded mode"
@@ -464,7 +481,6 @@ mod tests {
         use crate::crypto::aes::AesCbcAlgo;
         use crate::crypto::aes::AesCbcKey;
         use crate::crypto::aes::AES_CBC_BLOCK_IV_LENGTH;
-        use crate::crypto::EncryptOp;
         use crate::crypto::StreamingDecryptOp;
         use crate::crypto::StreamingEncryptOp;
         use crate::test_helpers::create_test_session;
@@ -535,8 +551,8 @@ mod tests {
             // Verify total output matches non-streaming encryption
             let mut aes_cbc_compare = AesCbcAlgo::new(iv, false);
             let mut expected_ct = vec![0u8; 48];
-            aes_cbc_compare
-                .encrypt(&session, &aes_key, plaintext, &mut expected_ct)
+            session
+                .encrypt(&mut aes_cbc_compare, &aes_key, plaintext, &mut expected_ct)
                 .expect("Failed non-streaming encryption");
 
             assert_eq!(
@@ -574,8 +590,8 @@ mod tests {
 
             let mut aes_cbc = AesCbcAlgo::new(iv, false);
             let mut ciphertext = vec![0u8; 32];
-            aes_cbc
-                .encrypt(&session, &aes_key, plaintext, &mut ciphertext)
+            session
+                .encrypt(&mut aes_cbc, &aes_key, plaintext, &mut ciphertext)
                 .expect("Failed to encrypt test data");
 
             // Now test streaming decryption
@@ -713,8 +729,8 @@ mod tests {
 
             let mut aes_cbc = AesCbcAlgo::new(iv, false);
             let mut ciphertext = vec![0u8; 48];
-            aes_cbc
-                .encrypt(&session, &aes_key, &plaintext, &mut ciphertext)
+            session
+                .encrypt(&mut aes_cbc, &aes_key, &plaintext, &mut ciphertext)
                 .expect("Failed to encrypt test data");
 
             // Now test streaming decryption with partial chunks
@@ -867,8 +883,8 @@ mod tests {
             // Verify against normal encryption
             let mut aes_cbc_compare = AesCbcAlgo::new(iv, false);
             let mut expected_ct = vec![0u8; 32];
-            aes_cbc_compare
-                .encrypt(&session, &aes_key, plaintext, &mut expected_ct)
+            session
+                .encrypt(&mut aes_cbc_compare, &aes_key, plaintext, &mut expected_ct)
                 .expect("Failed comparison encryption");
 
             assert_eq!(
@@ -939,8 +955,8 @@ mod tests {
             // Verify with non-streaming encryption
             let mut aes_cbc_compare = AesCbcAlgo::new(iv, false);
             let mut expected_ct = vec![0u8; 1024];
-            aes_cbc_compare
-                .encrypt(&session, &aes_key, &plaintext, &mut expected_ct)
+            session
+                .encrypt(&mut aes_cbc_compare, &aes_key, &plaintext, &mut expected_ct)
                 .expect("Failed comparison encryption");
 
             assert_eq!(
@@ -1065,7 +1081,6 @@ mod tests {
         use crate::crypto::aes::AesCbcAlgo;
         use crate::crypto::aes::AesCbcKey;
         use crate::crypto::aes::AES_CBC_BLOCK_IV_LENGTH;
-        use crate::crypto::DecryptOp;
         use crate::crypto::EncryptOp;
         use crate::test_helpers::create_test_session;
         use crate::types::KeyProps;
@@ -1106,8 +1121,8 @@ mod tests {
             let mut aes_cbc = AesCbcAlgo::new(iv, true);
 
             // Encrypt the plaintext
-            aes_cbc
-                .encrypt(&session, &aes_key, plaintext, &mut ciphertext)
+            session
+                .encrypt(&mut aes_cbc, &aes_key, plaintext, &mut ciphertext)
                 .expect("Failed to encrypt data with PKCS#7 padding");
 
             // Verify that ciphertext is different from plaintext
@@ -1121,8 +1136,8 @@ mod tests {
             aes_cbc.iv = iv;
 
             // Decrypt the ciphertext
-            aes_cbc
-                .decrypt(&session, &aes_key, &ciphertext, &mut decrypted)
+            session
+                .decrypt(&mut aes_cbc, &aes_key, &ciphertext, &mut decrypted)
                 .expect("Failed to decrypt data with PKCS#7 padding");
 
             // Verify that decrypted data matches original plaintext
@@ -1182,14 +1197,14 @@ mod tests {
                 let mut decrypted = vec![0u8; plaintext.len()];
 
                 // Encrypt
-                aes_cbc
-                    .encrypt(&session, &aes_key, plaintext, &mut ciphertext)
+                session
+                    .encrypt(&mut aes_cbc, &aes_key, plaintext, &mut ciphertext)
                     .unwrap_or_else(|_| panic!("Test case {}: Failed to encrypt", i));
 
                 // Reset IV and decrypt
                 aes_cbc.iv = iv;
-                aes_cbc
-                    .decrypt(&session, &aes_key, &ciphertext, &mut decrypted)
+                session
+                    .decrypt(&mut aes_cbc, &aes_key, &ciphertext, &mut decrypted)
                     .unwrap_or_else(|_| panic!("Test case {}: Failed to decrypt", i));
 
                 // Verify round-trip
@@ -1235,14 +1250,14 @@ mod tests {
             let mut aes_cbc = AesCbcAlgo::new(iv, true);
 
             // Encrypt empty input
-            aes_cbc
-                .encrypt(&session, &aes_key, plaintext, &mut ciphertext)
+            session
+                .encrypt(&mut aes_cbc, &aes_key, plaintext, &mut ciphertext)
                 .expect("Failed to encrypt empty input with PKCS#7 padding");
 
             // Reset IV and decrypt
             aes_cbc.iv = iv;
-            aes_cbc
-                .decrypt(&session, &aes_key, &ciphertext, &mut decrypted)
+            session
+                .decrypt(&mut aes_cbc, &aes_key, &ciphertext, &mut decrypted)
                 .expect("Failed to decrypt empty input with PKCS#7 padding");
 
             // Verify that decrypted data is empty
@@ -1287,14 +1302,14 @@ mod tests {
             let mut decrypted = vec![0u8; plaintext.len()];
 
             // Encrypt large input
-            aes_cbc
-                .encrypt(&session, &aes_key, &plaintext, &mut ciphertext)
+            session
+                .encrypt(&mut aes_cbc, &aes_key, &plaintext, &mut ciphertext)
                 .expect("Failed to encrypt large input with PKCS#7 padding");
 
             // Reset IV and decrypt
             aes_cbc.iv = iv;
-            aes_cbc
-                .decrypt(&session, &aes_key, &ciphertext, &mut decrypted)
+            session
+                .decrypt(&mut aes_cbc, &aes_key, &ciphertext, &mut decrypted)
                 .expect("Failed to decrypt large input with PKCS#7 padding");
 
             // Verify round-trip
@@ -1336,7 +1351,7 @@ mod tests {
             let mut aes_cbc = AesCbcAlgo::new(iv, true);
 
             // Should fail due to insufficient output buffer
-            let result = aes_cbc.encrypt(&session, &aes_key, plaintext, &mut small_buffer);
+            let result = session.encrypt(&mut aes_cbc, &aes_key, plaintext, &mut small_buffer);
             assert!(result.is_err(), "Should fail with insufficient buffer");
             assert_eq!(result.unwrap_err(), AZIHSM_ERROR_INSUFFICIENT_BUFFER);
 
@@ -1372,16 +1387,16 @@ mod tests {
             let mut aes_cbc_unpadded = AesCbcAlgo::new(iv, false);
             let mut ct_unpadded = vec![0u8; 16]; // Same size as input
 
-            aes_cbc_unpadded
-                .encrypt(&session, &aes_key, plaintext, &mut ct_unpadded)
+            session
+                .encrypt(&mut aes_cbc_unpadded, &aes_key, plaintext, &mut ct_unpadded)
                 .expect("Failed to encrypt in unpadded mode");
 
             // Test padded mode
             let mut aes_cbc_padded = AesCbcAlgo::new(iv, true);
             let mut ct_padded = vec![0u8; 32]; // Will be 32 bytes due to padding
 
-            aes_cbc_padded
-                .encrypt(&session, &aes_key, plaintext, &mut ct_padded)
+            session
+                .encrypt(&mut aes_cbc_padded, &aes_key, plaintext, &mut ct_padded)
                 .expect("Failed to encrypt in padded mode");
 
             // Verify that padded mode produces longer ciphertext
@@ -1396,14 +1411,19 @@ mod tests {
             // Verify both decrypt correctly
             let mut pt_unpadded = vec![0u8; 16];
             aes_cbc_unpadded.iv = iv;
-            aes_cbc_unpadded
-                .decrypt(&session, &aes_key, &ct_unpadded, &mut pt_unpadded)
+            session
+                .decrypt(
+                    &mut aes_cbc_unpadded,
+                    &aes_key,
+                    &ct_unpadded,
+                    &mut pt_unpadded,
+                )
                 .expect("Failed to decrypt unpadded");
 
             let mut pt_padded = vec![0u8; 16];
             aes_cbc_padded.iv = iv;
-            aes_cbc_padded
-                .decrypt(&session, &aes_key, &ct_padded, &mut pt_padded)
+            session
+                .decrypt(&mut aes_cbc_padded, &aes_key, &ct_padded, &mut pt_padded)
                 .expect("Failed to decrypt padded");
 
             assert_eq!(&pt_unpadded[..], &plaintext[..]);
@@ -1424,7 +1444,6 @@ mod tests {
         use crate::crypto::aes::AesCbcAlgo;
         use crate::crypto::aes::AesCbcKey;
         use crate::crypto::aes::AES_CBC_BLOCK_IV_LENGTH;
-        use crate::crypto::EncryptOp;
         use crate::crypto::StreamingDecryptOp;
         use crate::crypto::StreamingEncryptOp;
         use crate::test_helpers::create_test_session;
@@ -1483,8 +1502,8 @@ mod tests {
             // Verify against non-streaming encryption
             let mut aes_cbc_compare = AesCbcAlgo::new(iv, true);
             let mut expected_ct = vec![0u8; 48];
-            aes_cbc_compare
-                .encrypt(&session, &aes_key, plaintext, &mut expected_ct)
+            session
+                .encrypt(&mut aes_cbc_compare, &aes_key, plaintext, &mut expected_ct)
                 .expect("Failed to encrypt with non-streaming");
 
             assert_eq!(
@@ -1523,8 +1542,8 @@ mod tests {
 
             let mut aes_cbc = AesCbcAlgo::new(iv, true);
             let mut ciphertext = vec![0u8; 48]; // Will be padded to 48 bytes
-            aes_cbc
-                .encrypt(&session, &aes_key, plaintext, &mut ciphertext)
+            session
+                .encrypt(&mut aes_cbc, &aes_key, plaintext, &mut ciphertext)
                 .expect("Failed to encrypt");
 
             // Now test streaming decryption
@@ -1613,8 +1632,8 @@ mod tests {
             // Verify against non-streaming encryption
             let mut aes_cbc_compare = AesCbcAlgo::new(iv, true);
             let mut expected_ct = vec![0u8; 16];
-            aes_cbc_compare
-                .encrypt(&session, &aes_key, plaintext, &mut expected_ct)
+            session
+                .encrypt(&mut aes_cbc_compare, &aes_key, plaintext, &mut expected_ct)
                 .expect("Failed to encrypt empty input");
 
             assert_eq!(
@@ -1653,8 +1672,8 @@ mod tests {
 
             let mut aes_cbc_encrypt = AesCbcAlgo::new(iv, true);
             let mut ciphertext = vec![0u8; 16];
-            aes_cbc_encrypt
-                .encrypt(&session, &aes_key, plaintext, &mut ciphertext)
+            session
+                .encrypt(&mut aes_cbc_encrypt, &aes_key, plaintext, &mut ciphertext)
                 .expect("Failed to encrypt empty input");
 
             // Now test streaming decryption of the encrypted empty input
@@ -1741,8 +1760,8 @@ mod tests {
             // Verify against non-streaming encryption
             let mut aes_cbc_compare = AesCbcAlgo::new(iv, true);
             let mut expected_ct = vec![0u8; 16];
-            aes_cbc_compare
-                .encrypt(&session, &aes_key, plaintext, &mut expected_ct)
+            session
+                .encrypt(&mut aes_cbc_compare, &aes_key, plaintext, &mut expected_ct)
                 .expect("Failed to encrypt single byte");
 
             assert_eq!(
@@ -1781,8 +1800,8 @@ mod tests {
 
             let mut aes_cbc_encrypt = AesCbcAlgo::new(iv, true);
             let mut ciphertext = vec![0u8; 16];
-            aes_cbc_encrypt
-                .encrypt(&session, &aes_key, plaintext, &mut ciphertext)
+            session
+                .encrypt(&mut aes_cbc_encrypt, &aes_key, plaintext, &mut ciphertext)
                 .expect("Failed to encrypt single byte");
 
             // Now test streaming decryption
@@ -1877,8 +1896,8 @@ mod tests {
             // Verify against non-streaming encryption
             let mut aes_cbc_compare = AesCbcAlgo::new(iv, true);
             let mut expected_ct = vec![0u8; expected_size];
-            aes_cbc_compare
-                .encrypt(&session, &aes_key, &plaintext, &mut expected_ct)
+            session
+                .encrypt(&mut aes_cbc_compare, &aes_key, &plaintext, &mut expected_ct)
                 .expect("Failed to encrypt large data");
 
             assert_eq!(
@@ -2454,8 +2473,8 @@ mod tests {
             };
 
             // Encrypt the plaintext
-            aes_xts
-                .encrypt(&session, &aes_xts_key, plaintext, &mut ciphertext)
+            session
+                .encrypt(&mut aes_xts, &aes_xts_key, plaintext, &mut ciphertext)
                 .expect("Failed to encrypt plaintext");
 
             // Verify that ciphertext is different from plaintext
@@ -2466,8 +2485,8 @@ mod tests {
             );
 
             // Decrypt the ciphertext (XTS doesn't modify sector_num like CBC modifies IV)
-            aes_xts
-                .decrypt(&session, &aes_xts_key, &ciphertext, &mut decrypted)
+            session
+                .decrypt(&mut aes_xts, &aes_xts_key, &ciphertext, &mut decrypted)
                 .expect("Failed to decrypt ciphertext");
 
             // Verify that decrypted data matches original plaintext
@@ -2516,16 +2535,16 @@ mod tests {
             };
 
             // Encrypt large data
-            aes_xts
-                .encrypt(&session, &aes_xts_key, &plaintext, &mut ciphertext)
+            session
+                .encrypt(&mut aes_xts, &aes_xts_key, &plaintext, &mut ciphertext)
                 .expect("Failed to encrypt large data");
 
             // Verify encryption changed the data
             assert_ne!(&ciphertext[..], &plaintext[..]);
 
             // Decrypt large data
-            aes_xts
-                .decrypt(&session, &aes_xts_key, &ciphertext, &mut decrypted)
+            session
+                .decrypt(&mut aes_xts, &aes_xts_key, &ciphertext, &mut decrypted)
                 .expect("Failed to decrypt large data");
 
             // Verify round-trip success
@@ -2565,7 +2584,7 @@ mod tests {
             };
 
             // Encrypt should fail due to insufficient buffer
-            let result = aes_xts.encrypt(&session, &aes_xts_key, plaintext, &mut ciphertext);
+            let result = session.encrypt(&mut aes_xts, &aes_xts_key, plaintext, &mut ciphertext);
             assert!(
                 result.is_err(),
                 "Encrypt should fail with insufficient buffer"
@@ -2606,7 +2625,7 @@ mod tests {
             };
 
             // Decrypt should fail due to insufficient buffer
-            let result = aes_xts.decrypt(&session, &aes_xts_key, &ciphertext, &mut plaintext);
+            let result = session.decrypt(&mut aes_xts, &aes_xts_key, &ciphertext, &mut plaintext);
             assert!(
                 result.is_err(),
                 "Decrypt should fail with insufficient buffer"
@@ -2652,8 +2671,8 @@ mod tests {
             };
 
             // Encrypt with larger buffer - should succeed
-            let encrypted_len = aes_xts
-                .encrypt(&session, &aes_xts_key, plaintext, &mut ciphertext)
+            let encrypted_len = session
+                .encrypt(&mut aes_xts, &aes_xts_key, plaintext, &mut ciphertext)
                 .expect("Failed to encrypt with larger buffer");
 
             // Verify encrypted length equals original plaintext length
@@ -2667,9 +2686,9 @@ mod tests {
             );
 
             // Decrypt with larger buffer - should succeed
-            let decrypted_len = aes_xts
+            let decrypted_len = session
                 .decrypt(
-                    &session,
+                    &mut aes_xts,
                     &aes_xts_key,
                     &ciphertext[..encrypted_len],
                     &mut decrypted,
@@ -2724,7 +2743,7 @@ mod tests {
             };
 
             // Encrypt should fail - key not initialized
-            let result = aes_xts.encrypt(&session, &aes_xts_key, plaintext, &mut ciphertext);
+            let result = session.encrypt(&mut aes_xts, &aes_xts_key, plaintext, &mut ciphertext);
             assert!(
                 result.is_err(),
                 "Encrypt should fail with uninitialized key"
@@ -2732,7 +2751,7 @@ mod tests {
             assert_eq!(result.unwrap_err(), AZIHSM_KEY_NOT_INITIALIZED);
 
             // Decrypt should also fail - key not initialized
-            let result = aes_xts.decrypt(&session, &aes_xts_key, plaintext, &mut decrypted_buf);
+            let result = session.decrypt(&mut aes_xts, &aes_xts_key, plaintext, &mut decrypted_buf);
             assert!(
                 result.is_err(),
                 "Decrypt should fail with uninitialized key"
@@ -2782,13 +2801,13 @@ mod tests {
             };
 
             // Encrypt with sector number 1
-            aes_xts1
-                .encrypt(&session, &aes_xts_key, plaintext, &mut ciphertext1)
+            session
+                .encrypt(&mut aes_xts1, &aes_xts_key, plaintext, &mut ciphertext1)
                 .expect("Failed to encrypt with sector number 1");
 
             // Encrypt with sector number 2
-            aes_xts2
-                .encrypt(&session, &aes_xts_key, plaintext, &mut ciphertext2)
+            session
+                .encrypt(&mut aes_xts2, &aes_xts_key, plaintext, &mut ciphertext2)
                 .expect("Failed to encrypt with sector number 2");
 
             // Ciphertexts should be different due to different sector numbers (tweaks)
@@ -2806,12 +2825,12 @@ mod tests {
             let mut decrypted1 = vec![0u8; plaintext.len()];
             let mut decrypted2 = vec![0u8; plaintext.len()];
 
-            aes_xts1
-                .decrypt(&session, &aes_xts_key, &ciphertext1, &mut decrypted1)
+            session
+                .decrypt(&mut aes_xts1, &aes_xts_key, &ciphertext1, &mut decrypted1)
                 .expect("Failed to decrypt with sector number 1");
 
-            aes_xts2
-                .decrypt(&session, &aes_xts_key, &ciphertext2, &mut decrypted2)
+            session
+                .decrypt(&mut aes_xts2, &aes_xts_key, &ciphertext2, &mut decrypted2)
                 .expect("Failed to decrypt with sector number 2");
 
             // Both should decrypt to original plaintext
@@ -2860,8 +2879,8 @@ mod tests {
                 };
 
                 // Test encryption
-                let encrypted_len = aes_xts
-                    .encrypt(&session, &aes_xts_key, &plaintext, &mut ciphertext)
+                let encrypted_len = session
+                    .encrypt(&mut aes_xts, &aes_xts_key, &plaintext, &mut ciphertext)
                     .unwrap_or_else(|_| panic!("Failed to encrypt {} bytes", size));
 
                 assert_eq!(
@@ -2877,8 +2896,8 @@ mod tests {
                 );
 
                 // Test decryption
-                let decrypted_len = aes_xts
-                    .decrypt(&session, &aes_xts_key, &ciphertext, &mut decrypted)
+                let decrypted_len = session
+                    .decrypt(&mut aes_xts, &aes_xts_key, &ciphertext, &mut decrypted)
                     .unwrap_or_else(|_| panic!("Failed to decrypt {} bytes", size));
 
                 assert_eq!(
@@ -2954,8 +2973,8 @@ mod tests {
                 sector_num,
                 data_unit_len: None,
             };
-            aes_xts1
-                .encrypt(&session, &aes_xts_key, plaintext, &mut ciphertext)
+            session
+                .encrypt(&mut aes_xts1, &aes_xts_key, plaintext, &mut ciphertext)
                 .expect("Failed first encryption");
 
             // Second encryption with same sector number
@@ -2964,8 +2983,8 @@ mod tests {
                 sector_num,
                 data_unit_len: None,
             };
-            aes_xts2
-                .encrypt(&session, &aes_xts_key, plaintext, &mut ciphertext2)
+            session
+                .encrypt(&mut aes_xts2, &aes_xts_key, plaintext, &mut ciphertext2)
                 .expect("Failed second encryption");
 
             // Results should be identical
@@ -2976,8 +2995,8 @@ mod tests {
             );
 
             // Decrypt and verify
-            aes_xts1
-                .decrypt(&session, &aes_xts_key, &ciphertext, &mut decrypted)
+            session
+                .decrypt(&mut aes_xts1, &aes_xts_key, &ciphertext, &mut decrypted)
                 .expect("Failed decryption");
 
             assert_eq!(&decrypted[..], &plaintext[..]);
@@ -3015,12 +3034,12 @@ mod tests {
                 data_unit_len: Some(512),
             };
 
-            aes_xts
-                .encrypt(&session, &aes_xts_key, &plaintext, &mut ciphertext)
+            session
+                .encrypt(&mut aes_xts, &aes_xts_key, &plaintext, &mut ciphertext)
                 .expect("Encryption should succeed with data_unit_len=512");
 
-            aes_xts
-                .decrypt(&session, &aes_xts_key, &ciphertext, &mut decrypted)
+            session
+                .decrypt(&mut aes_xts, &aes_xts_key, &ciphertext, &mut decrypted)
                 .expect("Decryption should succeed with data_unit_len=512");
 
             assert_eq!(&decrypted[..], &plaintext[..]);
@@ -3057,12 +3076,12 @@ mod tests {
                 data_unit_len: Some(4096),
             };
 
-            aes_xts
-                .encrypt(&session, &aes_xts_key, &plaintext, &mut ciphertext)
+            session
+                .encrypt(&mut aes_xts, &aes_xts_key, &plaintext, &mut ciphertext)
                 .expect("Encryption should succeed with data_unit_len=4096");
 
-            aes_xts
-                .decrypt(&session, &aes_xts_key, &ciphertext, &mut decrypted)
+            session
+                .decrypt(&mut aes_xts, &aes_xts_key, &ciphertext, &mut decrypted)
                 .expect("Decryption should succeed with data_unit_len=4096");
 
             assert_eq!(&decrypted[..], &plaintext[..]);
@@ -3100,12 +3119,12 @@ mod tests {
                 data_unit_len: Some(8192),
             };
 
-            aes_xts
-                .encrypt(&session, &aes_xts_key, &plaintext, &mut ciphertext)
+            session
+                .encrypt(&mut aes_xts, &aes_xts_key, &plaintext, &mut ciphertext)
                 .expect("Encryption should succeed with data_unit_len=8192");
 
-            aes_xts
-                .decrypt(&session, &aes_xts_key, &ciphertext, &mut decrypted)
+            session
+                .decrypt(&mut aes_xts, &aes_xts_key, &ciphertext, &mut decrypted)
                 .expect("Decryption should succeed with data_unit_len=8192");
 
             assert_eq!(&decrypted[..], &plaintext[..]);
@@ -3141,7 +3160,7 @@ mod tests {
                 data_unit_len: Some(2048), // Invalid: not equal to plaintext length and not 512/4096/8192
             };
 
-            let result = aes_xts.encrypt(&session, &aes_xts_key, &plaintext, &mut ciphertext);
+            let result = session.encrypt(&mut aes_xts, &aes_xts_key, &plaintext, &mut ciphertext);
             assert!(result.is_err(), "Should fail with invalid data_unit_len");
             assert_eq!(result.unwrap_err(), AZIHSM_AES_UNSUPPORTED_DATA_UNIT_LENGTH);
 
@@ -3177,7 +3196,7 @@ mod tests {
                 data_unit_len: Some(4096), // Standard size, but plaintext is not a multiple
             };
 
-            let result = aes_xts.encrypt(&session, &aes_xts_key, &plaintext, &mut ciphertext);
+            let result = session.encrypt(&mut aes_xts, &aes_xts_key, &plaintext, &mut ciphertext);
             assert!(
                 result.is_err(),
                 "Should fail when plaintext is not a multiple of data_unit_len"
@@ -3192,7 +3211,8 @@ mod tests {
                 data_unit_len: Some(512),
             };
 
-            let result2 = aes_xts2.encrypt(&session, &aes_xts_key, &plaintext2, &mut ciphertext2);
+            let result2 =
+                session.encrypt(&mut aes_xts2, &aes_xts_key, &plaintext2, &mut ciphertext2);
             assert!(
                 result2.is_err(),
                 "Should fail when plaintext (1000 bytes) is not a multiple of data_unit_len (512)"
@@ -3207,12 +3227,991 @@ mod tests {
                 data_unit_len: Some(8096),
             };
 
-            let result3 = aes_xts3.encrypt(&session, &aes_xts_key, &plaintext3, &mut ciphertext3);
+            let result3 =
+                session.encrypt(&mut aes_xts3, &aes_xts_key, &plaintext3, &mut ciphertext3);
             assert!(
                 result3.is_err(),
                 "Should fail when plaintext (8097 bytes) is not a multiple of data_unit_len (8096)"
             );
 
+            session
+                .delete_key(&mut aes_xts_key)
+                .expect("Failed to delete key");
+            session.close().expect("Failed to close session");
+        }
+    }
+
+    mod xts_streaming {
+        use crate::crypto::aes::AesXtsAlgo;
+        use crate::crypto::aes::AesXtsKey;
+        use crate::crypto::StreamingDecryptOp;
+        use crate::crypto::StreamingEncryptOp;
+        use crate::test_helpers::create_test_session;
+        use crate::types::KeyProps;
+
+        #[test]
+        fn test_full_length_data_unit_oneshot_encrypt_streaming_decrypt() {
+            let (_partition, mut session) = create_test_session();
+
+            // Create AES XTS key
+            let key_props = KeyProps::builder()
+                .bit_len(512)
+                .encrypt(true)
+                .decrypt(true)
+                .build();
+
+            let mut aes_xts_key = AesXtsKey::new(key_props);
+            session
+                .generate_key(&mut aes_xts_key)
+                .expect("Failed to generate AES XTS key");
+
+            // Test data - 1024 bytes
+            let plaintext = vec![0x42u8; 1024];
+            let mut ciphertext = vec![0u8; plaintext.len()];
+
+            let sector_num = [
+                0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19, 0x1A, 0x1B, 0x1C, 0x1D, 0x1E,
+                0x1F, 0x20,
+            ];
+
+            // Encrypt using one-shot with data_unit_len: None (full length as single unit)
+            let mut aes_xts = AesXtsAlgo {
+                sector_num,
+                data_unit_len: None,
+            };
+
+            let ct_len = session
+                .encrypt(&mut aes_xts, &aes_xts_key, &plaintext, &mut ciphertext)
+                .expect("Failed to encrypt plaintext");
+            assert_eq!(ct_len, plaintext.len());
+
+            // Decrypt using streaming with data_unit_len: None
+            let aes_xts_stream = AesXtsAlgo {
+                sector_num,
+                data_unit_len: None,
+            };
+
+            let mut decrypt_stream = session
+                .decrypt_init(&aes_xts_stream, &aes_xts_key)
+                .expect("Failed to initialize decrypt stream");
+
+            // Feed data in chunks
+            let chunk_size = 256;
+            let mut decrypted = vec![0u8; plaintext.len()];
+            let mut total_decrypted = 0;
+
+            for chunk_start in (0..ciphertext.len()).step_by(chunk_size) {
+                let chunk_end = std::cmp::min(chunk_start + chunk_size, ciphertext.len());
+                let chunk = &ciphertext[chunk_start..chunk_end];
+
+                let bytes_written = decrypt_stream
+                    .update(chunk, &mut decrypted[total_decrypted..])
+                    .expect("Failed to decrypt chunk");
+
+                total_decrypted += bytes_written;
+            }
+
+            // Finalize decryption
+            let final_bytes = decrypt_stream
+                .finalize(&mut decrypted[total_decrypted..])
+                .expect("Failed to finalize decryption");
+            total_decrypted += final_bytes;
+
+            assert_eq!(total_decrypted, plaintext.len());
+            assert_eq!(
+                &decrypted[..],
+                &plaintext[..],
+                "Decrypted data should match original plaintext"
+            );
+
+            // Clean up
+            session
+                .delete_key(&mut aes_xts_key)
+                .expect("Failed to delete key");
+            session.close().expect("Failed to close session");
+        }
+
+        #[test]
+        fn test_full_length_data_unit_streaming_encrypt_oneshot_decrypt() {
+            let (_partition, mut session) = create_test_session();
+
+            // Create AES XTS key
+            let key_props = KeyProps::builder()
+                .bit_len(512)
+                .encrypt(true)
+                .decrypt(true)
+                .build();
+
+            let mut aes_xts_key = AesXtsKey::new(key_props);
+            session
+                .generate_key(&mut aes_xts_key)
+                .expect("Failed to generate AES XTS key");
+
+            // Test data - 1024 bytes
+            let plaintext = vec![0x42u8; 1024];
+            let mut ciphertext = vec![0u8; plaintext.len()];
+
+            let sector_num = [
+                0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19, 0x1A, 0x1B, 0x1C, 0x1D, 0x1E,
+                0x1F, 0x20,
+            ];
+
+            // Encrypt using streaming with data_unit_len: None (full length as single unit)
+            let aes_xts_stream = AesXtsAlgo {
+                sector_num,
+                data_unit_len: None,
+            };
+
+            let mut encrypt_stream = session
+                .encrypt_init(&aes_xts_stream, &aes_xts_key)
+                .expect("Failed to initialize encrypt stream");
+
+            // Feed plaintext in chunks
+            let chunk_size = 256;
+            let mut total_encrypted = 0;
+
+            for chunk_start in (0..plaintext.len()).step_by(chunk_size) {
+                let chunk_end = std::cmp::min(chunk_start + chunk_size, plaintext.len());
+                let chunk = &plaintext[chunk_start..chunk_end];
+
+                let bytes_written = encrypt_stream
+                    .update(chunk, &mut ciphertext[total_encrypted..])
+                    .expect("Failed to encrypt chunk");
+
+                total_encrypted += bytes_written;
+            }
+
+            // Finalize encryption
+            let final_bytes = encrypt_stream
+                .finalize(&mut ciphertext[total_encrypted..])
+                .expect("Failed to finalize encryption");
+            total_encrypted += final_bytes;
+
+            assert_eq!(total_encrypted, plaintext.len());
+
+            // Decrypt using one-shot with data_unit_len: None
+            let mut aes_xts = AesXtsAlgo {
+                sector_num,
+                data_unit_len: None,
+            };
+
+            let mut decrypted = vec![0u8; plaintext.len()];
+            let pt_len = session
+                .decrypt(&mut aes_xts, &aes_xts_key, &ciphertext, &mut decrypted)
+                .expect("Failed to decrypt ciphertext");
+
+            assert_eq!(pt_len, plaintext.len());
+            assert_eq!(
+                &decrypted[..],
+                &plaintext[..],
+                "Decrypted data should match original plaintext"
+            );
+
+            // Clean up
+            session
+                .delete_key(&mut aes_xts_key)
+                .expect("Failed to delete key");
+            session.close().expect("Failed to close session");
+        }
+
+        #[test]
+        fn test_streaming_with_data_unit_len_512() {
+            let (_partition, mut session) = create_test_session();
+
+            // Create AES XTS key
+            let key_props = KeyProps::builder()
+                .bit_len(512)
+                .encrypt(true)
+                .decrypt(true)
+                .build();
+
+            let mut aes_xts_key = AesXtsKey::new(key_props);
+            session
+                .generate_key(&mut aes_xts_key)
+                .expect("Failed to generate AES XTS key");
+
+            // Test data - 2048 bytes (4 data units of 512 bytes each)
+            let plaintext = vec![0xABu8; 2048];
+            let sector_num = [0x01; 16];
+
+            // Streaming encryption with data_unit_len: 512
+            let aes_xts_encrypt = AesXtsAlgo {
+                sector_num,
+                data_unit_len: Some(512),
+            };
+
+            let mut encrypt_stream = session
+                .encrypt_init(&aes_xts_encrypt, &aes_xts_key)
+                .expect("Failed to initialize encrypt stream");
+
+            let mut ciphertext = vec![0u8; plaintext.len()];
+            let mut total_encrypted = 0;
+
+            // Feed plaintext in 512-byte chunks (one data unit at a time)
+            for chunk_start in (0..plaintext.len()).step_by(512) {
+                let chunk_end = std::cmp::min(chunk_start + 512, plaintext.len());
+                let chunk = &plaintext[chunk_start..chunk_end];
+
+                let bytes_written = encrypt_stream
+                    .update(chunk, &mut ciphertext[total_encrypted..])
+                    .expect("Failed to encrypt chunk");
+
+                total_encrypted += bytes_written;
+            }
+
+            let final_bytes = encrypt_stream
+                .finalize(&mut ciphertext[total_encrypted..])
+                .expect("Failed to finalize encryption");
+            total_encrypted += final_bytes;
+
+            assert_eq!(total_encrypted, plaintext.len());
+
+            // Streaming decryption with data_unit_len: 512
+            let aes_xts_decrypt = AesXtsAlgo {
+                sector_num,
+                data_unit_len: Some(512),
+            };
+
+            let mut decrypt_stream = session
+                .decrypt_init(&aes_xts_decrypt, &aes_xts_key)
+                .expect("Failed to initialize decrypt stream");
+
+            let mut decrypted = vec![0u8; plaintext.len()];
+            let mut total_decrypted = 0;
+
+            // Decrypt in 512-byte chunks
+            for chunk_start in (0..ciphertext.len()).step_by(512) {
+                let chunk_end = std::cmp::min(chunk_start + 512, ciphertext.len());
+                let chunk = &ciphertext[chunk_start..chunk_end];
+
+                let bytes_written = decrypt_stream
+                    .update(chunk, &mut decrypted[total_decrypted..])
+                    .expect("Failed to decrypt chunk");
+
+                total_decrypted += bytes_written;
+            }
+
+            let final_bytes = decrypt_stream
+                .finalize(&mut decrypted[total_decrypted..])
+                .expect("Failed to finalize decryption");
+            total_decrypted += final_bytes;
+
+            assert_eq!(total_decrypted, plaintext.len());
+            assert_eq!(
+                &decrypted[..],
+                &plaintext[..],
+                "Decrypted data should match original plaintext"
+            );
+
+            // Clean up
+            session
+                .delete_key(&mut aes_xts_key)
+                .expect("Failed to delete key");
+            session.close().expect("Failed to close session");
+        }
+
+        #[test]
+        fn test_streaming_with_data_unit_len_4096() {
+            let (_partition, mut session) = create_test_session();
+
+            // Create AES XTS key
+            let key_props = KeyProps::builder()
+                .bit_len(512)
+                .encrypt(true)
+                .decrypt(true)
+                .build();
+
+            let mut aes_xts_key = AesXtsKey::new(key_props);
+            session
+                .generate_key(&mut aes_xts_key)
+                .expect("Failed to generate AES XTS key");
+
+            // Test data - 12288 bytes (3 data units of 4096 bytes each)
+            let plaintext = vec![0xCDu8; 12288];
+            let sector_num = [0x02; 16];
+
+            // Streaming encryption with data_unit_len: 4096
+            let aes_xts_encrypt = AesXtsAlgo {
+                sector_num,
+                data_unit_len: Some(4096),
+            };
+
+            let mut encrypt_stream = session
+                .encrypt_init(&aes_xts_encrypt, &aes_xts_key)
+                .expect("Failed to initialize encrypt stream");
+
+            let mut ciphertext = vec![0u8; plaintext.len()];
+            let mut total_encrypted = 0;
+
+            // Feed plaintext in 4096-byte chunks (one data unit at a time)
+            for chunk_start in (0..plaintext.len()).step_by(4096) {
+                let chunk_end = std::cmp::min(chunk_start + 4096, plaintext.len());
+                let chunk = &plaintext[chunk_start..chunk_end];
+
+                let bytes_written = encrypt_stream
+                    .update(chunk, &mut ciphertext[total_encrypted..])
+                    .expect("Failed to encrypt chunk");
+
+                total_encrypted += bytes_written;
+            }
+
+            let final_bytes = encrypt_stream
+                .finalize(&mut ciphertext[total_encrypted..])
+                .expect("Failed to finalize encryption");
+            total_encrypted += final_bytes;
+
+            assert_eq!(total_encrypted, plaintext.len());
+
+            // Streaming decryption with data_unit_len: 4096
+            let aes_xts_decrypt = AesXtsAlgo {
+                sector_num,
+                data_unit_len: Some(4096),
+            };
+
+            let mut decrypt_stream = session
+                .decrypt_init(&aes_xts_decrypt, &aes_xts_key)
+                .expect("Failed to initialize decrypt stream");
+
+            let mut decrypted = vec![0u8; plaintext.len()];
+            let mut total_decrypted = 0;
+
+            // Decrypt in 4096-byte chunks
+            for chunk_start in (0..ciphertext.len()).step_by(4096) {
+                let chunk_end = std::cmp::min(chunk_start + 4096, ciphertext.len());
+                let chunk = &ciphertext[chunk_start..chunk_end];
+
+                let bytes_written = decrypt_stream
+                    .update(chunk, &mut decrypted[total_decrypted..])
+                    .expect("Failed to decrypt chunk");
+
+                total_decrypted += bytes_written;
+            }
+
+            let final_bytes = decrypt_stream
+                .finalize(&mut decrypted[total_decrypted..])
+                .expect("Failed to finalize decryption");
+            total_decrypted += final_bytes;
+
+            assert_eq!(total_decrypted, plaintext.len());
+            assert_eq!(
+                &decrypted[..],
+                &plaintext[..],
+                "Decrypted data should match original plaintext"
+            );
+
+            // Clean up
+            session
+                .delete_key(&mut aes_xts_key)
+                .expect("Failed to delete key");
+            session.close().expect("Failed to close session");
+        }
+
+        #[test]
+        fn test_streaming_with_data_unit_len_8192() {
+            let (_partition, mut session) = create_test_session();
+
+            // Create AES XTS key
+            let key_props = KeyProps::builder()
+                .bit_len(512)
+                .encrypt(true)
+                .decrypt(true)
+                .build();
+
+            let mut aes_xts_key = AesXtsKey::new(key_props);
+            session
+                .generate_key(&mut aes_xts_key)
+                .expect("Failed to generate AES XTS key");
+
+            // Test data - 24576 bytes (3 data units of 8192 bytes each)
+            let plaintext = vec![0xEFu8; 24576];
+            let sector_num = [0x03; 16];
+
+            // Streaming encryption with data_unit_len: 8192
+            let aes_xts_encrypt = AesXtsAlgo {
+                sector_num,
+                data_unit_len: Some(8192),
+            };
+
+            let mut encrypt_stream = session
+                .encrypt_init(&aes_xts_encrypt, &aes_xts_key)
+                .expect("Failed to initialize encrypt stream");
+
+            let mut ciphertext = vec![0u8; plaintext.len()];
+            let mut total_encrypted = 0;
+
+            // Feed plaintext in 8192-byte chunks (one data unit at a time)
+            for chunk_start in (0..plaintext.len()).step_by(8192) {
+                let chunk_end = std::cmp::min(chunk_start + 8192, plaintext.len());
+                let chunk = &plaintext[chunk_start..chunk_end];
+
+                let bytes_written = encrypt_stream
+                    .update(chunk, &mut ciphertext[total_encrypted..])
+                    .expect("Failed to encrypt chunk");
+
+                total_encrypted += bytes_written;
+            }
+
+            let final_bytes = encrypt_stream
+                .finalize(&mut ciphertext[total_encrypted..])
+                .expect("Failed to finalize encryption");
+            total_encrypted += final_bytes;
+
+            assert_eq!(total_encrypted, plaintext.len());
+
+            // Streaming decryption with data_unit_len: 8192
+            let aes_xts_decrypt = AesXtsAlgo {
+                sector_num,
+                data_unit_len: Some(8192),
+            };
+
+            let mut decrypt_stream = session
+                .decrypt_init(&aes_xts_decrypt, &aes_xts_key)
+                .expect("Failed to initialize decrypt stream");
+
+            let mut decrypted = vec![0u8; plaintext.len()];
+            let mut total_decrypted = 0;
+
+            // Decrypt in 8192-byte chunks
+            for chunk_start in (0..ciphertext.len()).step_by(8192) {
+                let chunk_end = std::cmp::min(chunk_start + 8192, ciphertext.len());
+                let chunk = &ciphertext[chunk_start..chunk_end];
+
+                let bytes_written = decrypt_stream
+                    .update(chunk, &mut decrypted[total_decrypted..])
+                    .expect("Failed to decrypt chunk");
+
+                total_decrypted += bytes_written;
+            }
+
+            let final_bytes = decrypt_stream
+                .finalize(&mut decrypted[total_decrypted..])
+                .expect("Failed to finalize decryption");
+            total_decrypted += final_bytes;
+
+            assert_eq!(total_decrypted, plaintext.len());
+            assert_eq!(
+                &decrypted[..],
+                &plaintext[..],
+                "Decrypted data should match original plaintext"
+            );
+
+            // Clean up
+            session
+                .delete_key(&mut aes_xts_key)
+                .expect("Failed to delete key");
+            session.close().expect("Failed to close session");
+        }
+
+        #[test]
+        fn test_data_unit_len_512_oneshot_encrypt_streaming_decrypt() {
+            let (_partition, mut session) = create_test_session();
+
+            // Create AES XTS key
+            let key_props = KeyProps::builder()
+                .bit_len(512)
+                .encrypt(true)
+                .decrypt(true)
+                .build();
+
+            let mut aes_xts_key = AesXtsKey::new(key_props);
+            session
+                .generate_key(&mut aes_xts_key)
+                .expect("Failed to generate AES XTS key");
+
+            // Test data - 2048 bytes (4 data units of 512 bytes each)
+            let plaintext = vec![0xABu8; 2048];
+            let sector_num = [0x00; 16];
+
+            // One-shot encryption with data_unit_len: 512
+            let mut aes_xts_encrypt = AesXtsAlgo {
+                sector_num,
+                data_unit_len: Some(512),
+            };
+
+            let mut ciphertext = vec![0u8; plaintext.len()];
+            let bytes_encrypted = session
+                .encrypt(
+                    &mut aes_xts_encrypt,
+                    &aes_xts_key,
+                    &plaintext,
+                    &mut ciphertext,
+                )
+                .expect("Failed to encrypt");
+
+            assert_eq!(bytes_encrypted, plaintext.len());
+
+            // Streaming decryption with data_unit_len: 512
+            let aes_xts_decrypt = AesXtsAlgo {
+                sector_num,
+                data_unit_len: Some(512),
+            };
+
+            let mut decrypt_stream = session
+                .decrypt_init(&aes_xts_decrypt, &aes_xts_key)
+                .expect("Failed to initialize decrypt stream");
+
+            let mut decrypted = vec![0u8; plaintext.len()];
+            let mut total_decrypted = 0;
+
+            // Decrypt in irregular chunk sizes (not aligned to data unit boundaries)
+            let chunk_sizes = [200, 300, 512, 400, 636]; // Total: 2048 bytes
+            let mut offset = 0;
+
+            for chunk_size in chunk_sizes {
+                let chunk_end = std::cmp::min(offset + chunk_size, ciphertext.len());
+                let chunk = &ciphertext[offset..chunk_end];
+
+                let bytes_written = decrypt_stream
+                    .update(chunk, &mut decrypted[total_decrypted..])
+                    .expect("Failed to decrypt chunk");
+
+                total_decrypted += bytes_written;
+                offset = chunk_end;
+            }
+
+            let final_bytes = decrypt_stream
+                .finalize(&mut decrypted[total_decrypted..])
+                .expect("Failed to finalize decryption");
+            total_decrypted += final_bytes;
+
+            assert_eq!(total_decrypted, plaintext.len());
+            assert_eq!(
+                &decrypted[..],
+                &plaintext[..],
+                "Decrypted data should match original plaintext"
+            );
+
+            // Clean up
+            session
+                .delete_key(&mut aes_xts_key)
+                .expect("Failed to delete key");
+            session.close().expect("Failed to close session");
+        }
+
+        #[test]
+        fn test_data_unit_len_512_streaming_encrypt_oneshot_decrypt() {
+            let (_partition, mut session) = create_test_session();
+
+            // Create AES XTS key
+            let key_props = KeyProps::builder()
+                .bit_len(512)
+                .encrypt(true)
+                .decrypt(true)
+                .build();
+
+            let mut aes_xts_key = AesXtsKey::new(key_props);
+            session
+                .generate_key(&mut aes_xts_key)
+                .expect("Failed to generate AES XTS key");
+
+            // Test data - 2048 bytes (4 data units of 512 bytes each)
+            let plaintext = vec![0xABu8; 2048];
+            let sector_num = [0x12; 16];
+
+            // Streaming encryption with data_unit_len: 512
+            let aes_xts_encrypt = AesXtsAlgo {
+                sector_num,
+                data_unit_len: Some(512),
+            };
+
+            let mut encrypt_stream = session
+                .encrypt_init(&aes_xts_encrypt, &aes_xts_key)
+                .expect("Failed to initialize encrypt stream");
+
+            let mut ciphertext = vec![0u8; plaintext.len()];
+            let mut total_encrypted = 0;
+
+            // Feed plaintext in irregular chunk sizes (not aligned to data unit boundaries)
+            let chunk_sizes = [300, 500, 400, 848]; // Total: 2048 bytes
+            let mut offset = 0;
+
+            for chunk_size in chunk_sizes {
+                let chunk_end = std::cmp::min(offset + chunk_size, plaintext.len());
+                let chunk = &plaintext[offset..chunk_end];
+
+                let bytes_written = encrypt_stream
+                    .update(chunk, &mut ciphertext[total_encrypted..])
+                    .expect("Failed to encrypt chunk");
+
+                total_encrypted += bytes_written;
+                offset = chunk_end;
+            }
+
+            let final_bytes = encrypt_stream
+                .finalize(&mut ciphertext[total_encrypted..])
+                .expect("Failed to finalize encryption");
+            total_encrypted += final_bytes;
+
+            assert_eq!(total_encrypted, plaintext.len());
+
+            // One-shot decryption with data_unit_len: 512
+            let mut aes_xts_decrypt = AesXtsAlgo {
+                sector_num,
+                data_unit_len: Some(512),
+            };
+
+            let mut decrypted = vec![0u8; plaintext.len()];
+            let bytes_decrypted = session
+                .decrypt(
+                    &mut aes_xts_decrypt,
+                    &aes_xts_key,
+                    &ciphertext,
+                    &mut decrypted,
+                )
+                .expect("Failed to decrypt");
+
+            assert_eq!(bytes_decrypted, plaintext.len());
+            assert_eq!(
+                &decrypted[..],
+                &plaintext[..],
+                "Decrypted data should match original plaintext"
+            );
+
+            // Clean up
+            session
+                .delete_key(&mut aes_xts_key)
+                .expect("Failed to delete key");
+            session.close().expect("Failed to close session");
+        }
+
+        #[test]
+        fn test_data_unit_len_4096_oneshot_encrypt_streaming_decrypt() {
+            let (_partition, mut session) = create_test_session();
+
+            // Create AES XTS key
+            let key_props = KeyProps::builder()
+                .bit_len(512)
+                .encrypt(true)
+                .decrypt(true)
+                .build();
+
+            let mut aes_xts_key = AesXtsKey::new(key_props);
+            session
+                .generate_key(&mut aes_xts_key)
+                .expect("Failed to generate AES XTS key");
+
+            // Test data - 12288 bytes (3 data units of 4096 bytes each)
+            let plaintext = vec![0xCDu8; 12288];
+            let sector_num = [0x21; 16];
+
+            // One-shot encryption with data_unit_len: 4096
+            let mut aes_xts_encrypt = AesXtsAlgo {
+                sector_num,
+                data_unit_len: Some(4096),
+            };
+
+            let mut ciphertext = vec![0u8; plaintext.len()];
+            let bytes_encrypted = session
+                .encrypt(
+                    &mut aes_xts_encrypt,
+                    &aes_xts_key,
+                    &plaintext,
+                    &mut ciphertext,
+                )
+                .expect("Failed to encrypt");
+
+            assert_eq!(bytes_encrypted, plaintext.len());
+
+            // Streaming decryption with data_unit_len: 4096
+            let aes_xts_decrypt = AesXtsAlgo {
+                sector_num,
+                data_unit_len: Some(4096),
+            };
+
+            let mut decrypt_stream = session
+                .decrypt_init(&aes_xts_decrypt, &aes_xts_key)
+                .expect("Failed to initialize decrypt stream");
+
+            let mut decrypted = vec![0u8; plaintext.len()];
+            let mut total_decrypted = 0;
+
+            // Decrypt in irregular chunk sizes
+            let chunk_sizes = [2000, 3000, 4096, 3192]; // Total: 12288 bytes
+            let mut offset = 0;
+
+            for chunk_size in chunk_sizes {
+                let chunk_end = std::cmp::min(offset + chunk_size, ciphertext.len());
+                let chunk = &ciphertext[offset..chunk_end];
+
+                let bytes_written = decrypt_stream
+                    .update(chunk, &mut decrypted[total_decrypted..])
+                    .expect("Failed to decrypt chunk");
+
+                total_decrypted += bytes_written;
+                offset = chunk_end;
+            }
+
+            let final_bytes = decrypt_stream
+                .finalize(&mut decrypted[total_decrypted..])
+                .expect("Failed to finalize decryption");
+            total_decrypted += final_bytes;
+
+            assert_eq!(total_decrypted, plaintext.len());
+            assert_eq!(
+                &decrypted[..],
+                &plaintext[..],
+                "Decrypted data should match original plaintext"
+            );
+
+            // Clean up
+            session
+                .delete_key(&mut aes_xts_key)
+                .expect("Failed to delete key");
+            session.close().expect("Failed to close session");
+        }
+
+        #[test]
+        fn test_data_unit_len_4096_streaming_encrypt_oneshot_decrypt() {
+            let (_partition, mut session) = create_test_session();
+
+            // Create AES XTS key
+            let key_props = KeyProps::builder()
+                .bit_len(512)
+                .encrypt(true)
+                .decrypt(true)
+                .build();
+
+            let mut aes_xts_key = AesXtsKey::new(key_props);
+            session
+                .generate_key(&mut aes_xts_key)
+                .expect("Failed to generate AES XTS key");
+
+            // Test data - 12288 bytes (3 data units of 4096 bytes each)
+            let plaintext = vec![0xCDu8; 12288];
+            let sector_num = [0x22; 16];
+
+            // Streaming encryption with data_unit_len: 4096
+            let aes_xts_encrypt = AesXtsAlgo {
+                sector_num,
+                data_unit_len: Some(4096),
+            };
+
+            let mut encrypt_stream = session
+                .encrypt_init(&aes_xts_encrypt, &aes_xts_key)
+                .expect("Failed to initialize encrypt stream");
+
+            let mut ciphertext = vec![0u8; plaintext.len()];
+            let mut total_encrypted = 0;
+
+            // Feed plaintext in irregular chunk sizes
+            let chunk_sizes = [1500, 4000, 3788, 3000]; // Total: 12288 bytes
+            let mut offset = 0;
+
+            for chunk_size in chunk_sizes {
+                let chunk_end = std::cmp::min(offset + chunk_size, plaintext.len());
+                let chunk = &plaintext[offset..chunk_end];
+
+                let bytes_written = encrypt_stream
+                    .update(chunk, &mut ciphertext[total_encrypted..])
+                    .expect("Failed to encrypt chunk");
+
+                total_encrypted += bytes_written;
+                offset = chunk_end;
+            }
+
+            let final_bytes = encrypt_stream
+                .finalize(&mut ciphertext[total_encrypted..])
+                .expect("Failed to finalize encryption");
+            total_encrypted += final_bytes;
+
+            assert_eq!(total_encrypted, plaintext.len());
+
+            // One-shot decryption with data_unit_len: 4096
+            let mut aes_xts_decrypt = AesXtsAlgo {
+                sector_num,
+                data_unit_len: Some(4096),
+            };
+
+            let mut decrypted = vec![0u8; plaintext.len()];
+            let bytes_decrypted = session
+                .decrypt(
+                    &mut aes_xts_decrypt,
+                    &aes_xts_key,
+                    &ciphertext,
+                    &mut decrypted,
+                )
+                .expect("Failed to decrypt");
+
+            assert_eq!(bytes_decrypted, plaintext.len());
+            assert_eq!(
+                &decrypted[..],
+                &plaintext[..],
+                "Decrypted data should match original plaintext"
+            );
+
+            // Clean up
+            session
+                .delete_key(&mut aes_xts_key)
+                .expect("Failed to delete key");
+            session.close().expect("Failed to close session");
+        }
+
+        #[test]
+        fn test_data_unit_len_8192_oneshot_encrypt_streaming_decrypt() {
+            let (_partition, mut session) = create_test_session();
+
+            // Create AES XTS key
+            let key_props = KeyProps::builder()
+                .bit_len(512)
+                .encrypt(true)
+                .decrypt(true)
+                .build();
+
+            let mut aes_xts_key = AesXtsKey::new(key_props);
+            session
+                .generate_key(&mut aes_xts_key)
+                .expect("Failed to generate AES XTS key");
+
+            // Test data - 24576 bytes (3 data units of 8192 bytes each)
+            let plaintext = vec![0xEFu8; 24576];
+            let sector_num = [0x31; 16];
+
+            // One-shot encryption with data_unit_len: 8192
+            let mut aes_xts_encrypt = AesXtsAlgo {
+                sector_num,
+                data_unit_len: Some(8192),
+            };
+
+            let mut ciphertext = vec![0u8; plaintext.len()];
+            let bytes_encrypted = session
+                .encrypt(
+                    &mut aes_xts_encrypt,
+                    &aes_xts_key,
+                    &plaintext,
+                    &mut ciphertext,
+                )
+                .expect("Failed to encrypt");
+
+            assert_eq!(bytes_encrypted, plaintext.len());
+
+            // Streaming decryption with data_unit_len: 8192
+            let aes_xts_decrypt = AesXtsAlgo {
+                sector_num,
+                data_unit_len: Some(8192),
+            };
+
+            let mut decrypt_stream = session
+                .decrypt_init(&aes_xts_decrypt, &aes_xts_key)
+                .expect("Failed to initialize decrypt stream");
+
+            let mut decrypted = vec![0u8; plaintext.len()];
+            let mut total_decrypted = 0;
+
+            // Decrypt in irregular chunk sizes
+            let chunk_sizes = [5000, 8192, 6000, 5384]; // Total: 24576 bytes
+            let mut offset = 0;
+
+            for chunk_size in chunk_sizes {
+                let chunk_end = std::cmp::min(offset + chunk_size, ciphertext.len());
+                let chunk = &ciphertext[offset..chunk_end];
+
+                let bytes_written = decrypt_stream
+                    .update(chunk, &mut decrypted[total_decrypted..])
+                    .expect("Failed to decrypt chunk");
+
+                total_decrypted += bytes_written;
+                offset = chunk_end;
+            }
+
+            let final_bytes = decrypt_stream
+                .finalize(&mut decrypted[total_decrypted..])
+                .expect("Failed to finalize decryption");
+            total_decrypted += final_bytes;
+
+            assert_eq!(total_decrypted, plaintext.len());
+            assert_eq!(
+                &decrypted[..],
+                &plaintext[..],
+                "Decrypted data should match original plaintext"
+            );
+
+            // Clean up
+            session
+                .delete_key(&mut aes_xts_key)
+                .expect("Failed to delete key");
+            session.close().expect("Failed to close session");
+        }
+
+        #[test]
+        fn test_data_unit_len_8192_streaming_encrypt_oneshot_decrypt() {
+            let (_partition, mut session) = create_test_session();
+
+            // Create AES XTS key
+            let key_props = KeyProps::builder()
+                .bit_len(512)
+                .encrypt(true)
+                .decrypt(true)
+                .build();
+
+            let mut aes_xts_key = AesXtsKey::new(key_props);
+            session
+                .generate_key(&mut aes_xts_key)
+                .expect("Failed to generate AES XTS key");
+
+            // Test data - 24576 bytes (3 data units of 8192 bytes each)
+            let plaintext = vec![0xEFu8; 24576];
+            let sector_num = [0x32; 16];
+
+            // Streaming encryption with data_unit_len: 8192
+            let aes_xts_encrypt = AesXtsAlgo {
+                sector_num,
+                data_unit_len: Some(8192),
+            };
+
+            let mut encrypt_stream = session
+                .encrypt_init(&aes_xts_encrypt, &aes_xts_key)
+                .expect("Failed to initialize encrypt stream");
+
+            let mut ciphertext = vec![0u8; plaintext.len()];
+            let mut total_encrypted = 0;
+
+            // Feed plaintext in irregular chunk sizes
+            let chunk_sizes = [7000, 10000, 4576, 3000]; // Total: 24576 bytes
+            let mut offset = 0;
+
+            for chunk_size in chunk_sizes {
+                let chunk_end = std::cmp::min(offset + chunk_size, plaintext.len());
+                let chunk = &plaintext[offset..chunk_end];
+
+                let bytes_written = encrypt_stream
+                    .update(chunk, &mut ciphertext[total_encrypted..])
+                    .expect("Failed to encrypt chunk");
+
+                total_encrypted += bytes_written;
+                offset = chunk_end;
+            }
+
+            let final_bytes = encrypt_stream
+                .finalize(&mut ciphertext[total_encrypted..])
+                .expect("Failed to finalize encryption");
+            total_encrypted += final_bytes;
+
+            assert_eq!(total_encrypted, plaintext.len());
+
+            // One-shot decryption with data_unit_len: 8192
+            let mut aes_xts_decrypt = AesXtsAlgo {
+                sector_num,
+                data_unit_len: Some(8192),
+            };
+
+            let mut decrypted = vec![0u8; plaintext.len()];
+            let bytes_decrypted = session
+                .decrypt(
+                    &mut aes_xts_decrypt,
+                    &aes_xts_key,
+                    &ciphertext,
+                    &mut decrypted,
+                )
+                .expect("Failed to decrypt");
+
+            assert_eq!(bytes_decrypted, plaintext.len());
+            assert_eq!(
+                &decrypted[..],
+                &plaintext[..],
+                "Decrypted data should match original plaintext"
+            );
+
+            // Clean up
             session
                 .delete_key(&mut aes_xts_key)
                 .expect("Failed to delete key");

--- a/api/lib/src/session.rs
+++ b/api/lib/src/session.rs
@@ -583,7 +583,7 @@ impl Session {
     /// # Returns
     /// `Result<A::EncryptStream, AzihsmError>` - The streaming encryption context
     ///
-    #[allow(private_bounds)]
+    #[allow(private_bounds, private_interfaces)]
     pub fn encrypt_init<'a, A, K>(
         &'a self,
         algo: &A,
@@ -605,7 +605,7 @@ impl Session {
     /// # Returns
     /// `Result<A::DecryptStream, AzihsmError>` - The streaming decryption context
     ///
-    //#[allow(private_bounds)]
+    #[allow(private_bounds, private_interfaces)]
     pub fn decrypt_init<'a, A, K>(
         &'a self,
         algo: &A,
@@ -627,7 +627,7 @@ impl Session {
     /// # Returns
     /// A streaming sign context that can be updated with data and finalized to produce a signature.
     ///
-    #[allow(private_bounds)]
+    #[allow(private_bounds, private_interfaces)]
     pub fn sign_init<'a, A, K>(&'a self, algo: &A, key: &K) -> Result<A::SignStream, AzihsmError>
     where
         A: Algo + StreamingSignVerifyAlgo<'a, K>,
@@ -645,7 +645,7 @@ impl Session {
     /// # Returns
     /// A streaming verify context that can be updated with data and finalized to verify a signature.
     ///
-    #[allow(private_bounds)]
+    #[allow(private_bounds, private_interfaces)]
     pub fn verify_init<'a, A, K>(
         &'a self,
         algo: &A,
@@ -666,6 +666,7 @@ impl Session {
     /// # Returns
     /// `Result<A::DigestStream, AzihsmError>` - Ok with a digest stream context that can be updated with data and finalized to produce the digest,
     /// Err if the initialization failed.
+    #[allow(private_bounds, private_interfaces)]
     pub fn digest_init<'a, A>(&'a self, algo: &A) -> Result<A::DigestStream, AzihsmError>
     where
         A: crate::crypto::StreamingDigestAlgo<'a>,


### PR DESCRIPTION
Add streaming encrypt/decrypt operations for AES-XTS with configurable data unit lengths (512, 4096, 8192 bytes). Includes comprehensive test coverage for XTS streaming operations in both Rust and C++.