### PR TITLE
fix for resiliency part init neg test

### DIFF
--- a/api/tests/cpp/partition_tests.cpp
+++ b/api/tests/cpp/partition_tests.cpp
@@ -987,14 +987,15 @@ TEST(azihsm_part, init_with_resiliency_tpm_pota_with_callback_fails)
         PartInitConfig init_config{};
         make_part_init_config(part_handle, init_config);
 
-        // Force TPM POTA source — callback is still set by make_resiliency_config.
-        // TPM + callback is now rejected as InvalidArgument.
+        // Force TPM POTA source with a non-null callback.
+        // TPM + callback is rejected as InvalidArgument.
         init_config.pota_endorsement.source = AZIHSM_POTA_ENDORSEMENT_SOURCE_TPM;
         init_config.pota_endorsement.endorsement = nullptr;
 
         azihsm_resiliency_config resiliency_config{};
         auto resiliency_ctx = make_resiliency_config(resiliency_config);
-        // pota_callback_ops is non-null (set by make_resiliency_config)
+        // Force pota_callback_ops non-null so the TPM + callback mismatch triggers.
+        resiliency_config.pota_callback_ops = get_pota_callback_ops();
 
         err = azihsm_part_init(
             part_handle,

--- a/api/tests/cpp/utils/resiliency_config.cpp
+++ b/api/tests/cpp/utils/resiliency_config.cpp
@@ -274,13 +274,29 @@ void make_resiliency_config_in(
     static azihsm_resiliency_lock_ops lock_ops = {
         lock_acquire, lock_release};
 
-    static azihsm_pota_callback_ops pota_ops = {
-        pota_endorse};
-
     config_out.ctx = &ctx;
     config_out.storage_ops = storage_ops;
     config_out.lock_ops = lock_ops;
-    config_out.pota_callback_ops = &pota_ops;
+
+    // When POTA source is TPM, pota_callback_ops must be null.
+#ifdef _WIN32
+    char *use_tpm = nullptr;
+    size_t use_tpm_len = 0;
+    _dupenv_s(&use_tpm, &use_tpm_len, "AZIHSM_USE_TPM");
+    bool is_tpm = (use_tpm != nullptr);
+    free(use_tpm);
+#else
+    bool is_tpm = (std::getenv("AZIHSM_USE_TPM") != nullptr);
+#endif
+    config_out.pota_callback_ops = is_tpm ? nullptr : get_pota_callback_ops();
+}
+
+/// Returns a pointer to the shared POTA callback ops vtable backed by
+/// `pota_endorse`. The returned pointer has static lifetime.
+const azihsm_pota_callback_ops *get_pota_callback_ops()
+{
+    static azihsm_pota_callback_ops pota_ops = {pota_endorse};
+    return &pota_ops;
 }
 
 std::unique_ptr<ResiliencyTestCtx> make_resiliency_config(

--- a/api/tests/cpp/utils/resiliency_config.hpp
+++ b/api/tests/cpp/utils/resiliency_config.hpp
@@ -58,3 +58,7 @@ void make_resiliency_config_in(
 /// @return Owning pointer to the test context.
 std::unique_ptr<ResiliencyTestCtx> make_resiliency_config(
     azihsm_resiliency_config &config_out);
+
+/// Returns a pointer to the shared POTA callback ops vtable used by
+/// the resiliency test helpers.
+const azihsm_pota_callback_ops *get_pota_callback_ops();


### PR DESCRIPTION
fix for init_with_resiliency_tpm_pota_with_callback_fails when AZIHSM_USE_TPM is used