### PR TITLE
[refactor] provider: consolidate error cleanup 

### DIFF
--- a/plugins/ossl_prov/src/azihsm_ossl_hsm.c
+++ b/plugins/ossl_prov/src/azihsm_ossl_hsm.c
@@ -577,6 +577,7 @@ static azihsm_status der_to_uncompressed_point(
     unsigned char point[P384_UNCOMPRESSED_POINT_SIZE]
 )
 {
+    azihsm_status status = AZIHSM_STATUS_INTERNAL_ERROR;
     const unsigned char *der_ptr = NULL;
     EVP_PKEY *pkey = NULL;
     BIGNUM *qx = NULL;
@@ -592,20 +593,15 @@ static azihsm_status der_to_uncompressed_point(
     if (pkey == NULL)
     {
         ERR_raise(ERR_LIB_PROV, ERR_R_INTERNAL_ERROR);
-        return AZIHSM_STATUS_INTERNAL_ERROR;
+        goto cleanup;
     }
 
     if (!EVP_PKEY_get_bn_param(pkey, OSSL_PKEY_PARAM_EC_PUB_X, &qx) ||
         !EVP_PKEY_get_bn_param(pkey, OSSL_PKEY_PARAM_EC_PUB_Y, &qy))
     {
         ERR_raise(ERR_LIB_PROV, ERR_R_INTERNAL_ERROR);
-        BN_free(qx);
-        BN_free(qy);
-        EVP_PKEY_free(pkey);
-        return AZIHSM_STATUS_INTERNAL_ERROR;
+        goto cleanup;
     }
-
-    EVP_PKEY_free(pkey);
 
     point[0] = 0x04;
     if (BN_bn2binpad(qx, point + 1, P384_COORD_SIZE) != P384_COORD_SIZE ||
@@ -616,14 +612,17 @@ static azihsm_status der_to_uncompressed_point(
             ERR_R_INTERNAL_ERROR,
             "BN_bn2binpad failed serializing P-384 coordinate"
         );
-        BN_free(qx);
-        BN_free(qy);
-        return AZIHSM_STATUS_INTERNAL_ERROR;
+        goto cleanup;
     }
 
+    status = AZIHSM_STATUS_SUCCESS;
+
+cleanup:
+    /* OpenSSL free functions are NULL-safe — call unconditionally */
     BN_free(qx);
     BN_free(qy);
-    return AZIHSM_STATUS_SUCCESS;
+    EVP_PKEY_free(pkey);
+    return status;
 }
 
 /*
@@ -640,6 +639,7 @@ static azihsm_status sign_with_pota_key(
     struct azihsm_buffer *sig_out
 )
 {
+    azihsm_status status = AZIHSM_STATUS_INTERNAL_ERROR;
     const unsigned char *der_ptr = priv_key_der;
     EVP_PKEY *pota_pkey = NULL;
     EVP_MD_CTX *md_ctx = NULL;
@@ -657,66 +657,49 @@ static azihsm_status sign_with_pota_key(
     if (pota_pkey == NULL)
     {
         ERR_raise(ERR_LIB_PROV, ERR_R_INTERNAL_ERROR);
-        return AZIHSM_STATUS_INTERNAL_ERROR;
+        goto cleanup;
     }
 
     md_ctx = EVP_MD_CTX_new();
     if (md_ctx == NULL)
     {
         ERR_raise(ERR_LIB_PROV, ERR_R_MALLOC_FAILURE);
-        EVP_PKEY_free(pota_pkey);
-        return AZIHSM_STATUS_INTERNAL_ERROR;
+        goto cleanup;
     }
 
     if (EVP_DigestSignInit(md_ctx, NULL, EVP_sha384(), NULL, pota_pkey) != 1)
     {
         ERR_raise(ERR_LIB_PROV, ERR_R_INTERNAL_ERROR);
-        EVP_MD_CTX_free(md_ctx);
-        EVP_PKEY_free(pota_pkey);
-        return AZIHSM_STATUS_INTERNAL_ERROR;
+        goto cleanup;
     }
 
     /* Determine required DER signature buffer size */
     if (EVP_DigestSign(md_ctx, NULL, &der_sig_len, data, data_len) != 1)
     {
         ERR_raise(ERR_LIB_PROV, ERR_R_INTERNAL_ERROR);
-        EVP_MD_CTX_free(md_ctx);
-        EVP_PKEY_free(pota_pkey);
-        return AZIHSM_STATUS_INTERNAL_ERROR;
+        goto cleanup;
     }
 
     der_sig_buf = OPENSSL_malloc(der_sig_len);
     if (der_sig_buf == NULL)
     {
         ERR_raise(ERR_LIB_PROV, ERR_R_MALLOC_FAILURE);
-        EVP_MD_CTX_free(md_ctx);
-        EVP_PKEY_free(pota_pkey);
-        return AZIHSM_STATUS_INTERNAL_ERROR;
+        goto cleanup;
     }
 
     if (EVP_DigestSign(md_ctx, der_sig_buf, &der_sig_len, data, data_len) != 1)
     {
         ERR_raise(ERR_LIB_PROV, ERR_R_INTERNAL_ERROR);
-        OPENSSL_cleanse(der_sig_buf, der_sig_len);
-        OPENSSL_free(der_sig_buf);
-        EVP_MD_CTX_free(md_ctx);
-        EVP_PKEY_free(pota_pkey);
-        return AZIHSM_STATUS_INTERNAL_ERROR;
+        goto cleanup;
     }
-
-    EVP_MD_CTX_free(md_ctx);
-    EVP_PKEY_free(pota_pkey);
 
     /* Convert DER-encoded ECDSA signature to raw r||s format */
     der_ptr = der_sig_buf;
     ecdsa_sig = d2i_ECDSA_SIG(NULL, &der_ptr, (long)der_sig_len);
-    OPENSSL_cleanse(der_sig_buf, der_sig_len);
-    OPENSSL_free(der_sig_buf);
-
     if (ecdsa_sig == NULL)
     {
         ERR_raise(ERR_LIB_PROV, ERR_R_INTERNAL_ERROR);
-        return AZIHSM_STATUS_INTERNAL_ERROR;
+        goto cleanup;
     }
 
     ECDSA_SIG_get0(ecdsa_sig, &sig_r, &sig_s);
@@ -728,8 +711,7 @@ static azihsm_status sign_with_pota_key(
             ERR_R_INTERNAL_ERROR,
             "ECDSA_SIG_get0 returned NULL r or s component"
         );
-        ECDSA_SIG_free(ecdsa_sig);
-        return AZIHSM_STATUS_INTERNAL_ERROR;
+        goto cleanup;
     }
 
     /* Serialize r and s components into a fixed-size raw buffer */
@@ -737,8 +719,7 @@ static azihsm_status sign_with_pota_key(
     if (sig_out->ptr == NULL)
     {
         ERR_raise(ERR_LIB_PROV, ERR_R_MALLOC_FAILURE);
-        ECDSA_SIG_free(ecdsa_sig);
-        return AZIHSM_STATUS_INTERNAL_ERROR;
+        goto cleanup;
     }
 
     if (BN_bn2binpad(sig_r, sig_out->ptr, P384_COORD_SIZE) != P384_COORD_SIZE ||
@@ -752,13 +733,19 @@ static azihsm_status sign_with_pota_key(
         OPENSSL_cleanse(sig_out->ptr, P384_RAW_SIG_SIZE);
         OPENSSL_free(sig_out->ptr);
         sig_out->ptr = NULL;
-        ECDSA_SIG_free(ecdsa_sig);
-        return AZIHSM_STATUS_INTERNAL_ERROR;
+        goto cleanup;
     }
 
     sig_out->len = P384_RAW_SIG_SIZE;
+    status = AZIHSM_STATUS_SUCCESS;
+
+cleanup:
+    /* OpenSSL free functions are NULL-safe — call unconditionally */
     ECDSA_SIG_free(ecdsa_sig);
-    return AZIHSM_STATUS_SUCCESS;
+    OPENSSL_clear_free(der_sig_buf, der_sig_len);
+    EVP_MD_CTX_free(md_ctx);
+    EVP_PKEY_free(pota_pkey);
+    return status;
 }
 
 /*
@@ -810,20 +797,29 @@ azihsm_status azihsm_open_device_and_session(
     struct azihsm_resiliency_ctx **resiliency_ctx
 )
 {
-    azihsm_status status;
+    azihsm_status status = AZIHSM_STATUS_INTERNAL_ERROR;
 
     struct azihsm_buffer bmk_buf = { NULL, 0 };
     struct azihsm_buffer muk_buf = { NULL, 0 };
     struct azihsm_buffer obk_buf = { NULL, 0 };
     struct azihsm_buffer retrieved_bmk = { NULL, 0 };
+    struct azihsm_buffer pota_priv_buf = { NULL, 0 };
+    struct azihsm_buffer pota_pub_buf = { NULL, 0 };
+    struct azihsm_buffer pota_sig_buf = { NULL, 0 };
+    struct azihsm_buffer pid_pub_key_buf = { NULL, 0 };
 
     struct azihsm_resiliency_config resiliency_cfg;
     struct azihsm_resiliency_ctx *res_ctx = NULL;
 
+    bool device_opened = false;
+    bool session_opened = false;
     bool muk_was_loaded = false;
 
     struct azihsm_api_rev api_rev = { 0 };
     struct azihsm_credentials creds = { 0 };
+    struct azihsm_owner_backup_key_config backup_config = { 0 };
+    struct azihsm_pota_endorsement pota_endorsement = { 0 };
+    struct azihsm_pota_endorsement_data pota_data = { 0 };
 
     if (config == NULL || device == NULL || session == NULL)
     {
@@ -849,9 +845,7 @@ azihsm_status azihsm_open_device_and_session(
     {
         status = load_credentials_from_file(AZIHSM_DEFAULT_CREDENTIALS_ID_PATH, creds.id);
         if (status != AZIHSM_STATUS_SUCCESS)
-        {
-            return status;
-        }
+            goto cleanup;
     }
 
     if (config->credentials_pin_from_env)
@@ -862,32 +856,20 @@ azihsm_status azihsm_open_device_and_session(
     {
         status = load_credentials_from_file(AZIHSM_DEFAULT_CREDENTIALS_PIN_PATH, creds.pin);
         if (status != AZIHSM_STATUS_SUCCESS)
-        {
-            OPENSSL_cleanse(&creds, sizeof(creds));
-            return status;
-        }
+            goto cleanup;
     }
 
     // Load key files if they exist
     status = azihsm_file_load(config->bmk_path, &bmk_buf);
     if (status != AZIHSM_STATUS_SUCCESS)
-    {
-        OPENSSL_cleanse(&creds, sizeof(creds));
-        return status;
-    }
+        goto cleanup;
 
     status = azihsm_file_load(config->muk_path, &muk_buf);
     if (status != AZIHSM_STATUS_SUCCESS)
-    {
-        free_buffer(&bmk_buf);
-        OPENSSL_cleanse(&creds, sizeof(creds));
-        return status;
-    }
+        goto cleanup;
     muk_was_loaded = (muk_buf.ptr != NULL);
 
     // Configure OBK based on source selection
-    struct azihsm_owner_backup_key_config backup_config = { 0 };
-
     if (config->use_tpm_obk)
     {
         backup_config.source = AZIHSM_OWNER_BACKUP_KEY_SOURCE_TPM;
@@ -900,12 +882,7 @@ azihsm_status azihsm_open_device_and_session(
         // owner backup key (MOBK) returned by the HSM.
         status = azihsm_file_load(config->obk_path, &obk_buf);
         if (status != AZIHSM_STATUS_SUCCESS)
-        {
-            free_buffer(&bmk_buf);
-            free_buffer(&muk_buf);
-            OPENSSL_cleanse(&creds, sizeof(creds));
-            return status;
-        }
+            goto cleanup;
 
         if (obk_buf.ptr == NULL)
         {
@@ -921,10 +898,8 @@ azihsm_status azihsm_open_device_and_session(
                 config->obk_path,
                 AZIHSM_OBK_SIZE
             );
-            free_buffer(&bmk_buf);
-            free_buffer(&muk_buf);
-            OPENSSL_cleanse(&creds, sizeof(creds));
-            return AZIHSM_STATUS_INTERNAL_ERROR;
+            status = AZIHSM_STATUS_INTERNAL_ERROR;
+            goto cleanup;
         }
 
         if (obk_buf.len != AZIHSM_OBK_SIZE)
@@ -940,11 +915,8 @@ azihsm_status azihsm_open_device_and_session(
                 config->obk_path,
                 AZIHSM_OBK_SIZE
             );
-            free_buffer(&obk_buf);
-            free_buffer(&bmk_buf);
-            free_buffer(&muk_buf);
-            OPENSSL_cleanse(&creds, sizeof(creds));
-            return AZIHSM_STATUS_INTERNAL_ERROR;
+            status = AZIHSM_STATUS_INTERNAL_ERROR;
+            goto cleanup;
         }
 
         backup_config.source = AZIHSM_OWNER_BACKUP_KEY_SOURCE_CALLER;
@@ -953,13 +925,8 @@ azihsm_status azihsm_open_device_and_session(
 
     status = azihsm_get_device_handle(device, api_rev);
     if (status != AZIHSM_STATUS_SUCCESS)
-    {
-        free_buffer(&obk_buf);
-        free_buffer(&bmk_buf);
-        free_buffer(&muk_buf);
-        OPENSSL_cleanse(&creds, sizeof(creds));
-        return status;
-    }
+        goto cleanup;
+    device_opened = true;
 
     /* Create resiliency config if enabled */
     if (config->resiliency_enabled)
@@ -976,26 +943,10 @@ azihsm_status azihsm_open_device_and_session(
             &res_ctx
         );
         if (status != AZIHSM_STATUS_SUCCESS)
-        {
-            free_buffer(&bmk_buf);
-            free_buffer(&muk_buf);
-            if (!config->use_tpm_obk)
-            {
-                free_buffer(&obk_buf);
-            }
-            OPENSSL_cleanse(&creds, sizeof(creds));
-            azihsm_part_close(*device);
-            return status;
-        }
+            goto cleanup;
     }
 
     // Configure POTA endorsement based on source selection
