### PR TITLE
Reject RSA-PSS saltlen=auto as unsupported

### DIFF
--- a/plugins/ossl_prov/README.md
+++ b/plugins/ossl_prov/README.md
@@ -308,7 +308,7 @@ openssl dgst -sha256 ${PROV} \
 
 openssl dgst -sha256 ${PROV} \
     -sigopt rsa_padding_mode:pss \
-    -sigopt rsa_pss_saltlen:auto \
+    -sigopt rsa_pss_saltlen:digest \
     -verify "azihsm://./rsa_2048_sign.bin;type=rsa" \
     -signature rsa_pss_sig.bin data.bin
 ```
@@ -318,7 +318,7 @@ openssl dgst -sha256 ${PROV} \
 | Option | Values |
 |--------|--------|
 | `rsa_padding_mode` | `pss` |
-| `rsa_pss_saltlen` | `digest` (hash length), `max` (maximum), `auto` (auto-detect on verify), or an integer |
+| `rsa_pss_saltlen` | `digest` (hash length), `max` (maximum), or an integer (`auto` is not supported) |
 | `rsa_mgf1_md` | Hash for MGF1 (defaults to same as digest) |
 
 ### RSA Encryption and Decryption

--- a/plugins/ossl_prov/inc/azihsm_ossl_signature_rsa.h
+++ b/plugins/ossl_prov/inc/azihsm_ossl_signature_rsa.h
@@ -15,7 +15,7 @@
 
 /* Special salt length values (matching OpenSSL's RSA_PSS_SALTLEN_* constants) */
 #define AZIHSM_RSA_PSS_SALTLEN_DIGEST -1 /* Salt length equals hash length */
-#define AZIHSM_RSA_PSS_SALTLEN_AUTO -2   /* Auto-detect on verify */
+#define AZIHSM_RSA_PSS_SALTLEN_AUTO -2   /* Not supported; kept for reference only */
 #define AZIHSM_RSA_PSS_SALTLEN_MAX -3    /* Maximum possible salt */
 
 /* Signature context for RSA operations */

--- a/plugins/ossl_prov/src/azihsm_ossl_signature_rsa.c
+++ b/plugins/ossl_prov/src/azihsm_ossl_signature_rsa.c
@@ -234,9 +234,19 @@ static int azihsm_ossl_rsa_sign(
         {
             pss_params.salt_len = (uint32_t)ctx->salt_len;
         }
+        else if (ctx->salt_len == AZIHSM_RSA_PSS_SALTLEN_AUTO)
+        {
+            ERR_raise_data(
+                ERR_LIB_PROV,
+                PROV_R_INVALID_SALT_LENGTH,
+                "PSS saltlen \"auto\" is not supported"
+            );
+            return OSSL_FAILURE;
+        }
         else
         {
-            pss_params.salt_len = (uint32_t)EVP_MD_size(ctx->md);
+            ERR_raise(ERR_LIB_PROV, ERR_R_INTERNAL_ERROR);
+            return OSSL_FAILURE;
         }
 
         algo.id = AZIHSM_ALGO_ID_RSA_PKCS_PSS;
@@ -365,8 +375,7 @@ static int azihsm_ossl_rsa_verify(
         pss_params.mgf_id = azihsm_ossl_evp_md_to_mgf1_id(mgf1_md);
 
         /* Resolve salt length for verify */
-        if (ctx->salt_len == AZIHSM_RSA_PSS_SALTLEN_DIGEST ||
-            ctx->salt_len == AZIHSM_RSA_PSS_SALTLEN_AUTO)
+        if (ctx->salt_len == AZIHSM_RSA_PSS_SALTLEN_DIGEST)
         {
             pss_params.salt_len = (uint32_t)EVP_MD_size(ctx->md);
         }
@@ -380,9 +389,19 @@ static int azihsm_ossl_rsa_verify(
         {
             pss_params.salt_len = (uint32_t)ctx->salt_len;
         }
+        else if (ctx->salt_len == AZIHSM_RSA_PSS_SALTLEN_AUTO)
+        {
+            ERR_raise_data(
+                ERR_LIB_PROV,
+                PROV_R_INVALID_SALT_LENGTH,
+                "PSS saltlen \"auto\" is not supported"
+            );
+            return OSSL_FAILURE;
+        }
         else
         {
-            pss_params.salt_len = (uint32_t)EVP_MD_size(ctx->md);
+            ERR_raise(ERR_LIB_PROV, ERR_R_INTERNAL_ERROR);
+            return OSSL_FAILURE;
         }
 
         algo.id = AZIHSM_ALGO_ID_RSA_PKCS_PSS;
@@ -495,10 +514,19 @@ static int azihsm_ossl_rsa_digest_sign_init(
         {
             pss_params.salt_len = (uint32_t)ctx->salt_len;
         }
+        else if (ctx->salt_len == AZIHSM_RSA_PSS_SALTLEN_AUTO)
+        {
+            ERR_raise_data(
+                ERR_LIB_PROV,
+                PROV_R_INVALID_SALT_LENGTH,
+                "PSS saltlen \"auto\" is not supported"
+            );
+            return OSSL_FAILURE;
+        }
         else
         {
-            /* Default to hash size for other special values */
-            pss_params.salt_len = (uint32_t)EVP_MD_size(ctx->md);
+            ERR_raise(ERR_LIB_PROV, ERR_R_INTERNAL_ERROR);
+            return OSSL_FAILURE;
         }
 
         algo.id = azihsm_ossl_evp_md_to_rsa_pss_algo_id(ctx->md);
@@ -683,9 +711,8 @@ static int azihsm_ossl_rsa_digest_verify_init(
         pss_params.hash_algo_id = azihsm_ossl_evp_md_to_algo_id(ctx->md);
         pss_params.mgf_id = azihsm_ossl_evp_md_to_mgf1_id(mgf1_md);
 
-        /* Resolve salt length for verify (auto-detect if SALTLEN_AUTO) */
-        if (ctx->salt_len == AZIHSM_RSA_PSS_SALTLEN_DIGEST ||
-            ctx->salt_len == AZIHSM_RSA_PSS_SALTLEN_AUTO)
+        /* Resolve salt length for verify */
+        if (ctx->salt_len == AZIHSM_RSA_PSS_SALTLEN_DIGEST)
         {
             pss_params.salt_len = (uint32_t)EVP_MD_size(ctx->md);
         }
@@ -699,9 +726,19 @@ static int azihsm_ossl_rsa_digest_verify_init(
         {
             pss_params.salt_len = (uint32_t)ctx->salt_len;
         }
+        else if (ctx->salt_len == AZIHSM_RSA_PSS_SALTLEN_AUTO)
+        {
+            ERR_raise_data(
+                ERR_LIB_PROV,
+                PROV_R_INVALID_SALT_LENGTH,
+                "PSS saltlen \"auto\" is not supported"
+            );
+            return OSSL_FAILURE;
+        }
         else
         {
-            pss_params.salt_len = (uint32_t)EVP_MD_size(ctx->md);
+            ERR_raise(ERR_LIB_PROV, ERR_R_INTERNAL_ERROR);
+            return OSSL_FAILURE;
         }
 
         algo.id = azihsm_ossl_evp_md_to_rsa_pss_algo_id(ctx->md);
@@ -894,7 +931,13 @@ static int azihsm_ossl_rsa_set_ctx_params(void *sctx, const OSSL_PARAM params[])
             }
             else if (strcmp(saltlen_str, OSSL_PKEY_RSA_PSS_SALT_LEN_AUTO) == 0)
             {
-                ctx->salt_len = AZIHSM_RSA_PSS_SALTLEN_AUTO;
+                ERR_raise_data(
+                    ERR_LIB_PROV,
+                    PROV_R_INVALID_SALT_LENGTH,
+                    "PSS saltlen \"auto\" is not supported; "
+                    "use \"digest\", \"max\", or an explicit integer"
+                );
+                return OSSL_FAILURE;
             }
             else if (strcmp(saltlen_str, OSSL_PKEY_RSA_PSS_SALT_LEN_MAX) == 0)
             {
@@ -924,6 +967,19 @@ static int azihsm_ossl_rsa_set_ctx_params(void *sctx, const OSSL_PARAM params[])
             if (!OSSL_PARAM_get_int(p, &salt_len_int))
             {
                 ERR_raise(ERR_LIB_PROV, ERR_R_OPERATION_FAIL);
+                return OSSL_FAILURE;
+            }
+            if (salt_len_int == AZIHSM_RSA_PSS_SALTLEN_AUTO)
+            {
+                ERR_raise_data(
+                    ERR_LIB_PROV,
+                    PROV_R_INVALID_SALT_LENGTH,
+                    "PSS saltlen \"auto\" (%d) is not supported; "
+                    "use \"digest\" (%d), \"max\" (%d), or an explicit integer",
+                    AZIHSM_RSA_PSS_SALTLEN_AUTO,
+                    AZIHSM_RSA_PSS_SALTLEN_DIGEST,
+                    AZIHSM_RSA_PSS_SALTLEN_MAX
+                );
                 return OSSL_FAILURE;
             }
             ctx->salt_len = salt_len_int;


### PR DESCRIPTION
The HSM API requires an explicit salt length and cannot auto-detect it by inspecting a PSS signature. Previously, saltlen=auto was silently accepted and fell back to hash-length behaviour (identical to "digest"), giving misleading results without any error.

Changes:
- Reject "auto" (string) and -2 (integer) in set_ctx_params with PROV_R_INVALID_SALT_LENGTH
- Replace silent AUTO fallback in all four salt-length resolution blocks (one-shot sign/verify, streaming sign/verify init) with explicit errors
- Update AZIHSM_RSA_PSS_SALTLEN_AUTO comment in header to reflect unsupported status
- Update README: replace saltlen:auto verify example with saltlen:digest and remove auto from the PSS options table

Closes #225 