### PR TITLE
Add RSA signature generation

### DIFF
--- a/plugins/ossl_prov/inc/azihsm_ossl_helpers.h
+++ b/plugins/ossl_prov/inc/azihsm_ossl_helpers.h
@@ -71,6 +71,90 @@ static inline azihsm_algo_id azihsm_ossl_evp_md_to_ecdsa_algo_id(const EVP_MD *m
     }
 }
 
+/* Helper function: Convert OpenSSL EVP_MD to RSA PKCS#1 v1.5 + Hash combined algorithm ID */
+static inline azihsm_algo_id azihsm_ossl_evp_md_to_rsa_pkcs_algo_id(const EVP_MD *md)
+{
+    int type;
+
+    if (md == NULL)
+        return 0;
+
+    type = EVP_MD_type(md);
+
+    switch (type)
+    {
+    case NID_sha1:
+        return AZIHSM_ALGO_ID_RSA_PKCS_SHA1;
+    case NID_sha256:
+        return AZIHSM_ALGO_ID_RSA_PKCS_SHA256;
+    case NID_sha384:
+        return AZIHSM_ALGO_ID_RSA_PKCS_SHA384;
+    case NID_sha512:
+        return AZIHSM_ALGO_ID_RSA_PKCS_SHA512;
+    default:
+        return 0;
+    }
+}
+
+/* Helper function: Convert OpenSSL EVP_MD to RSA-PSS + Hash combined algorithm ID */
+static inline azihsm_algo_id azihsm_ossl_evp_md_to_rsa_pss_algo_id(const EVP_MD *md)
+{
+    int type;
+
+    if (md == NULL)
+        return 0;
+
+    type = EVP_MD_type(md);
+
+    switch (type)
+    {
+    case NID_sha1:
+        return AZIHSM_ALGO_ID_RSA_PKCS_PSS_SHA1;
+    case NID_sha256:
+        return AZIHSM_ALGO_ID_RSA_PKCS_PSS_SHA256;
+    case NID_sha384:
+        return AZIHSM_ALGO_ID_RSA_PKCS_PSS_SHA384;
+    case NID_sha512:
+        return AZIHSM_ALGO_ID_RSA_PKCS_PSS_SHA512;
+    default:
+        return 0;
+    }
+}
+
+/* Helper function: Convert OpenSSL EVP_MD to MGF1 ID for PSS/OAEP */
+static inline azihsm_mgf1_id azihsm_ossl_evp_md_to_mgf1_id(const EVP_MD *md)
+{
+    int type;
+
+    if (md == NULL)
+        return 0;
+
+    type = EVP_MD_type(md);
+
+    switch (type)
+    {
+    case NID_sha1:
+        return AZIHSM_MGF1_ID_SHA1;
+    case NID_sha256:
+        return AZIHSM_MGF1_ID_SHA256;
+    case NID_sha384:
+        return AZIHSM_MGF1_ID_SHA384;
+    case NID_sha512:
+        return AZIHSM_MGF1_ID_SHA512;
+    default:
+        return 0;
+    }
+}
+
+/* Helper function: Get default salt length for a hash algorithm (equals hash output size) */
+static inline uint32_t azihsm_ossl_evp_md_to_salt_len(const EVP_MD *md)
+{
+    if (md == NULL)
+        return 0;
+
+    return (uint32_t)EVP_MD_size(md);
+}
+
 /*
  * Normalize a private key DER blob to PKCS#8 format.
  *

--- a/plugins/ossl_prov/inc/azihsm_ossl_rsa.h
+++ b/plugins/ossl_prov/inc/azihsm_ossl_rsa.h
@@ -14,6 +14,7 @@ extern "C"
 #include <azihsm.h>
 
 #include "azihsm_ossl_base.h"
+#include "azihsm_ossl_pkey_param.h"
 
 /*
  * RSA-specific definitions which are shared
@@ -23,11 +24,20 @@ extern "C"
 #define AIHSM_KEY_TYPE_RSA 0
 #define AIHSM_KEY_TYPE_RSA_PSS 1
 
+/* Supported RSA key sizes in bits */
+#define AZIHSM_RSA_2048_KEY_BITS 2048
+#define AZIHSM_RSA_3072_KEY_BITS 3072
+#define AZIHSM_RSA_4096_KEY_BITS 4096
+
 typedef struct
 {
     int key_type;
     uint32_t pubkey_bits;
+    AZIHSM_KEY_USAGE_TYPE key_usage;
     azihsm_handle session;
+    bool session_flag;
+    char masked_key_file[4096];
+    char input_key_file[4096];
 } AZIHSM_RSA_GEN_CTX;
 
 typedef struct

--- a/plugins/ossl_prov/inc/azihsm_ossl_signature_rsa.h
+++ b/plugins/ossl_prov/inc/azihsm_ossl_signature_rsa.h
@@ -1,0 +1,37 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include <openssl/core_dispatch.h>
+#include <openssl/evp.h>
+
+#include "azihsm_ossl_base.h"
+#include "azihsm_ossl_rsa.h"
+
+/* RSA padding modes */
+#define AZIHSM_RSA_PAD_MODE_PKCSV15 0
+#define AZIHSM_RSA_PAD_MODE_PSS 1
+
+/* Special salt length values (matching OpenSSL's RSA_PSS_SALTLEN_* constants) */
+#define AZIHSM_RSA_PSS_SALTLEN_DIGEST -1 /* Salt length equals hash length */
+#define AZIHSM_RSA_PSS_SALTLEN_AUTO -2   /* Auto-detect on verify */
+#define AZIHSM_RSA_PSS_SALTLEN_MAX -3    /* Maximum possible salt */
+
+/* Signature context for RSA operations */
+typedef struct
+{
+    AZIHSM_OSSL_PROV_CTX *provctx; /* Provider context */
+    AZIHSM_RSA_KEY *key;           /* RSA key (public or private) */
+    const EVP_MD *md;              /* Hash algorithm (SHA1, SHA256, etc.) */
+    int operation;                 /* Sign (1) or Verify (0) */
+    azihsm_handle sign_ctx;        /* HSM streaming sign/verify context */
+
+    /* PSS-specific fields */
+    int pad_mode;          /* AZIHSM_RSA_PAD_MODE_PKCSV15 or _PSS */
+    const EVP_MD *mgf1_md; /* MGF1 hash (defaults to md if NULL) */
+    int salt_len;          /* PSS salt length (-1 = digest len) */
+} azihsm_rsa_sig_ctx;
+
+/* Dispatch tables */
+extern const OSSL_DISPATCH azihsm_ossl_rsa_signature_functions[];

