### PR TITLE
fix: allow HKDF output_file to work with openssl kdf CLI

### DIFF
--- a/plugins/ossl_prov/src/azihsm_ossl_kdf.c
+++ b/plugins/ossl_prov/src/azihsm_ossl_kdf.c
@@ -824,15 +824,10 @@ static int azihsm_ossl_hkdf_derive(
     }
 
     /*
-     * Output destination: output_file or key buffer, mutually exclusive.
-     * If output_file is set, write masked key blob to file.
+     * Output destination: output_file takes priority over the key buffer.
+     * If output_file is set, write masked key blob to file (key buffer is ignored).
      * If output_file is not set, write masked key blob into key buffer.
      */
-    if (ctx->output_file[0] != '\0' && keylen > 0)
-    {
-        ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_GET_PARAMETER);
-        return OSSL_FAILURE;
-    }
 
     /* Step 1: Load and unmask IKM */
     if (!load_and_unmask_ikm(ctx))


### PR DESCRIPTION
The openssl kdf command always passes keylen > 0, which caused the HKDF derive to reject output_file mode. Let output_file take priority over the key buffer instead of treating them as mutually exclusive.