### PR TITLE
Dummy PEM encoder

### DIFF
--- a/plugins/ossl_prov/src/azihsm_ossl_base.c
+++ b/plugins/ossl_prov/src/azihsm_ossl_base.c
@@ -123,9 +123,11 @@ static const OSSL_ALGORITHM azihsm_ossl_asym_cipher[] = {
 extern const OSSL_DISPATCH azihsm_ossl_rsa_text_encoder_functions[];
 extern const OSSL_DISPATCH azihsm_ossl_rsa_der_spki_encoder_functions[];
 extern const OSSL_DISPATCH azihsm_ossl_rsa_der_pki_encoder_functions[];
+extern const OSSL_DISPATCH azihsm_ossl_rsa_pem_encoder_functions[];
 extern const OSSL_DISPATCH azihsm_ossl_ec_text_encoder_functions[];
 extern const OSSL_DISPATCH azihsm_ossl_ec_der_spki_encoder_functions[];
 extern const OSSL_DISPATCH azihsm_ossl_ec_der_pki_encoder_functions[];
+extern const OSSL_DISPATCH azihsm_ossl_ec_pem_encoder_functions[];
 
 // Store
 extern const OSSL_DISPATCH azihsm_ossl_store_functions[];
@@ -150,6 +152,12 @@ static const OSSL_ALGORITHM azihsm_ossl_encoders[] = {
         NULL,
     },
     {
+        "RSA",
+        "provider=azihsm,output=pem,structure=PrivateKeyInfo",
+        azihsm_ossl_rsa_pem_encoder_functions,
+        NULL,
+    },
+    {
         "RSA-PSS",
         "provider=azihsm,output=text",
         azihsm_ossl_rsa_text_encoder_functions,
@@ -168,6 +176,12 @@ static const OSSL_ALGORITHM azihsm_ossl_encoders[] = {
         NULL,
     },
     {
+        "RSA-PSS",
+        "provider=azihsm,output=pem,structure=PrivateKeyInfo",
+        azihsm_ossl_rsa_pem_encoder_functions,
+        NULL,
+    },
+    {
         "EC",
         "provider=azihsm,output=text",
         azihsm_ossl_ec_text_encoder_functions,
@@ -183,6 +197,12 @@ static const OSSL_ALGORITHM azihsm_ossl_encoders[] = {
         "EC",
         "provider=azihsm,output=der,structure=PrivateKeyInfo",
         azihsm_ossl_ec_der_pki_encoder_functions,
+        NULL,
+    },
+    {
+        "EC",
+        "provider=azihsm,output=pem,structure=PrivateKeyInfo",
+        azihsm_ossl_ec_pem_encoder_functions,
         NULL,
     },
     { NULL, NULL, NULL, NULL },


### PR DESCRIPTION
Implements a placeholder PEM encoder for all keys in. This encoder outputs informative metadata instead of actual key material, since HSM-backed private keys are by design non-exportable.

# Problem
OpenSSL uses PEM as the default output format for key operations. After every key generation, OpenSSL automatically invokes the configured encoder to serialize the key. Without a registered PEM encoder implementation, OpenSSL falls back to the default encoder, which:

Cannot handle our masked key blob format
Prints cryptic error messages to stderr
May cause applications to fail or behave unexpectedly

# Solution
Register a custom PEM encoder that:

Accepts the encode request (preventing fallback to the default encoder)
Returns success so OpenSSL considers the operation complete
Outputs informative text in a PEM-like block format containing:
Clear indication that the key is HSM-backed and not exportable
Key algorithm and bit length
Path to the saved masked key blob file
The store URI needed to reload the key (e.g., azihsm://path/to/key;type=rsa)

# Example Output
```
-----BEGIN AZIHSM PRIVATE KEY-----
HSM-backed private key - not exportable

algorithm            : RSA
public-key bit length: 2048

A masked key blob has been saved to:
  /path/to/masked_key.bin

Use the store URI to reload this key:
  azihsm:///path/to/masked_key.bin;type=rsa
-----END AZIHSM PRIVATE KEY-----
```

Open to other output ideas here.