### PR TITLE
Run OSSL Provider integration tests in xtask precheck by default

### DIFF
--- a/xtask/src/integration_tests.rs
+++ b/xtask/src/integration_tests.rs
@@ -4,8 +4,6 @@
 #![warn(missing_docs)]
 #![forbid(unsafe_code)]
 
-use std::fs;
-
 use clap::Parser;
 
 use crate::nextest;
@@ -21,10 +19,30 @@ impl Xtask for IntegrationTest {
     fn run(self, ctx: XtaskCtx) -> anyhow::Result<()> {
         log::trace!("start testing");
 
+        if !cfg!(target_os = "linux") {
+            log::warn!("skipping provider integration tests: only supported on Linux");
+            return Ok(());
+        }
+
+        let openssl_dir = crate::openssl_install::ensure_openssl()?;
+
+        // Derive OPENSSL_BIN if not set — CLI integration tests (env.sh) hard-require it.
+        if std::env::var("OPENSSL_BIN").is_err() {
+            std::env::set_var("OPENSSL_BIN", openssl_dir.join("bin/openssl"));
+        }
+        // Derive OPENSSL_LIB if not set — CLI env.sh uses it to set LD_LIBRARY_PATH.
+        if std::env::var("OPENSSL_LIB").is_err() {
+            std::env::set_var("OPENSSL_LIB", openssl_dir.join("lib"));
+        }
+        // Ensure OPENSSL_DIR is set for the CAPI build script and test binary.
+        if std::env::var("OPENSSL_DIR").is_err() {
+            std::env::set_var("OPENSSL_DIR", &openssl_dir);
+        }
+
         // Clean previous test key material for fresh-per-run isolation
         let keymat_dir = ctx.root.join("target").join("test-keymat");
         if keymat_dir.exists() {
-            fs::remove_dir_all(&keymat_dir)?;
+            std::fs::remove_dir_all(&keymat_dir)?;
             log::trace!(
                 "cleaned previous test key material at {}",
                 keymat_dir.display()

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -30,6 +30,7 @@ mod install;
 mod integration_tests;
 mod nextest;
 mod nextest_report;
+mod openssl_install;
 mod precheck;
 mod rustup_component_add;
 mod setup;

--- a/xtask/src/openssl_install.rs
+++ b/xtask/src/openssl_install.rs
@@ -1,0 +1,125 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#![warn(missing_docs)]
+#![forbid(unsafe_code)]
+
+//! Helper to resolve an OpenSSL installation, building one if necessary.
+
+use std::path::PathBuf;
+
+#[cfg(target_os = "linux")]
+use xshell::cmd;
+#[cfg(target_os = "linux")]
+use xshell::Shell;
+
+#[cfg(target_os = "linux")]
+const OPENSSL_VERSION: &str = "3.0.3";
+
+#[cfg(target_os = "linux")]
+const OPENSSL_INSTALL_DIR: &str = "/opt/openssl-3.0.3";
+
+/// Resolves an OpenSSL installation, building one if necessary.
+///
+/// Resolution order:
+/// 1. `OPENSSL_DIR` env var — if set, checked (must be an existing directory),
+///    and returned as-is. No deep validation of contents is performed; downstream
+///    build scripts and test harnesses will report specific missing-file errors.
+/// 2. `/opt/openssl-3.0.3` — if it already exists (local equivalent of the CI cache).
+/// 3. Download, build, and install OpenSSL 3.0.3 to `/opt/openssl-3.0.3`,
+///    using the same commands as CI. Requires `curl`, `make`, a C compiler,
+///    and `sudo` (system path). The installation persists across `cargo clean`
+///    and `cargo xtask clean`.
+///
+/// Only supported on Linux; returns an error on other platforms.
+#[cfg(not(target_os = "linux"))]
+pub fn ensure_openssl() -> anyhow::Result<PathBuf> {
+    anyhow::bail!("OpenSSL auto-install is only supported on Linux");
+}
+
+/// Resolves an OpenSSL installation, building one if necessary.
+///
+/// Resolution order:
+/// 1. `OPENSSL_DIR` env var — if set, checked (must be an existing directory),
+///    and returned as-is. No deep validation of contents is performed; downstream
+///    build scripts and test harnesses will report specific missing-file errors.
+/// 2. `/opt/openssl-3.0.3` — if it already exists (local equivalent of the CI cache).
+/// 3. Download, build, and install OpenSSL 3.0.3 to `/opt/openssl-3.0.3`,
+///    using the same commands as CI. Requires `curl`, `make`, a C compiler,
+///    and `sudo` (system path). The installation persists across `cargo clean`
+///    and `cargo xtask clean`.
+#[cfg(target_os = "linux")]
+pub fn ensure_openssl() -> anyhow::Result<PathBuf> {
+    // 1. Honour explicit OPENSSL_DIR
+    match std::env::var("OPENSSL_DIR") {
+        Ok(val) if val.trim().is_empty() => {
+            anyhow::bail!(
+                "OPENSSL_DIR is set but empty. \
+                 Set it to an OpenSSL 3.x installation prefix."
+            );
+        }
+        Ok(ref val) if !std::path::Path::new(val).is_dir() => {
+            anyhow::bail!("OPENSSL_DIR={val:?} does not point to an existing directory.");
+        }
+        Ok(val) => {
+            log::info!("using OPENSSL_DIR={val}");
+            return Ok(PathBuf::from(val));
+        }
+        Err(_) => {}
+    }
+
+    let install_dir = PathBuf::from(OPENSSL_INSTALL_DIR);
+
+    // 2. Local cache: already installed to /opt
+    if install_dir.is_dir() {
+        log::info!("using cached OpenSSL at {OPENSSL_INSTALL_DIR}");
+        return Ok(install_dir);
+    }
+
+    // 3. Download and build (mirrors CI exactly)
+    log::info!(
+        "OPENSSL_DIR not set — building OpenSSL {OPENSSL_VERSION} into {OPENSSL_INSTALL_DIR}"
+    );
+
+    // Preflight: check required tools before starting a long build.
+    let sh = Shell::new()?;
+    for tool in ["curl", "make", "cc"] {
+        if cmd!(sh, "which {tool}").quiet().run().is_err() {
+            anyhow::bail!(
+                "required tool `{tool}` not found. \
+                 Install build prerequisites: sudo apt-get install build-essential curl"
+            );
+        }
+    }
+    if cmd!(sh, "sudo -n true").quiet().run().is_err() {
+        anyhow::bail!(
+            "sudo access required to install OpenSSL into {OPENSSL_INSTALL_DIR}. \
+             Either run with sudo or set OPENSSL_DIR to a user-writable installation."
+        );
+    }
+
+    let url = format!(
+        "https://github.com/openssl/openssl/releases/download/openssl-{OPENSSL_VERSION}/openssl-{OPENSSL_VERSION}.tar.gz"
+    );
+    let tarball = format!("/tmp/openssl-{OPENSSL_VERSION}.tar.gz");
+    let src_dir = format!("/tmp/openssl-{OPENSSL_VERSION}");
+
+    log::info!("downloading OpenSSL {OPENSSL_VERSION}...");
+    cmd!(sh, "curl -fsSL -o {tarball} {url}").run()?;
+    cmd!(sh, "tar xz -C /tmp -f {tarball}").run()?;
+
+    sh.change_dir(&src_dir);
+    cmd!(
+        sh,
+        "./Configure --prefix={OPENSSL_INSTALL_DIR} --libdir=lib"
+    )
+    .run()?;
+
+    let nproc = cmd!(sh, "nproc").read()?;
+    let nproc = nproc.trim();
+    cmd!(sh, "make -j{nproc}").run()?;
+    cmd!(sh, "sudo make install_sw").run()?;
+
+    log::info!("OpenSSL {OPENSSL_VERSION} installed to {OPENSSL_INSTALL_DIR}");
+    Ok(install_dir)
+}

--- a/xtask/src/precheck.rs
+++ b/xtask/src/precheck.rs
@@ -15,6 +15,8 @@ use crate::copyright::Copyright;
 use crate::coverage::Coverage;
 use crate::coverage_report::CoverageReport;
 use crate::fmt::Fmt;
+#[cfg(target_os = "linux")]
+use crate::integration_tests;
 use crate::nextest::Nextest;
 use crate::nextest_report::NextestReport;
 use crate::setup::Setup;
@@ -211,6 +213,10 @@ impl Xtask for Precheck {
                         exclude: self.exclude.clone(),
                     }
                     .run(ctx.clone())?;
+
+                    // OSSL Provider integration tests (CLI + C API, Linux only)
+                    #[cfg(target_os = "linux")]
+                    integration_tests::IntegrationTest {}.run(ctx.clone())?;
                 }
             } else {
                 Nextest {


### PR DESCRIPTION
Developers can now catch provider test failures locally before opening a PR, without needing to run `cargo xtask integration-tests` separately.


Closes #264