### PR TITLE
Check GenericSecret Key properties

### DIFF
--- a/napi/lib/src/algo/ecc/ecdh.rs
+++ b/napi/lib/src/algo/ecc/ecdh.rs
@@ -98,6 +98,9 @@ impl HsmKeyDeriveOp for EcdhAlgo {
             return Err(HsmError::InvalidArgument);
         }
 
+        //check if props are valid for shared secret
+        HsmGenericSecretKey::validate_props(&props)?;
+
         // Perform the ECDH derive operation via DDI.
         let (handle, props) = ddi::ecdh_derive(base_key, &self.peer_der, props)?;
         // update derived key properties based on base key properties if needed

--- a/napi/lib/src/algo/hmac/sign.rs
+++ b/napi/lib/src/algo/hmac/sign.rs
@@ -99,6 +99,11 @@ impl HsmSignOp for HsmHmacAlgo {
         data: &[u8],
         signature: Option<&mut [u8]>,
     ) -> Result<usize, Self::Error> {
+        // check if key can sign
+        if !key.can_sign() {
+            Err(HsmError::InvalidKey)?;
+        }
+
         // return size of signature if signature buffer is None
         let Some(signature) = signature else {
             return Ok(key.size());
@@ -150,6 +155,11 @@ impl HsmVerifyOp for HsmHmacAlgo {
         data: &[u8],
         signature: &[u8],
     ) -> Result<bool, Self::Error> {
+        //check key can verify
+        if !key.can_verify() {
+            Err(HsmError::InvalidKey)?;
+        }
+
         //check if data length exceeds limit
         if data.len() > Self::MAX_MESSAGE_SIZE {
             return Err(HsmError::IndexOutOfRange);
@@ -224,6 +234,11 @@ impl HsmSignStreamingOp for HsmHmacAlgo {
     ///
     /// This initializer currently cannot fail.
     fn sign_init(self, key: Self::Key) -> Result<Self::Context, Self::Error> {
+        // check if key can sign
+        if !key.can_sign() {
+            Err(HsmError::InvalidKey)?;
+        }
+
         Ok(HsmHmacSignContext {
             algo: self,
             key,
@@ -327,6 +342,11 @@ impl HsmVerifyStreamingOp for HsmHmacAlgo {
     ///
     /// This initializer currently cannot fail.
     fn verify_init(self, key: Self::Key) -> Result<Self::Context, Self::Error> {
+        // check if key can verify
+        if !key.can_verify() {
+            Err(HsmError::InvalidKey)?;
+        }
+
         Ok(HsmHmacVerifyContext {
             algo: self,
             key,

--- a/napi/lib/src/algo/secret/key.rs
+++ b/napi/lib/src/algo/secret/key.rs
@@ -18,4 +18,63 @@ pub use super::*;
 // material (e.g., ECDH). It intentionally does not encode an algorithm-specific key kind.
 define_hsm_key!(pub HsmGenericSecretKey);
 
+impl HsmGenericSecretKey {
+    /// Returns whether `props.kind()` is a supported generic-secret kind and whether its
+    /// usage flags are valid for that kind.
+    ///
+    /// Supported kinds in this layer:
+    /// - [`HsmKeyKind::SharedSecret`] (allowed flags: `DERIVE`)
+    /// - [`HsmKeyKind::Aes`] (allowed flags: `ENCRYPT | DECRYPT`)
+    /// - [`HsmKeyKind::HmacSha256`]/[`HsmKeyKind::HmacSha384`]/[`HsmKeyKind::HmacSha512`]
+    ///   (allowed flags: `SIGN | VERIFY`)
+    ///
+    /// Note: [`HsmKeyProps::check_supported_flags`] permits the global `SESSION` flag in
+    /// addition to the per-kind flags listed above.
+    fn check_key_kind(props: &HsmKeyProps) -> bool {
+        let supported_flag = match props.kind() {
+            HsmKeyKind::SharedSecret => HsmKeyFlags::DERIVE,
+            HsmKeyKind::Aes => HsmKeyFlags::ENCRYPT | HsmKeyFlags::DECRYPT,
+            HsmKeyKind::HmacSha256 | HsmKeyKind::HmacSha384 | HsmKeyKind::HmacSha512 => {
+                HsmKeyFlags::SIGN | HsmKeyFlags::VERIFY
+            }
+            _ => return false,
+        };
+        props.check_supported_flags(supported_flag)
+    }
+
+    /// Validates that these key properties describe a well-formed generic secret key.
+    ///
+    /// This is used by higher-level operations (e.g. ECDH/HKDF) to fail fast before issuing
+    /// DDI calls when the requested key metadata is inconsistent.
+    ///
+    /// Requirements enforced here:
+    /// - `class` must be [`HsmKeyClass::Secret`]
+    /// - `kind` must be one of the supported generic-secret kinds (see [`Self::check_key_kind`])
+    /// - `ecc_curve` must be `None`
+    /// - `bits` must be non-zero
+    pub(crate) fn validate_props(props: &HsmKeyProps) -> HsmResult<()> {
+        // Kind/class: ensure we're validating a secret key.
+        if props.class() != HsmKeyClass::Secret {
+            Err(HsmError::InvalidKeyProps)?;
+        }
+
+        //check key kind, GenericSecretKey can be of kind SharedSecret, AES or HMAC
+        if !Self::check_key_kind(props) {
+            Err(HsmError::InvalidKeyProps)?;
+        }
+
+        // Secret keys in this layer should not have an associated ECC curve.
+        if props.ecc_curve().is_some() {
+            Err(HsmError::InvalidKeyProps)?;
+        }
+
+        //check if key size is non-zero
+        if props.bits() == 0 {
+            Err(HsmError::InvalidKeyProps)?;
+        }
+
+        Ok(())
+    }
+}
+
 impl HsmDerivationKey for HsmGenericSecretKey {}

--- a/napi/tests/src/algo/hmac/hmac_tests.rs
+++ b/napi/tests/src/algo/hmac/hmac_tests.rs
@@ -6,7 +6,7 @@ use azihsm_napi_tests_macro::*;
 use crate::algo::ecc::*;
 
 // Maps an HMAC key kind to the hash algorithm used for HKDF.
-fn hkdf_hash_for_hmac_key_kind(key_kind: HsmKeyKind) -> HsmHashAlgo {
+pub(crate) fn hkdf_hash_for_hmac_key_kind(key_kind: HsmKeyKind) -> HsmHashAlgo {
     match key_kind {
         HsmKeyKind::HmacSha256 => HsmHashAlgo::Sha256,
         HsmKeyKind::HmacSha384 => HsmHashAlgo::Sha384,
@@ -16,7 +16,7 @@ fn hkdf_hash_for_hmac_key_kind(key_kind: HsmKeyKind) -> HsmHashAlgo {
 }
 
 // Chooses an ECDH curve to derive shared secrets for a given HMAC key kind.
-fn ecc_curve_for_hmac_key_kind(key_kind: HsmKeyKind) -> HsmEccCurve {
+pub(crate) fn ecc_curve_for_hmac_key_kind(key_kind: HsmKeyKind) -> HsmEccCurve {
     match key_kind {
         HsmKeyKind::HmacSha256 => HsmEccCurve::P256,
         HsmKeyKind::HmacSha384 => HsmEccCurve::P384,
@@ -50,7 +50,7 @@ fn test_message_bytes(seed: u8, len: usize) -> Vec<u8> {
 }
 
 // Derives a pair of ECDH shared secrets (party A and party B) that should match.
-fn derive_ecdh_shared_secrets(
+pub(crate) fn derive_ecdh_shared_secrets(
     session: &HsmSession,
     curve: HsmEccCurve,
 ) -> (HsmGenericSecretKey, HsmGenericSecretKey) {

--- a/napi/tests/src/algo/hmac/key_prop_tests.rs
+++ b/napi/tests/src/algo/hmac/key_prop_tests.rs
@@ -1,0 +1,184 @@
+// Copyright (C) Microsoft Corporation. All rights reserved.
+
+use super::hmac_tests::*;
+use super::*;
+
+fn derive_base_secret_for_hkdf(session: &HsmSession, curve: HsmEccCurve) -> HsmGenericSecretKey {
+    let (shared_secret_a, _shared_secret_b) = derive_ecdh_shared_secrets(session, curve);
+    shared_secret_a
+}
+
+fn derive_hmac_key_with_props(
+    session: &HsmSession,
+    base_secret: &HsmGenericSecretKey,
+    hkdf_hash: HsmHashAlgo,
+    props: HsmKeyProps,
+) -> Result<HsmHmacKey, HsmError> {
+    let mut hkdf_algo = HsmHkdfAlgo::new(hkdf_hash, None, None).expect("HKDF algo creation failed");
+    let derived_key = HsmKeyManager::derive_key(session, &mut hkdf_algo, base_secret, props)?;
+    derived_key.try_into()
+}
+
+/// HMAC derived key must be a secret key.
+#[session_test]
+fn test_hmac_derived_key_prop_class_rejected(session: HsmSession) {
+    let base_secret = derive_base_secret_for_hkdf(&session, HsmEccCurve::P256);
+
+    let invalid_props = HsmKeyPropsBuilder::default()
+        .class(HsmKeyClass::Public)
+        .key_kind(HsmKeyKind::HmacSha256)
+        .bits(256)
+        .can_sign(true)
+        .can_verify(true)
+        .build()
+        .expect("Failed to build HMAC key props");
+
+    let result =
+        derive_hmac_key_with_props(&session, &base_secret, HsmHashAlgo::Sha256, invalid_props);
+    assert!(matches!(result, Err(HsmError::InvalidKeyProps)));
+}
+
+/// HMAC derived key must have an HMAC key kind.
+#[session_test]
+fn test_hmac_derived_key_prop_kind_rejected(session: HsmSession) {
+    let base_secret = derive_base_secret_for_hkdf(&session, HsmEccCurve::P256);
+
+    let invalid_props = HsmKeyPropsBuilder::default()
+        .class(HsmKeyClass::Secret)
+        .key_kind(HsmKeyKind::Aes)
+        .bits(256)
+        .can_sign(true)
+        .can_verify(true)
+        .build()
+        .expect("Failed to build HMAC key props");
+
+    let result =
+        derive_hmac_key_with_props(&session, &base_secret, HsmHashAlgo::Sha256, invalid_props);
+    assert!(matches!(result, Err(HsmError::InvalidKeyProps)));
+}
+
+/// HMAC derived key must not carry ECC curve metadata.
+#[session_test]
+fn test_hmac_derived_key_prop_ecc_curve_rejected(session: HsmSession) {
+    let base_secret = derive_base_secret_for_hkdf(&session, HsmEccCurve::P256);
+
+    let invalid_props = HsmKeyPropsBuilder::default()
+        .class(HsmKeyClass::Secret)
+        .key_kind(HsmKeyKind::HmacSha256)
+        .bits(256)
+        .ecc_curve(HsmEccCurve::P256)
+        .can_sign(true)
+        .can_verify(true)
+        .build()
+        .expect("Failed to build HMAC key props");
+
+    let result =
+        derive_hmac_key_with_props(&session, &base_secret, HsmHashAlgo::Sha256, invalid_props);
+    assert!(matches!(result, Err(HsmError::InvalidKeyProps)));
+}
+
+/// HMAC derived key must have a non-zero bit length.
+#[session_test]
+fn test_hmac_derived_key_prop_bits_zero_rejected(session: HsmSession) {
+    let base_secret = derive_base_secret_for_hkdf(&session, HsmEccCurve::P256);
+
+    let invalid_props = HsmKeyPropsBuilder::default()
+        .class(HsmKeyClass::Secret)
+        .key_kind(HsmKeyKind::HmacSha256)
+        .bits(0)
+        .can_sign(true)
+        .can_verify(true)
+        .build()
+        .expect("Failed to build HMAC key props");
+
+    let result =
+        derive_hmac_key_with_props(&session, &base_secret, HsmHashAlgo::Sha256, invalid_props);
+    assert!(matches!(result, Err(HsmError::InvalidKeyProps)));
+}
+
+/// HMAC derived key must not request unsupported usage flags (e.g. ENCRYPT).
+#[session_test]
+fn test_hmac_derived_key_prop_encrypt_flag_rejected(session: HsmSession) {
+    let base_secret = derive_base_secret_for_hkdf(&session, HsmEccCurve::P256);
+
+    let invalid_props = HsmKeyPropsBuilder::default()
+        .class(HsmKeyClass::Secret)
+        .key_kind(HsmKeyKind::HmacSha256)
+        .bits(256)
+        .can_encrypt(true)
+        .can_sign(true)
+        .can_verify(true)
+        .build()
+        .expect("Failed to build HMAC key props");
+
+    let result =
+        derive_hmac_key_with_props(&session, &base_secret, HsmHashAlgo::Sha256, invalid_props);
+    assert!(matches!(result, Err(HsmError::InvalidKeyProps)));
+}
+
+/// HMAC derived key must not request unsupported usage flags (e.g. DERIVE).
+#[session_test]
+fn test_hmac_derived_key_prop_derive_flag_rejected(session: HsmSession) {
+    let base_secret = derive_base_secret_for_hkdf(&session, HsmEccCurve::P256);
+
+    let invalid_props = HsmKeyPropsBuilder::default()
+        .class(HsmKeyClass::Secret)
+        .key_kind(HsmKeyKind::HmacSha256)
+        .bits(256)
+        .can_derive(true)
+        .can_sign(true)
+        .can_verify(true)
+        .build()
+        .expect("Failed to build HMAC key props");
+
+    let result =
+        derive_hmac_key_with_props(&session, &base_secret, HsmHashAlgo::Sha256, invalid_props);
+    assert!(matches!(result, Err(HsmError::InvalidKeyProps)));
+}
+
+/// SESSION lifetime flag is allowed for derived HMAC keys.
+#[session_test]
+fn test_hmac_derived_key_prop_session_flag_allowed(session: HsmSession) {
+    let base_secret = derive_base_secret_for_hkdf(&session, HsmEccCurve::P256);
+
+    let valid_props = HsmKeyPropsBuilder::default()
+        .class(HsmKeyClass::Secret)
+        .key_kind(HsmKeyKind::HmacSha256)
+        .bits(256)
+        .is_session(true)
+        .can_sign(true)
+        .can_verify(true)
+        .build()
+        .expect("Failed to build HMAC key props");
+
+    let derived =
+        derive_hmac_key_with_props(&session, &base_secret, HsmHashAlgo::Sha256, valid_props)
+            .expect("Expected HKDF-derived HMAC key to succeed");
+    assert!(derived.is_session());
+}
+
+/// Valid HMAC key props should succeed across all supported HMAC kinds.
+#[session_test]
+fn test_hmac_derived_key_prop_valid_kinds_succeed(session: HsmSession) {
+    for (key_kind, bits) in [
+        (HsmKeyKind::HmacSha256, 256),
+        (HsmKeyKind::HmacSha384, 384),
+        (HsmKeyKind::HmacSha512, 512),
+    ] {
+        let hkdf_hash = hkdf_hash_for_hmac_key_kind(key_kind);
+        let curve = ecc_curve_for_hmac_key_kind(key_kind);
+        let base_secret = derive_base_secret_for_hkdf(&session, curve);
+
+        let props = HsmKeyPropsBuilder::default()
+            .class(HsmKeyClass::Secret)
+            .key_kind(key_kind)
+            .bits(bits)
+            .can_sign(true)
+            .can_verify(true)
+            .build()
+            .expect("Failed to build HMAC key props");
+
+        let _derived = derive_hmac_key_with_props(&session, &base_secret, hkdf_hash, props)
+            .expect("Expected HKDF-derived HMAC key to succeed");
+    }
+}

--- a/napi/tests/src/algo/hmac/mod.rs
+++ b/napi/tests/src/algo/hmac/mod.rs
@@ -1,3 +1,6 @@
 // Copyright (C) Microsoft Corporation. All rights reserved.
 
 mod hmac_tests;
+mod key_prop_tests;
+
+use super::*;

--- a/napi/tests/src/algo/kdf/hkdf_tests.rs
+++ b/napi/tests/src/algo/kdf/hkdf_tests.rs
@@ -241,5 +241,5 @@ fn test_hkdf_unsupported_derived_key_kind_fails(session: HsmSession) {
         Ok(_) => panic!("HKDF derive should fail for unsupported derived key kind"),
         Err(err) => err,
     };
-    assert_eq!(err, HsmError::InvalidArgument);
+    assert_eq!(err, HsmError::InvalidKeyProps);
 }


### PR DESCRIPTION
Added checks to validate GenericSecretKey properties, HMAC, and HKDF
