### PR TITLE
[fix] Move Drop from HsmPartition to HsmPartitionInner

### DIFF
--- a/api/lib/src/partition.rs
+++ b/api/lib/src/partition.rs
@@ -780,6 +780,6 @@ impl HsmPartitionInner {
 /// Fires exactly once when the final `Arc` reference is released and the
 /// inner state is consumed — no `RwLock` acquisition needed.
 impl Drop for HsmPartitionInner {
-    #[instrument(skip_all, fields(path = self.path))]
+    #[instrument(skip_all, fields(path = self.path.as_str()))]
     fn drop(&mut self) {}
 }


### PR DESCRIPTION
The outer HsmPartition is Clone (via Arc), so Drop fired on every clone, not just the final one, and acquired the RwLock to read the path, risking deadlocks. Moving Drop to HsmPartitionInner ensures it fires exactly once when the last Arc ref is released, and accesses self.path directly without locking.