-    struct azihsm_pota_endorsement pota_endorsement = { 0 };
-    struct azihsm_buffer pota_sig_buf = { 0 };
-    struct azihsm_pota_endorsement_data pota_data = { 0 };
-
-    struct azihsm_buffer pota_priv_buf = { NULL, 0 };
-    struct azihsm_buffer pota_pub_buf = { NULL, 0 };
     if (config->use_tpm_pota)
     {
         pota_endorsement.source = AZIHSM_POTA_ENDORSEMENT_SOURCE_TPM;
@@ -1006,28 +957,11 @@ azihsm_status azihsm_open_device_and_session(
         // Load POTA keys from files
         status = azihsm_file_load(config->pota_private_key_path, &pota_priv_buf);
         if (status != AZIHSM_STATUS_SUCCESS)
-        {
-            free_buffer(&obk_buf);
-            free_buffer(&bmk_buf);
-            free_buffer(&muk_buf);
-            OPENSSL_cleanse(&creds, sizeof(creds));
-            azihsm_resiliency_destroy(res_ctx);
-            azihsm_part_close(*device);
-            return status;
-        }
+            goto cleanup;
 
         status = azihsm_file_load(config->pota_public_key_path, &pota_pub_buf);
         if (status != AZIHSM_STATUS_SUCCESS)
-        {
-            free_buffer(&pota_priv_buf);
-            free_buffer(&obk_buf);
-            free_buffer(&bmk_buf);
-            free_buffer(&muk_buf);
-            OPENSSL_cleanse(&creds, sizeof(creds));
-            azihsm_resiliency_destroy(res_ctx);
-            azihsm_part_close(*device);
-            return status;
-        }
+            goto cleanup;
 
         // POTA key files are required when using caller source — both must be present.
         if (pota_priv_buf.ptr == NULL && pota_pub_buf.ptr == NULL)
@@ -1042,13 +976,8 @@ azihsm_status azihsm_open_device_and_session(
                 config->pota_private_key_path,
                 config->pota_public_key_path
             );
-            free_buffer(&obk_buf);
-            free_buffer(&bmk_buf);
-            free_buffer(&muk_buf);
-            OPENSSL_cleanse(&creds, sizeof(creds));
-            azihsm_resiliency_destroy(res_ctx);
-            azihsm_part_close(*device);
-            return AZIHSM_STATUS_INTERNAL_ERROR;
+            status = AZIHSM_STATUS_INTERNAL_ERROR;
+            goto cleanup;
         }
         else if (pota_priv_buf.ptr == NULL || pota_pub_buf.ptr == NULL)
         {
@@ -1063,46 +992,19 @@ azihsm_status azihsm_open_device_and_session(
                 config->pota_private_key_path,
                 config->pota_public_key_path
             );
-            free_buffer(&pota_priv_buf);
-            free_buffer(&pota_pub_buf);
-            free_buffer(&obk_buf);
-            free_buffer(&bmk_buf);
-            free_buffer(&muk_buf);
-            OPENSSL_cleanse(&creds, sizeof(creds));
-            azihsm_resiliency_destroy(res_ctx);
-            azihsm_part_close(*device);
-            return AZIHSM_STATUS_INTERNAL_ERROR;
+            status = AZIHSM_STATUS_INTERNAL_ERROR;
+            goto cleanup;
         }
 
         // Compute POTA endorsement: sign PID public key with POTA key
-        struct azihsm_buffer pid_pub_key_buf = { NULL, 0 };
         status = get_part_property(*device, AZIHSM_PART_PROP_ID_PART_PUB_KEY, &pid_pub_key_buf);
         if (status != AZIHSM_STATUS_SUCCESS)
-        {
-            free_buffer(&pota_priv_buf);
-            free_buffer(&pota_pub_buf);
-            free_buffer(&obk_buf);
-            free_buffer(&bmk_buf);
-            free_buffer(&muk_buf);
-            OPENSSL_cleanse(&creds, sizeof(creds));
-            azihsm_resiliency_destroy(res_ctx);
-            azihsm_part_close(*device);
-            return status;
-        }
+            goto cleanup;
+
         status = compute_pota_endorsement(&pid_pub_key_buf, &pota_priv_buf, &pota_sig_buf);
         free_buffer(&pid_pub_key_buf);
         if (status != AZIHSM_STATUS_SUCCESS)
-        {
-            free_buffer(&pota_priv_buf);
-            free_buffer(&pota_pub_buf);
-            free_buffer(&obk_buf);
-            free_buffer(&bmk_buf);
-            free_buffer(&muk_buf);
-            OPENSSL_cleanse(&creds, sizeof(creds));
-            azihsm_resiliency_destroy(res_ctx);
-            azihsm_part_close(*device);
-            return status;
-        }
+            goto cleanup;
 
         pota_data.signature = &pota_sig_buf;
         pota_data.public_key = &pota_pub_buf;
@@ -1120,22 +1022,8 @@ azihsm_status azihsm_open_device_and_session(
         &pota_endorsement,
         config->resiliency_enabled ? &resiliency_cfg : NULL
     );
-
-    // Input buffers no longer needed after part_init
-    free_buffer(&bmk_buf);
-    free_buffer(&muk_buf);
-    free_buffer(&pota_sig_buf);
-    free_buffer(&pota_priv_buf);
-    free_buffer(&pota_pub_buf);
-    free_buffer(&obk_buf);
-
     if (status != AZIHSM_STATUS_SUCCESS)
-    {
-        OPENSSL_cleanse(&creds, sizeof(creds));
-        azihsm_resiliency_destroy(res_ctx);
-        azihsm_part_close(*device);
-        return status;
-    }
+        goto cleanup;
 
     // Retrieve and persist BMK property
     status = get_part_property(*device, AZIHSM_PART_PROP_ID_BACKUP_MASKING_KEY, &retrieved_bmk);
@@ -1143,48 +1031,60 @@ azihsm_status azihsm_open_device_and_session(
     {
         status = write_buffer_to_file(config->bmk_path, &retrieved_bmk);
         if (status != AZIHSM_STATUS_SUCCESS)
-        {
-            free_buffer(&retrieved_bmk);
-            OPENSSL_cleanse(&creds, sizeof(creds));
-            azihsm_resiliency_destroy(res_ctx);
-            azihsm_part_close(*device);
-            return status;
-        }
+            goto cleanup;
     }
-    free_buffer(&retrieved_bmk);
 
     // Open session (seed=NULL lets the library generate random bytes internally)
     status = azihsm_sess_open(*device, &creds, NULL, session);
-    OPENSSL_cleanse(&creds, sizeof(creds));
     if (status != AZIHSM_STATUS_SUCCESS)
-    {
-        azihsm_resiliency_destroy(res_ctx);
-        azihsm_part_close(*device);
-        return status;
-    }
+        goto cleanup;
+    session_opened = true;
 
     // If MUK wasn't loaded from file, generate and save it
     if (!muk_was_loaded)
     {
         status = generate_and_save_muk(*session, config->muk_path);
         if (status != AZIHSM_STATUS_SUCCESS)
-        {
+            goto cleanup;
+    }
+
+    status = AZIHSM_STATUS_SUCCESS;
+
+cleanup:
+    /* Always free temporary buffers — needed on both success and error.
+     * free_buffer() is NULL-safe (checks ptr before cleanse+free). */
+    free_buffer(&bmk_buf);
+    free_buffer(&muk_buf);
+    free_buffer(&obk_buf);
+    free_buffer(&pota_priv_buf);
+    free_buffer(&pota_pub_buf);
+    free_buffer(&pota_sig_buf);
+    free_buffer(&pid_pub_key_buf);
+    free_buffer(&retrieved_bmk);
+    OPENSSL_cleanse(&creds, sizeof(creds));
+
+    if (status != AZIHSM_STATUS_SUCCESS)
+    {
+        /* Tear down device/session/resiliency only on failure */
+        azihsm_resiliency_destroy(res_ctx);
+        if (session_opened)
             azihsm_sess_close(*session);
-            azihsm_resiliency_destroy(res_ctx);
+        if (device_opened)
             azihsm_part_close(*device);
-            return status;
+    }
+    else
+    {
+        /* Pass resiliency context to caller for lifetime management */
+        if (resiliency_ctx != NULL)
+        {
+            *resiliency_ctx = res_ctx;
+        }
+        else
+        {
+            azihsm_resiliency_destroy(res_ctx);
         }
     }
-
-    // Pass resiliency context back to caller for lifetime management
-    if (resiliency_ctx != NULL)
-    {
-        *resiliency_ctx = res_ctx;
-        res_ctx = NULL;
-    }
-    azihsm_resiliency_destroy(res_ctx);
-
-    return AZIHSM_STATUS_SUCCESS;
+    return status;
 }
 
 void azihsm_close_device_and_session(azihsm_handle device, azihsm_handle session)
@@ -1259,11 +1159,7 @@ static azihsm_status wrap_and_unwrap_pkcs8(
 
     status = azihsm_crypt_encrypt(&wrap_algo, wrapping_pub, &plain_buf, &wrapped_buf);
     if (status != AZIHSM_STATUS_SUCCESS)
-    {
-        OPENSSL_cleanse(wrapped_data, wrapped_size);
-        OPENSSL_free(wrapped_data);
-        return status;
-    }
+        goto cleanup;
 
     /* Unwrap into the HSM */
     struct azihsm_algo_rsa_aes_key_wrap_params unwrap_params = {
@@ -1287,9 +1183,8 @@ static azihsm_status wrap_and_unwrap_pkcs8(
         out_pub
     );
 
-    OPENSSL_cleanse(wrapped_data, wrapped_size);
-    OPENSSL_free(wrapped_data);
-
+cleanup:
+    OPENSSL_clear_free(wrapped_data, wrapped_size);
     return status;
 }
 
@@ -1305,6 +1200,8 @@ azihsm_status azihsm_import_key_pair(
     azihsm_status status;
     azihsm_handle wrapping_pub = 0, wrapping_priv = 0;
     struct azihsm_buffer input_buf = { NULL, 0 };
+    uint8_t *pkcs8_buf = NULL;
+    int pkcs8_len = 0;
 
     if (provctx == NULL || input_key_file == NULL || priv_key_prop_list == NULL ||
         pub_key_prop_list == NULL || out_priv == NULL || out_pub == NULL)
@@ -1315,9 +1212,8 @@ azihsm_status azihsm_import_key_pair(
     /* 1. Read the input file from disk */
     status = azihsm_file_load(input_key_file, &input_buf);
     if (status != AZIHSM_STATUS_SUCCESS)
-    {
-        return status;
-    }
+        goto cleanup;
+
     if (input_buf.ptr == NULL || input_buf.len == 0)
     {
         ERR_raise_data(
@@ -1326,33 +1222,25 @@ azihsm_status azihsm_import_key_pair(
             "input key file '%s' is missing or empty",
             input_key_file
         );
-        return AZIHSM_STATUS_INVALID_ARGUMENT;
+        status = AZIHSM_STATUS_INVALID_ARGUMENT;
+        goto cleanup;
     }
 
     /* 2. Get the RSA unwrapping key pair from the HSM */
     status = azihsm_get_unwrapping_key(provctx, &wrapping_pub, &wrapping_priv);
     if (status != AZIHSM_STATUS_SUCCESS)
-    {
-        free_buffer(&input_buf);
-        return status;
-    }
+        goto cleanup;
 
     /* 3. Try to normalize as DER-encoded private key (SEC1, PKCS#1, or PKCS#8) */
-    uint8_t *pkcs8_buf = NULL;
-    int pkcs8_len = 0;
-
-    int norm_rc = azihsm_ossl_normalize_der_to_pkcs8(
-        input_buf.ptr,
-        (long)input_buf.len,
-        &pkcs8_buf,
-        &pkcs8_len
-    );
-
-    free_buffer(&input_buf);
-
-    if (norm_rc != OSSL_SUCCESS)
+    if (azihsm_ossl_normalize_der_to_pkcs8(
+            input_buf.ptr,
+            (long)input_buf.len,
+            &pkcs8_buf,
+            &pkcs8_len
+        ) != OSSL_SUCCESS)
     {
-        return AZIHSM_STATUS_INVALID_ARGUMENT;
+        status = AZIHSM_STATUS_INVALID_ARGUMENT;
+        goto cleanup;
     }
 
     /* Plaintext DER path: wrap then unwrap into HSM */
@@ -1367,8 +1255,9 @@ azihsm_status azihsm_import_key_pair(
         out_pub
     );
 
-    OPENSSL_cleanse(pkcs8_buf, (size_t)pkcs8_len);
-    OPENSSL_free(pkcs8_buf);
+cleanup:
+    free_buffer(&input_buf);
+    OPENSSL_clear_free(pkcs8_buf, (size_t)pkcs8_len);
     return status;
 }
 
@@ -1394,9 +1283,8 @@ azihsm_status azihsm_unwrap_key_pair(
     /* 1. Read the wrapped blob from disk */
     status = azihsm_file_load(wrapped_key_file, &input_buf);
     if (status != AZIHSM_STATUS_SUCCESS)
-    {
-        return status;
-    }
+        goto cleanup;
+
     if (input_buf.ptr == NULL || input_buf.len == 0)
     {
         ERR_raise_data(
@@ -1405,16 +1293,14 @@ azihsm_status azihsm_unwrap_key_pair(
             "wrapped key file '%s' is missing or empty",
             wrapped_key_file
         );
-        return AZIHSM_STATUS_INVALID_ARGUMENT;
+        status = AZIHSM_STATUS_INVALID_ARGUMENT;
+        goto cleanup;
     }
 
     /* 2. Get the RSA unwrapping key pair from the HSM */
     status = azihsm_get_unwrapping_key(provctx, &wrapping_pub, &wrapping_priv);
     if (status != AZIHSM_STATUS_SUCCESS)
-    {
-        free_buffer(&input_buf);
-        return status;
-    }
+        goto cleanup;
 
     /* 3. Unwrap directly — the blob is already wrapped */
     struct azihsm_algo_rsa_pkcs_oaep_params oaep_params = {
@@ -1444,6 +1330,7 @@ azihsm_status azihsm_unwrap_key_pair(
         out_pub
     );
 
+cleanup:
     free_buffer(&input_buf);
     return status;
 }

--- a/plugins/ossl_prov/src/azihsm_ossl_hsm.c
+++ b/plugins/ossl_prov/src/azihsm_ossl_hsm.c
@@ -585,7 +585,8 @@ static azihsm_status der_to_uncompressed_point(
 
     if (pub_key_der == NULL || pub_key_der->ptr == NULL)
     {
-        return AZIHSM_STATUS_INVALID_ARGUMENT;
+        status = AZIHSM_STATUS_INVALID_ARGUMENT;
+        goto cleanup;
     }
 
     der_ptr = pub_key_der->ptr;
@@ -771,9 +772,7 @@ azihsm_status compute_pota_endorsement(
 
     status = der_to_uncompressed_point(pid_pub_key_der, uncompressed_point);
     if (status != AZIHSM_STATUS_SUCCESS)
-    {
-        return status;
-    }
+        goto cleanup;
 
     status = sign_with_pota_key(
         priv_key_buf->ptr,
@@ -782,12 +781,9 @@ azihsm_status compute_pota_endorsement(
         sizeof(uncompressed_point),
         sig_out
     );
-    if (status != AZIHSM_STATUS_SUCCESS)
-    {
-        return status;
-    }
 
-    return AZIHSM_STATUS_SUCCESS;
+cleanup:
+    return status;
 }
 
 azihsm_status azihsm_open_device_and_session(
@@ -828,7 +824,8 @@ azihsm_status azihsm_open_device_and_session(
             ERR_R_PASSED_NULL_PARAMETER,
             "azihsm_open_device_and_session: NULL argument"
         );
-        return AZIHSM_STATUS_INVALID_ARGUMENT;
+        status = AZIHSM_STATUS_INVALID_ARGUMENT;
+        goto cleanup;
     }
 
     /* Use API revision from configuration */
@@ -1206,7 +1203,8 @@ azihsm_status azihsm_import_key_pair(
     if (provctx == NULL || input_key_file == NULL || priv_key_prop_list == NULL ||
         pub_key_prop_list == NULL || out_priv == NULL || out_pub == NULL)
     {
-        return AZIHSM_STATUS_INVALID_ARGUMENT;
+        status = AZIHSM_STATUS_INVALID_ARGUMENT;
+        goto cleanup;
     }
 
     /* 1. Read the input file from disk */
@@ -1277,7 +1275,8 @@ azihsm_status azihsm_unwrap_key_pair(
     if (provctx == NULL || wrapped_key_file == NULL || priv_key_prop_list == NULL ||
         pub_key_prop_list == NULL || out_priv == NULL || out_pub == NULL)
     {
-        return AZIHSM_STATUS_INVALID_ARGUMENT;
+        status = AZIHSM_STATUS_INVALID_ARGUMENT;
+        goto cleanup;
     }
 
     /* 1. Read the wrapped blob from disk */

--- a/plugins/ossl_prov/src/azihsm_ossl_hsm.c
+++ b/plugins/ossl_prov/src/azihsm_ossl_hsm.c
@@ -772,7 +772,9 @@ azihsm_status compute_pota_endorsement(
 
     status = der_to_uncompressed_point(pid_pub_key_der, uncompressed_point);
     if (status != AZIHSM_STATUS_SUCCESS)
+    {
         goto cleanup;
+    }
 
     status = sign_with_pota_key(
         priv_key_buf->ptr,
@@ -842,7 +844,9 @@ azihsm_status azihsm_open_device_and_session(
     {
         status = load_credentials_from_file(AZIHSM_DEFAULT_CREDENTIALS_ID_PATH, creds.id);
         if (status != AZIHSM_STATUS_SUCCESS)
+        {
             goto cleanup;
+        }
     }
 
     if (config->credentials_pin_from_env)
@@ -853,17 +857,23 @@ azihsm_status azihsm_open_device_and_session(
     {
         status = load_credentials_from_file(AZIHSM_DEFAULT_CREDENTIALS_PIN_PATH, creds.pin);
         if (status != AZIHSM_STATUS_SUCCESS)
+        {
             goto cleanup;
+        }
     }
 
     // Load key files if they exist
     status = azihsm_file_load(config->bmk_path, &bmk_buf);
     if (status != AZIHSM_STATUS_SUCCESS)
+    {
         goto cleanup;
+    }
 
     status = azihsm_file_load(config->muk_path, &muk_buf);
     if (status != AZIHSM_STATUS_SUCCESS)
+    {
         goto cleanup;
+    }
     muk_was_loaded = (muk_buf.ptr != NULL);
 
     // Configure OBK based on source selection
@@ -879,7 +889,9 @@ azihsm_status azihsm_open_device_and_session(
         // owner backup key (MOBK) returned by the HSM.
         status = azihsm_file_load(config->obk_path, &obk_buf);
         if (status != AZIHSM_STATUS_SUCCESS)
+        {
             goto cleanup;
+        }
 
         if (obk_buf.ptr == NULL)
         {
@@ -922,7 +934,9 @@ azihsm_status azihsm_open_device_and_session(
 
     status = azihsm_get_device_handle(device, api_rev);
     if (status != AZIHSM_STATUS_SUCCESS)
+    {
         goto cleanup;
+    }
     device_opened = true;
 
     /* Create resiliency config if enabled */
@@ -940,7 +954,9 @@ azihsm_status azihsm_open_device_and_session(
             &res_ctx
         );
         if (status != AZIHSM_STATUS_SUCCESS)
+        {
             goto cleanup;
+        }
     }
 
     // Configure POTA endorsement based on source selection
@@ -954,11 +970,15 @@ azihsm_status azihsm_open_device_and_session(
         // Load POTA keys from files
         status = azihsm_file_load(config->pota_private_key_path, &pota_priv_buf);
         if (status != AZIHSM_STATUS_SUCCESS)
+        {
             goto cleanup;
+        }
 
         status = azihsm_file_load(config->pota_public_key_path, &pota_pub_buf);
         if (status != AZIHSM_STATUS_SUCCESS)
+        {
             goto cleanup;
+        }
 
         // POTA key files are required when using caller source — both must be present.
         if (pota_priv_buf.ptr == NULL && pota_pub_buf.ptr == NULL)
@@ -996,11 +1016,15 @@ azihsm_status azihsm_open_device_and_session(
         // Compute POTA endorsement: sign PID public key with POTA key
         status = get_part_property(*device, AZIHSM_PART_PROP_ID_PART_PUB_KEY, &pid_pub_key_buf);
         if (status != AZIHSM_STATUS_SUCCESS)
+        {
             goto cleanup;
+        }
 
         status = compute_pota_endorsement(&pid_pub_key_buf, &pota_priv_buf, &pota_sig_buf);
         if (status != AZIHSM_STATUS_SUCCESS)
+        {
             goto cleanup;
+        }
 
         pota_data.signature = &pota_sig_buf;
         pota_data.public_key = &pota_pub_buf;
@@ -1019,7 +1043,9 @@ azihsm_status azihsm_open_device_and_session(
         config->resiliency_enabled ? &resiliency_cfg : NULL
     );
     if (status != AZIHSM_STATUS_SUCCESS)
+    {
         goto cleanup;
+    }
 
     // Retrieve and persist BMK property
     status = get_part_property(*device, AZIHSM_PART_PROP_ID_BACKUP_MASKING_KEY, &retrieved_bmk);
@@ -1027,13 +1053,17 @@ azihsm_status azihsm_open_device_and_session(
     {
         status = write_buffer_to_file(config->bmk_path, &retrieved_bmk);
         if (status != AZIHSM_STATUS_SUCCESS)
+        {
             goto cleanup;
+        }
     }
 
     // Open session (seed=NULL lets the library generate random bytes internally)
     status = azihsm_sess_open(*device, &creds, NULL, session);
     if (status != AZIHSM_STATUS_SUCCESS)
+    {
         goto cleanup;
+    }
     session_opened = true;
 
     // If MUK wasn't loaded from file, generate and save it
@@ -1041,7 +1071,9 @@ azihsm_status azihsm_open_device_and_session(
     {
         status = generate_and_save_muk(*session, config->muk_path);
         if (status != AZIHSM_STATUS_SUCCESS)
+        {
             goto cleanup;
+        }
     }
 
     status = AZIHSM_STATUS_SUCCESS;
@@ -1177,7 +1209,9 @@ static azihsm_status wrap_and_unwrap_pkcs8(
 
     status = azihsm_crypt_encrypt(&wrap_algo, wrapping_pub, &plain_buf, &wrapped_buf);
     if (status != AZIHSM_STATUS_SUCCESS)
+    {
         goto cleanup;
+    }
 
     /* Unwrap into the HSM */
     status = azihsm_key_unwrap_pair(
@@ -1220,7 +1254,9 @@ azihsm_status azihsm_import_key_pair(
     /* 1. Read the input file from disk */
     status = azihsm_file_load(input_key_file, &input_buf);
     if (status != AZIHSM_STATUS_SUCCESS)
+    {
         goto cleanup;
+    }
 
     if (input_buf.ptr == NULL || input_buf.len == 0)
     {
@@ -1237,7 +1273,9 @@ azihsm_status azihsm_import_key_pair(
     /* 2. Get the RSA unwrapping key pair from the HSM */
     status = azihsm_get_unwrapping_key(provctx, &wrapping_pub, &wrapping_priv);
     if (status != AZIHSM_STATUS_SUCCESS)
+    {
         goto cleanup;
+    }
 
     /* 3. Try to normalize as DER-encoded private key (SEC1, PKCS#1, or PKCS#8) */
     if (azihsm_ossl_normalize_der_to_pkcs8(
@@ -1309,7 +1347,9 @@ azihsm_status azihsm_unwrap_key_pair(
     /* 1. Read the wrapped blob from disk */
     status = azihsm_file_load(wrapped_key_file, &input_buf);
     if (status != AZIHSM_STATUS_SUCCESS)
+    {
         goto cleanup;
+    }
 
     if (input_buf.ptr == NULL || input_buf.len == 0)
     {
@@ -1326,7 +1366,9 @@ azihsm_status azihsm_unwrap_key_pair(
     /* 2. Get the RSA unwrapping key pair from the HSM */
     status = azihsm_get_unwrapping_key(provctx, &wrapping_pub, &wrapping_priv);
     if (status != AZIHSM_STATUS_SUCCESS)
+    {
         goto cleanup;
+    }
 
     /* 3. Unwrap directly — the blob is already wrapped */
     status = azihsm_key_unwrap_pair(

--- a/plugins/ossl_prov/src/azihsm_ossl_hsm.c
+++ b/plugins/ossl_prov/src/azihsm_ossl_hsm.c
@@ -999,7 +999,6 @@ azihsm_status azihsm_open_device_and_session(
             goto cleanup;
 
         status = compute_pota_endorsement(&pid_pub_key_buf, &pota_priv_buf, &pota_sig_buf);
-        free_buffer(&pid_pub_key_buf);
         if (status != AZIHSM_STATUS_SUCCESS)
             goto cleanup;
 

--- a/plugins/ossl_prov/src/azihsm_ossl_hsm.c
+++ b/plugins/ossl_prov/src/azihsm_ossl_hsm.c
@@ -1107,6 +1107,8 @@ static azihsm_status wrap_and_unwrap_pkcs8(
 )
 {
     azihsm_status status;
+    uint8_t *wrapped_data = NULL;
+    uint32_t wrapped_size = 0;
 
     struct azihsm_algo_rsa_pkcs_oaep_params oaep_params = {
         .hash_algo_id = AZIHSM_ALGO_ID_SHA256,
@@ -1130,35 +1132,6 @@ static azihsm_status wrap_and_unwrap_pkcs8(
         .len = (uint32_t)pkcs8_len,
     };
 
-    /* Two-call pattern: first query required size */
-    struct azihsm_buffer wrapped_buf = {
-        .ptr = NULL,
-        .len = 0,
-    };
-
-    status = azihsm_crypt_encrypt(&wrap_algo, wrapping_pub, &plain_buf, &wrapped_buf);
-    if (status != AZIHSM_STATUS_BUFFER_TOO_SMALL || wrapped_buf.len == 0)
-    {
-        return (status == AZIHSM_STATUS_SUCCESS) ? AZIHSM_STATUS_INTERNAL_ERROR : status;
-    }
-
-    /* Allocate buffer for wrapped data */
-    uint32_t wrapped_size = wrapped_buf.len;
-    uint8_t *wrapped_data = OPENSSL_malloc(wrapped_size);
-    if (wrapped_data == NULL)
-    {
-        return AZIHSM_STATUS_INTERNAL_ERROR;
-    }
-
-    /* Second call: perform actual wrap */
-    wrapped_buf.ptr = wrapped_data;
-    wrapped_buf.len = wrapped_size;
-
-    status = azihsm_crypt_encrypt(&wrap_algo, wrapping_pub, &plain_buf, &wrapped_buf);
-    if (status != AZIHSM_STATUS_SUCCESS)
-        goto cleanup;
-
-    /* Unwrap into the HSM */
     struct azihsm_algo_rsa_aes_key_wrap_params unwrap_params = {
         .aes_key_bits = 256,
         .oaep_params = &oaep_params,
@@ -1170,6 +1143,37 @@ static azihsm_status wrap_and_unwrap_pkcs8(
         .len = sizeof(unwrap_params),
     };
 
+    /* Two-call pattern: first query required size */
+    struct azihsm_buffer wrapped_buf = {
+        .ptr = NULL,
+        .len = 0,
+    };
+
+    status = azihsm_crypt_encrypt(&wrap_algo, wrapping_pub, &plain_buf, &wrapped_buf);
+    if (status != AZIHSM_STATUS_BUFFER_TOO_SMALL || wrapped_buf.len == 0)
+    {
+        status = (status == AZIHSM_STATUS_SUCCESS) ? AZIHSM_STATUS_INTERNAL_ERROR : status;
+        goto cleanup;
+    }
+
+    /* Allocate buffer for wrapped data */
+    wrapped_size = wrapped_buf.len;
+    wrapped_data = OPENSSL_malloc(wrapped_size);
+    if (wrapped_data == NULL)
+    {
+        status = AZIHSM_STATUS_INTERNAL_ERROR;
+        goto cleanup;
+    }
+
+    /* Second call: perform actual wrap */
+    wrapped_buf.ptr = wrapped_data;
+    wrapped_buf.len = wrapped_size;
+
+    status = azihsm_crypt_encrypt(&wrap_algo, wrapping_pub, &plain_buf, &wrapped_buf);
+    if (status != AZIHSM_STATUS_SUCCESS)
+        goto cleanup;
+
+    /* Unwrap into the HSM */
     status = azihsm_key_unwrap_pair(
         &unwrap_algo,
         wrapping_priv,
@@ -1272,6 +1276,23 @@ azihsm_status azihsm_unwrap_key_pair(
     azihsm_handle wrapping_pub = 0, wrapping_priv = 0;
     struct azihsm_buffer input_buf = { NULL, 0 };
 
+    struct azihsm_algo_rsa_pkcs_oaep_params oaep_params = {
+        .hash_algo_id = AZIHSM_ALGO_ID_SHA256,
+        .mgf1_hash_algo_id = AZIHSM_MGF1_ID_SHA256,
+        .label = NULL,
+    };
+
+    struct azihsm_algo_rsa_aes_key_wrap_params unwrap_params = {
+        .aes_key_bits = 256,
+        .oaep_params = &oaep_params,
+    };
+
+    struct azihsm_algo unwrap_algo = {
+        .id = AZIHSM_ALGO_ID_RSA_AES_KEY_WRAP,
+        .params = &unwrap_params,
+        .len = sizeof(unwrap_params),
+    };
+
     if (provctx == NULL || wrapped_key_file == NULL || priv_key_prop_list == NULL ||
         pub_key_prop_list == NULL || out_priv == NULL || out_pub == NULL)
     {
@@ -1302,23 +1323,6 @@ azihsm_status azihsm_unwrap_key_pair(
         goto cleanup;
 
     /* 3. Unwrap directly — the blob is already wrapped */
-    struct azihsm_algo_rsa_pkcs_oaep_params oaep_params = {
-        .hash_algo_id = AZIHSM_ALGO_ID_SHA256,
-        .mgf1_hash_algo_id = AZIHSM_MGF1_ID_SHA256,
-        .label = NULL,
-    };
-
-    struct azihsm_algo_rsa_aes_key_wrap_params unwrap_params = {
-        .aes_key_bits = 256,
-        .oaep_params = &oaep_params,
-    };
-
-    struct azihsm_algo unwrap_algo = {
-        .id = AZIHSM_ALGO_ID_RSA_AES_KEY_WRAP,
-        .params = &unwrap_params,
-        .len = sizeof(unwrap_params),
-    };
-
     status = azihsm_key_unwrap_pair(
         &unwrap_algo,
         wrapping_priv,

--- a/plugins/ossl_prov/src/azihsm_ossl_hsm.c
+++ b/plugins/ossl_prov/src/azihsm_ossl_hsm.c
@@ -1061,12 +1061,19 @@ cleanup:
 
     if (status != AZIHSM_STATUS_SUCCESS)
     {
-        /* Tear down device/session/resiliency only on failure */
+        /* Tear down device/session/resiliency only on failure.
+         * Zero handles after closing to prevent stale handle usage by caller. */
         azihsm_resiliency_destroy(res_ctx);
         if (session_opened)
+        {
             azihsm_sess_close(*session);
+            *session = 0;
+        }
         if (device_opened)
+        {
             azihsm_part_close(*device);
+            *device = 0;
+        }
     }
     else
     {

--- a/plugins/ossl_prov/src/azihsm_ossl_kdf.c
+++ b/plugins/ossl_prov/src/azihsm_ossl_kdf.c
@@ -276,8 +276,7 @@ static void *azihsm_ossl_hkdf_dupctx(void *kctx)
         if (dup->ikm_data == NULL)
         {
             ERR_raise(ERR_LIB_PROV, ERR_R_MALLOC_FAILURE);
-            OPENSSL_clear_free(dup, sizeof(AZIHSM_HKDF_CTX));
-            return NULL;
+            goto cleanup;
         }
         memcpy(dup->ikm_data, ctx->ikm_data, ctx->ikm_data_len);
     }
@@ -290,13 +289,7 @@ static void *azihsm_ossl_hkdf_dupctx(void *kctx)
         if (dup->salt == NULL)
         {
             ERR_raise(ERR_LIB_PROV, ERR_R_MALLOC_FAILURE);
-            if (dup->ikm_data != NULL)
-            {
-                OPENSSL_cleanse(dup->ikm_data, dup->ikm_data_len);
-                OPENSSL_free(dup->ikm_data);
-            }
-            OPENSSL_clear_free(dup, sizeof(AZIHSM_HKDF_CTX));
-            return NULL;
+            goto cleanup;
         }
         memcpy(dup->salt, ctx->salt, ctx->salt_len);
     }
@@ -309,15 +302,7 @@ static void *azihsm_ossl_hkdf_dupctx(void *kctx)
         if (dup->info == NULL)
         {
             ERR_raise(ERR_LIB_PROV, ERR_R_MALLOC_FAILURE);
-            if (dup->ikm_data != NULL)
-            {
-                OPENSSL_cleanse(dup->ikm_data, dup->ikm_data_len);
-                OPENSSL_free(dup->ikm_data);
-            }
-            OPENSSL_cleanse(dup->salt, ctx->salt_len);
-            OPENSSL_free(dup->salt);
-            OPENSSL_clear_free(dup, sizeof(AZIHSM_HKDF_CTX));
-            return NULL;
+            goto cleanup;
         }
         memcpy(dup->info, ctx->info, ctx->info_len);
     }
@@ -327,6 +312,13 @@ static void *azihsm_ossl_hkdf_dupctx(void *kctx)
     dup->ikm_handle = 0;
 
     return dup;
+
+cleanup:
+    OPENSSL_clear_free(dup->ikm_data, dup->ikm_data_len);
+    OPENSSL_clear_free(dup->salt, dup->salt_len);
+    OPENSSL_clear_free(dup->info, dup->info_len);
+    OPENSSL_clear_free(dup, sizeof(AZIHSM_HKDF_CTX));
+    return NULL;
 }
 
 static void azihsm_ossl_hkdf_reset(void *kctx)

--- a/plugins/ossl_prov/src/azihsm_ossl_kdf.c
+++ b/plugins/ossl_prov/src/azihsm_ossl_kdf.c
@@ -252,18 +252,19 @@ static void azihsm_ossl_hkdf_freectx(void *kctx)
 static void *azihsm_ossl_hkdf_dupctx(void *kctx)
 {
     AZIHSM_HKDF_CTX *ctx = (AZIHSM_HKDF_CTX *)kctx;
-    AZIHSM_HKDF_CTX *dup;
+    AZIHSM_HKDF_CTX *dup = NULL;
+    bool failed = false;
 
     if (ctx == NULL)
     {
-        return NULL;
+        goto cleanup;
     }
 
     dup = OPENSSL_zalloc(sizeof(AZIHSM_HKDF_CTX));
     if (dup == NULL)
     {
         ERR_raise(ERR_LIB_PROV, ERR_R_MALLOC_FAILURE);
-        return NULL;
+        goto cleanup;
     }
 
     memcpy(dup, ctx, sizeof(AZIHSM_HKDF_CTX));
@@ -276,6 +277,7 @@ static void *azihsm_ossl_hkdf_dupctx(void *kctx)
         if (dup->ikm_data == NULL)
         {
             ERR_raise(ERR_LIB_PROV, ERR_R_MALLOC_FAILURE);
+            failed = true;
             goto cleanup;
         }
         memcpy(dup->ikm_data, ctx->ikm_data, ctx->ikm_data_len);
@@ -289,6 +291,7 @@ static void *azihsm_ossl_hkdf_dupctx(void *kctx)
         if (dup->salt == NULL)
         {
             ERR_raise(ERR_LIB_PROV, ERR_R_MALLOC_FAILURE);
+            failed = true;
             goto cleanup;
         }
         memcpy(dup->salt, ctx->salt, ctx->salt_len);
@@ -302,6 +305,7 @@ static void *azihsm_ossl_hkdf_dupctx(void *kctx)
         if (dup->info == NULL)
         {
             ERR_raise(ERR_LIB_PROV, ERR_R_MALLOC_FAILURE);
+            failed = true;
             goto cleanup;
         }
         memcpy(dup->info, ctx->info, ctx->info_len);
@@ -311,14 +315,21 @@ static void *azihsm_ossl_hkdf_dupctx(void *kctx)
     dup->ikm_loaded = false;
     dup->ikm_handle = 0;
 
-    return dup;
-
 cleanup:
-    OPENSSL_clear_free(dup->ikm_data, dup->ikm_data_len);
-    OPENSSL_clear_free(dup->salt, dup->salt_len);
-    OPENSSL_clear_free(dup->info, dup->info_len);
-    OPENSSL_clear_free(dup, sizeof(AZIHSM_HKDF_CTX));
-    return NULL;
+    /* On error (dup allocation succeeded but a deep-copy failed), free partial state.
+     * OPENSSL_clear_free is NULL-safe — safe to call unconditionally. */
+    if (failed)
+    {
+        if (dup != NULL)
+        {
+            OPENSSL_clear_free(dup->ikm_data, dup->ikm_data_len);
+            OPENSSL_clear_free(dup->salt, dup->salt_len);
+            OPENSSL_clear_free(dup->info, dup->info_len);
+            OPENSSL_clear_free(dup, sizeof(AZIHSM_HKDF_CTX));
+        }
+        return NULL;
+    }
+    return dup;
 }
 
 static void azihsm_ossl_hkdf_reset(void *kctx)

--- a/plugins/ossl_prov/src/azihsm_ossl_keyexch.c
+++ b/plugins/ossl_prov/src/azihsm_ossl_keyexch.c
@@ -188,18 +188,19 @@ static void azihsm_ossl_keyexch_freectx(void *kectx)
 static void *azihsm_ossl_keyexch_dupctx(void *kectx)
 {
     AZIHSM_KEYEXCH_CTX *ctx = (AZIHSM_KEYEXCH_CTX *)kectx;
-    AZIHSM_KEYEXCH_CTX *dup;
+    AZIHSM_KEYEXCH_CTX *dup = NULL;
+    bool failed = false;
 
     if (ctx == NULL)
     {
-        return NULL;
+        goto cleanup;
     }
 
     dup = OPENSSL_zalloc(sizeof(AZIHSM_KEYEXCH_CTX));
     if (dup == NULL)
     {
         ERR_raise(ERR_LIB_PROV, ERR_R_MALLOC_FAILURE);
-        return NULL;
+        goto cleanup;
     }
 
     memcpy(dup, ctx, sizeof(AZIHSM_KEYEXCH_CTX));
@@ -210,6 +211,7 @@ static void *azihsm_ossl_keyexch_dupctx(void *kectx)
         if (dup->peer_key == NULL)
         {
             ERR_raise(ERR_LIB_PROV, ERR_R_MALLOC_FAILURE);
+            failed = true;
             goto cleanup;
         }
         memcpy(dup->peer_key, ctx->peer_key, sizeof(AZIHSM_EC_KEY));
@@ -221,6 +223,7 @@ static void *azihsm_ossl_keyexch_dupctx(void *kectx)
             if (dup->peer_key->pub_key_data == NULL)
             {
                 ERR_raise(ERR_LIB_PROV, ERR_R_MALLOC_FAILURE);
+                failed = true;
                 goto cleanup;
             }
             memcpy(
@@ -231,16 +234,15 @@ static void *azihsm_ossl_keyexch_dupctx(void *kectx)
         }
     }
 
-    return dup;
-
 cleanup:
     /* OPENSSL_free is NULL-safe — call unconditionally */
-    if (dup != NULL)
+    if (failed && dup != NULL)
     {
         OPENSSL_free(dup->peer_key);
         OPENSSL_free(dup);
+        dup = NULL;
     }
-    return NULL;
+    return dup;
 }
 
 static int azihsm_ossl_keyexch_set_ctx_params(void *kectx, const OSSL_PARAM params[])

--- a/plugins/ossl_prov/src/azihsm_ossl_keyexch.c
+++ b/plugins/ossl_prov/src/azihsm_ossl_keyexch.c
@@ -71,6 +71,7 @@ static int ec_point_to_der_spki(
     int *der_len
 )
 {
+    int ret = OSSL_FAILURE;
     EC_GROUP *group = NULL;
     EC_POINT *point = NULL;
     EC_KEY *ec_key = NULL;
@@ -84,93 +85,53 @@ static int ec_point_to_der_spki(
     if (group == NULL)
     {
         ERR_raise(ERR_LIB_PROV, ERR_R_EC_LIB);
-
-        EVP_PKEY_free(pkey);
-        EC_KEY_free(ec_key);
-        EC_POINT_free(point);
-        EC_GROUP_free(group);
-        return OSSL_FAILURE;
+        goto cleanup;
     }
 
     point = EC_POINT_new(group);
     if (point == NULL)
     {
         ERR_raise(ERR_LIB_PROV, ERR_R_MALLOC_FAILURE);
-
-        EVP_PKEY_free(pkey);
-        EC_KEY_free(ec_key);
-        EC_POINT_free(point);
-        EC_GROUP_free(group);
-        return OSSL_FAILURE;
+        goto cleanup;
     }
 
     /* Decode the uncompressed EC point from its octet-string form */
     if (!EC_POINT_oct2point(group, point, pub_point, pub_point_len, NULL))
     {
         ERR_raise(ERR_LIB_PROV, ERR_R_EC_LIB);
-
-        EVP_PKEY_free(pkey);
-        EC_KEY_free(ec_key);
-        EC_POINT_free(point);
-        EC_GROUP_free(group);
-        return OSSL_FAILURE;
+        goto cleanup;
     }
 
     ec_key = EC_KEY_new();
     if (ec_key == NULL)
     {
         ERR_raise(ERR_LIB_PROV, ERR_R_MALLOC_FAILURE);
-
-        EVP_PKEY_free(pkey);
-        EC_KEY_free(ec_key);
-        EC_POINT_free(point);
-        EC_GROUP_free(group);
-        return OSSL_FAILURE;
+        goto cleanup;
     }
 
     if (!EC_KEY_set_group(ec_key, group))
     {
         ERR_raise(ERR_LIB_PROV, ERR_R_EC_LIB);
-
-        EVP_PKEY_free(pkey);
-        EC_KEY_free(ec_key);
-        EC_POINT_free(point);
-        EC_GROUP_free(group);
-        return OSSL_FAILURE;
+        goto cleanup;
     }
 
     if (!EC_KEY_set_public_key(ec_key, point))
     {
         ERR_raise(ERR_LIB_PROV, ERR_R_EC_LIB);
-
-        EVP_PKEY_free(pkey);
-        EC_KEY_free(ec_key);
-        EC_POINT_free(point);
-        EC_GROUP_free(group);
-        return OSSL_FAILURE;
+        goto cleanup;
     }
 
     pkey = EVP_PKEY_new();
     if (pkey == NULL)
     {
         ERR_raise(ERR_LIB_PROV, ERR_R_MALLOC_FAILURE);
-
-        EVP_PKEY_free(pkey);
-        EC_KEY_free(ec_key);
-        EC_POINT_free(point);
-        EC_GROUP_free(group);
-        return OSSL_FAILURE;
+        goto cleanup;
     }
 
     if (!EVP_PKEY_assign_EC_KEY(pkey, ec_key))
     {
         ERR_raise(ERR_LIB_PROV, ERR_R_EVP_LIB);
-
-        EVP_PKEY_free(pkey);
-        EC_KEY_free(ec_key);
-        EC_POINT_free(point);
-        EC_GROUP_free(group);
-        return OSSL_FAILURE;
+        goto cleanup;
     }
     ec_key = NULL; /* Ownership transferred to pkey */
 
@@ -181,20 +142,18 @@ static int ec_point_to_der_spki(
         *der_out = NULL;
         *der_len = 0;
         ERR_raise(ERR_LIB_PROV, ERR_R_ASN1_LIB);
-
-        EVP_PKEY_free(pkey);
-        EC_KEY_free(ec_key);
-        EC_POINT_free(point);
-        EC_GROUP_free(group);
-        return OSSL_FAILURE;
+        goto cleanup;
     }
 
+    ret = OSSL_SUCCESS;
+
+cleanup:
+    /* OpenSSL free functions are NULL-safe — call unconditionally */
     EVP_PKEY_free(pkey);
     EC_KEY_free(ec_key);
     EC_POINT_free(point);
     EC_GROUP_free(group);
-
-    return OSSL_SUCCESS;
+    return ret;
 }
 
 static void *azihsm_ossl_keyexch_newctx(void *provctx)
@@ -250,10 +209,8 @@ static void *azihsm_ossl_keyexch_dupctx(void *kectx)
         dup->peer_key = OPENSSL_zalloc(sizeof(AZIHSM_EC_KEY));
         if (dup->peer_key == NULL)
         {
-            OPENSSL_free(dup);
-
             ERR_raise(ERR_LIB_PROV, ERR_R_MALLOC_FAILURE);
-            return NULL;
+            goto cleanup;
         }
         memcpy(dup->peer_key, ctx->peer_key, sizeof(AZIHSM_EC_KEY));
         dup->peer_key->pub_key_data = NULL;
@@ -263,11 +220,8 @@ static void *azihsm_ossl_keyexch_dupctx(void *kectx)
             dup->peer_key->pub_key_data = OPENSSL_malloc(ctx->peer_key->pub_key_data_len);
             if (dup->peer_key->pub_key_data == NULL)
             {
-                OPENSSL_free(dup->peer_key);
-                OPENSSL_free(dup);
-
                 ERR_raise(ERR_LIB_PROV, ERR_R_MALLOC_FAILURE);
-                return NULL;
+                goto cleanup;
             }
             memcpy(
                 dup->peer_key->pub_key_data,
@@ -278,6 +232,15 @@ static void *azihsm_ossl_keyexch_dupctx(void *kectx)
     }
 
     return dup;
+
+cleanup:
+    /* OPENSSL_free is NULL-safe — call unconditionally */
+    if (dup != NULL)
+    {
+        OPENSSL_free(dup->peer_key);
+        OPENSSL_free(dup);
+    }
+    return NULL;
 }
 
 static int azihsm_ossl_keyexch_set_ctx_params(void *kectx, const OSSL_PARAM params[])
@@ -376,8 +339,8 @@ static int azihsm_ossl_keyexch_set_peer(void *kectx, void *provkey)
         copy->pub_key_data = OPENSSL_malloc(key->pub_key_data_len);
         if (copy->pub_key_data == NULL)
         {
-            OPENSSL_free(copy);
             ERR_raise(ERR_LIB_PROV, ERR_R_MALLOC_FAILURE);
+            OPENSSL_free(copy);
             return OSSL_FAILURE;
         }
         memcpy(copy->pub_key_data, key->pub_key_data, key->pub_key_data_len);

--- a/plugins/ossl_prov/src/azihsm_ossl_keymgmt_ec.c
+++ b/plugins/ossl_prov/src/azihsm_ossl_keymgmt_ec.c
@@ -314,6 +314,7 @@ static AZIHSM_EC_KEY *azihsm_ossl_keymgmt_gen(
             if (masked_key_buffer == NULL)
             {
                 ERR_raise(ERR_LIB_PROV, ERR_R_MALLOC_FAILURE);
+                status = AZIHSM_STATUS_INTERNAL_ERROR;
                 goto cleanup;
             }
 
@@ -325,6 +326,7 @@ static AZIHSM_EC_KEY *azihsm_ossl_keymgmt_gen(
             {
                 OPENSSL_clear_free(masked_key_buffer, masked_key_buffer_size);
                 ERR_raise(ERR_LIB_PROV, ERR_R_OPERATION_FAIL);
+                status = AZIHSM_STATUS_INTERNAL_ERROR;
                 goto cleanup;
             }
 
@@ -336,6 +338,7 @@ static AZIHSM_EC_KEY *azihsm_ossl_keymgmt_gen(
                 ) != OSSL_SUCCESS)
             {
                 OPENSSL_clear_free(masked_key_buffer, masked_key_buffer_size);
+                status = AZIHSM_STATUS_INTERNAL_ERROR;
                 goto cleanup;
             }
 
@@ -345,20 +348,27 @@ static AZIHSM_EC_KEY *azihsm_ossl_keymgmt_gen(
         {
             /* Unexpected error - not BUFFER_TOO_SMALL and not PROPERTY_NOT_PRESENT */
             ERR_raise(ERR_LIB_PROV, ERR_R_OPERATION_FAIL);
+            status = AZIHSM_STATUS_INTERNAL_ERROR;
             goto cleanup;
         }
         /* If PROPERTY_NOT_PRESENT, continue without masked key */
     }
 
-    return ec_key;
+    /* Success — prevent cleanup from freeing the result */
+    private = 0;
+    public = 0;
 
 cleanup:
     if (private != 0)
         azihsm_key_delete(private);
     if (public != 0)
         azihsm_key_delete(public);
-    OPENSSL_free(ec_key);
-    return NULL;
+    if (status != AZIHSM_STATUS_SUCCESS)
+    {
+        OPENSSL_free(ec_key);
+        ec_key = NULL;
+    }
+    return ec_key;
 }
 
 static AZIHSM_EC_KEY *azihsm_ossl_keymgmt_new(ossl_unused void *provctx)

--- a/plugins/ossl_prov/src/azihsm_ossl_keymgmt_ec.c
+++ b/plugins/ossl_prov/src/azihsm_ossl_keymgmt_ec.c
@@ -241,7 +241,8 @@ static AZIHSM_EC_KEY *azihsm_ossl_keymgmt_gen(
         .count = priv_key_prop_count,
     };
 
-    if ((ec_key = OPENSSL_zalloc(sizeof(AZIHSM_EC_KEY))) == NULL)
+    ec_key = OPENSSL_zalloc(sizeof(AZIHSM_EC_KEY));
+    if (ec_key == NULL)
     {
         ERR_raise(ERR_LIB_PROV, ERR_R_MALLOC_FAILURE);
         return NULL;
@@ -285,17 +286,8 @@ static AZIHSM_EC_KEY *azihsm_ossl_keymgmt_gen(
 
     if (status != AZIHSM_STATUS_SUCCESS)
     {
-        if (public != 0)
-        {
-            azihsm_key_delete(public);
-        }
-        if (private != 0)
-        {
-            azihsm_key_delete(private);
-        }
-        OPENSSL_free(ec_key);
         ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_GENERATE_KEY);
-        return NULL;
+        goto cleanup;
     }
 
     ec_key->genctx = *genctx;
@@ -321,11 +313,8 @@ static AZIHSM_EC_KEY *azihsm_ossl_keymgmt_gen(
             uint8_t *masked_key_buffer = OPENSSL_malloc(masked_key_buffer_size);
             if (masked_key_buffer == NULL)
             {
-                azihsm_key_delete(private);
-                azihsm_key_delete(public);
-                OPENSSL_free(ec_key);
                 ERR_raise(ERR_LIB_PROV, ERR_R_MALLOC_FAILURE);
-                return NULL;
+                goto cleanup;
             }
 
             /* Second call to retrieve the masked key */
@@ -334,14 +323,9 @@ static AZIHSM_EC_KEY *azihsm_ossl_keymgmt_gen(
 
             if (retrieve_status != AZIHSM_STATUS_SUCCESS)
             {
-                azihsm_key_delete(private);
-                azihsm_key_delete(public);
-
-                OPENSSL_cleanse(masked_key_buffer, masked_key_buffer_size);
-                OPENSSL_free(masked_key_buffer);
-                OPENSSL_free(ec_key);
+                OPENSSL_clear_free(masked_key_buffer, masked_key_buffer_size);
                 ERR_raise(ERR_LIB_PROV, ERR_R_OPERATION_FAIL);
-                return NULL;
+                goto cleanup;
             }
 
             /* Write masked key to file with restricted permissions (owner-only) */
@@ -351,30 +335,30 @@ static AZIHSM_EC_KEY *azihsm_ossl_keymgmt_gen(
                     genctx->masked_key_file
                 ) != OSSL_SUCCESS)
             {
-                azihsm_key_delete(private);
-                azihsm_key_delete(public);
-                OPENSSL_cleanse(masked_key_buffer, masked_key_buffer_size);
-                OPENSSL_free(masked_key_buffer);
-                OPENSSL_free(ec_key);
-                return NULL;
+                OPENSSL_clear_free(masked_key_buffer, masked_key_buffer_size);
+                goto cleanup;
             }
 
-            OPENSSL_cleanse(masked_key_buffer, masked_key_buffer_size);
-            OPENSSL_free(masked_key_buffer);
+            OPENSSL_clear_free(masked_key_buffer, masked_key_buffer_size);
         }
         else if (retrieve_status != AZIHSM_STATUS_PROPERTY_NOT_PRESENT)
         {
             /* Unexpected error - not BUFFER_TOO_SMALL and not PROPERTY_NOT_PRESENT */
-            azihsm_key_delete(private);
-            azihsm_key_delete(public);
-            OPENSSL_free(ec_key);
             ERR_raise(ERR_LIB_PROV, ERR_R_OPERATION_FAIL);
-            return NULL;
+            goto cleanup;
         }
         /* If PROPERTY_NOT_PRESENT, continue without masked key */
     }
 
     return ec_key;
+
+cleanup:
+    if (private != 0)
+        azihsm_key_delete(private);
+    if (public != 0)
+        azihsm_key_delete(public);
+    OPENSSL_free(ec_key);
+    return NULL;
 }
 
 static AZIHSM_EC_KEY *azihsm_ossl_keymgmt_new(ossl_unused void *provctx)

--- a/plugins/ossl_prov/src/azihsm_ossl_keymgmt_ec.c
+++ b/plugins/ossl_prov/src/azihsm_ossl_keymgmt_ec.c
@@ -164,7 +164,7 @@ static AZIHSM_EC_KEY *azihsm_ossl_keymgmt_gen(
 {
     AZIHSM_EC_KEY *ec_key;
     azihsm_handle public = 0, private = 0;
-    azihsm_status status;
+    azihsm_status status = AZIHSM_STATUS_INTERNAL_ERROR;
     const bool enable = true;
     const azihsm_key_class priv_class = AZIHSM_KEY_CLASS_PRIVATE;
     const azihsm_key_class pub_class = AZIHSM_KEY_CLASS_PUBLIC;

--- a/plugins/ossl_prov/src/azihsm_ossl_keymgmt_ec.c
+++ b/plugins/ossl_prov/src/azihsm_ossl_keymgmt_ec.c
@@ -338,6 +338,12 @@ static AZIHSM_EC_KEY *azihsm_ossl_keymgmt_gen(
                 ) != OSSL_SUCCESS)
             {
                 OPENSSL_clear_free(masked_key_buffer, masked_key_buffer_size);
+                ERR_raise_data(
+                    ERR_LIB_PROV,
+                    ERR_R_OPERATION_FAIL,
+                    "failed to write masked key to '%s'",
+                    genctx->masked_key_file
+                );
                 status = AZIHSM_STATUS_INTERNAL_ERROR;
                 goto cleanup;
             }

--- a/plugins/ossl_prov/src/azihsm_ossl_keymgmt_rsa.c
+++ b/plugins/ossl_prov/src/azihsm_ossl_keymgmt_rsa.c
@@ -241,7 +241,8 @@ static AZIHSM_RSA_KEY *azihsm_ossl_keymgmt_gen(
         .count = priv_key_prop_count,
     };
 
-    if ((rsa_key = OPENSSL_zalloc(sizeof(AZIHSM_RSA_KEY))) == NULL)
+    rsa_key = OPENSSL_zalloc(sizeof(AZIHSM_RSA_KEY));
+    if (rsa_key == NULL)
     {
         ERR_raise(ERR_LIB_PROV, ERR_R_MALLOC_FAILURE);
         return NULL;
@@ -273,9 +274,8 @@ static AZIHSM_RSA_KEY *azihsm_ossl_keymgmt_gen(
 
     if (status != AZIHSM_STATUS_SUCCESS)
     {
-        OPENSSL_free(rsa_key);
         ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_GENERATE_KEY);
-        return NULL;
+        goto cleanup;
     }
 
     rsa_key->genctx = *genctx;
@@ -301,11 +301,8 @@ static AZIHSM_RSA_KEY *azihsm_ossl_keymgmt_gen(
             uint8_t *masked_key_buffer = OPENSSL_malloc(masked_key_buffer_size);
             if (masked_key_buffer == NULL)
             {
-                azihsm_key_delete(private);
-                azihsm_key_delete(public);
-                OPENSSL_free(rsa_key);
                 ERR_raise(ERR_LIB_PROV, ERR_R_MALLOC_FAILURE);
-                return NULL;
+                goto cleanup;
             }
 
             /* Second call to retrieve the masked key */
@@ -314,13 +311,9 @@ static AZIHSM_RSA_KEY *azihsm_ossl_keymgmt_gen(
 
             if (retrieve_status != AZIHSM_STATUS_SUCCESS)
             {
-                azihsm_key_delete(private);
-                azihsm_key_delete(public);
-                OPENSSL_cleanse(masked_key_buffer, masked_key_buffer_size);
-                OPENSSL_free(masked_key_buffer);
-                OPENSSL_free(rsa_key);
+                OPENSSL_clear_free(masked_key_buffer, masked_key_buffer_size);
                 ERR_raise(ERR_LIB_PROV, ERR_R_OPERATION_FAIL);
-                return NULL;
+                goto cleanup;
             }
 
             /* Write masked key to file with restricted permissions (owner-only) */
@@ -330,30 +323,30 @@ static AZIHSM_RSA_KEY *azihsm_ossl_keymgmt_gen(
                     genctx->masked_key_file
                 ) != OSSL_SUCCESS)
             {
-                azihsm_key_delete(private);
-                azihsm_key_delete(public);
-                OPENSSL_cleanse(masked_key_buffer, masked_key_buffer_size);
-                OPENSSL_free(masked_key_buffer);
-                OPENSSL_free(rsa_key);
-                return NULL;
+                OPENSSL_clear_free(masked_key_buffer, masked_key_buffer_size);
+                goto cleanup;
             }
 
-            OPENSSL_cleanse(masked_key_buffer, masked_key_buffer_size);
-            OPENSSL_free(masked_key_buffer);
+            OPENSSL_clear_free(masked_key_buffer, masked_key_buffer_size);
         }
         else if (retrieve_status != AZIHSM_STATUS_PROPERTY_NOT_PRESENT)
         {
             /* Unexpected error - not BUFFER_TOO_SMALL and not PROPERTY_NOT_PRESENT */
-            azihsm_key_delete(private);
-            azihsm_key_delete(public);
-            OPENSSL_free(rsa_key);
             ERR_raise(ERR_LIB_PROV, ERR_R_OPERATION_FAIL);
-            return NULL;
+            goto cleanup;
         }
         /* If PROPERTY_NOT_PRESENT, continue without masked key */
     }
 
     return rsa_key;
+
+cleanup:
+    if (private != 0)
+        azihsm_key_delete(private);
+    if (public != 0)
+        azihsm_key_delete(public);
+    OPENSSL_free(rsa_key);
+    return NULL;
 }
 
 static AZIHSM_RSA_KEY *azihsm_ossl_keymgmt_new(ossl_unused void *provctx)

--- a/plugins/ossl_prov/src/azihsm_ossl_keymgmt_rsa.c
+++ b/plugins/ossl_prov/src/azihsm_ossl_keymgmt_rsa.c
@@ -302,6 +302,7 @@ static AZIHSM_RSA_KEY *azihsm_ossl_keymgmt_gen(
             if (masked_key_buffer == NULL)
             {
                 ERR_raise(ERR_LIB_PROV, ERR_R_MALLOC_FAILURE);
+                status = AZIHSM_STATUS_INTERNAL_ERROR;
                 goto cleanup;
             }
 
@@ -313,6 +314,7 @@ static AZIHSM_RSA_KEY *azihsm_ossl_keymgmt_gen(
             {
                 OPENSSL_clear_free(masked_key_buffer, masked_key_buffer_size);
                 ERR_raise(ERR_LIB_PROV, ERR_R_OPERATION_FAIL);
+                status = AZIHSM_STATUS_INTERNAL_ERROR;
                 goto cleanup;
             }
 
@@ -324,6 +326,7 @@ static AZIHSM_RSA_KEY *azihsm_ossl_keymgmt_gen(
                 ) != OSSL_SUCCESS)
             {
                 OPENSSL_clear_free(masked_key_buffer, masked_key_buffer_size);
+                status = AZIHSM_STATUS_INTERNAL_ERROR;
                 goto cleanup;
             }
 
@@ -333,20 +336,27 @@ static AZIHSM_RSA_KEY *azihsm_ossl_keymgmt_gen(
         {
             /* Unexpected error - not BUFFER_TOO_SMALL and not PROPERTY_NOT_PRESENT */
             ERR_raise(ERR_LIB_PROV, ERR_R_OPERATION_FAIL);
+            status = AZIHSM_STATUS_INTERNAL_ERROR;
             goto cleanup;
         }
         /* If PROPERTY_NOT_PRESENT, continue without masked key */
     }
 
-    return rsa_key;
+    /* Success — prevent cleanup from freeing the result */
+    private = 0;
+    public = 0;
 
 cleanup:
     if (private != 0)
         azihsm_key_delete(private);
     if (public != 0)
         azihsm_key_delete(public);
-    OPENSSL_free(rsa_key);
-    return NULL;
+    if (status != AZIHSM_STATUS_SUCCESS)
+    {
+        OPENSSL_free(rsa_key);
+        rsa_key = NULL;
+    }
+    return rsa_key;
 }
 
 static AZIHSM_RSA_KEY *azihsm_ossl_keymgmt_new(ossl_unused void *provctx)

--- a/plugins/ossl_prov/src/azihsm_ossl_keymgmt_rsa.c
+++ b/plugins/ossl_prov/src/azihsm_ossl_keymgmt_rsa.c
@@ -111,7 +111,7 @@ static AZIHSM_RSA_KEY *azihsm_ossl_keymgmt_gen(
 {
     AZIHSM_RSA_KEY *rsa_key;
     azihsm_handle public = 0, private = 0;
-    azihsm_status status;
+    azihsm_status status = AZIHSM_STATUS_INTERNAL_ERROR;
     const bool enable = true;
     const azihsm_key_class priv_class = AZIHSM_KEY_CLASS_PRIVATE;
     const azihsm_key_class pub_class = AZIHSM_KEY_CLASS_PUBLIC;

--- a/plugins/ossl_prov/src/azihsm_ossl_keymgmt_rsa.c
+++ b/plugins/ossl_prov/src/azihsm_ossl_keymgmt_rsa.c
@@ -326,6 +326,12 @@ static AZIHSM_RSA_KEY *azihsm_ossl_keymgmt_gen(
                 ) != OSSL_SUCCESS)
             {
                 OPENSSL_clear_free(masked_key_buffer, masked_key_buffer_size);
+                ERR_raise_data(
+                    ERR_LIB_PROV,
+                    ERR_R_OPERATION_FAIL,
+                    "failed to write masked key to '%s'",
+                    genctx->masked_key_file
+                );
                 status = AZIHSM_STATUS_INTERNAL_ERROR;
                 goto cleanup;
             }

--- a/plugins/ossl_prov/src/azihsm_ossl_signature_ec.c
+++ b/plugins/ossl_prov/src/azihsm_ossl_signature_ec.c
@@ -75,6 +75,7 @@ static int ecdsa_raw_to_der(
     size_t *out_der_len
 )
 {
+    int ret = OSSL_FAILURE;
     ECDSA_SIG *esig = NULL;
     BIGNUM *r = NULL, *s = NULL;
     size_t half = raw_len / 2;
@@ -83,7 +84,7 @@ static int ecdsa_raw_to_der(
 
     if (raw_len == 0 || (raw_len & 1) != 0)
     {
-        return OSSL_FAILURE;
+        goto cleanup;
     }
 
     r = BN_bin2bn(raw, (int)half, NULL);
@@ -115,14 +116,14 @@ static int ecdsa_raw_to_der(
 
     *out_der = der;
     *out_der_len = (size_t)der_len;
-    ECDSA_SIG_free(esig);
-    return OSSL_SUCCESS;
+    ret = OSSL_SUCCESS;
 
 cleanup:
+    /* OpenSSL free functions are NULL-safe — call unconditionally */
     BN_free(r);
     BN_free(s);
     ECDSA_SIG_free(esig);
-    return OSSL_FAILURE;
+    return ret;
 }
 
 /*

--- a/plugins/ossl_prov/src/azihsm_ossl_signature_ec.c
+++ b/plugins/ossl_prov/src/azihsm_ossl_signature_ec.c
@@ -184,10 +184,12 @@ static int ecdsa_der_to_raw(
 
     *out_raw = raw;
     *out_raw_len = raw_len;
+    raw = NULL; /* Ownership transferred to caller */
     ret = OSSL_SUCCESS;
 
 cleanup:
     /* OpenSSL free functions are NULL-safe — call unconditionally */
+    OPENSSL_free(raw);
     ECDSA_SIG_free(esig);
     return ret;
 }

--- a/plugins/ossl_prov/src/azihsm_ossl_signature_ec.c
+++ b/plugins/ossl_prov/src/azihsm_ossl_signature_ec.c
@@ -90,19 +90,19 @@ static int ecdsa_raw_to_der(
     s = BN_bin2bn(raw + half, (int)half, NULL);
     if (r == NULL || s == NULL)
     {
-        goto err;
+        goto cleanup;
     }
 
     esig = ECDSA_SIG_new();
     if (esig == NULL)
     {
-        goto err;
+        goto cleanup;
     }
 
     /* ECDSA_SIG_set0 takes ownership of r and s on success. */
     if (!ECDSA_SIG_set0(esig, r, s))
     {
-        goto err;
+        goto cleanup;
     }
     r = NULL;
     s = NULL;
@@ -110,7 +110,7 @@ static int ecdsa_raw_to_der(
     der_len = i2d_ECDSA_SIG(esig, &der);
     if (der_len <= 0)
     {
-        goto err;
+        goto cleanup;
     }
 
     *out_der = der;
@@ -118,7 +118,7 @@ static int ecdsa_raw_to_der(
     ECDSA_SIG_free(esig);
     return OSSL_SUCCESS;
 
-err:
+cleanup:
     BN_free(r);
     BN_free(s);
     ECDSA_SIG_free(esig);
@@ -140,6 +140,7 @@ static int ecdsa_der_to_raw(
     size_t *out_raw_len
 )
 {
+    int ret = OSSL_FAILURE;
     ECDSA_SIG *esig = NULL;
     const BIGNUM *r = NULL, *s = NULL;
     unsigned char *raw = NULL;
@@ -154,14 +155,13 @@ static int ecdsa_der_to_raw(
     esig = d2i_ECDSA_SIG(NULL, &der, (long)der_len);
     if (esig == NULL)
     {
-        return OSSL_FAILURE;
+        goto cleanup;
     }
 
     ECDSA_SIG_get0(esig, &r, &s);
     if (r == NULL || s == NULL)
     {
-        ECDSA_SIG_free(esig);
-        return OSSL_FAILURE;
+        goto cleanup;
     }
 
     r_len = BN_num_bytes(r);
@@ -169,26 +169,27 @@ static int ecdsa_der_to_raw(
 
     if ((size_t)r_len > coord_size || (size_t)s_len > coord_size)
     {
-        ECDSA_SIG_free(esig);
-        return OSSL_FAILURE;
+        goto cleanup;
     }
 
     raw = OPENSSL_zalloc(raw_len);
     if (raw == NULL)
     {
-        ECDSA_SIG_free(esig);
-        return OSSL_FAILURE;
+        goto cleanup;
     }
 
     /* Write r and s right-aligned (zero-padded on the left) */
     BN_bn2bin(r, raw + (coord_size - (size_t)r_len));
     BN_bn2bin(s, raw + coord_size + (coord_size - (size_t)s_len));
 
-    ECDSA_SIG_free(esig);
-
     *out_raw = raw;
     *out_raw_len = raw_len;
-    return OSSL_SUCCESS;
+    ret = OSSL_SUCCESS;
+
+cleanup:
+    /* OpenSSL free functions are NULL-safe — call unconditionally */
+    ECDSA_SIG_free(esig);
+    return ret;
 }
 
 /*
@@ -344,11 +345,15 @@ static int azihsm_ossl_ecdsa_sign(
     size_t tbslen
 )
 {
+    int ret = OSSL_FAILURE;
     azihsm_ec_sig_ctx *ctx = (azihsm_ec_sig_ctx *)sctx;
     struct azihsm_algo algo = { 0 };
     struct azihsm_buffer data_buf, sig_buf;
     azihsm_status status;
     size_t raw_sig_size;
+    unsigned char *raw_buf = NULL;
+    unsigned char *der = NULL;
+    size_t der_len = 0;
 
     if (ctx == NULL || ctx->key == NULL)
     {
@@ -391,51 +396,45 @@ static int azihsm_ossl_ecdsa_sign(
 
     raw_sig_size = sig_buf.len;
 
-    /* Allocate temporary buffer for the raw signature from the HSM. */
+    /* Allocate temporary buffer for the raw signature from the HSM */
+    raw_buf = OPENSSL_zalloc(raw_sig_size);
+    if (raw_buf == NULL)
     {
-        unsigned char *raw_buf = OPENSSL_zalloc(raw_sig_size);
-        unsigned char *der = NULL;
-        size_t der_len = 0;
-
-        if (raw_buf == NULL)
-        {
-            ERR_raise(ERR_LIB_PROV, ERR_R_MALLOC_FAILURE);
-            return OSSL_FAILURE;
-        }
-
-        sig_buf.ptr = raw_buf;
-        sig_buf.len = (uint32_t)raw_sig_size;
-
-        status = azihsm_crypt_sign(&algo, ctx->key->key.priv, &data_buf, &sig_buf);
-        if (status != AZIHSM_STATUS_SUCCESS)
-        {
-            OPENSSL_clear_free(raw_buf, raw_sig_size);
-            ERR_raise(ERR_LIB_PROV, ERR_R_OPERATION_FAIL);
-            return OSSL_FAILURE;
-        }
-
-        /* Convert raw (r || s) to DER ECDSA-Sig-Value. */
-        if (ecdsa_raw_to_der(raw_buf, sig_buf.len, &der, &der_len) != OSSL_SUCCESS)
-        {
-            OPENSSL_clear_free(raw_buf, raw_sig_size);
-            ERR_raise(ERR_LIB_PROV, ERR_R_INTERNAL_ERROR);
-            return OSSL_FAILURE;
-        }
-        OPENSSL_clear_free(raw_buf, raw_sig_size);
-
-        if (der_len > sigsize)
-        {
-            OPENSSL_free(der);
-            ERR_raise(ERR_LIB_PROV, ERR_R_PASSED_INVALID_ARGUMENT);
-            return OSSL_FAILURE;
-        }
-
-        memcpy(sig, der, der_len);
-        *siglen = der_len;
-        OPENSSL_free(der);
+        ERR_raise(ERR_LIB_PROV, ERR_R_MALLOC_FAILURE);
+        goto cleanup;
     }
 
-    return OSSL_SUCCESS;
+    sig_buf.ptr = raw_buf;
+    sig_buf.len = (uint32_t)raw_sig_size;
+
+    status = azihsm_crypt_sign(&algo, ctx->key->key.priv, &data_buf, &sig_buf);
+    if (status != AZIHSM_STATUS_SUCCESS)
+    {
+        ERR_raise(ERR_LIB_PROV, ERR_R_OPERATION_FAIL);
+        goto cleanup;
+    }
+
+    /* Convert raw (r || s) to DER ECDSA-Sig-Value */
+    if (ecdsa_raw_to_der(raw_buf, sig_buf.len, &der, &der_len) != OSSL_SUCCESS)
+    {
+        ERR_raise(ERR_LIB_PROV, ERR_R_INTERNAL_ERROR);
+        goto cleanup;
+    }
+
+    if (der_len > sigsize)
+    {
+        ERR_raise(ERR_LIB_PROV, ERR_R_PASSED_INVALID_ARGUMENT);
+        goto cleanup;
+    }
+
+    memcpy(sig, der, der_len);
+    *siglen = der_len;
+    ret = OSSL_SUCCESS;
+
+cleanup:
+    OPENSSL_clear_free(raw_buf, raw_sig_size);
+    OPENSSL_free(der);
+    return ret;
 }
 
 static int azihsm_ossl_ecdsa_verify_init(void *sctx, void *provkey, const OSSL_PARAM params[])

--- a/plugins/ossl_prov/src/azihsm_ossl_store.c
+++ b/plugins/ossl_prov/src/azihsm_ossl_store.c
@@ -192,6 +192,7 @@ static int parse_uri_attribute(const char *attr_str, char **out_key, char **out_
 
 static int parse_azihsm_uri(const char *uri, AZIHSM_URI_INFO *out_info)
 {
+    int ret = OSSL_FAILURE;
     const char *scheme = "azihsm://";
     size_t scheme_len = 9;
     const char *path_start, *semicolon;
@@ -248,7 +249,7 @@ static int parse_azihsm_uri(const char *uri, AZIHSM_URI_INFO *out_info)
         attr_copy = OPENSSL_strdup(semicolon + 1);
         if (attr_copy == NULL)
         {
-            return OSSL_FAILURE;
+            goto cleanup;
         }
 
         attr_token = strtok_r(attr_copy, ";", &attr_saveptr);
@@ -274,10 +275,14 @@ static int parse_azihsm_uri(const char *uri, AZIHSM_URI_INFO *out_info)
     // Validate that type was provided
     if (out_info->key_type == 0)
     {
-        return OSSL_FAILURE;
+        goto cleanup;
     }
 
     return OSSL_SUCCESS;
+
+cleanup:
+    azihsm_uri_info_free(out_info);
+    return ret;
 }
 
 static int load_and_unmask_key(AZIHSM_STORE_CTX *ctx)

--- a/plugins/ossl_prov/src/azihsm_ossl_store.c
+++ b/plugins/ossl_prov/src/azihsm_ossl_store.c
@@ -192,7 +192,6 @@ static int parse_uri_attribute(const char *attr_str, char **out_key, char **out_
 
 static int parse_azihsm_uri(const char *uri, AZIHSM_URI_INFO *out_info)
 {
-    int ret = OSSL_FAILURE;
     const char *scheme = "azihsm://";
     size_t scheme_len = 9;
     const char *path_start, *semicolon;
@@ -249,7 +248,8 @@ static int parse_azihsm_uri(const char *uri, AZIHSM_URI_INFO *out_info)
         attr_copy = OPENSSL_strdup(semicolon + 1);
         if (attr_copy == NULL)
         {
-            goto cleanup;
+            /* Caller owns out_info and will free via azihsm_uri_info_free() */
+            return OSSL_FAILURE;
         }
 
         attr_token = strtok_r(attr_copy, ";", &attr_saveptr);
@@ -275,14 +275,11 @@ static int parse_azihsm_uri(const char *uri, AZIHSM_URI_INFO *out_info)
     // Validate that type was provided
     if (out_info->key_type == 0)
     {
-        goto cleanup;
+        /* Caller owns out_info and will free via azihsm_uri_info_free() */
+        return OSSL_FAILURE;
     }
 
     return OSSL_SUCCESS;
-
-cleanup:
-    azihsm_uri_info_free(out_info);
-    return ret;
 }
 
 static int load_and_unmask_key(AZIHSM_STORE_CTX *ctx)


### PR DESCRIPTION
Replace duplicated manual cleanup at each error return with centralized goto cleanup blocks across 7 provider C files. This eliminates many lines of repeated free/delete/cleanse calls, improves maintainability.

Key changes:
- Adopt `cleanup:` label convention consistently (matching OpenSSL's goto-based cleanup idiom, using `cleanup` instead of `err` since several functions require cleanup on both success and error paths)
- Use OPENSSL_clear_free() for sensitive buffers (NULL-safe cleanse+free)
- Use boolean flags (device_opened, session_opened) for lifecycle-managed resources in azihsm_open_device_and_session
- Leverage NULL-safety of all OpenSSL free functions to call unconditionally in cleanup blocks