### PR TITLE
Release HSM streaming context handles in OpenSSL provider

### DIFF
--- a/plugins/ossl_prov/inc/azihsm_ossl_helpers.h
+++ b/plugins/ossl_prov/inc/azihsm_ossl_helpers.h
@@ -156,6 +156,24 @@ static inline uint32_t azihsm_ossl_evp_md_to_salt_len(const EVP_MD *md)
 }
 
 /*
+ * Release a streaming HSM operation context handle if active, then
+ * clear the caller's copy.  Safe to call when *handle_ptr == 0 (no-op).
+ *
+ * This wraps the AZIHSM API function azihsm_free_ctx_handle(), which
+ * frees HSM-internal resources for streaming crypto operations (digest,
+ * sign, verify, encrypt, decrypt).  It does NOT apply to provider-level
+ * context structs (AZIHSM_OSSL_PROV_CTX) or key handles.
+ */
+static inline void azihsm_ossl_release_hsm_ctx(azihsm_handle *handle_ptr)
+{
+    if (*handle_ptr != 0)
+    {
+        azihsm_free_ctx_handle(*handle_ptr);
+        *handle_ptr = 0;
+    }
+}
+
+/*
  * Normalize a private key DER blob to PKCS#8 format.
  *
  * The HSM expects PKCS#8 (PrivateKeyInfo) DER encoding. Users may provide

--- a/plugins/ossl_prov/src/azihsm_ossl_signature_rsa.c
+++ b/plugins/ossl_prov/src/azihsm_ossl_signature_rsa.c
@@ -67,6 +67,9 @@ static void azihsm_ossl_rsa_freectx(void *sctx)
     if (ctx == NULL)
         return;
 
+    /* Free streaming HSM context if still active */
+    azihsm_ossl_release_hsm_ctx(&ctx->sign_ctx);
+
     /* Note: Don't free key - caller owns it */
     OPENSSL_free(ctx);
 }
@@ -89,8 +92,25 @@ static void *azihsm_ossl_rsa_dupctx(void *sctx)
         return NULL;
     }
 
-    /* Copy all fields INCLUDING sign_ctx handle */
+    /*
+     * Copy all fields, then transfer HSM handle ownership to the duplicate.
+     *
+     * OpenSSL 3.x's EVP_DigestSignFinal / EVP_DigestVerifyFinal duplicate
+     * the PKEY_CTX (calling this dupctx) and run the actual _finish on the
+     * duplicate — preserving the original for potential reuse.  The HSM
+     * streaming handle is a non-duplicatable opaque ID in a global handle
+     * table; it cannot be shared or reference-counted.
+     *
+     * By transferring ownership (moving the handle to the duplicate and
+     * zeroing the source), we ensure:
+     *   - The duplicate can complete the streaming operation (_finish + free).
+     *   - The source remains valid: freectx sees sign_ctx == 0 (no-op),
+     *     and any subsequent _init creates a fresh HSM handle.
+     *   - The 1:1 ownership invariant is preserved — exactly one context
+     *     owns the handle at any time.
+     */
     *dst_ctx = *src_ctx;
+    src_ctx->sign_ctx = 0;
 
     return dst_ctx;
 }
