### PR TITLE
upgrade ubuntu in actions to 24.04

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -12,7 +12,7 @@ env:
 jobs:
   build_ubuntu:
 
-    runs-on: ubuntu-${{ vars.UBUNTU_VER }}
+    runs-on: ubuntu-24.04
 
     defaults:
       run:


### PR DESCRIPTION
upgrades the ubuntu version as well as removes use of UBUNTU_VER repository variable