--- a/plugins/ossl_prov/src/azihsm_ossl_base.c
+++ b/plugins/ossl_prov/src/azihsm_ossl_base.c
@@ -106,6 +106,7 @@ extern const OSSL_DISPATCH azihsm_ossl_ecdsa_signature_functions[];
 
 static const OSSL_ALGORITHM azihsm_ossl_signature[] = {
     ALG(AZIHSM_OSSL_ALG_NAME_RSA, azihsm_ossl_rsa_signature_functions),
+    ALG(AZIHSM_OSSL_ALG_NAME_RSA_PSS, azihsm_ossl_rsa_signature_functions),
     ALG(AZIHSM_OSSL_ALG_NAME_EC, azihsm_ossl_ecdsa_signature_functions),
     ALG(AZIHSM_OSSL_ALG_NAME_ECDSA, azihsm_ossl_ecdsa_signature_functions),
     ALG_TABLE_END

--- a/plugins/ossl_prov/src/azihsm_ossl_encoder_rsa.c
+++ b/plugins/ossl_prov/src/azihsm_ossl_encoder_rsa.c
@@ -74,17 +74,26 @@ static int azihsm_ossl_encoder_encode(
 )
 {
     BIO *bio;
+    const AZIHSM_RSA_GEN_CTX *genctx = &rsa_key->genctx;
 
     if ((bio = BIO_new_from_core_bio(ctx->libctx, out)) == NULL)
     {
         return 0;
     }
 
+    const char *key_usage_str = azihsm_ossl_key_usage_to_str(genctx->key_usage);
+
     BIO_printf(bio, "\n");
     BIO_printf(bio, "==== Key Generation Details ====\n");
     BIO_printf(bio, "provider             : azihsm\n");
-    BIO_printf(bio, "algorithm            : %s\n", key_type_to_str(rsa_key->genctx.key_type));
-    BIO_printf(bio, "public-key bit length: %" PRIu32 "\n", rsa_key->genctx.pubkey_bits);
+    BIO_printf(bio, "algorithm            : %s\n", key_type_to_str(genctx->key_type));
+    BIO_printf(bio, "public-key bit length: %" PRIu32 "\n", genctx->pubkey_bits);
+    BIO_printf(bio, "session              : %s\n", genctx->session_flag ? "yes" : "no");
+    if (genctx->masked_key_file[0] != '\0')
+    {
+        BIO_printf(bio, "masked-key file      : %s\n", genctx->masked_key_file);
+    }
+    BIO_printf(bio, "key usage            : %s\n", key_usage_str);
     BIO_printf(bio, "handle (public-key)  : %" PRIu32 "\n", rsa_key->key.pub);
     BIO_printf(bio, "handle (private-key) : %" PRIu32 "\n", rsa_key->key.priv);
 
@@ -194,6 +203,7 @@ static int azihsm_ossl_encoder_der_pki_encode(
 )
 {
     BIO *bio;
+    const AZIHSM_RSA_GEN_CTX *genctx = &rsa_key->genctx;
 
     if ((bio = BIO_new_from_core_bio(ctx->libctx, out)) == NULL)
     {
@@ -202,11 +212,19 @@ static int azihsm_ossl_encoder_der_pki_encode(
 
     if (selection & OSSL_KEYMGMT_SELECT_PRIVATE_KEY)
     {
+        const char *key_usage_str = azihsm_ossl_key_usage_to_str(genctx->key_usage);
+
         BIO_printf(bio, "\n");
         BIO_printf(bio, "==== PrivateKeyInfo (PKCS#8) ====\n");
         BIO_printf(bio, "provider             : azihsm\n");
-        BIO_printf(bio, "algorithm            : %s\n", key_type_to_str(rsa_key->genctx.key_type));
-        BIO_printf(bio, "public-key bit length: %" PRIu32 "\n", rsa_key->genctx.pubkey_bits);
+        BIO_printf(bio, "algorithm            : %s\n", key_type_to_str(genctx->key_type));
+        BIO_printf(bio, "public-key bit length: %" PRIu32 "\n", genctx->pubkey_bits);
+        BIO_printf(bio, "session              : %s\n", genctx->session_flag ? "yes" : "no");
+        if (genctx->masked_key_file[0] != '\0')
+        {
+            BIO_printf(bio, "masked-key file      : %s\n", genctx->masked_key_file);
+        }
+        BIO_printf(bio, "key usage            : %s\n", key_usage_str);
         BIO_printf(bio, "handle (public-key)  : %" PRIu32 "\n", rsa_key->key.pub);
         BIO_printf(bio, "handle (private-key) : %" PRIu32 "\n", rsa_key->key.priv);
         BIO_printf(bio, "\n");

--- a/plugins/ossl_prov/src/azihsm_ossl_keymgmt_rsa.c
+++ b/plugins/ossl_prov/src/azihsm_ossl_keymgmt_rsa.c
@@ -1,30 +1,60 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-#include <string.h>
-
 #include <openssl/core_dispatch.h>
 #include <openssl/core_names.h>
 #include <openssl/err.h>
 #include <openssl/params.h>
 #include <openssl/proverr.h>
+#include <string.h>
 
 #include "azihsm_ossl_base.h"
 #include "azihsm_ossl_helpers.h"
 #include "azihsm_ossl_hsm.h"
+#include "azihsm_ossl_pkey_param.h"
 #include "azihsm_ossl_rsa.h"
 
 /*
  * RSA/RSA-PSS KeyManagement
  *
+ * NOTE: The HSM is not capable of generating RSA keys natively.
+ * All RSA keys must be provided externally and imported into the HSM
+ * via the azihsm.input_key parameter.
+ *
  * supported parameters (pkeyopt):
  *
- *   @bits
+ *   @rsa_keygen_bits
  *   Description: RSA public key bit length
- *   Accepted values: 2048, ??
+ *   Accepted values: 2048, 3072, 4096
  *   Default: 2048
  *   Example:
- *      -pkeyopt group:2048
+ *      -pkeyopt rsa_keygen_bits:2048
+ *
+ *   @azihsm.key_usage
+ *   Description: Key usage type for the key pair
+ *   Accepted values: digitalSignature (private: sign, public: verify)
+ *   Default value: digitalSignature
+ *   Example:
+ *      -pkeyopt azihsm.key_usage:digitalSignature
+ *
+ *   @azihsm.session
+ *   Description: Whether to create a session key or persistent key
+ *   Accepted values: true, false, 1, 0, yes, no
+ *   Default value: false
+ *   Example:
+ *      -pkeyopt azihsm.session:true
+ *
+ *   @azihsm.input_key
+ *   Description: Path to an external DER-encoded RSA private key to import.
+ *   When set, the key is wrapped (RSA-AES) and unwrapped into the HSM.
+ *   THIS PARAMETER IS REQUIRED - the HSM cannot generate RSA keys natively.
+ *   Example:
+ *      -pkeyopt azihsm.input_key:/path/to/rsa_key.der
+ *
+ *   @azihsm.masked_key
+ *   Description: Path to write the masked key blob for later reload via store
+ *   Example:
+ *      -pkeyopt azihsm.masked_key:/path/to/masked.bin
  *
  * */
 
@@ -34,7 +64,256 @@
 #define AIHSM_RSA_PUBKEY_BITS_MIN 2048
 #define AIHSM_RSA_PUBKEY_BITS_DEFAULT AIHSM_RSA_PUBKEY_BITS_MIN
 
+#define AIHSM_KEY_USAGE_DEFAULT KEY_USAGE_DIGITAL_SIGNATURE
+
+#define MAX_INPUT_KEY_SIZE (64 * 1024)
+
 /* Key Management Functions */
+
+/*
+ * Import an external DER-encoded RSA private key into the HSM via wrap-then-unwrap.
+ *
+ * Flow:
+ *   1. Read the DER file from disk
+ *   2. Get the RSA wrapping key pair from the HSM
+ *   3. Wrap the DER blob with azihsm_crypt_encrypt (RSA-AES-WRAP)
+ *   4. Unwrap into the HSM with azihsm_key_unwrap_pair (RSA-AES-KEY-WRAP)
+ *   5. Return the resulting key handles
+ */
+static azihsm_status azihsm_ossl_rsa_keymgmt_gen_import(
+    AZIHSM_RSA_GEN_CTX *genctx,
+    const struct azihsm_key_prop_list *priv_key_prop_list,
+    const struct azihsm_key_prop_list *pub_key_prop_list,
+    azihsm_handle *out_priv,
+    azihsm_handle *out_pub
+)
+{
+    azihsm_status status;
+    azihsm_handle wrapping_pub = 0, wrapping_priv = 0;
+    uint8_t *input_buf = NULL;
+    long input_size = 0;
+    FILE *f = NULL;
+
+    /* 1. Read the input DER file */
+    f = fopen(genctx->input_key_file, "rb");
+    if (f == NULL)
+    {
+        return AZIHSM_STATUS_INVALID_ARGUMENT;
+    }
+
+    if (fseek(f, 0, SEEK_END) != 0)
+    {
+        fclose(f);
+        return AZIHSM_STATUS_INVALID_ARGUMENT;
+    }
+
+    input_size = ftell(f);
+    if (input_size <= 0 || input_size > MAX_INPUT_KEY_SIZE)
+    {
+        fclose(f);
+        return AZIHSM_STATUS_INVALID_ARGUMENT;
+    }
+
+    if (fseek(f, 0, SEEK_SET) != 0)
+    {
+        fclose(f);
+        return AZIHSM_STATUS_INVALID_ARGUMENT;
+    }
+
+    input_buf = OPENSSL_malloc((size_t)input_size);
+    if (input_buf == NULL)
+    {
+        fclose(f);
+        return AZIHSM_STATUS_INVALID_ARGUMENT;
+    }
+
+    if (fread(input_buf, 1, (size_t)input_size, f) != (size_t)input_size)
+    {
+        fclose(f);
+        OPENSSL_cleanse(input_buf, (size_t)input_size);
+        OPENSSL_free(input_buf);
+        return AZIHSM_STATUS_INVALID_ARGUMENT;
+    }
+    fclose(f);
+
+    /* Normalize to PKCS#8 DER (handles both PKCS#1 and PKCS#8 input) */
+    {
+        uint8_t *pkcs8_buf = NULL;
+        int pkcs8_len = 0;
+
+        if (azihsm_ossl_normalize_der_to_pkcs8(input_buf, input_size, &pkcs8_buf, &pkcs8_len) !=
+            OSSL_SUCCESS)
+        {
+            OPENSSL_cleanse(input_buf, (size_t)input_size);
+            OPENSSL_free(input_buf);
+            return AZIHSM_STATUS_INVALID_ARGUMENT;
+        }
+
+        /* Replace input buffer with PKCS#8 version */
+        OPENSSL_cleanse(input_buf, (size_t)input_size);
+        OPENSSL_free(input_buf);
+        input_buf = pkcs8_buf;
+        input_size = pkcs8_len;
+    }
+
+    /* 2. Retrieve the RSA unwrapping key pair from the HSM */
+    {
+        struct azihsm_algo rsa_keygen_algo = {
+            .id = AZIHSM_ALGO_ID_RSA_KEY_UNWRAPPING_KEY_PAIR_GEN,
+            .params = NULL,
+            .len = 0,
+        };
+
+        const uint32_t rsa_bits = 2048;
+        const azihsm_key_class rsa_priv_class = AZIHSM_KEY_CLASS_PRIVATE;
+        const azihsm_key_class rsa_pub_class = AZIHSM_KEY_CLASS_PUBLIC;
+        const azihsm_key_kind rsa_kind = AZIHSM_KEY_KIND_RSA;
+        const bool rsa_enable = true;
+
+        struct azihsm_key_prop rsa_priv_props[] = {
+            { .id = AZIHSM_KEY_PROP_ID_BIT_LEN, .val = (void *)&rsa_bits, .len = sizeof(rsa_bits) },
+            { .id = AZIHSM_KEY_PROP_ID_CLASS,
+              .val = (void *)&rsa_priv_class,
+              .len = sizeof(rsa_priv_class) },
+            { .id = AZIHSM_KEY_PROP_ID_KIND, .val = (void *)&rsa_kind, .len = sizeof(rsa_kind) },
+            { .id = AZIHSM_KEY_PROP_ID_UNWRAP,
+              .val = (void *)&rsa_enable,
+              .len = sizeof(rsa_enable) },
+        };
+
+        struct azihsm_key_prop rsa_pub_props[] = {
+            { .id = AZIHSM_KEY_PROP_ID_BIT_LEN, .val = (void *)&rsa_bits, .len = sizeof(rsa_bits) },
+            { .id = AZIHSM_KEY_PROP_ID_CLASS,
+              .val = (void *)&rsa_pub_class,
+              .len = sizeof(rsa_pub_class) },
+            { .id = AZIHSM_KEY_PROP_ID_KIND, .val = (void *)&rsa_kind, .len = sizeof(rsa_kind) },
+            { .id = AZIHSM_KEY_PROP_ID_WRAP,
+              .val = (void *)&rsa_enable,
+              .len = sizeof(rsa_enable) },
+        };
+
+        struct azihsm_key_prop_list rsa_priv_prop_list = {
+            .props = rsa_priv_props,
+            .count = 4,
+        };
+
+        struct azihsm_key_prop_list rsa_pub_prop_list = {
+            .props = rsa_pub_props,
+            .count = 4,
+        };
+
+        status = azihsm_key_gen_pair(
+            genctx->session,
+            &rsa_keygen_algo,
+            &rsa_priv_prop_list,
+            &rsa_pub_prop_list,
+            &wrapping_priv,
+            &wrapping_pub
+        );
+    }
+    if (status != AZIHSM_STATUS_SUCCESS)
+    {
+        OPENSSL_cleanse(input_buf, input_size);
+        OPENSSL_free(input_buf);
+        return status;
+    }
+
+    /* 3. Wrap the DER blob */
+    struct azihsm_algo_rsa_pkcs_oaep_params oaep_params = {
+        .hash_algo_id = AZIHSM_ALGO_ID_SHA256,
+        .mgf1_hash_algo_id = AZIHSM_MGF1_ID_SHA256,
+        .label = NULL,
+    };
+
+    struct azihsm_algo_rsa_aes_wrap_params wrap_params = {
+        .oaep_params = &oaep_params,
+        .aes_key_bits = 256,
+    };
+
+    struct azihsm_algo wrap_algo = {
+        .id = AZIHSM_ALGO_ID_RSA_AES_WRAP,
+        .params = &wrap_params,
+        .len = sizeof(wrap_params),
+    };
+
+    struct azihsm_buffer plain_buf = {
+        .ptr = input_buf,
+        .len = (uint32_t)input_size,
+    };
+
+    /* Two-call pattern: first query required size */
+    struct azihsm_buffer wrapped_buf = {
+        .ptr = NULL,
+        .len = 0,
+    };
+
+    status = azihsm_crypt_encrypt(&wrap_algo, wrapping_pub, &plain_buf, &wrapped_buf);
+    if (status != AZIHSM_STATUS_BUFFER_TOO_SMALL || wrapped_buf.len == 0)
+    {
+        OPENSSL_cleanse(input_buf, (size_t)input_size);
+        OPENSSL_free(input_buf);
+        azihsm_key_delete(wrapping_pub);
+        azihsm_key_delete(wrapping_priv);
+        return (status == AZIHSM_STATUS_SUCCESS) ? AZIHSM_STATUS_INTERNAL_ERROR : status;
+    }
+
+    /* Allocate buffer for wrapped data */
+    uint32_t wrapped_size = wrapped_buf.len;
+    uint8_t *wrapped_data = OPENSSL_malloc(wrapped_size);
+    if (wrapped_data == NULL)
+    {
+        OPENSSL_cleanse(input_buf, (size_t)input_size);
+        OPENSSL_free(input_buf);
+        azihsm_key_delete(wrapping_pub);
+        azihsm_key_delete(wrapping_priv);
+        return AZIHSM_STATUS_INVALID_ARGUMENT;
+    }
+
+    /* Second call: perform actual wrap */
+    wrapped_buf.ptr = wrapped_data;
+    wrapped_buf.len = wrapped_size;
+
+    status = azihsm_crypt_encrypt(&wrap_algo, wrapping_pub, &plain_buf, &wrapped_buf);
+    OPENSSL_cleanse(input_buf, (size_t)input_size);
+    OPENSSL_free(input_buf);
+
+    if (status != AZIHSM_STATUS_SUCCESS)
+    {
+        OPENSSL_cleanse(wrapped_data, wrapped_size);
+        OPENSSL_free(wrapped_data);
+        azihsm_key_delete(wrapping_pub);
+        azihsm_key_delete(wrapping_priv);
+        return status;
+    }
+
+    /* 4. Unwrap into the HSM */
+    struct azihsm_algo_rsa_aes_key_wrap_params unwrap_params = {
+        .oaep_params = &oaep_params,
+    };
+
+    struct azihsm_algo unwrap_algo = {
+        .id = AZIHSM_ALGO_ID_RSA_AES_KEY_WRAP,
+        .params = &unwrap_params,
+        .len = sizeof(unwrap_params),
+    };
+
+    status = azihsm_key_unwrap_pair(
+        &unwrap_algo,
+        wrapping_priv,
+        &wrapped_buf,
+        priv_key_prop_list,
+        pub_key_prop_list,
+        out_priv,
+        out_pub
+    );
+    azihsm_key_delete(wrapping_pub);
+    azihsm_key_delete(wrapping_priv);
+
+    OPENSSL_cleanse(wrapped_data, wrapped_size);
+    OPENSSL_free(wrapped_data);
+
+    return status;
+}
 
 static AZIHSM_RSA_KEY *azihsm_ossl_keymgmt_gen(
     AZIHSM_RSA_GEN_CTX *genctx,
@@ -43,25 +322,87 @@ static AZIHSM_RSA_KEY *azihsm_ossl_keymgmt_gen(
 )
 {
     AZIHSM_RSA_KEY *rsa_key;
-    azihsm_handle public, private;
+    azihsm_handle public = 0, private = 0;
     azihsm_status status;
+    const bool enable = true;
+    const azihsm_key_class priv_class = AZIHSM_KEY_CLASS_PRIVATE;
+    const azihsm_key_class pub_class = AZIHSM_KEY_CLASS_PUBLIC;
+    const azihsm_key_kind key_kind = AZIHSM_KEY_KIND_RSA;
 
-    struct azihsm_algo algo = {
-        .id = AZIHSM_ALGO_ID_RSA_KEY_UNWRAPPING_KEY_PAIR_GEN,
-        .params = NULL,
-        .len = 0,
+    /*
+     * The HSM cannot generate RSA keys natively.
+     * RSA keys must be provided externally via the azihsm.input_key parameter.
+     */
+    if (genctx->input_key_file[0] == '\0')
+    {
+        ERR_raise_data(
+            ERR_LIB_PROV,
+            PROV_R_MISSING_KEY,
+            "azihsm: RSA key generation requires azihsm.input_key parameter. "
+            "The HSM cannot generate RSA keys natively. "
+            "Please provide an external DER-encoded RSA private key: "
+            "-pkeyopt azihsm.input_key:/path/to/rsa_key.der"
+        );
+        return NULL;
+    }
+
+    /* RSA key properties: class, kind, bit_len, usage, and optionally session */
+#define AZIHSM_RSA_KEY_PROPS_SIZE 5
+    struct azihsm_key_prop pub_key_props[AZIHSM_RSA_KEY_PROPS_SIZE] = {
+        [0] = { .id = AZIHSM_KEY_PROP_ID_CLASS,
+                .val = (void *)&pub_class,
+                .len = sizeof(pub_class) },
+        [1] = { .id = AZIHSM_KEY_PROP_ID_KIND, .val = (void *)&key_kind, .len = sizeof(key_kind) },
+        [2] = { .id = AZIHSM_KEY_PROP_ID_BIT_LEN,
+                .val = (void *)&genctx->pubkey_bits,
+                .len = sizeof(genctx->pubkey_bits) },
+        [3] = { .id = (azihsm_key_prop_id)azihsm_ossl_get_pub_key_property(genctx->key_usage),
+                .val = (void *)&enable,
+                .len = sizeof(bool) },
     };
 
-    struct azihsm_key_prop pub_key_prop = {
-        .id = AZIHSM_KEY_PROP_ID_BIT_LEN,
-        .val = (void *)&genctx->pubkey_bits,
-        .len = sizeof(genctx->pubkey_bits),
+    struct azihsm_key_prop priv_key_props[AZIHSM_RSA_KEY_PROPS_SIZE] = {
+        [0] = { .id = AZIHSM_KEY_PROP_ID_CLASS,
+                .val = (void *)&priv_class,
+                .len = sizeof(priv_class) },
+        [1] = { .id = AZIHSM_KEY_PROP_ID_KIND, .val = (void *)&key_kind, .len = sizeof(key_kind) },
+        [2] = { .id = AZIHSM_KEY_PROP_ID_BIT_LEN,
+                .val = (void *)&genctx->pubkey_bits,
+                .len = sizeof(genctx->pubkey_bits) },
+        [3] = { .id = (azihsm_key_prop_id)azihsm_ossl_get_priv_key_property(genctx->key_usage),
+                .val = (void *)&enable,
+                .len = sizeof(bool) },
     };
+
+    uint32_t pub_key_prop_count = 4;
+    uint32_t priv_key_prop_count = 4;
+
+    /* Add SESSION property if requested */
+    if (genctx->session_flag)
+    {
+        pub_key_props[4] = (struct azihsm_key_prop){
+            .id = AZIHSM_KEY_PROP_ID_SESSION,
+            .val = (void *)&enable,
+            .len = sizeof(bool),
+        };
+        pub_key_prop_count++;
+
+        priv_key_props[4] = (struct azihsm_key_prop){
+            .id = AZIHSM_KEY_PROP_ID_SESSION,
+            .val = (void *)&enable,
+            .len = sizeof(bool),
+        };
+        priv_key_prop_count++;
+    }
 
     struct azihsm_key_prop_list pub_key_prop_list = {
+        .props = pub_key_props,
+        .count = pub_key_prop_count,
+    };
 
-        .props = &pub_key_prop,
-        .count = 1
+    struct azihsm_key_prop_list priv_key_prop_list = {
+        .props = priv_key_props,
+        .count = priv_key_prop_count,
     };
 
     if ((rsa_key = OPENSSL_zalloc(sizeof(AZIHSM_RSA_KEY))) == NULL)
@@ -70,12 +411,19 @@ static AZIHSM_RSA_KEY *azihsm_ossl_keymgmt_gen(
         return NULL;
     }
 
-    status =
-        azihsm_key_gen_pair(genctx->session, &algo, &pub_key_prop_list, NULL, &public, &private);
+    /* Import external key via wrap-unwrap */
+    status = azihsm_ossl_rsa_keymgmt_gen_import(
+        genctx,
+        &priv_key_prop_list,
+        &pub_key_prop_list,
+        &private,
+        &public
+    );
 
     if (status != AZIHSM_STATUS_SUCCESS)
     {
         OPENSSL_free(rsa_key);
+        ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_GENERATE_KEY);
         return NULL;
     }
 
@@ -84,6 +432,74 @@ static AZIHSM_RSA_KEY *azihsm_ossl_keymgmt_gen(
     rsa_key->has_public = true;
     rsa_key->key.priv = private;
     rsa_key->has_private = true;
+
+    /* Handle masked key file output if requested */
+    if (genctx->masked_key_file[0] != '\0')
+    {
+        /* Allocate a 8192-byte buffer for the masked key */
+        const uint32_t masked_key_buffer_size = 8192;
+        uint8_t *masked_key_buffer = OPENSSL_malloc(masked_key_buffer_size);
+        if (masked_key_buffer == NULL)
+        {
+            azihsm_key_delete(private);
+            azihsm_key_delete(public);
+            OPENSSL_free(rsa_key);
+            ERR_raise(ERR_LIB_PROV, ERR_R_MALLOC_FAILURE);
+            return NULL;
+        }
+
+        /* Retrieve masked key with the allocated buffer */
+        struct azihsm_key_prop prop = { .id = AZIHSM_KEY_PROP_ID_MASKED_KEY,
+                                        .val = masked_key_buffer,
+                                        .len = masked_key_buffer_size };
+
+        azihsm_status retrieve_status = azihsm_key_get_prop(private, &prop);
+
+        /* Check if we got the masked key */
+        if (retrieve_status == AZIHSM_STATUS_SUCCESS && prop.len > 0)
+        {
+            /* Write masked key to file */
+            FILE *f = fopen(genctx->masked_key_file, "wb");
+            if (f == NULL)
+            {
+                azihsm_key_delete(private);
+                azihsm_key_delete(public);
+                OPENSSL_cleanse(masked_key_buffer, masked_key_buffer_size);
+                OPENSSL_free(masked_key_buffer);
+                OPENSSL_free(rsa_key);
+                ERR_raise(ERR_LIB_PROV, ERR_R_OPERATION_FAIL);
+                return NULL;
+            }
+
+            size_t written = fwrite(masked_key_buffer, 1, prop.len, f);
+            fclose(f);
+
+            if (written != prop.len)
+            {
+                azihsm_key_delete(private);
+                azihsm_key_delete(public);
+                OPENSSL_cleanse(masked_key_buffer, masked_key_buffer_size);
+                OPENSSL_free(masked_key_buffer);
+                OPENSSL_free(rsa_key);
+                ERR_raise(ERR_LIB_PROV, ERR_R_OPERATION_FAIL);
+                return NULL;
+            }
+        }
+        else if (retrieve_status != AZIHSM_STATUS_PROPERTY_NOT_PRESENT)
+        {
+            azihsm_key_delete(private);
+            azihsm_key_delete(public);
+            OPENSSL_cleanse(masked_key_buffer, masked_key_buffer_size);
+            OPENSSL_free(masked_key_buffer);
+            OPENSSL_free(rsa_key);
+            ERR_raise(ERR_LIB_PROV, ERR_R_OPERATION_FAIL);
+            return NULL;
+        }
+        /* If PROPERTY_NOT_PRESENT, just continue without masked key */
+
+        OPENSSL_cleanse(masked_key_buffer, masked_key_buffer_size);
+        OPENSSL_free(masked_key_buffer);
+    }
 
     return rsa_key;
 }
@@ -123,30 +539,99 @@ static int azihsm_ossl_keymgmt_gen_set_params(AZIHSM_RSA_GEN_CTX *genctx, const 
 
     if (params == NULL)
     {
-        return 1;
+        return OSSL_SUCCESS;
     }
 
     if ((p = OSSL_PARAM_locate_const(params, OSSL_PKEY_PARAM_RSA_BITS)) != NULL)
     {
-
         uint32_t bits;
 
         if (!OSSL_PARAM_get_uint32(p, &bits))
         {
             ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_GET_PARAMETER);
-            return 0;
+            return OSSL_FAILURE;
         }
 
         if (bits < AIHSM_RSA_PUBKEY_BITS_MIN)
         {
             ERR_raise(ERR_LIB_PROV, PROV_R_KEY_SIZE_TOO_SMALL);
-            return 0;
+            return OSSL_FAILURE;
         }
 
         genctx->pubkey_bits = bits;
     }
 
-    return 1;
+    if ((p = OSSL_PARAM_locate_const(params, AZIHSM_OSSL_PKEY_PARAM_KEY_USAGE)) != NULL)
+    {
+        if (p->data_type != OSSL_PARAM_UTF8_STRING)
+        {
+            ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_GET_PARAMETER);
+            return OSSL_FAILURE;
+        }
+
+        if (azihsm_ossl_key_usage_from_str(p->data, &genctx->key_usage) < 0)
+        {
+            ERR_raise(ERR_LIB_PROV, PROV_R_INVALID_KEY);
+            return OSSL_FAILURE;
+        }
+    }
+
+    if ((p = OSSL_PARAM_locate_const(params, AZIHSM_OSSL_PKEY_PARAM_SESSION)) != NULL)
+    {
+        int session_result;
+
+        if (p->data_type != OSSL_PARAM_UTF8_STRING)
+        {
+            ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_GET_PARAMETER);
+            return OSSL_FAILURE;
+        }
+
+        if ((session_result = azihsm_ossl_session_from_str(p->data)) < 0)
+        {
+            ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_GET_PARAMETER);
+            return OSSL_FAILURE;
+        }
+
+        genctx->session_flag = (bool)session_result;
+    }
+
+    if ((p = OSSL_PARAM_locate_const(params, AZIHSM_OSSL_PKEY_PARAM_MASKED_KEY)) != NULL)
+    {
+        if (p->data_type != OSSL_PARAM_UTF8_STRING)
+        {
+            ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_GET_PARAMETER);
+            return OSSL_FAILURE;
+        }
+
+        if (azihsm_ossl_masked_key_filepath_validate(p->data) < 0)
+        {
+            ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_GET_PARAMETER);
+            return OSSL_FAILURE;
+        }
+
+        strncpy(genctx->masked_key_file, p->data, sizeof(genctx->masked_key_file) - 1);
+        genctx->masked_key_file[sizeof(genctx->masked_key_file) - 1] = '\0';
+    }
+
+    if ((p = OSSL_PARAM_locate_const(params, AZIHSM_OSSL_PKEY_PARAM_INPUT_KEY)) != NULL)
+    {
+        if (p->data_type != OSSL_PARAM_UTF8_STRING)
+        {
+            ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_GET_PARAMETER);
+            return OSSL_FAILURE;
+        }
+
+        if (azihsm_ossl_input_key_filepath_validate(p->data) < 0)
+        {
+            ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_GET_PARAMETER);
+            return OSSL_FAILURE;
+        }
+
+        strncpy(genctx->input_key_file, p->data, sizeof(genctx->input_key_file) - 1);
+        genctx->input_key_file[sizeof(genctx->input_key_file) - 1] = '\0';
+    }
+
+    return OSSL_SUCCESS;
 }
 
 static AZIHSM_RSA_GEN_CTX *azihsm_ossl_keymgmt_gen_init_common(
@@ -173,9 +658,12 @@ static AZIHSM_RSA_GEN_CTX *azihsm_ossl_keymgmt_gen_init_common(
     }
 
     genctx->session = provctx->session;
-
     genctx->key_type = key_type;
     genctx->pubkey_bits = AIHSM_RSA_PUBKEY_BITS_DEFAULT;
+    genctx->key_usage = AIHSM_KEY_USAGE_DEFAULT;
+    genctx->session_flag = false;
+    genctx->masked_key_file[0] = '\0';
+    genctx->input_key_file[0] = '\0';
 
     if (azihsm_ossl_keymgmt_gen_set_params(genctx, params) == 0)
     {
@@ -210,12 +698,12 @@ static int azihsm_ossl_keymgmt_has(const AZIHSM_RSA_KEY *rsa_key, int selection)
 
     if (rsa_key == NULL)
     {
-        return 0;
+        return OSSL_FAILURE;
     }
 
     if ((selection & AIHSM_RSA_POSSIBLE_SELECTIONS) == 0)
     {
-        return 1;
+        return OSSL_SUCCESS;
     }
 
     if ((selection & OSSL_KEYMGMT_SELECT_PRIVATE_KEY) != 0)
@@ -228,7 +716,7 @@ static int azihsm_ossl_keymgmt_has(const AZIHSM_RSA_KEY *rsa_key, int selection)
         has_selection &= rsa_key->has_public;
     }
 
-    return has_selection;
+    return has_selection ? OSSL_SUCCESS : OSSL_FAILURE;
 }
 
 static int azihsm_ossl_keymgmt_match(
@@ -237,38 +725,36 @@ static int azihsm_ossl_keymgmt_match(
     ossl_unused int selection
 )
 {
-    /*
-     * todo: implement selection bits?
-     * */
-
     if (rsa_key1 == NULL || rsa_key2 == NULL)
     {
-        return 0;
+        return OSSL_FAILURE;
     }
 
     if (rsa_key1->key.pub != rsa_key2->key.pub)
     {
-        return 0;
+        return OSSL_FAILURE;
     }
 
     if (rsa_key1->key.priv != rsa_key2->key.priv)
     {
-        return 0;
+        return OSSL_FAILURE;
     }
 
-    return 1;
+    return OSSL_SUCCESS;
 }
 
 static void *azihsm_ossl_keymgmt_load(const void *reference, size_t reference_sz)
 {
     AZIHSM_RSA_KEY *dst_key;
 
+    /* Validate reference size matches our key object */
     if (reference == NULL || reference_sz != sizeof(AZIHSM_RSA_KEY))
     {
         ERR_raise(ERR_LIB_PROV, ERR_R_PASSED_NULL_PARAMETER);
         return NULL;
     }
 
+    /* Create a copy of the key - reference contains the raw bytes of AZIHSM_RSA_KEY */
     dst_key = OPENSSL_zalloc(sizeof(AZIHSM_RSA_KEY));
     if (dst_key == NULL)
     {
@@ -276,6 +762,7 @@ static void *azihsm_ossl_keymgmt_load(const void *reference, size_t reference_sz
         return NULL;
     }
 
+    /* Copy the key structure from reference */
     memcpy(dst_key, reference, sizeof(AZIHSM_RSA_KEY));
 
     return dst_key;
@@ -325,12 +812,25 @@ static int azihsm_ossl_keymgmt_get_params(AZIHSM_RSA_KEY *key, OSSL_PARAM params
         return 0;
     }
 
+    p = OSSL_PARAM_locate(params, OSSL_PKEY_PARAM_MAX_SIZE);
+    if (p != NULL)
+    {
+        /* RSA signature size equals key size in bytes */
+        size_t sig_size = key->genctx.pubkey_bits / 8;
+        if (!OSSL_PARAM_set_size_t(p, sig_size))
+        {
+            ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_SET_PARAMETER);
+            return 0;
+        }
+    }
+
     return 1;
 }
 
 static const OSSL_PARAM *azihsm_ossl_keymgmt_gettable_params(ossl_unused void *ctx)
 {
     static const OSSL_PARAM gettable_params[] = { OSSL_PARAM_uint32(OSSL_PKEY_PARAM_BITS, NULL),
+                                                  OSSL_PARAM_size_t(OSSL_PKEY_PARAM_MAX_SIZE, NULL),
                                                   OSSL_PARAM_END };
 
     return gettable_params;
@@ -341,8 +841,14 @@ static const OSSL_PARAM *azihsm_ossl_keymgmt_gen_settable_params(
     ossl_unused void *ctx
 )
 {
-    static const OSSL_PARAM settable_params[] = { OSSL_PARAM_uint32(OSSL_PKEY_PARAM_RSA_BITS, NULL),
-                                                  OSSL_PARAM_END };
+    static const OSSL_PARAM settable_params[] = {
+        OSSL_PARAM_uint32(OSSL_PKEY_PARAM_RSA_BITS, NULL),
+        OSSL_PARAM_utf8_string(AZIHSM_OSSL_PKEY_PARAM_KEY_USAGE, NULL, 0),
+        OSSL_PARAM_utf8_string(AZIHSM_OSSL_PKEY_PARAM_SESSION, NULL, 0),
+        OSSL_PARAM_utf8_string(AZIHSM_OSSL_PKEY_PARAM_MASKED_KEY, NULL, 0),
+        OSSL_PARAM_utf8_string(AZIHSM_OSSL_PKEY_PARAM_INPUT_KEY, NULL, 0),
+        OSSL_PARAM_END
+    };
 
     return settable_params;
 }
@@ -356,9 +862,9 @@ const OSSL_DISPATCH azihsm_ossl_rsa_keymgmt_functions[] = {
     { OSSL_FUNC_KEYMGMT_GEN_SETTABLE_PARAMS,
       (void (*)(void))azihsm_ossl_keymgmt_gen_settable_params },
     { OSSL_FUNC_KEYMGMT_FREE, (void (*)(void))azihsm_ossl_keymgmt_free },
-    { OSSL_FUNC_KEYMGMT_LOAD, (void (*)(void))azihsm_ossl_keymgmt_load },
     { OSSL_FUNC_KEYMGMT_HAS, (void (*)(void))azihsm_ossl_keymgmt_has },
     { OSSL_FUNC_KEYMGMT_MATCH, (void (*)(void))azihsm_ossl_keymgmt_match },
+    { OSSL_FUNC_KEYMGMT_LOAD, (void (*)(void))azihsm_ossl_keymgmt_load },
     { OSSL_FUNC_KEYMGMT_IMPORT, (void (*)(void))azihsm_ossl_keymgmt_import },
     { OSSL_FUNC_KEYMGMT_EXPORT, (void (*)(void))azihsm_ossl_keymgmt_export },
     { OSSL_FUNC_KEYMGMT_IMPORT_TYPES, (void (*)(void))azihsm_ossl_keymgmt_import_types },
@@ -376,9 +882,9 @@ const OSSL_DISPATCH azihsm_ossl_rsa_pss_keymgmt_functions[] = {
     { OSSL_FUNC_KEYMGMT_GEN_SETTABLE_PARAMS,
       (void (*)(void))azihsm_ossl_keymgmt_gen_settable_params },
     { OSSL_FUNC_KEYMGMT_FREE, (void (*)(void))azihsm_ossl_keymgmt_free },
-    { OSSL_FUNC_KEYMGMT_LOAD, (void (*)(void))azihsm_ossl_keymgmt_load },
     { OSSL_FUNC_KEYMGMT_HAS, (void (*)(void))azihsm_ossl_keymgmt_has },
     { OSSL_FUNC_KEYMGMT_MATCH, (void (*)(void))azihsm_ossl_keymgmt_match },
+    { OSSL_FUNC_KEYMGMT_LOAD, (void (*)(void))azihsm_ossl_keymgmt_load },
     { OSSL_FUNC_KEYMGMT_IMPORT, (void (*)(void))azihsm_ossl_keymgmt_import },
     { OSSL_FUNC_KEYMGMT_EXPORT, (void (*)(void))azihsm_ossl_keymgmt_export },
     { OSSL_FUNC_KEYMGMT_IMPORT_TYPES, (void (*)(void))azihsm_ossl_keymgmt_import_types },

--- a/plugins/ossl_prov/src/azihsm_ossl_keymgmt_rsa.c
+++ b/plugins/ossl_prov/src/azihsm_ossl_keymgmt_rsa.c
@@ -436,28 +436,42 @@ static AZIHSM_RSA_KEY *azihsm_ossl_keymgmt_gen(
     /* Handle masked key file output if requested */
     if (genctx->masked_key_file[0] != '\0')
     {
-        /* Allocate a 8192-byte buffer for the masked key */
-        const uint32_t masked_key_buffer_size = 8192;
-        uint8_t *masked_key_buffer = OPENSSL_malloc(masked_key_buffer_size);
-        if (masked_key_buffer == NULL)
-        {
-            azihsm_key_delete(private);
-            azihsm_key_delete(public);
-            OPENSSL_free(rsa_key);
-            ERR_raise(ERR_LIB_PROV, ERR_R_MALLOC_FAILURE);
-            return NULL;
-        }
-
-        /* Retrieve masked key with the allocated buffer */
+        /* First call to get required buffer size */
         struct azihsm_key_prop prop = { .id = AZIHSM_KEY_PROP_ID_MASKED_KEY,
-                                        .val = masked_key_buffer,
-                                        .len = masked_key_buffer_size };
+                                        .val = NULL,
+                                        .len = 0 };
 
         azihsm_status retrieve_status = azihsm_key_get_prop(private, &prop);
 
-        /* Check if we got the masked key */
-        if (retrieve_status == AZIHSM_STATUS_SUCCESS && prop.len > 0)
+        if (retrieve_status == AZIHSM_STATUS_BUFFER_TOO_SMALL && prop.len > 0)
         {
+            /* Allocate buffer of exact size */
+            uint32_t masked_key_buffer_size = prop.len;
+            uint8_t *masked_key_buffer = OPENSSL_malloc(masked_key_buffer_size);
+            if (masked_key_buffer == NULL)
+            {
+                azihsm_key_delete(private);
+                azihsm_key_delete(public);
+                OPENSSL_free(rsa_key);
+                ERR_raise(ERR_LIB_PROV, ERR_R_MALLOC_FAILURE);
+                return NULL;
+            }
+
+            /* Second call to retrieve the masked key */
+            prop.val = masked_key_buffer;
+            retrieve_status = azihsm_key_get_prop(private, &prop);
+
+            if (retrieve_status != AZIHSM_STATUS_SUCCESS)
+            {
+                azihsm_key_delete(private);
+                azihsm_key_delete(public);
+                OPENSSL_cleanse(masked_key_buffer, masked_key_buffer_size);
+                OPENSSL_free(masked_key_buffer);
+                OPENSSL_free(rsa_key);
+                ERR_raise(ERR_LIB_PROV, ERR_R_OPERATION_FAIL);
+                return NULL;
+            }
+
             /* Write masked key to file */
             FILE *f = fopen(genctx->masked_key_file, "wb");
             if (f == NULL)
@@ -484,21 +498,20 @@ static AZIHSM_RSA_KEY *azihsm_ossl_keymgmt_gen(
                 ERR_raise(ERR_LIB_PROV, ERR_R_OPERATION_FAIL);
                 return NULL;
             }
+
+            OPENSSL_cleanse(masked_key_buffer, masked_key_buffer_size);
+            OPENSSL_free(masked_key_buffer);
         }
         else if (retrieve_status != AZIHSM_STATUS_PROPERTY_NOT_PRESENT)
         {
+            /* Unexpected error - not BUFFER_TOO_SMALL and not PROPERTY_NOT_PRESENT */
             azihsm_key_delete(private);
             azihsm_key_delete(public);
-            OPENSSL_cleanse(masked_key_buffer, masked_key_buffer_size);
-            OPENSSL_free(masked_key_buffer);
             OPENSSL_free(rsa_key);
             ERR_raise(ERR_LIB_PROV, ERR_R_OPERATION_FAIL);
             return NULL;
         }
-        /* If PROPERTY_NOT_PRESENT, just continue without masked key */
-
-        OPENSSL_cleanse(masked_key_buffer, masked_key_buffer_size);
-        OPENSSL_free(masked_key_buffer);
+        /* If PROPERTY_NOT_PRESENT, continue without masked key */
     }
 
     return rsa_key;

--- a/plugins/ossl_prov/src/azihsm_ossl_signature_ec.c
+++ b/plugins/ossl_prov/src/azihsm_ossl_signature_ec.c
@@ -93,6 +93,13 @@ static int azihsm_ossl_ecdsa_sign_init(void *sctx, void *provkey, const OSSL_PAR
     /* Extract key from provider key object */
     ctx->key = (AZIHSM_EC_KEY *)provkey;
 
+    /* Verify the key has a private component for signing */
+    if (!ctx->key->has_private)
+    {
+        ERR_raise(ERR_LIB_PROV, PROV_R_NOT_A_PRIVATE_KEY);
+        return OSSL_FAILURE;
+    }
+
     ctx->operation = 1; /* Sign */
 
     /* Set default hash algorithm if not already set */
@@ -282,6 +289,13 @@ static int azihsm_ossl_ecdsa_digest_sign_init(
 
     /* Extract key from provider key object */
     ctx->key = (AZIHSM_EC_KEY *)provkey;
+
+    /* Verify the key has a private component for signing */
+    if (!ctx->key->has_private)
+    {
+        ERR_raise(ERR_LIB_PROV, PROV_R_NOT_A_PRIVATE_KEY);
+        return OSSL_FAILURE;
+    }
 
     ctx->operation = 1; /* Sign */
 

--- a/plugins/ossl_prov/src/azihsm_ossl_signature_rsa.c
+++ b/plugins/ossl_prov/src/azihsm_ossl_signature_rsa.c
@@ -112,6 +112,13 @@ static int azihsm_ossl_rsa_sign_init(void *sctx, void *provkey, const OSSL_PARAM
     /* Extract key from provider key object */
     ctx->key = (AZIHSM_RSA_KEY *)provkey;
 
+    /* Verify the key has a private component for signing */
+    if (!ctx->key->has_private)
+    {
+        ERR_raise(ERR_LIB_PROV, PROV_R_NOT_A_PRIVATE_KEY);
+        return OSSL_FAILURE;
+    }
+
     ctx->operation = 1; /* Sign */
 
     /* Set default hash algorithm if not already set */
@@ -394,6 +401,13 @@ static int azihsm_ossl_rsa_digest_sign_init(
 
     /* Extract key from provider key object */
     ctx->key = (AZIHSM_RSA_KEY *)provkey;
+
+    /* Verify the key has a private component for signing */
+    if (!ctx->key->has_private)
+    {
+        ERR_raise(ERR_LIB_PROV, PROV_R_NOT_A_PRIVATE_KEY);
+        return OSSL_FAILURE;
+    }
 
     ctx->operation = 1; /* Sign */
 

--- a/plugins/ossl_prov/src/azihsm_ossl_signature_rsa.c
+++ b/plugins/ossl_prov/src/azihsm_ossl_signature_rsa.c
@@ -1,16 +1,992 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+#include <limits.h>
 #include <openssl/core_dispatch.h>
+#include <openssl/core_names.h>
+#include <openssl/err.h>
+#include <openssl/evp.h>
+#include <openssl/params.h>
+#include <openssl/proverr.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
 
-/*
- * RSA Signature Operations for azihsm Provider
+#include "azihsm_ossl_helpers.h"
+#include "azihsm_ossl_signature_rsa.h"
+
+/**
+ * Get the RSA signature size based on key bit length.
+ * RSA signature size equals the key size in bytes.
  *
- * Placeholder implementation. Full RSA signature support coming soon.
- * For now, we provide stub dispatch table to allow provider to load.
+ * @param key_bits The RSA key size in bits
+ * @return Signature size in bytes
  */
+static size_t azihsm_ossl_rsa_signature_size(uint32_t key_bits)
+{
+    return key_bits / 8;
+}
 
-/* Stub dispatch table - RSA signatures not yet implemented */
+/* ═══════════════════════════════════════════════════════════════════════════
+   RSA SIGNATURE CONTEXT LIFECYCLE
+   ═══════════════════════════════════════════════════════════════════════════ */
+
+static void *azihsm_ossl_rsa_newctx(void *provctx, ossl_unused const char *propq)
+{
+    azihsm_rsa_sig_ctx *ctx;
+    AZIHSM_OSSL_PROV_CTX *prov = (AZIHSM_OSSL_PROV_CTX *)provctx;
+
+    if (prov == NULL)
+    {
+        ERR_raise(ERR_LIB_PROV, ERR_R_PASSED_NULL_PARAMETER);
+        return NULL;
+    }
+
+    ctx = OPENSSL_zalloc(sizeof(*ctx));
+    if (ctx == NULL)
+    {
+        ERR_raise(ERR_LIB_PROV, ERR_R_MALLOC_FAILURE);
+        return NULL;
+    }
+
+    ctx->provctx = prov;
+    ctx->sign_ctx = 0; /* No streaming context yet */
+
+    /* Default to PKCS#1 v1.5 padding */
+    ctx->pad_mode = AZIHSM_RSA_PAD_MODE_PKCSV15;
+    ctx->mgf1_md = NULL;                           /* Will default to same as md */
+    ctx->salt_len = AZIHSM_RSA_PSS_SALTLEN_DIGEST; /* Default: salt = hash length */
+
+    return ctx;
+}
+
+static void azihsm_ossl_rsa_freectx(void *sctx)
+{
+    azihsm_rsa_sig_ctx *ctx = (azihsm_rsa_sig_ctx *)sctx;
+
+    if (ctx == NULL)
+        return;
+
+    /* Note: Don't free key - caller owns it */
+    OPENSSL_free(ctx);
+}
+
+static void *azihsm_ossl_rsa_dupctx(void *sctx)
+{
+    azihsm_rsa_sig_ctx *src_ctx = (azihsm_rsa_sig_ctx *)sctx;
+    azihsm_rsa_sig_ctx *dst_ctx;
+
+    if (src_ctx == NULL)
+    {
+        ERR_raise(ERR_LIB_PROV, ERR_R_PASSED_NULL_PARAMETER);
+        return NULL;
+    }
+
+    dst_ctx = OPENSSL_zalloc(sizeof(*dst_ctx));
+    if (dst_ctx == NULL)
+    {
+        ERR_raise(ERR_LIB_PROV, ERR_R_MALLOC_FAILURE);
+        return NULL;
+    }
+
+    /* Copy all fields INCLUDING sign_ctx handle */
+    *dst_ctx = *src_ctx;
+
+    return dst_ctx;
+}
+
+/* ═══════════════════════════════════════════════════════════════════════════
+   RSA ONE-SHOT OPERATIONS
+   ═══════════════════════════════════════════════════════════════════════════ */
+
+static int azihsm_ossl_rsa_sign_init(void *sctx, void *provkey, const OSSL_PARAM params[])
+{
+    azihsm_rsa_sig_ctx *ctx = (azihsm_rsa_sig_ctx *)sctx;
+
+    if (ctx == NULL || provkey == NULL)
+    {
+        ERR_raise(ERR_LIB_PROV, ERR_R_PASSED_NULL_PARAMETER);
+        return OSSL_FAILURE;
+    }
+
+    /* Extract key from provider key object */
+    ctx->key = (AZIHSM_RSA_KEY *)provkey;
+
+    ctx->operation = 1; /* Sign */
+
+    /* Set default hash algorithm if not already set */
+    if (ctx->md == NULL)
+    {
+        ctx->md = EVP_sha256();
+    }
+
+    return OSSL_SUCCESS;
+}
+
+static int azihsm_ossl_rsa_sign(
+    void *sctx,
+    unsigned char *sig,
+    size_t *siglen,
+    size_t sigsize,
+    const unsigned char *tbs,
+    size_t tbslen
+)
+{
+    azihsm_rsa_sig_ctx *ctx = (azihsm_rsa_sig_ctx *)sctx;
+    struct azihsm_algo algo = { 0 };
+    struct azihsm_algo_rsa_pkcs_pss_params pss_params;
+    struct azihsm_buffer data_buf, sig_buf;
+    azihsm_status status;
+    int use_pss;
+
+    if (ctx == NULL || ctx->key == NULL)
+    {
+        ERR_raise(ERR_LIB_PROV, ERR_R_PASSED_NULL_PARAMETER);
+        return OSSL_FAILURE;
+    }
+
+    /* Bounds check to prevent truncation when casting to uint32_t */
+    if (tbslen > UINT32_MAX)
+    {
+        ERR_raise(ERR_LIB_PROV, PROV_R_BAD_LENGTH);
+        return OSSL_FAILURE;
+    }
+
+    /* Determine if PSS mode: either key type is RSA-PSS or pad_mode is PSS */
+    use_pss = (ctx->key->genctx.key_type == AIHSM_KEY_TYPE_RSA_PSS) ||
+              (ctx->pad_mode == AZIHSM_RSA_PAD_MODE_PSS);
+
+    if (use_pss)
+    {
+        /* Build PSS parameters - input is raw hash, not DigestInfo */
+        const EVP_MD *mgf1_md = (ctx->mgf1_md != NULL) ? ctx->mgf1_md : ctx->md;
+
+        pss_params.hash_algo_id = azihsm_ossl_evp_md_to_algo_id(ctx->md);
+        pss_params.mgf_id = azihsm_ossl_evp_md_to_mgf1_id(mgf1_md);
+
+        /* Resolve salt length */
+        if (ctx->salt_len == AZIHSM_RSA_PSS_SALTLEN_DIGEST)
+        {
+            pss_params.salt_len = (uint32_t)EVP_MD_size(ctx->md);
+        }
+        else if (ctx->salt_len == AZIHSM_RSA_PSS_SALTLEN_MAX)
+        {
+            uint32_t key_bytes = ctx->key->genctx.pubkey_bits / 8;
+            uint32_t hash_size = (uint32_t)EVP_MD_size(ctx->md);
+            pss_params.salt_len = key_bytes - hash_size - 2;
+        }
+        else if (ctx->salt_len >= 0)
+        {
+            pss_params.salt_len = (uint32_t)ctx->salt_len;
+        }
+        else
+        {
+            pss_params.salt_len = (uint32_t)EVP_MD_size(ctx->md);
+        }
+
+        algo.id = AZIHSM_ALGO_ID_RSA_PKCS_PSS;
+        algo.params = &pss_params;
+        algo.len = sizeof(pss_params);
+    }
+    else
+    {
+        /*
+         * One-shot signing with PKCS#1 v1.5 padding is not supported by the HSM.
+         * The HSM API only supports pre-hashed input for RSA-PSS (AZIHSM_ALGO_ID_RSA_PKCS_PSS).
+         * For PKCS#1 v1.5, use streaming sign (dgst -sign) which passes raw message data
+         * to hash-specific algorithms like AZIHSM_ALGO_ID_RSA_PKCS_SHA256.
+         */
+        ERR_raise_data(
+            ERR_LIB_PROV,
+            PROV_R_OPERATION_NOT_SUPPORTED_FOR_THIS_KEYTYPE,
+            "one-shot PKCS#1 v1.5 signing not supported; use dgst -sign or RSA-PSS key"
+        );
+        return OSSL_FAILURE;
+    }
+
+    /* Set up data buffer */
+    data_buf.ptr = (uint8_t *)tbs;
+    data_buf.len = (uint32_t)tbslen;
+
+    /* Size query: ask the HSM for the required signature buffer size */
+    if (sig == NULL)
+    {
+        sig_buf.ptr = NULL;
+        sig_buf.len = 0;
+        status = azihsm_crypt_sign(&algo, ctx->key->key.priv, &data_buf, &sig_buf);
+        if (status != AZIHSM_STATUS_BUFFER_TOO_SMALL || sig_buf.len == 0)
+        {
+            ERR_raise(ERR_LIB_PROV, ERR_R_INTERNAL_ERROR);
+            return OSSL_FAILURE;
+        }
+        *siglen = sig_buf.len;
+        return OSSL_SUCCESS;
+    }
+
+    /* Bounds check for signature buffer size */
+    if (sigsize > UINT32_MAX)
+    {
+        ERR_raise(ERR_LIB_PROV, PROV_R_BAD_LENGTH);
+        return OSSL_FAILURE;
+    }
+
+    /* Set up signature buffer and sign */
+    sig_buf.ptr = sig;
+    sig_buf.len = (uint32_t)sigsize;
+
+    status = azihsm_crypt_sign(&algo, ctx->key->key.priv, &data_buf, &sig_buf);
+
+    if (status != AZIHSM_STATUS_SUCCESS)
+    {
+        ERR_raise(ERR_LIB_PROV, ERR_R_OPERATION_FAIL);
+        return OSSL_FAILURE;
+    }
+
+    *siglen = sig_buf.len;
+    return OSSL_SUCCESS;
+}
+
+static int azihsm_ossl_rsa_verify_init(void *sctx, void *provkey, const OSSL_PARAM params[])
+{
+    azihsm_rsa_sig_ctx *ctx = (azihsm_rsa_sig_ctx *)sctx;
+
+    if (ctx == NULL || provkey == NULL)
+    {
+        ERR_raise(ERR_LIB_PROV, ERR_R_PASSED_NULL_PARAMETER);
+        return OSSL_FAILURE;
+    }
+
+    /* Extract key from provider key object */
+    ctx->key = (AZIHSM_RSA_KEY *)provkey;
+    ctx->operation = 0; /* Verify */
+
+    /* Set default hash algorithm if not already set */
+    if (ctx->md == NULL)
+    {
+        ctx->md = EVP_sha256();
+    }
+
+    return OSSL_SUCCESS;
+}
+
+static int azihsm_ossl_rsa_verify(
+    void *sctx,
+    const unsigned char *sig,
+    size_t siglen,
+    const unsigned char *tbs,
+    size_t tbslen
+)
+{
+    azihsm_rsa_sig_ctx *ctx = (azihsm_rsa_sig_ctx *)sctx;
+    struct azihsm_algo algo = { 0 };
+    struct azihsm_algo_rsa_pkcs_pss_params pss_params;
+    struct azihsm_buffer data_buf, sig_buf;
+    azihsm_status status;
+    int use_pss;
+
+    if (ctx == NULL || ctx->key == NULL)
+    {
+        ERR_raise(ERR_LIB_PROV, ERR_R_PASSED_NULL_PARAMETER);
+        return OSSL_FAILURE;
+    }
+
+    /* Bounds check to prevent truncation when casting to uint32_t */
+    if (tbslen > UINT32_MAX || siglen > UINT32_MAX)
+    {
+        ERR_raise(ERR_LIB_PROV, PROV_R_BAD_LENGTH);
+        return OSSL_FAILURE;
+    }
+
+    /* Determine if PSS mode: either key type is RSA-PSS or pad_mode is PSS */
+    use_pss = (ctx->key->genctx.key_type == AIHSM_KEY_TYPE_RSA_PSS) ||
+              (ctx->pad_mode == AZIHSM_RSA_PAD_MODE_PSS);
+
+    if (use_pss)
+    {
+        /* Build PSS parameters */
+        const EVP_MD *mgf1_md = (ctx->mgf1_md != NULL) ? ctx->mgf1_md : ctx->md;
+
+        pss_params.hash_algo_id = azihsm_ossl_evp_md_to_algo_id(ctx->md);
+        pss_params.mgf_id = azihsm_ossl_evp_md_to_mgf1_id(mgf1_md);
+
+        /* Resolve salt length for verify */
+        if (ctx->salt_len == AZIHSM_RSA_PSS_SALTLEN_DIGEST ||
+            ctx->salt_len == AZIHSM_RSA_PSS_SALTLEN_AUTO)
+        {
+            pss_params.salt_len = (uint32_t)EVP_MD_size(ctx->md);
+        }
+        else if (ctx->salt_len == AZIHSM_RSA_PSS_SALTLEN_MAX)
+        {
+            uint32_t key_bytes = ctx->key->genctx.pubkey_bits / 8;
+            uint32_t hash_size = (uint32_t)EVP_MD_size(ctx->md);
+            pss_params.salt_len = key_bytes - hash_size - 2;
+        }
+        else if (ctx->salt_len >= 0)
+        {
+            pss_params.salt_len = (uint32_t)ctx->salt_len;
+        }
+        else
+        {
+            pss_params.salt_len = (uint32_t)EVP_MD_size(ctx->md);
+        }
+
+        algo.id = AZIHSM_ALGO_ID_RSA_PKCS_PSS;
+        algo.params = &pss_params;
+        algo.len = sizeof(pss_params);
+    }
+    else
+    {
+        /* Use raw RSA PKCS#1 */
+        algo.id = AZIHSM_ALGO_ID_RSA_PKCS;
+        algo.params = NULL;
+        algo.len = 0;
+    }
+
+    /* Set up buffers */
+    data_buf.ptr = (uint8_t *)tbs;
+    data_buf.len = (uint32_t)tbslen;
+    sig_buf.ptr = (uint8_t *)sig;
+    sig_buf.len = (uint32_t)siglen;
+
+    status = azihsm_crypt_verify(&algo, ctx->key->key.pub, &data_buf, &sig_buf);
+
+    if (status == AZIHSM_STATUS_SUCCESS)
+    {
+        return OSSL_SUCCESS;
+    }
+    else if (status == AZIHSM_STATUS_INVALID_SIGNATURE)
+    {
+        return OSSL_FAILURE;
+    }
+
+    ERR_raise(ERR_LIB_PROV, ERR_R_OPERATION_FAIL);
+    return OSSL_FAILURE;
+}
+
+/* ═══════════════════════════════════════════════════════════════════════════
+   RSA STREAMING OPERATIONS
+   ═══════════════════════════════════════════════════════════════════════════ */
+
+static int azihsm_ossl_rsa_digest_sign_init(
+    void *sctx,
+    const char *mdname,
+    void *provkey,
+    const OSSL_PARAM params[]
+)
+{
+    azihsm_rsa_sig_ctx *ctx = (azihsm_rsa_sig_ctx *)sctx;
+    struct azihsm_algo algo = { 0 };
+    struct azihsm_algo_rsa_pkcs_pss_params pss_params;
+    azihsm_status status;
+    int use_pss;
+
+    if (provkey == NULL)
+    {
+        /* Silently succeed - this is a cleanup/reset operation */
+        return OSSL_SUCCESS;
+    }
+
+    if (ctx == NULL)
+    {
+        ERR_raise(ERR_LIB_PROV, ERR_R_PASSED_NULL_PARAMETER);
+        return OSSL_FAILURE;
+    }
+
+    /* Extract key from provider key object */
+    ctx->key = (AZIHSM_RSA_KEY *)provkey;
+
+    ctx->operation = 1; /* Sign */
+
+    /* Get hash algorithm by name */
+    ctx->md = EVP_get_digestbyname(mdname);
+    if (ctx->md == NULL)
+    {
+        ERR_raise(ERR_LIB_PROV, ERR_R_OPERATION_FAIL);
+        return OSSL_FAILURE;
+    }
+
+    /* Determine if PSS mode: either key type is RSA-PSS or pad_mode is PSS */
+    use_pss = (ctx->key->genctx.key_type == AIHSM_KEY_TYPE_RSA_PSS) ||
+              (ctx->pad_mode == AZIHSM_RSA_PAD_MODE_PSS);
+
+    if (use_pss)
+    {
+        /* Build PSS parameters */
+        const EVP_MD *mgf1_md = (ctx->mgf1_md != NULL) ? ctx->mgf1_md : ctx->md;
+
+        pss_params.hash_algo_id = azihsm_ossl_evp_md_to_algo_id(ctx->md);
+        pss_params.mgf_id = azihsm_ossl_evp_md_to_mgf1_id(mgf1_md);
+
+        /* Resolve salt length */
+        if (ctx->salt_len == AZIHSM_RSA_PSS_SALTLEN_DIGEST)
+        {
+            pss_params.salt_len = (uint32_t)EVP_MD_size(ctx->md);
+        }
+        else if (ctx->salt_len == AZIHSM_RSA_PSS_SALTLEN_MAX)
+        {
+            /* Max salt = key_size - hash_size - 2 */
+            uint32_t key_bytes = ctx->key->genctx.pubkey_bits / 8;
+            uint32_t hash_size = (uint32_t)EVP_MD_size(ctx->md);
+            pss_params.salt_len = key_bytes - hash_size - 2;
+        }
+        else if (ctx->salt_len >= 0)
+        {
+            pss_params.salt_len = (uint32_t)ctx->salt_len;
+        }
+        else
+        {
+            /* Default to hash size for other special values */
+            pss_params.salt_len = (uint32_t)EVP_MD_size(ctx->md);
+        }
+
+        algo.id = azihsm_ossl_evp_md_to_rsa_pss_algo_id(ctx->md);
+        algo.params = &pss_params;
+        algo.len = sizeof(pss_params);
+    }
+    else
+    {
+        /* PKCS#1 v1.5 mode */
+        algo.id = azihsm_ossl_evp_md_to_rsa_pkcs_algo_id(ctx->md);
+        algo.params = NULL;
+        algo.len = 0;
+    }
+
+    if (algo.id == 0)
+    {
+        ERR_raise(ERR_LIB_PROV, ERR_R_OPERATION_FAIL);
+        return OSSL_FAILURE;
+    }
+
+    status = azihsm_crypt_sign_init(&algo, ctx->key->key.priv, &ctx->sign_ctx);
+
+    if (status != AZIHSM_STATUS_SUCCESS)
+    {
+        ERR_raise(ERR_LIB_PROV, ERR_R_OPERATION_FAIL);
+        return OSSL_FAILURE;
+    }
+
+    return OSSL_SUCCESS;
+}
+
+static int azihsm_ossl_rsa_digest_sign_update(void *sctx, const unsigned char *data, size_t datalen)
+{
+    azihsm_rsa_sig_ctx *ctx = (azihsm_rsa_sig_ctx *)sctx;
+    struct azihsm_buffer data_buf;
+    azihsm_status status;
+
+    if (ctx == NULL || ctx->sign_ctx == 0)
+    {
+        ERR_raise(ERR_LIB_PROV, ERR_R_PASSED_NULL_PARAMETER);
+        return OSSL_FAILURE;
+    }
+
+    /* Bounds check to prevent truncation when casting to uint32_t */
+    if (datalen > UINT32_MAX)
+    {
+        ERR_raise(ERR_LIB_PROV, PROV_R_BAD_LENGTH);
+        return OSSL_FAILURE;
+    }
+
+    /* Set up buffer */
+    data_buf.ptr = (uint8_t *)data;
+    data_buf.len = (uint32_t)datalen;
+
+    /* Update streaming sign with raw data */
+    status = azihsm_crypt_sign_update(ctx->sign_ctx, &data_buf);
+
+    if (status != AZIHSM_STATUS_SUCCESS)
+    {
+        ERR_raise(ERR_LIB_PROV, ERR_R_OPERATION_FAIL);
+        return OSSL_FAILURE;
+    }
+
+    return OSSL_SUCCESS;
+}
+
+static int azihsm_ossl_rsa_digest_sign_final(
+    void *sctx,
+    unsigned char *sig,
+    size_t *siglen,
+    size_t sigsize
+)
+{
+    azihsm_rsa_sig_ctx *ctx = (azihsm_rsa_sig_ctx *)sctx;
+    struct azihsm_buffer sig_buf;
+    azihsm_status status;
+
+    if (ctx == NULL || ctx->sign_ctx == 0)
+    {
+        ERR_raise(ERR_LIB_PROV, ERR_R_PASSED_NULL_PARAMETER);
+        return OSSL_FAILURE;
+    }
+
+    /* If sig is NULL, caller is querying for signature size */
+    if (sig == NULL)
+    {
+        /* Return exact size for this key if known, otherwise max size */
+        if (ctx->key == NULL)
+        {
+            *siglen = 512; /* Max size for RSA-4096 */
+        }
+        else
+        {
+            *siglen = azihsm_ossl_rsa_signature_size(ctx->key->genctx.pubkey_bits);
+        }
+        return OSSL_SUCCESS;
+    }
+
+    /* Query the HSM for the exact signature size */
+    sig_buf.ptr = NULL;
+    sig_buf.len = 0;
+    status = azihsm_crypt_sign_finish(ctx->sign_ctx, &sig_buf);
+    if (status != AZIHSM_STATUS_BUFFER_TOO_SMALL || sig_buf.len == 0)
+    {
+        ERR_raise(ERR_LIB_PROV, ERR_R_INTERNAL_ERROR);
+        ctx->sign_ctx = 0;
+        return OSSL_FAILURE;
+    }
+
+    /* Verify OpenSSL provided enough space */
+    if (sigsize < sig_buf.len)
+    {
+        ERR_raise(ERR_LIB_PROV, ERR_R_PASSED_INVALID_ARGUMENT);
+        ctx->sign_ctx = 0;
+        return OSSL_FAILURE;
+    }
+
+    /* Finish streaming sign with exact size required by HSM */
+    sig_buf.ptr = sig;
+    status = azihsm_crypt_sign_finish(ctx->sign_ctx, &sig_buf);
+
+    if (status != AZIHSM_STATUS_SUCCESS)
+    {
+        ERR_raise(ERR_LIB_PROV, ERR_R_OPERATION_FAIL);
+        ctx->sign_ctx = 0;
+        return OSSL_FAILURE;
+    }
+
+    *siglen = sig_buf.len;
+    ctx->sign_ctx = 0; /* Context consumed */
+    return OSSL_SUCCESS;
+}
+
+static int azihsm_ossl_rsa_digest_verify_init(
+    void *sctx,
+    const char *mdname,
+    void *provkey,
+    const OSSL_PARAM params[]
+)
+{
+    azihsm_rsa_sig_ctx *ctx = (azihsm_rsa_sig_ctx *)sctx;
+    struct azihsm_algo algo = { 0 };
+    struct azihsm_algo_rsa_pkcs_pss_params pss_params;
+    azihsm_status status;
+    int use_pss;
+
+    if (provkey == NULL)
+    {
+        /* Silently succeed - this is a cleanup/reset operation */
+        return OSSL_SUCCESS;
+    }
+
+    if (ctx == NULL)
+    {
+        ERR_raise(ERR_LIB_PROV, ERR_R_PASSED_NULL_PARAMETER);
+        return OSSL_FAILURE;
+    }
+
+    /* Extract key from provider key object */
+    ctx->key = (AZIHSM_RSA_KEY *)provkey;
+    ctx->operation = 0; /* Verify */
+
+    /* Get hash algorithm by name */
+    ctx->md = EVP_get_digestbyname(mdname);
+    if (ctx->md == NULL)
+    {
+        ERR_raise(ERR_LIB_PROV, ERR_R_OPERATION_FAIL);
+        return OSSL_FAILURE;
+    }
+
+    /* Determine if PSS mode: either key type is RSA-PSS or pad_mode is PSS */
+    use_pss = (ctx->key->genctx.key_type == AIHSM_KEY_TYPE_RSA_PSS) ||
+              (ctx->pad_mode == AZIHSM_RSA_PAD_MODE_PSS);
+
+    if (use_pss)
+    {
+        /* Build PSS parameters */
+        const EVP_MD *mgf1_md = (ctx->mgf1_md != NULL) ? ctx->mgf1_md : ctx->md;
+
+        pss_params.hash_algo_id = azihsm_ossl_evp_md_to_algo_id(ctx->md);
+        pss_params.mgf_id = azihsm_ossl_evp_md_to_mgf1_id(mgf1_md);
+
+        /* Resolve salt length for verify (auto-detect if SALTLEN_AUTO) */
+        if (ctx->salt_len == AZIHSM_RSA_PSS_SALTLEN_DIGEST ||
+            ctx->salt_len == AZIHSM_RSA_PSS_SALTLEN_AUTO)
+        {
+            pss_params.salt_len = (uint32_t)EVP_MD_size(ctx->md);
+        }
+        else if (ctx->salt_len == AZIHSM_RSA_PSS_SALTLEN_MAX)
+        {
+            uint32_t key_bytes = ctx->key->genctx.pubkey_bits / 8;
+            uint32_t hash_size = (uint32_t)EVP_MD_size(ctx->md);
+            pss_params.salt_len = key_bytes - hash_size - 2;
+        }
+        else if (ctx->salt_len >= 0)
+        {
+            pss_params.salt_len = (uint32_t)ctx->salt_len;
+        }
+        else
+        {
+            pss_params.salt_len = (uint32_t)EVP_MD_size(ctx->md);
+        }
+
+        algo.id = azihsm_ossl_evp_md_to_rsa_pss_algo_id(ctx->md);
+        algo.params = &pss_params;
+        algo.len = sizeof(pss_params);
+    }
+    else
+    {
+        /* PKCS#1 v1.5 mode */
+        algo.id = azihsm_ossl_evp_md_to_rsa_pkcs_algo_id(ctx->md);
+        algo.params = NULL;
+        algo.len = 0;
+    }
+
+    if (algo.id == 0)
+    {
+        ERR_raise(ERR_LIB_PROV, ERR_R_OPERATION_FAIL);
+        return OSSL_FAILURE;
+    }
+
+    /* Initialize streaming verify context */
+    status = azihsm_crypt_verify_init(&algo, ctx->key->key.pub, &ctx->sign_ctx);
+
+    if (status != AZIHSM_STATUS_SUCCESS)
+    {
+        ERR_raise(ERR_LIB_PROV, ERR_R_OPERATION_FAIL);
+        return OSSL_FAILURE;
+    }
+
+    return OSSL_SUCCESS;
+}
+
+static int azihsm_ossl_rsa_digest_verify_update(
+    void *sctx,
+    const unsigned char *data,
+    size_t datalen
+)
+{
+    azihsm_rsa_sig_ctx *ctx = (azihsm_rsa_sig_ctx *)sctx;
+    struct azihsm_buffer data_buf;
+    azihsm_status status;
+
+    if (ctx == NULL || ctx->sign_ctx == 0)
+    {
+        ERR_raise(ERR_LIB_PROV, ERR_R_PASSED_NULL_PARAMETER);
+        return OSSL_FAILURE;
+    }
+
+    /* Bounds check to prevent truncation when casting to uint32_t */
+    if (datalen > UINT32_MAX)
+    {
+        ERR_raise(ERR_LIB_PROV, PROV_R_BAD_LENGTH);
+        return OSSL_FAILURE;
+    }
+
+    /* Set up buffer */
+    data_buf.ptr = (uint8_t *)data;
+    data_buf.len = (uint32_t)datalen;
+
+    /* Update streaming verify with raw data */
+    status = azihsm_crypt_verify_update(ctx->sign_ctx, &data_buf);
+
+    if (status != AZIHSM_STATUS_SUCCESS)
+    {
+        ERR_raise(ERR_LIB_PROV, ERR_R_OPERATION_FAIL);
+        return OSSL_FAILURE;
+    }
+
+    return OSSL_SUCCESS;
+}
+
+static int azihsm_ossl_rsa_digest_verify_final(void *sctx, const unsigned char *sig, size_t siglen)
+{
+    azihsm_rsa_sig_ctx *ctx = (azihsm_rsa_sig_ctx *)sctx;
+    struct azihsm_buffer sig_buf;
+    azihsm_status status;
+
+    if (ctx == NULL || ctx->sign_ctx == 0)
+    {
+        ERR_raise(ERR_LIB_PROV, ERR_R_PASSED_NULL_PARAMETER);
+        return OSSL_FAILURE;
+    }
+
+    /* Bounds check to prevent truncation when casting to uint32_t */
+    if (siglen > UINT32_MAX)
+    {
+        ERR_raise(ERR_LIB_PROV, PROV_R_BAD_LENGTH);
+        return OSSL_FAILURE;
+    }
+
+    /* Set up buffer */
+    sig_buf.ptr = (uint8_t *)sig;
+    sig_buf.len = (uint32_t)siglen;
+
+    /* Finish streaming verify */
+    status = azihsm_crypt_verify_finish(ctx->sign_ctx, &sig_buf);
+    ctx->sign_ctx = 0;
+
+    if (status == AZIHSM_STATUS_SUCCESS)
+    {
+        return OSSL_SUCCESS;
+    }
+    else if (status == AZIHSM_STATUS_INVALID_SIGNATURE)
+    {
+        return OSSL_FAILURE;
+    }
+    else
+    {
+        ERR_raise(ERR_LIB_PROV, ERR_R_OPERATION_FAIL);
+        return OSSL_FAILURE;
+    }
+}
+
+/* ═══════════════════════════════════════════════════════════════════════════
+   RSA PARAMETER HANDLING
+   ═══════════════════════════════════════════════════════════════════════════ */
+
+static int azihsm_ossl_rsa_set_ctx_params(void *sctx, const OSSL_PARAM params[])
+{
+    azihsm_rsa_sig_ctx *ctx = (azihsm_rsa_sig_ctx *)sctx;
+    const OSSL_PARAM *p;
+
+    if (ctx == NULL || params == NULL)
+        return OSSL_SUCCESS;
+
+    /* Parse digest algorithm */
+    p = OSSL_PARAM_locate_const(params, OSSL_SIGNATURE_PARAM_DIGEST);
+    if (p != NULL)
+    {
+        const char *mdname = NULL;
+        if (!OSSL_PARAM_get_utf8_string_ptr(p, &mdname) || mdname == NULL)
+        {
+            ERR_raise(ERR_LIB_PROV, ERR_R_OPERATION_FAIL);
+            return OSSL_FAILURE;
+        }
+
+        ctx->md = EVP_get_digestbyname(mdname);
+        if (ctx->md == NULL)
+        {
+            ERR_raise(ERR_LIB_PROV, ERR_R_OPERATION_FAIL);
+            return OSSL_FAILURE;
+        }
+    }
+
+    /* Parse padding mode */
+    p = OSSL_PARAM_locate_const(params, OSSL_SIGNATURE_PARAM_PAD_MODE);
+    if (p != NULL)
+    {
+        const char *pad_mode_str = NULL;
+        if (!OSSL_PARAM_get_utf8_string_ptr(p, &pad_mode_str) || pad_mode_str == NULL)
+        {
+            ERR_raise(ERR_LIB_PROV, ERR_R_OPERATION_FAIL);
+            return OSSL_FAILURE;
+        }
+
+        if (strcmp(pad_mode_str, OSSL_PKEY_RSA_PAD_MODE_PKCSV15) == 0)
+        {
+            ctx->pad_mode = AZIHSM_RSA_PAD_MODE_PKCSV15;
+        }
+        else if (strcmp(pad_mode_str, OSSL_PKEY_RSA_PAD_MODE_PSS) == 0)
+        {
+            ctx->pad_mode = AZIHSM_RSA_PAD_MODE_PSS;
+        }
+        else
+        {
+            ERR_raise(ERR_LIB_PROV, ERR_R_OPERATION_FAIL);
+            return OSSL_FAILURE;
+        }
+    }
+
+    /* Parse PSS salt length */
+    p = OSSL_PARAM_locate_const(params, OSSL_SIGNATURE_PARAM_PSS_SALTLEN);
+    if (p != NULL)
+    {
+        if (p->data_type == OSSL_PARAM_UTF8_STRING)
+        {
+            const char *saltlen_str = NULL;
+            if (!OSSL_PARAM_get_utf8_string_ptr(p, &saltlen_str) || saltlen_str == NULL)
+            {
+                ERR_raise(ERR_LIB_PROV, ERR_R_OPERATION_FAIL);
+                return OSSL_FAILURE;
+            }
+
+            if (strcmp(saltlen_str, OSSL_PKEY_RSA_PSS_SALT_LEN_DIGEST) == 0)
+            {
+                ctx->salt_len = AZIHSM_RSA_PSS_SALTLEN_DIGEST;
+            }
+            else if (strcmp(saltlen_str, OSSL_PKEY_RSA_PSS_SALT_LEN_AUTO) == 0)
+            {
+                ctx->salt_len = AZIHSM_RSA_PSS_SALTLEN_AUTO;
+            }
+            else if (strcmp(saltlen_str, OSSL_PKEY_RSA_PSS_SALT_LEN_MAX) == 0)
+            {
+                ctx->salt_len = AZIHSM_RSA_PSS_SALTLEN_MAX;
+            }
+            else
+            {
+                /* Parse as integer with validation */
+                char *endptr = NULL;
+                long val = strtol(saltlen_str, &endptr, 10);
+                if (endptr == saltlen_str || *endptr != '\0' || val < 0 || val > INT_MAX)
+                {
+                    ERR_raise_data(
+                        ERR_LIB_PROV,
+                        ERR_R_PASSED_INVALID_ARGUMENT,
+                        "invalid PSS salt length: %s",
+                        saltlen_str
+                    );
+                    return OSSL_FAILURE;
+                }
+                ctx->salt_len = (int)val;
+            }
+        }
+        else
+        {
+            int salt_len_int = 0;
+            if (!OSSL_PARAM_get_int(p, &salt_len_int))
+            {
+                ERR_raise(ERR_LIB_PROV, ERR_R_OPERATION_FAIL);
+                return OSSL_FAILURE;
+            }
+            ctx->salt_len = salt_len_int;
+        }
+    }
+
+    /* Parse MGF1 digest */
+    p = OSSL_PARAM_locate_const(params, OSSL_SIGNATURE_PARAM_MGF1_DIGEST);
+    if (p != NULL)
+    {
+        const char *mgf1_mdname = NULL;
+        if (!OSSL_PARAM_get_utf8_string_ptr(p, &mgf1_mdname) || mgf1_mdname == NULL)
+        {
+            ERR_raise(ERR_LIB_PROV, ERR_R_OPERATION_FAIL);
+            return OSSL_FAILURE;
+        }
+
+        ctx->mgf1_md = EVP_get_digestbyname(mgf1_mdname);
+        if (ctx->mgf1_md == NULL)
+        {
+            ERR_raise(ERR_LIB_PROV, ERR_R_OPERATION_FAIL);
+            return OSSL_FAILURE;
+        }
+    }
+
+    return OSSL_SUCCESS;
+}
+
+static int azihsm_ossl_rsa_get_ctx_params(void *sctx, OSSL_PARAM params[])
+{
+    azihsm_rsa_sig_ctx *ctx = (azihsm_rsa_sig_ctx *)sctx;
+    OSSL_PARAM *p;
+
+    if (ctx == NULL || params == NULL)
+        return OSSL_SUCCESS;
+
+    p = OSSL_PARAM_locate(params, OSSL_SIGNATURE_PARAM_DIGEST);
+    if (p != NULL)
+    {
+        const char *mdname = (ctx->md != NULL) ? EVP_MD_name(ctx->md) : NULL;
+        if (!OSSL_PARAM_set_utf8_string(p, mdname))
+        {
+            ERR_raise(ERR_LIB_PROV, ERR_R_OPERATION_FAIL);
+            return OSSL_FAILURE;
+        }
+    }
+
+    p = OSSL_PARAM_locate(params, OSSL_SIGNATURE_PARAM_PAD_MODE);
+    if (p != NULL)
+    {
+        const char *pad_mode_str = (ctx->pad_mode == AZIHSM_RSA_PAD_MODE_PSS)
+                                       ? OSSL_PKEY_RSA_PAD_MODE_PSS
+                                       : OSSL_PKEY_RSA_PAD_MODE_PKCSV15;
+        if (!OSSL_PARAM_set_utf8_string(p, pad_mode_str))
+        {
+            ERR_raise(ERR_LIB_PROV, ERR_R_OPERATION_FAIL);
+            return OSSL_FAILURE;
+        }
+    }
+
+    p = OSSL_PARAM_locate(params, OSSL_SIGNATURE_PARAM_PSS_SALTLEN);
+    if (p != NULL)
+    {
+        if (!OSSL_PARAM_set_int(p, ctx->salt_len))
+        {
+            ERR_raise(ERR_LIB_PROV, ERR_R_OPERATION_FAIL);
+            return OSSL_FAILURE;
+        }
+    }
+
+    p = OSSL_PARAM_locate(params, OSSL_SIGNATURE_PARAM_MGF1_DIGEST);
+    if (p != NULL)
+    {
+        const EVP_MD *mgf1_md = (ctx->mgf1_md != NULL) ? ctx->mgf1_md : ctx->md;
+        const char *mgf1_mdname = (mgf1_md != NULL) ? EVP_MD_name(mgf1_md) : NULL;
+        if (!OSSL_PARAM_set_utf8_string(p, mgf1_mdname))
+        {
+            ERR_raise(ERR_LIB_PROV, ERR_R_OPERATION_FAIL);
+            return OSSL_FAILURE;
+        }
+    }
+
+    return OSSL_SUCCESS;
+}
+
+static const OSSL_PARAM *azihsm_ossl_rsa_settable_ctx_params(void *sctx, void *provctx)
+{
+    static const OSSL_PARAM settable[] = {
+        OSSL_PARAM_utf8_string(OSSL_SIGNATURE_PARAM_DIGEST, NULL, 0),
+        OSSL_PARAM_utf8_string(OSSL_SIGNATURE_PARAM_PAD_MODE, NULL, 0),
+        OSSL_PARAM_utf8_string(OSSL_SIGNATURE_PARAM_PSS_SALTLEN, NULL, 0),
+        OSSL_PARAM_utf8_string(OSSL_SIGNATURE_PARAM_MGF1_DIGEST, NULL, 0),
+        OSSL_PARAM_END,
+    };
+    return settable;
+}
+
+static const OSSL_PARAM *azihsm_ossl_rsa_gettable_ctx_params(void *sctx, void *provctx)
+{
+    static const OSSL_PARAM gettable[] = {
+        OSSL_PARAM_utf8_string(OSSL_SIGNATURE_PARAM_DIGEST, NULL, 0),
+        OSSL_PARAM_utf8_string(OSSL_SIGNATURE_PARAM_PAD_MODE, NULL, 0),
+        OSSL_PARAM_int(OSSL_SIGNATURE_PARAM_PSS_SALTLEN, NULL),
+        OSSL_PARAM_utf8_string(OSSL_SIGNATURE_PARAM_MGF1_DIGEST, NULL, 0),
+        OSSL_PARAM_END,
+    };
+    return gettable;
+}
+
 const OSSL_DISPATCH azihsm_ossl_rsa_signature_functions[] = {
-    { 0, NULL }, /* Empty dispatch table - RSA signatures TODO */
+    { OSSL_FUNC_SIGNATURE_NEWCTX, (void (*)(void))azihsm_ossl_rsa_newctx },
+    { OSSL_FUNC_SIGNATURE_FREECTX, (void (*)(void))azihsm_ossl_rsa_freectx },
+    { OSSL_FUNC_SIGNATURE_DUPCTX, (void (*)(void))azihsm_ossl_rsa_dupctx },
+    { OSSL_FUNC_SIGNATURE_SIGN_INIT, (void (*)(void))azihsm_ossl_rsa_sign_init },
+    { OSSL_FUNC_SIGNATURE_SIGN, (void (*)(void))azihsm_ossl_rsa_sign },
+    { OSSL_FUNC_SIGNATURE_VERIFY_INIT, (void (*)(void))azihsm_ossl_rsa_verify_init },
+    { OSSL_FUNC_SIGNATURE_VERIFY, (void (*)(void))azihsm_ossl_rsa_verify },
+    { OSSL_FUNC_SIGNATURE_DIGEST_SIGN_INIT, (void (*)(void))azihsm_ossl_rsa_digest_sign_init },
+    { OSSL_FUNC_SIGNATURE_DIGEST_SIGN_UPDATE, (void (*)(void))azihsm_ossl_rsa_digest_sign_update },
+    { OSSL_FUNC_SIGNATURE_DIGEST_SIGN_FINAL, (void (*)(void))azihsm_ossl_rsa_digest_sign_final },
+    { OSSL_FUNC_SIGNATURE_DIGEST_VERIFY_INIT, (void (*)(void))azihsm_ossl_rsa_digest_verify_init },
+    { OSSL_FUNC_SIGNATURE_DIGEST_VERIFY_UPDATE,
+      (void (*)(void))azihsm_ossl_rsa_digest_verify_update },
+    { OSSL_FUNC_SIGNATURE_DIGEST_VERIFY_FINAL,
+      (void (*)(void))azihsm_ossl_rsa_digest_verify_final },
+    { OSSL_FUNC_SIGNATURE_SET_CTX_PARAMS, (void (*)(void))azihsm_ossl_rsa_set_ctx_params },
+    { OSSL_FUNC_SIGNATURE_GET_CTX_PARAMS, (void (*)(void))azihsm_ossl_rsa_get_ctx_params },
+    { OSSL_FUNC_SIGNATURE_SETTABLE_CTX_PARAMS,
+      (void (*)(void))azihsm_ossl_rsa_settable_ctx_params },
+    { OSSL_FUNC_SIGNATURE_GETTABLE_CTX_PARAMS,
+      (void (*)(void))azihsm_ossl_rsa_gettable_ctx_params },
+    { 0, NULL },
 };


### PR DESCRIPTION
> [!NOTE]  
> This builds on top of #118. I'll rebase once 118 is in. 

Can be tested as follows: 
Taken an OpenSSL codebase next to the HSM lib:
```
tree -L 1
.
├── azihsm-sdk
├── openssl
├── openssl-build
```
# Key generation
Generate usual RSA keys in PKCS#8 DER format first, as the HSM cannot do it.
```
LD_LIBRARY_PATH=$(pwd)/openssl-build/lib64 ./openssl-build/bin/openssl genpkey \
    -algorithm RSA \
    -pkeyopt rsa_keygen_bits:2048 \
    -outform DER \
    -out rsa_2048_key.der
    
LD_LIBRARY_PATH=$(pwd)/openssl-build/lib64 ./openssl-build/bin/openssl genpkey \
    -algorithm RSA \
    -pkeyopt rsa_keygen_bits:4096 \
    -outform DER \
    -out rsa_4096_key.der
```

    
## Import 2048-bit RSA key with explicit key usage 
(default values for session and usage) 
```   
LD_LIBRARY_PATH=$(pwd)/openssl-build/lib64 ./openssl-build/bin/openssl genpkey \
    -provider-path ./azihsm-sdk/target/debug/ \
    -provider default -provider azihsm_provider \
    -propquery "provider=azihsm" \
    -algorithm RSA \
    -pkeyopt rsa_keygen_bits:2048 \
    -pkeyopt azihsm.session:false \
    -pkeyopt azihsm.key_usage:digitalSignature \
    -pkeyopt azihsm.input_key:./rsa_2048_key.der \
    -pkeyopt azihsm.masked_key:./rsa_2048_masked.bin \
    -text
```
##Import 4096-bit RSA-PSS key (key does not differ, but metadata is set to use PSS padding when signing)
```
LD_LIBRARY_PATH=$(pwd)/openssl-build/lib64 ./openssl-build/bin/openssl genpkey \
    -provider-path ./azihsm-sdk/target/debug/ \
    -provider default -provider azihsm_provider \
    -propquery "provider=azihsm" \
    -algorithm RSA-PSS \
    -pkeyopt rsa_keygen_bits:4096 \
    -pkeyopt azihsm.input_key:./rsa_4096_key.der \
    -pkeyopt azihsm.masked_key:./rsa-pss_4096_masked.bin \
    -text
```
  
# Streaming RSA Sign Operations

Create test file
```
echo "Small test document" > small_doc.txt
```

## Sign file with PKCSv1.5 padding, SHA-256 hash
```
LD_LIBRARY_PATH=$(pwd)/openssl-build/lib64 ./openssl-build/bin/openssl dgst \
    -sha256 \
    -provider-path ./azihsm-sdk/target/debug/ \
    -provider default -provider azihsm_provider \
    -propquery "provider=azihsm" \
    -sign 'azihsm://./rsa_2048_masked.bin;type=rsa' \
    -out small_doc.rsa.sig \
    ./small_doc.txt

LD_LIBRARY_PATH=$(pwd)/openssl-build/lib64 ./openssl-build/bin/openssl dgst \
    -sha256 \
    -provider-path ./azihsm-sdk/target/debug/ \
    -provider default -provider azihsm_provider \
    -propquery "provider=azihsm" \
    -verify 'azihsm://./rsa_2048_masked.bin;type=rsa' \
    -signature small_doc.rsa.sig \
    ./small_doc.txt
```
    
## Sign file with PSS padding, SHA-512 hash
```
LD_LIBRARY_PATH=$(pwd)/openssl-build/lib64 ./openssl-build/bin/openssl dgst \
    -sha512 \
    -provider-path ./azihsm-sdk/target/debug/ \
    -provider default -provider azihsm_provider \
    -propquery "provider=azihsm" \
    -sign 'azihsm://./rsa-pss_4096_masked.bin;type=rsa-pss' \
    -out small_doc.rsa.sig \
    ./small_doc.txt

LD_LIBRARY_PATH=$(pwd)/openssl-build/lib64 ./openssl-build/bin/openssl dgst \
    -sha512 \
    -provider-path ./azihsm-sdk/target/debug/ \
    -provider default -provider azihsm_provider \
    -propquery "provider=azihsm" \
    -verify 'azihsm://./rsa-pss_4096_masked.bin;type=rsa-pss' \
    -signature small_doc.rsa.sig \
    ./small_doc.txt
```
 
# One-shot RSA Sign Operations 
First hash the document
```
LD_LIBRARY_PATH=$(pwd)/openssl-build/lib64 ./openssl-build/bin/openssl dgst \
    -sha256 -binary ./small_doc.txt > small_doc.sha256
```

## Sign pre-hashed data with PSS padding, SHA-256
```
LD_LIBRARY_PATH=$(pwd)/openssl-build/lib64 ./openssl-build/bin/openssl pkeyutl \
    -sign \
    -provider-path ./azihsm-sdk/target/debug/ \
    -provider default -provider azihsm_provider \
    -propquery "provider=azihsm" \
    -inkey 'azihsm://./rsa-pss_4096_masked.bin;type=rsa-pss' \
    -pkeyopt digest:sha256 \
    -in small_doc.sha256 \
    -out small_doc.pkeyutl.sig
    
LD_LIBRARY_PATH=$(pwd)/openssl-build/lib64 ./openssl-build/bin/openssl pkeyutl \
    -verify \
    -provider-path ./azihsm-sdk/target/debug/ \
    -provider default -provider azihsm_provider \
    -propquery "provider=azihsm" \
    -inkey 'azihsm://./rsa-pss_4096_masked.bin;type=rsa-pss' \
    -pkeyopt digest:sha256 \
    -pkeyopt rsa_padding_mode:pss \
    -pkeyopt rsa_pss_saltlen:32 \
    -in small_doc.sha256 \
    -sigfile small_doc.pkeyutl.sig
 ```
 
 ## Sign pre-hashed data with PKCS1 padding
Not supported by AZIHSM
