### PR TITLE
fix(ossl_prov): make ECDH derive API-compliant with dual output mode

### DIFF
--- a/plugins/ossl_prov/CMakeLists.txt
+++ b/plugins/ossl_prov/CMakeLists.txt
@@ -115,6 +115,7 @@ set(AZIHSM_OSSL_SOURCES
     ./src/azihsm_ossl_signature_rsa.c
     ./src/azihsm_ossl_asym_cipher.c
     ./src/azihsm_ossl_pkey_param.c
+    ./src/azihsm_ossl_masked_key.c
     ./src/azihsm_ossl_encoder_rsa.c
     ./src/azihsm_ossl_encoder_ec.c
 )

--- a/plugins/ossl_prov/inc/azihsm_ossl_masked_key.h
+++ b/plugins/ossl_prov/inc/azihsm_ossl_masked_key.h
@@ -1,0 +1,54 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include <azihsm.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+/*
+ * Two-call pattern for masked key extraction.
+ *
+ * First call with NULL buffer to query the required size, then allocate
+ * and retrieve the masked key data. On success, *out_buf and *out_len
+ * are set and the caller must OPENSSL_cleanse + OPENSSL_free the buffer.
+ *
+ * @derived_handle  HSM handle for the derived key
+ * @out_buf         On success, set to a newly allocated buffer (OPENSSL_malloc)
+ * @out_len         On success, set to the length of the buffer in bytes
+ *
+ * @returns OSSL_SUCCESS (1) on success, OSSL_FAILURE (0) on failure
+ */
+int azihsm_ossl_extract_masked_key(
+    azihsm_handle derived_handle,
+    uint8_t **out_buf,
+    uint32_t *out_len
+);
+
+/*
+ * Write a buffer to a file with proper error handling.
+ *
+ * Opens the file with O_NOFOLLOW and 0600 permissions. Loops write() to
+ * handle short writes and EINTR. On failure, removes the partially written
+ * file.
+ *
+ * @buffer       Data to write
+ * @len          Number of bytes to write
+ * @output_file  Destination file path
+ *
+ * @returns OSSL_SUCCESS (1) on success, OSSL_FAILURE (0) on failure
+ */
+int azihsm_ossl_write_masked_key_to_file(
+    const uint8_t *buffer,
+    uint32_t len,
+    const char *output_file
+);
+
+#ifdef __cplusplus
+}
+#endif

--- a/plugins/ossl_prov/src/azihsm_ossl_masked_key.c
+++ b/plugins/ossl_prov/src/azihsm_ossl_masked_key.c
@@ -1,0 +1,105 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#include <errno.h>
+#include <fcntl.h>
+#include <openssl/crypto.h>
+#include <openssl/err.h>
+#include <openssl/proverr.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include "azihsm_ossl_helpers.h"
+#include "azihsm_ossl_masked_key.h"
+
+int azihsm_ossl_extract_masked_key(
+    azihsm_handle derived_handle,
+    uint8_t **out_buf,
+    uint32_t *out_len
+)
+{
+    uint8_t *buffer = NULL;
+    uint32_t alloc_len = 0;
+    azihsm_status status;
+
+    struct azihsm_key_prop masked_prop = {
+        .id = AZIHSM_KEY_PROP_ID_MASKED_KEY,
+        .val = NULL,
+        .len = 0,
+    };
+
+    /* First call to get required size (expect BUFFER_TOO_SMALL, which sets len) */
+    status = azihsm_key_get_prop(derived_handle, &masked_prop);
+    if (status != AZIHSM_STATUS_BUFFER_TOO_SMALL)
+    {
+        ERR_raise(ERR_LIB_PROV, ERR_R_INTERNAL_ERROR);
+        return OSSL_FAILURE;
+    }
+
+    if (masked_prop.len == 0)
+    {
+        ERR_raise(ERR_LIB_PROV, ERR_R_INTERNAL_ERROR);
+        return OSSL_FAILURE;
+    }
+
+    alloc_len = masked_prop.len;
+    buffer = OPENSSL_malloc(alloc_len);
+    if (buffer == NULL)
+    {
+        ERR_raise(ERR_LIB_PROV, ERR_R_MALLOC_FAILURE);
+        return OSSL_FAILURE;
+    }
+
+    /* Second call to get the actual masked key data */
+    masked_prop.val = buffer;
+    status = azihsm_key_get_prop(derived_handle, &masked_prop);
+    if (status != AZIHSM_STATUS_SUCCESS || masked_prop.len == 0)
+    {
+        ERR_raise(ERR_LIB_PROV, ERR_R_INTERNAL_ERROR);
+        OPENSSL_cleanse(buffer, alloc_len);
+        OPENSSL_free(buffer);
+        return OSSL_FAILURE;
+    }
+
+    *out_buf = buffer;
+    *out_len = masked_prop.len;
+    return OSSL_SUCCESS;
+}
+
+int azihsm_ossl_write_masked_key_to_file(
+    const uint8_t *buffer,
+    uint32_t len,
+    const char *output_file
+)
+{
+    int fd;
+
+    fd = open(output_file, O_WRONLY | O_CREAT | O_TRUNC | O_NOFOLLOW, S_IRUSR | S_IWUSR);
+    if (fd < 0)
+    {
+        ERR_raise(ERR_LIB_PROV, ERR_R_SYS_LIB);
+        return OSSL_FAILURE;
+    }
+
+    /* Write all bytes, retrying on short writes and EINTR */
+    uint32_t total_written = 0;
+    while (total_written < len)
+    {
+        ssize_t written = write(fd, buffer + total_written, len - total_written);
+        if (written <= 0)
+        {
+            if (written < 0 && errno == EINTR)
+            {
+                continue;
+            }
+            ERR_raise(ERR_LIB_PROV, ERR_R_SYS_LIB);
+            close(fd);
+            unlink(output_file);
+            return OSSL_FAILURE;
+        }
+        total_written += (uint32_t)written;
+    }
+
+    close(fd);
+    return OSSL_SUCCESS;
+}


### PR DESCRIPTION
  The ECDH keyexch derive function previously required the output_file
  pkeyopt and ignored the caller's buffer entirely, violating the OpenSSL
  provider contract. Rewrite it to support both output modes:

    - output_file set: write masked key blob to file, set *secretlen = 0
    - output_file unset: copy masked key blob into caller's buffer

  The size query (secret == NULL) now returns MASKED_KEY_MAX_BUFFER for
  buffer mode so OpenSSL allocates an appropriately sized buffer.

  Extract the duplicated extract_masked_key() and write_masked_key_to_file()
  helpers from kdf.c and keyexch.c into a shared azihsm_ossl_masked_key
  module.