@@ -387,16 +407,16 @@ static int azihsm_ossl_rsa_digest_sign_init(
     azihsm_status status;
     int use_pss;
 
-    if (provkey == NULL)
-    {
-        /* Silently succeed - this is a cleanup/reset operation */
-        return OSSL_SUCCESS;
-    }
-
     if (ctx == NULL)
     {
         ERR_raise(ERR_LIB_PROV, ERR_R_PASSED_NULL_PARAMETER);
         return OSSL_FAILURE;
+    }
+
+    if (provkey == NULL)
+    {
+        /* OpenSSL reinit with existing key — keep streaming context intact */
+        return OSSL_SUCCESS;
     }
 
     /* Extract key from provider key object */
@@ -470,6 +490,9 @@ static int azihsm_ossl_rsa_digest_sign_init(
         ERR_raise(ERR_LIB_PROV, ERR_R_OPERATION_FAIL);
         return OSSL_FAILURE;
     }
+
+    /* Free previous HSM context if reinitializing */
+    azihsm_ossl_release_hsm_ctx(&ctx->sign_ctx);
 
     status = azihsm_crypt_sign_init(&algo, ctx->key->key.priv, &ctx->sign_ctx);
 
@@ -556,7 +579,7 @@ static int azihsm_ossl_rsa_digest_sign_final(
     if (status != AZIHSM_STATUS_BUFFER_TOO_SMALL || sig_buf.len == 0)
     {
         ERR_raise(ERR_LIB_PROV, ERR_R_INTERNAL_ERROR);
-        ctx->sign_ctx = 0;
+        azihsm_ossl_release_hsm_ctx(&ctx->sign_ctx);
         return OSSL_FAILURE;
     }
 
@@ -564,23 +587,22 @@ static int azihsm_ossl_rsa_digest_sign_final(
     if (sigsize < sig_buf.len)
     {
         ERR_raise(ERR_LIB_PROV, ERR_R_PASSED_INVALID_ARGUMENT);
-        ctx->sign_ctx = 0;
+        azihsm_ossl_release_hsm_ctx(&ctx->sign_ctx);
         return OSSL_FAILURE;
     }
 
     /* Finish streaming sign with exact size required by HSM */
     sig_buf.ptr = sig;
     status = azihsm_crypt_sign_finish(ctx->sign_ctx, &sig_buf);
+    azihsm_ossl_release_hsm_ctx(&ctx->sign_ctx);
 
     if (status != AZIHSM_STATUS_SUCCESS)
     {
         ERR_raise(ERR_LIB_PROV, ERR_R_OPERATION_FAIL);
-        ctx->sign_ctx = 0;
         return OSSL_FAILURE;
     }
 
     *siglen = sig_buf.len;
-    ctx->sign_ctx = 0; /* Context consumed */
     return OSSL_SUCCESS;
 }
 
@@ -597,16 +619,16 @@ static int azihsm_ossl_rsa_digest_verify_init(
     azihsm_status status;
     int use_pss;
 
-    if (provkey == NULL)
-    {
-        /* Silently succeed - this is a cleanup/reset operation */
-        return OSSL_SUCCESS;
-    }
-
     if (ctx == NULL)
     {
         ERR_raise(ERR_LIB_PROV, ERR_R_PASSED_NULL_PARAMETER);
         return OSSL_FAILURE;
+    }
+
+    if (provkey == NULL)
+    {
+        /* OpenSSL reinit with existing key — keep streaming context intact */
+        return OSSL_SUCCESS;
     }
 
     /* Extract key from provider key object */
@@ -671,6 +693,9 @@ static int azihsm_ossl_rsa_digest_verify_init(
         ERR_raise(ERR_LIB_PROV, ERR_R_OPERATION_FAIL);
         return OSSL_FAILURE;
     }
+
+    /* Free previous HSM context if reinitializing */
+    azihsm_ossl_release_hsm_ctx(&ctx->sign_ctx);
 
     /* Initialize streaming verify context */
     status = azihsm_crypt_verify_init(&algo, ctx->key->key.pub, &ctx->sign_ctx);
@@ -748,7 +773,7 @@ static int azihsm_ossl_rsa_digest_verify_final(void *sctx, const unsigned char *
 
     /* Finish streaming verify */
     status = azihsm_crypt_verify_finish(ctx->sign_ctx, &sig_buf);
-    ctx->sign_ctx = 0;
+    azihsm_ossl_release_hsm_ctx(&ctx->sign_ctx);
 
     if (status == AZIHSM_STATUS_SUCCESS)
     {


### PR DESCRIPTION
- Introduce azihsm_ossl_release_hsm_ctx() helper for idempotent HSM streaming context cleanup
- Fix handle leaks in digest, ECDSA, and RSA signature providers
- Fix double-free vulnerability in ECDSA and RSA dupctx
- Migrate the MAC provider's existing cleanup to the shared helper and fix its post-finish leak

# Motivation
The AZIHSM API requires that `azihsm_free_ctx_handle` is called for every context handle returned by `azihsm_crypt_*_init`, whether the operation completed successfully, failed, or was abandoned.

Prior to this change, only azihsm_ossl_mac.c called azihsm_free_ctx_handle (in 2 places), and even that implementation leaked the handle after _finish. The digest, RSA, and EC signature providers never called it.

# Where azihsm_ossl_release_hsm_ctx is called and why
**freectx** (digest, EC sig, RSA sig, MAC)
OpenSSL calls freectx when tearing down a provider context. If a streaming operation was started but never finished (e.g., the caller abandoned an EVP_DigestSign mid-stream), the HSM handle is still alive. Without the release call, these handles leak permanently in the global handle table.

**dupctx** (EC sig, RSA sig) — ownership transfer
OpenSSL 3.x's EVP_DigestSignFinal and EVP_DigestVerifyFinal duplicate the EVP_PKEY_CTX via EVP_PKEY_CTX_dup (which calls the provider's dupctx) and then run the actual _finish on the duplicate — preserving the original context for potential reuse (m_sigver.c:484, m_sigver.c:610). Only when sigret == NULL (size query) or the EVP_MD_CTX_FLAG_FINALISE flag is set does OpenSSL operate directly on the original.

HSM streaming handles are non-duplicatable opaque IDs in a global handle table — they cannot be shared or reference-counted. The previous code did *dst_ctx = *src_ctx, which shallow-copied the sign_ctx handle into both contexts. This violated the 1:1 ownership invariant: the first freectx or _finish would invalidate the handle, and the second would either get INVALID_HANDLE or — if the handle ID had been reassigned — corrupt an unrelated operation.

The fix transfers ownership to the duplicate by zeroing the source's handle after the copy (src_ctx->sign_ctx = 0). This ensures:

The duplicate can complete the streaming operation (_finish + free).
The source remains valid: freectx sees sign_ctx == 0 (no-op), and any subsequent _init creates a fresh HSM handle.
The 1:1 ownership invariant holds — exactly one context owns the handle at any time.

**provkey == NULL in streaming _init** (EC sig, RSA sig) — reinit acceptance
OpenSSL's do_sigver_init has a reinit path (m_sigver.c:98-103) triggered when EVP_DigestSignInit/EVP_DigestVerifyInit is called on an already-initialized context with pkey == NULL. In this case, provkey is never resolved and reaches the provider as NULL. The provider returns OSSL_SUCCESS without modifying the streaming context, acknowledging the reinit while preserving the active HSM operation. The ctx == NULL guard is checked first to prevent NULL dereference in this path.

**_init — reinit with new key** (digest, EC sig, RSA sig, MAC)
When provkey != NULL, OpenSSL is starting a new operation (or reinitializing with a different key). The context may already hold a live HSM handle from a previous operation (e.g., signing multiple messages with the same key). Without cleanup, azihsm_crypt_*_init would overwrite the handle field and the old handle would leak. The release call before _init ensures the previous handle is freed. When no handle is active (handle == 0), the call is a no-op.

**After _finish — success path** (digest final, EC sign/verify final, RSA sign/verify final, MAC final)
Since _finish does not consume the handle (it uses HANDLE_TABLE.as_mut(), not free_handle), an explicit free is required even on the success path. Previously all providers just set ctx_handle = 0, discarding the reference without actually freeing the HSM resource.

**After _finish — error paths** (digest final, EC sign/verify final, RSA sign/verify final)
When _finish returns an error, or when a pre-finish check fails (buffer too small, size mismatch), the handle is still valid and must be freed before returning the failure to OpenSSL. Previously these error paths also just set the handle to zero without freeing.