### PR TITLE
[feat] offload: new crate to offload blocking work to a worker thread

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ members = [
   "api/tests/macro",
   "crates/cred_encrypt",
   "crates/crypto",
+  "crates/offload",
   "crates/resiliency_macro",
   "crates/resiliency_test_helpers",
   "crates/test_with_tracing",
@@ -52,6 +53,7 @@ azihsm_ddi_win = { path = "ddi/win" }
 azihsm_res_test_dev = { path = "ddi/res_test_dev" }
 azihsm_resiliency_test_helpers = { path = "crates/resiliency_test_helpers" }
 azihsm_tpm = { path = "crates/tpm" }
+offload = { path = "crates/offload" }
 resiliency_macro = { path = "crates/resiliency_macro" }
 test_with_tracing = { path = "crates/test_with_tracing" }
 test_with_tracing_macro = { path = "crates/test_with_tracing/test_with_tracing_macro" }

--- a/crates/offload/Cargo.toml
+++ b/crates/offload/Cargo.toml
@@ -1,0 +1,32 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+[package]
+autotests = false
+edition = "2024"
+name = "offload"
+version = "0.1.0"
+
+[lib]
+doctest = false
+proc-macro = true
+
+[dependencies]
+darling.workspace = true
+proc-macro2.workspace = true
+quote.workspace = true
+syn = { features = ["full"], workspace = true }
+
+[dev-dependencies]
+trybuild.workspace = true
+
+[[test]]
+name = "compile_tests"
+path = "tests/compile_tests.rs"
+
+[[test]]
+name = "integration"
+path = "tests/integration.rs"
+
+[lints]
+workspace = true

--- a/crates/offload/src/classify.rs
+++ b/crates/offload/src/classify.rs
@@ -1,0 +1,156 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Parameter type classification for the `offload` macro.
+//!
+//! Determines how each handler parameter should be converted between the
+//! borrowed form (handler function) and the owned form (enum variant / async method).
+
+use proc_macro2::TokenStream;
+use quote::quote;
+use syn::Type;
+
+/// Classification of a handler parameter type.
+pub(crate) enum ParamKind {
+    /// `&[T]` — store `Vec<T>`, accept `&[T]`, pack with `.to_vec()`, unpack with `&field`.
+    SliceRef { elem: Box<Type> },
+    /// `&mut [T]` — store `Vec<T>`, accept `&mut [T]`, pack with `.to_vec()`,
+    /// unpack with `&mut field`.
+    MutSliceRef { elem: Box<Type> },
+    /// `&T` (non-slice) — store `T`, accept `T` by value, pack by move, unpack with `&field`.
+    Ref { inner: Box<Type> },
+    /// `Option<&[T]>` — store `Option<Vec<T>>`, accept `Option<&[T]>`,
+    /// pack with `.map(|v| v.to_vec())`, unpack with `.as_deref()`.
+    OptionSliceRef { elem: Box<Type> },
+    /// `Option<&mut [T]>` — store `Option<Vec<T>>`, accept `Option<&mut [T]>`,
+    /// pack with `.as_deref().map(|v| v.to_vec())`, unpack with `.as_deref_mut()`.
+    OptionMutSliceRef { elem: Box<Type> },
+    /// `Option<&T>` (non-slice) — store `Option<T>`, accept `Option<T>` by value,
+    /// pack by move, unpack with `.as_ref()`.
+    OptionRef { inner: Box<Type> },
+    /// `T` by value — stored, accepted, packed, and unpacked as-is.
+    ByValue,
+}
+
+/// Inspect a `syn::Type` and classify it for owned/borrowed conversion.
+pub(crate) fn classify(ty: &Type) -> ParamKind {
+    // &[T] or &T
+    if let Type::Reference(r) = ty {
+        if let Type::Slice(slice) = r.elem.as_ref() {
+            if r.mutability.is_some() {
+                return ParamKind::MutSliceRef {
+                    elem: slice.elem.clone(),
+                };
+            }
+            return ParamKind::SliceRef {
+                elem: slice.elem.clone(),
+            };
+        }
+        return ParamKind::Ref {
+            inner: r.elem.clone(),
+        };
+    }
+
+    // Option<&[T]>, Option<&mut [T]>, or Option<&T>
+    if let Some(inner) = extract_option_inner(ty) {
+        if let Type::Reference(r) = inner {
+            if let Type::Slice(slice) = r.elem.as_ref() {
+                if r.mutability.is_some() {
+                    return ParamKind::OptionMutSliceRef {
+                        elem: slice.elem.clone(),
+                    };
+                }
+                return ParamKind::OptionSliceRef {
+                    elem: slice.elem.clone(),
+                };
+            }
+            return ParamKind::OptionRef {
+                inner: r.elem.clone(),
+            };
+        }
+    }
+
+    ParamKind::ByValue
+}
+
+impl ParamKind {
+    /// The type to store in the enum variant field.
+    pub(crate) fn enum_field_type(&self, original_type: &Type) -> TokenStream {
+        match self {
+            ParamKind::SliceRef { elem } => quote! { Vec<#elem> },
+            ParamKind::MutSliceRef { elem } => quote! { Vec<#elem> },
+            ParamKind::Ref { inner } => quote! { #inner },
+            ParamKind::OptionSliceRef { elem } => quote! { Option<Vec<#elem>> },
+            ParamKind::OptionMutSliceRef { elem } => quote! { Option<Vec<#elem>> },
+            ParamKind::OptionRef { inner } => quote! { Option<#inner> },
+            ParamKind::ByValue => quote! { #original_type },
+        }
+    }
+
+    /// The type for the async method parameter (what the caller passes).
+    pub(crate) fn async_param_type(&self, original_type: &Type) -> TokenStream {
+        match self {
+            ParamKind::SliceRef { .. }
+            | ParamKind::MutSliceRef { .. }
+            | ParamKind::OptionSliceRef { .. }
+            | ParamKind::OptionMutSliceRef { .. } => {
+                // Keep the original borrowed type for the public API.
+                quote! { #original_type }
+            }
+            ParamKind::Ref { inner } => quote! { #inner },
+            ParamKind::OptionRef { inner } => quote! { Option<#inner> },
+            ParamKind::ByValue => quote! { #original_type },
+        }
+    }
+
+    /// Expression in the async method body to convert from the async param to the enum field.
+    pub(crate) fn pack_expr(&self, param_name: &syn::Ident) -> TokenStream {
+        match self {
+            ParamKind::SliceRef { .. } => quote! { #param_name.to_vec() },
+            ParamKind::MutSliceRef { .. } => quote! { #param_name.to_vec() },
+            ParamKind::Ref { .. } => quote! { #param_name },
+            ParamKind::OptionSliceRef { .. } => {
+                quote! { #param_name.map(|__v| __v.to_vec()) }
+            }
+            ParamKind::OptionMutSliceRef { .. } => {
+                quote! { #param_name.as_deref().map(|__v| __v.to_vec()) }
+            }
+            ParamKind::OptionRef { .. } => quote! { #param_name },
+            ParamKind::ByValue => quote! { #param_name },
+        }
+    }
+
+    /// Expression in the dispatch match arm to convert from the enum field to the handler param.
+    pub(crate) fn unpack_expr(&self, param_name: &syn::Ident) -> TokenStream {
+        match self {
+            ParamKind::SliceRef { .. } => quote! { &#param_name },
+            ParamKind::MutSliceRef { .. } => quote! { &mut #param_name },
+            ParamKind::Ref { .. } => quote! { &#param_name },
+            ParamKind::OptionSliceRef { .. } => quote! { #param_name.as_deref() },
+            ParamKind::OptionMutSliceRef { .. } => quote! { #param_name.as_deref_mut() },
+            ParamKind::OptionRef { .. } => quote! { #param_name.as_ref() },
+            ParamKind::ByValue => quote! { #param_name },
+        }
+    }
+}
+
+/// If `ty` is `Option<T>`, returns `Some(T)`. Otherwise `None`.
+fn extract_option_inner(ty: &Type) -> Option<&Type> {
+    let Type::Path(type_path) = ty else {
+        return None;
+    };
+    let segment = type_path.path.segments.last()?;
+    if segment.ident != "Option" {
+        return None;
+    }
+    let syn::PathArguments::AngleBracketed(args) = &segment.arguments else {
+        return None;
+    };
+    if args.args.len() != 1 {
+        return None;
+    }
+    let syn::GenericArgument::Type(inner) = &args.args[0] else {
+        return None;
+    };
+    Some(inner)
+}

--- a/crates/offload/src/classify.rs
+++ b/crates/offload/src/classify.rs
@@ -52,22 +52,20 @@ pub(crate) fn classify(ty: &Type) -> ParamKind {
     }
 
     // Option<&[T]>, Option<&mut [T]>, or Option<&T>
-    if let Some(inner) = extract_option_inner(ty) {
-        if let Type::Reference(r) = inner {
-            if let Type::Slice(slice) = r.elem.as_ref() {
-                if r.mutability.is_some() {
-                    return ParamKind::OptionMutSliceRef {
-                        elem: slice.elem.clone(),
-                    };
-                }
-                return ParamKind::OptionSliceRef {
+    if let Some(Type::Reference(r)) = extract_option_inner(ty) {
+        if let Type::Slice(slice) = r.elem.as_ref() {
+            if r.mutability.is_some() {
+                return ParamKind::OptionMutSliceRef {
                     elem: slice.elem.clone(),
                 };
             }
-            return ParamKind::OptionRef {
-                inner: r.elem.clone(),
+            return ParamKind::OptionSliceRef {
+                elem: slice.elem.clone(),
             };
         }
+        return ParamKind::OptionRef {
+            inner: r.elem.clone(),
+        };
     }
 
     ParamKind::ByValue

--- a/crates/offload/src/lib.rs
+++ b/crates/offload/src/lib.rs
@@ -1,0 +1,1023 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Proc macro that offloads synchronous, blocking work to a dedicated thread.
+//!
+//! # Overview
+//!
+//! The [`offload`] attribute macro takes an `impl` block of **synchronous**
+//! handler functions and generates an async-friendly wrapper struct backed by a
+//! dedicated worker thread and an `mpsc` channel. This lets you call blocking
+//! code (cryptography, FFI, file I/O, etc.) from async contexts without
+//! stalling the async executor.
+//!
+//! The macro generates:
+//!
+//! - A `pub struct` with a `new()` constructor that spawns background
+//!   `std::thread`(s).
+//! - An `async fn` wrapper for each handler that sends the operation to the
+//!   worker thread and `.await`s the result.
+//! - A `shutdown()` method and a `Drop` implementation that cleanly stop the
+//!   worker thread(s).
+//!
+//! All generated code uses only `std` primitives (`std::sync::mpsc`,
+//! `std::thread`, `Arc<Mutex<…>>`). No async runtime (tokio, async-std, etc.)
+//! is required.
+//!
+//! # When to use
+//!
+//! Use this macro when you have synchronous, possibly blocking operations
+//! that need to be called from async code without blocking the async executor.
+//!
+//! # Macro attributes
+//!
+//! ```text
+//! #[offload(error = <ErrorType>, shutdown_error = <ErrorExpr>)]
+//! ```
+//!
+//! | Attribute        | Description |
+//! |------------------|-------------|
+//! | `error`          | The error type `E` used in every handler's `Result<T, E>` return type. |
+//! | `shutdown_error` | An expression of type `E` returned when the caller tries to use the worker after it has shut down (i.e., the channel is disconnected). |
+//! | `workers`        | *(Optional, default `1`)* Number of worker threads to spawn. |
+//!
+//! # Handler rules
+//!
+//! Each function in the `impl` block must:
+//!
+//! - **Not** take `self` — the macro generates `&self` methods on the struct.
+//! - **Not** be `async` — the macro generates async wrappers automatically.
+//! - Return `Result<T, E>` where `E` matches the `error` attribute.
+//! - Use simple identifier patterns for parameters (no destructuring).
+//!
+//! # Parameter type handling
+//!
+//! Because parameters must cross a thread boundary (from the async caller to
+//! the `std::thread` worker), borrowed types are automatically converted to
+//! owned types for transit and borrowed back in the handler:
+//!
+//! | Handler signature        | Async method signature       | Stored in enum as |
+//! |--------------------------|------------------------------|-------------------|
+//! | `data: &[u8]`            | `data: &[u8]`                | `Vec<u8>`         |
+//! | `out: &mut [u8]`         | `out: &mut [u8]`             | `Vec<u8>`         |
+//! | `mode: &MyEnum`          | `mode: MyEnum`               | `MyEnum`          |
+//! | `x: Option<&[u8]>`       | `x: Option<&[u8]>`           | `Option<Vec<u8>>` |
+//! | `x: Option<&mut [u8]>`   | `mut x: Option<&mut [u8]>`   | `Option<Vec<u8>>` |
+//! | `x: Option<&T>`          | `x: Option<T>`               | `Option<T>`       |
+//! | `n: usize`               | `n: usize`                   | `usize`           |
+//!
+//! Slice references (`&[T]`) keep borrowed signatures in the async API for
+//! ergonomics — the macro copies them into a `Vec<T>` internally.
+//! Mutable slice references (`&mut [T]`) are copied into a temporary `Vec<T>`
+//! for worker execution, then copied back to the caller's slice after `.await`.
+//! Optional mutable slice references (`Option<&mut [T]>`) work the same way:
+//! when the caller passes `Some`, the data is copied back after `.await`.
+//! Non-slice references (`&T`) become by-value in the async API to avoid
+//! lifetime issues.
+//!
+//! # Generated API
+//!
+//! For a struct named `Foo`, the macro generates:
+//!
+//! - `Foo::new() -> Self` — spawns the worker thread.
+//! - `Foo::shutdown(&self)` — sends a shutdown signal (non-blocking).
+//! - One `async fn` per handler with the same name and visibility.
+//! - `Drop for Foo` — sends shutdown and joins the worker thread.
+//!
+//! Doc comments (`///`) on individual handler functions are forwarded to the
+//! generated async methods. Doc comments on the `impl` block are forwarded to
+//! the generated struct definition.
+//!
+//! # Example
+//!
+//! ```ignore
+//! use offload::offload;
+//!
+//! #[offload(error = MyError, shutdown_error = MyError::WorkerShutdown)]
+//! impl MathWorker {
+//!     /// Add two numbers.
+//!     pub fn add(a: usize, b: usize) -> Result<usize, MyError> {
+//!         Ok(a + b)
+//!     }
+//!
+//!     pub fn hash(data: &[u8]) -> Result<Vec<u8>, MyError> {
+//!         // some blocking computation ...
+//!         # Ok(data.to_vec())
+//!     }
+//! }
+//!
+//! // Generated usage:
+//! // let w = MathWorker::new();
+//! // let sum = w.add(3, 4).await?;      // async, runs on the worker thread
+//! // let h = w.hash(b"hello").await?;
+//! // drop(w);                            // joins the worker thread
+//! ```
+
+mod classify;
+
+use classify::classify;
+use darling::FromMeta;
+use proc_macro::TokenStream;
+use proc_macro2::TokenStream as TokenStream2;
+use quote::format_ident;
+use quote::quote;
+use syn::FnArg;
+use syn::ImplItem;
+use syn::ItemImpl;
+use syn::Pat;
+use syn::ReturnType;
+use syn::Type;
+use syn::parse_macro_input;
+use syn::spanned::Spanned;
+
+#[derive(Debug, FromMeta)]
+struct OffloadArgs {
+    /// Error type used in all `Result` return types.
+    error: syn::Path,
+    /// Expression for the error produced when the worker channel disconnects.
+    shutdown_error: syn::Path,
+    /// Number of worker threads to spawn (default: 1).
+    workers: Option<usize>,
+}
+
+/// Attribute macro that offloads synchronous handler functions to a dedicated
+/// worker thread, generating async wrappers for each.
+///
+/// See the [crate-level documentation](crate) for usage, parameter rules, and
+/// examples.
+#[proc_macro_attribute]
+pub fn offload(attr: TokenStream, item: TokenStream) -> TokenStream {
+    let attr_args = match darling::ast::NestedMeta::parse_meta_list(attr.into()) {
+        Ok(v) => v,
+        Err(e) => return TokenStream::from(darling::Error::from(e).write_errors()),
+    };
+    let item = parse_macro_input!(item as ItemImpl);
+
+    let args = match OffloadArgs::from_list(&attr_args) {
+        Ok(v) => v,
+        Err(e) => return e.write_errors().into(),
+    };
+
+    expand_offload(args, item)
+        .unwrap_or_else(|err| err.to_compile_error())
+        .into()
+}
+
+/// Parsed representation of one handler function.
+struct HandlerInfo {
+    /// Original function name (e.g., `hash`).
+    name: syn::Ident,
+    /// PascalCase variant name (e.g., `Hash`).
+    variant_name: syn::Ident,
+    /// Visibility of the method (e.g., `pub`).
+    vis: syn::Visibility,
+    /// Doc attributes to forward.
+    doc_attrs: Vec<syn::Attribute>,
+    /// Non-doc attributes to forward (e.g., `#[cfg(...)]`).
+    other_attrs: Vec<syn::Attribute>,
+    /// Parameter names.
+    param_names: Vec<syn::Ident>,
+    /// Original parameter types (as written in the handler).
+    param_types: Vec<Type>,
+    /// Classified param kinds.
+    param_kinds: Vec<classify::ParamKind>,
+    /// The success type `T` from `Result<T, E>`.
+    ok_type: Type,
+    /// The full function body.
+    body: syn::Block,
+}
+
+fn expand_offload(args: OffloadArgs, item: ItemImpl) -> syn::Result<TokenStream2> {
+    // Validate: no generics
+    if !item.generics.params.is_empty() {
+        return Err(syn::Error::new(
+            item.generics.span(),
+            "offload does not support generic impl blocks",
+        ));
+    }
+
+    // Validate: no trait impl
+    if item.trait_.is_some() {
+        return Err(syn::Error::new(
+            item.span(),
+            "offload does not support trait implementations",
+        ));
+    }
+
+    // Validate: workers >= 1
+    let num_workers = args.workers.unwrap_or(1);
+    if num_workers == 0 {
+        return Err(syn::Error::new(
+            proc_macro2::Span::call_site(),
+            "offload `workers` must be at least 1",
+        ));
+    }
+
+    // Extract struct name
+    let struct_type = &item.self_ty;
+    let struct_name = extract_type_ident(struct_type)?;
+
+    // Collect doc attrs from the impl block (to forward to the struct)
+    let struct_doc_attrs: Vec<_> = item
+        .attrs
+        .iter()
+        .filter(|a| a.path().is_ident("doc"))
+        .collect();
+
+    // Parse all handler functions
+    let mut handlers = Vec::new();
+    for impl_item in &item.items {
+        let ImplItem::Fn(method) = impl_item else {
+            return Err(syn::Error::new(
+                impl_item.span(),
+                "offload impl block may only contain functions",
+            ));
+        };
+
+        let sig = &method.sig;
+
+        // Validate: no self receiver
+        if sig.receiver().is_some() {
+            return Err(syn::Error::new(
+                sig.span(),
+                "offload handler functions must not take self",
+            ));
+        }
+
+        // Validate: not async
+        if sig.asyncness.is_some() {
+            return Err(syn::Error::new(
+                sig.asyncness.span(),
+                "offload handler functions must be synchronous; \
+                 the macro generates async wrappers",
+            ));
+        }
+
+        // Extract return type
+        let ok_type = extract_result_ok_type(&sig.output, &args.error)?;
+
+        // Parse parameters
+        let mut param_names = Vec::new();
+        let mut param_types = Vec::new();
+        let mut param_kinds = Vec::new();
+
+        for input in &sig.inputs {
+            let FnArg::Typed(pat_type) = input else {
+                return Err(syn::Error::new(input.span(), "unexpected receiver"));
+            };
+            let Pat::Ident(pat_ident) = pat_type.pat.as_ref() else {
+                return Err(syn::Error::new(
+                    pat_type.pat.span(),
+                    "offload handler parameters must be simple identifiers",
+                ));
+            };
+            param_names.push(pat_ident.ident.clone());
+            param_types.push(*pat_type.ty.clone());
+            param_kinds.push(classify(&pat_type.ty));
+        }
+
+        // Split attributes
+        let doc_attrs: Vec<_> = method
+            .attrs
+            .iter()
+            .filter(|a| a.path().is_ident("doc"))
+            .cloned()
+            .collect();
+        let other_attrs: Vec<_> = method
+            .attrs
+            .iter()
+            .filter(|a| !a.path().is_ident("doc"))
+            .cloned()
+            .collect();
+
+        let variant_name = to_pascal_case(&sig.ident);
+
+        handlers.push(HandlerInfo {
+            name: sig.ident.clone(),
+            variant_name,
+            vis: method.vis.clone(),
+            doc_attrs,
+            other_attrs,
+            param_names,
+            param_types,
+            param_kinds,
+            ok_type,
+            body: method.block.clone(),
+        });
+    }
+
+    if handlers.is_empty() {
+        return Err(syn::Error::new(
+            item.span(),
+            "offload impl block must contain at least one handler function",
+        ));
+    }
+
+    // Generate all output items
+    let error_type = &args.error;
+    let shutdown_error = &args.shutdown_error;
+    let enum_name = format_ident!("{}Op", struct_name);
+    let worker_fn_name = format_ident!("__wq_{}_worker", to_snake_case(&struct_name));
+
+    let handler_fns = gen_handler_fns(&handlers, error_type);
+    let op_enum = gen_op_enum(&enum_name, &handlers, error_type);
+    let worker_fn = gen_worker_fn(&worker_fn_name, &enum_name, &handlers);
+    let struct_def = gen_struct_def(&struct_name, &enum_name, &struct_doc_attrs);
+    let impl_block = gen_impl_block(
+        &struct_name,
+        &enum_name,
+        &worker_fn_name,
+        &handlers,
+        error_type,
+        shutdown_error,
+        num_workers,
+    );
+    let drop_impl = gen_drop_impl(&struct_name, &enum_name, num_workers);
+
+    Ok(quote! {
+        #handler_fns
+        #op_enum
+        #worker_fn
+        #struct_def
+        #impl_block
+        #drop_impl
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Code generation helpers
+// ---------------------------------------------------------------------------
+
+fn gen_handler_fns(handlers: &[HandlerInfo], error_type: &syn::Path) -> TokenStream2 {
+    let fns: Vec<_> = handlers
+        .iter()
+        .map(|h| {
+            let fn_name = format_ident!("__wq_{}", h.name);
+            let params: Vec<_> = h
+                .param_names
+                .iter()
+                .zip(h.param_types.iter().zip(&h.param_kinds))
+                .map(|(name, (ty, kind))| match kind {
+                    classify::ParamKind::OptionMutSliceRef { .. } => quote! { mut #name: #ty },
+                    _ => quote! { #name: #ty },
+                })
+                .collect();
+            let ok_type = &h.ok_type;
+            let body = &h.body;
+            let other_attrs = &h.other_attrs;
+            quote! {
+                #(#other_attrs)*
+                fn #fn_name(#(#params),*) -> Result<#ok_type, #error_type> #body
+            }
+        })
+        .collect();
+    quote! { #(#fns)* }
+}
+
+fn gen_op_enum(
+    enum_name: &syn::Ident,
+    handlers: &[HandlerInfo],
+    error_type: &syn::Path,
+) -> TokenStream2 {
+    let variants: Vec<_> = handlers
+        .iter()
+        .map(|h| {
+            let variant = &h.variant_name;
+            let fields: Vec<_> = h
+                .param_names
+                .iter()
+                .zip(h.param_types.iter().zip(&h.param_kinds))
+                .map(|(name, (orig_ty, kind))| {
+                    let field_ty = kind.enum_field_type(orig_ty);
+                    quote! { #name: #field_ty }
+                })
+                .collect();
+            let ok_type = &h.ok_type;
+            let mut_slice_elem_types: Vec<_> = h
+                .param_kinds
+                .iter()
+                .filter_map(|kind| match kind {
+                    classify::ParamKind::MutSliceRef { elem } => Some(elem.as_ref().clone()),
+                    _ => None,
+                })
+                .collect();
+            let opt_mut_slice_elem_types: Vec<_> = h
+                .param_kinds
+                .iter()
+                .filter_map(|kind| match kind {
+                    classify::ParamKind::OptionMutSliceRef { elem } => {
+                        Some(elem.as_ref().clone())
+                    }
+                    _ => None,
+                })
+                .collect();
+            let state_ok_type =
+                if mut_slice_elem_types.is_empty() && opt_mut_slice_elem_types.is_empty() {
+                    quote! { #ok_type }
+                } else {
+                    quote! { (#ok_type, #(::std::vec::Vec<#mut_slice_elem_types>,)* #(::std::option::Option<::std::vec::Vec<#opt_mut_slice_elem_types>>,)*) }
+                };
+            let other_attrs = &h.other_attrs;
+            quote! {
+                #(#other_attrs)*
+                #variant {
+                    #(#fields,)*
+                    __state: ::std::sync::Arc<
+                        ::std::sync::Mutex<(
+                            ::std::option::Option<Result<#state_ok_type, #error_type>>,
+                            ::std::option::Option<::std::task::Waker>,
+                        )>
+                    >,
+                }
+            }
+        })
+        .collect();
+
+    quote! {
+        enum #enum_name {
+            #(#variants,)*
+            __Shutdown,
+        }
+    }
+}
+
+fn gen_worker_fn(
+    worker_fn_name: &syn::Ident,
+    enum_name: &syn::Ident,
+    handlers: &[HandlerInfo],
+) -> TokenStream2 {
+    let arms: Vec<_> = handlers
+        .iter()
+        .map(|h| {
+            let variant = &h.variant_name;
+            let handler_fn = format_ident!("__wq_{}", h.name);
+            let pattern_fields: Vec<_> = h
+                .param_names
+                .iter()
+                .zip(&h.param_kinds)
+                .map(|(name, kind)| match kind {
+                    classify::ParamKind::MutSliceRef { .. }
+                    | classify::ParamKind::OptionMutSliceRef { .. } => quote! { mut #name },
+                    _ => quote! { #name },
+                })
+                .collect();
+            let unpack_exprs: Vec<_> = h
+                .param_names
+                .iter()
+                .zip(&h.param_kinds)
+                .map(|(name, kind)| kind.unpack_expr(name))
+                .collect();
+            let mut_slice_param_names: Vec<_> = h
+                .param_names
+                .iter()
+                .zip(&h.param_kinds)
+                .filter_map(|(name, kind)| match kind {
+                    classify::ParamKind::MutSliceRef { .. } => Some(name.clone()),
+                    _ => None,
+                })
+                .collect();
+            let opt_mut_slice_param_names: Vec<_> = h
+                .param_names
+                .iter()
+                .zip(&h.param_kinds)
+                .filter_map(|(name, kind)| match kind {
+                    classify::ParamKind::OptionMutSliceRef { .. } => Some(name.clone()),
+                    _ => None,
+                })
+                .collect();
+            let has_any_mut_slices =
+                !mut_slice_param_names.is_empty() || !opt_mut_slice_param_names.is_empty();
+            let store_result = if !has_any_mut_slices {
+                quote! { __result }
+            } else {
+                quote! {
+                    __result.map(|__ok| (
+                        __ok,
+                        #(#mut_slice_param_names,)*
+                        #(#opt_mut_slice_param_names,)*
+                    ))
+                }
+            };
+            let other_attrs = &h.other_attrs;
+            quote! {
+                #(#other_attrs)*
+                #enum_name::#variant { #(#pattern_fields,)* __state } => {
+                    let __result = #handler_fn(#(#unpack_exprs),*);
+                    #[allow(clippy::unwrap_used)]
+                    let __waker = {
+                        let mut __guard = __state.lock().unwrap();
+                        __guard.0 = ::std::option::Option::Some(#store_result);
+                        __guard.1.take()
+                    };
+                    if let ::std::option::Option::Some(__w) = __waker {
+                        __w.wake();
+                    }
+                }
+            }
+        })
+        .collect();
+
+    quote! {
+        fn #worker_fn_name(
+            __rx: ::std::sync::Arc<::std::sync::Mutex<::std::sync::mpsc::Receiver<#enum_name>>>
+        ) {
+            loop {
+                let __op = {
+                    #[allow(clippy::unwrap_used)]
+                    let __rx_guard = __rx.lock().unwrap();
+                    match __rx_guard.recv() {
+                        ::std::result::Result::Ok(__op) => __op,
+                        ::std::result::Result::Err(_) => break,
+                    }
+                };
+                match __op {
+                    #enum_name::__Shutdown => break,
+                    #(#arms)*
+                }
+            }
+        }
+    }
+}
+
+fn gen_struct_def(
+    struct_name: &syn::Ident,
+    enum_name: &syn::Ident,
+    doc_attrs: &[&syn::Attribute],
+) -> TokenStream2 {
+    quote! {
+        #(#doc_attrs)*
+        pub struct #struct_name {
+            __tx: ::std::sync::mpsc::Sender<#enum_name>,
+            __handles: ::std::vec::Vec<::std::thread::JoinHandle<()>>,
+        }
+    }
+}
+
+fn gen_impl_block(
+    struct_name: &syn::Ident,
+    enum_name: &syn::Ident,
+    worker_fn_name: &syn::Ident,
+    handlers: &[HandlerInfo],
+    error_type: &syn::Path,
+    shutdown_error: &syn::Path,
+    num_workers: usize,
+) -> TokenStream2 {
+    let response_future_name = format_ident!("__WqResponseFuture{}", struct_name);
+
+    let async_methods: Vec<_> = handlers
+        .iter()
+        .map(|h| {
+            let name = &h.name;
+            let vis = &h.vis;
+            let variant = &h.variant_name;
+            let doc_attrs = &h.doc_attrs;
+            let other_attrs = &h.other_attrs;
+            let ok_type = &h.ok_type;
+
+            let async_params: Vec<_> = h
+                .param_names
+                .iter()
+                .zip(h.param_types.iter().zip(&h.param_kinds))
+                .map(|(name, (orig_ty, kind))| {
+                    let ty = kind.async_param_type(orig_ty);
+                    match kind {
+                        classify::ParamKind::OptionMutSliceRef { .. } => {
+                            quote! { mut #name: #ty }
+                        }
+                        _ => quote! { #name: #ty },
+                    }
+                })
+                .collect();
+
+            let pack_fields: Vec<_> = h
+                .param_names
+                .iter()
+                .zip(&h.param_kinds)
+                .map(|(name, kind)| {
+                    let expr = kind.pack_expr(name);
+                    quote! { #name: #expr }
+                })
+                .collect();
+
+            let mut_slice_param_names: Vec<_> = h
+                .param_names
+                .iter()
+                .zip(&h.param_kinds)
+                .filter_map(|(name, kind)| match kind {
+                    classify::ParamKind::MutSliceRef { .. } => Some(name.clone()),
+                    _ => None,
+                })
+                .collect();
+            let opt_mut_slice_param_names: Vec<_> = h
+                .param_names
+                .iter()
+                .zip(&h.param_kinds)
+                .filter_map(|(name, kind)| match kind {
+                    classify::ParamKind::OptionMutSliceRef { .. } => Some(name.clone()),
+                    _ => None,
+                })
+                .collect();
+            let has_any_mut_slices =
+                !mut_slice_param_names.is_empty() || !opt_mut_slice_param_names.is_empty();
+
+            let return_expr = if !has_any_mut_slices {
+                quote! { #response_future_name { __state }.await }
+            } else {
+                let returned_vec_names: Vec<_> = mut_slice_param_names
+                    .iter()
+                    .map(|name| format_ident!("__returned_{}", name))
+                    .collect();
+                let returned_opt_vec_names: Vec<_> = opt_mut_slice_param_names
+                    .iter()
+                    .map(|name| format_ident!("__returned_{}", name))
+                    .collect();
+                // Copy-back for plain &mut [T] params.
+                let copy_back_slices: Vec<_> = mut_slice_param_names
+                    .iter()
+                    .zip(&returned_vec_names)
+                    .map(|(param, ret)| quote! { #param.copy_from_slice(&#ret); })
+                    .collect();
+                // Copy-back for Option<&mut [T]> params — only when both
+                // the caller provided Some and the worker returned Some.
+                let copy_back_opt_slices: Vec<_> = opt_mut_slice_param_names
+                    .iter()
+                    .zip(&returned_opt_vec_names)
+                    .map(|(param, ret)| {
+                        quote! {
+                            if let ::std::option::Option::Some(ref __src) = #ret {
+                                if let ::std::option::Option::Some(ref mut __dst) = #param {
+                                    __dst.copy_from_slice(__src);
+                                }
+                            }
+                        }
+                    })
+                    .collect();
+                quote! {
+                    match (#response_future_name { __state }.await) {
+                        ::std::result::Result::Ok((__ok, #(#returned_vec_names,)* #(#returned_opt_vec_names,)*)) => {
+                            #(#copy_back_slices)*
+                            #(#copy_back_opt_slices)*
+                            ::std::result::Result::Ok(__ok)
+                        }
+                        ::std::result::Result::Err(__err) => ::std::result::Result::Err(__err),
+                    }
+                }
+            };
+
+            quote! {
+                #(#doc_attrs)*
+                #(#other_attrs)*
+                #vis async fn #name(&self, #(#async_params),*) -> Result<#ok_type, #error_type> {
+                    let __state = ::std::sync::Arc::new(
+                        ::std::sync::Mutex::new((
+                            ::std::option::Option::None,
+                            ::std::option::Option::None,
+                        ))
+                    );
+                    let __op = #enum_name::#variant {
+                        #(#pack_fields,)*
+                        __state: ::std::sync::Arc::clone(&__state),
+                    };
+                    self.__tx.send(__op).map_err(|_| #shutdown_error)?;
+                    #return_expr
+                }
+            }
+        })
+        .collect();
+
+    quote! {
+        #[allow(clippy::unwrap_used)]
+        struct #response_future_name<__T> {
+            __state: ::std::sync::Arc<
+                ::std::sync::Mutex<(
+                    ::std::option::Option<__T>,
+                    ::std::option::Option<::std::task::Waker>,
+                )>
+            >,
+        }
+
+        #[allow(clippy::unwrap_used)]
+        impl<__T> ::std::future::Future for #response_future_name<__T> {
+            type Output = __T;
+
+            fn poll(
+                self: ::std::pin::Pin<&mut Self>,
+                __cx: &mut ::std::task::Context<'_>,
+            ) -> ::std::task::Poll<Self::Output> {
+                let mut __guard = self.__state.lock().unwrap();
+                if let ::std::option::Option::Some(__val) = __guard.0.take() {
+                    ::std::task::Poll::Ready(__val)
+                } else {
+                    __guard.1 = ::std::option::Option::Some(__cx.waker().clone());
+                    ::std::task::Poll::Pending
+                }
+            }
+        }
+
+        impl #struct_name {
+            /// Create a new instance, spawning the background worker thread(s).
+            pub fn new() -> Self {
+                let (__tx, __rx) = ::std::sync::mpsc::channel();
+                let __rx = ::std::sync::Arc::new(::std::sync::Mutex::new(__rx));
+                let mut __handles = ::std::vec::Vec::with_capacity(#num_workers);
+                for _ in 0..#num_workers {
+                    let __rx = ::std::sync::Arc::clone(&__rx);
+                    __handles.push(::std::thread::spawn(move || #worker_fn_name(__rx)));
+                }
+                Self {
+                    __tx,
+                    __handles,
+                }
+            }
+
+            /// Shut down the worker thread(s).
+            pub fn shutdown(&self) {
+                for _ in 0..#num_workers {
+                    let _ = self.__tx.send(#enum_name::__Shutdown);
+                }
+            }
+
+            #(#async_methods)*
+        }
+    }
+}
+
+fn gen_drop_impl(
+    struct_name: &syn::Ident,
+    enum_name: &syn::Ident,
+    num_workers: usize,
+) -> TokenStream2 {
+    quote! {
+        impl ::std::ops::Drop for #struct_name {
+            fn drop(&mut self) {
+                for _ in 0..#num_workers {
+                    let _ = self.__tx.send(#enum_name::__Shutdown);
+                }
+                for __handle in self.__handles.drain(..) {
+                    let _ = __handle.join();
+                }
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Utility helpers
+// ---------------------------------------------------------------------------
+
+/// Extract the type identifier from a `Type` (e.g., `CryptoPal` from `impl CryptoPal`).
+fn extract_type_ident(ty: &Type) -> syn::Result<syn::Ident> {
+    let Type::Path(type_path) = ty else {
+        return Err(syn::Error::new(
+            ty.span(),
+            "offload requires a simple type name (not a path or generic)",
+        ));
+    };
+    let Some(segment) = type_path.path.segments.last() else {
+        return Err(syn::Error::new(ty.span(), "empty type path"));
+    };
+    if !segment.arguments.is_none() {
+        return Err(syn::Error::new(
+            segment.arguments.span(),
+            "offload does not support generic types",
+        ));
+    }
+    Ok(segment.ident.clone())
+}
+
+/// Extract the `T` from `-> Result<T, E>`.
+fn extract_result_ok_type(output: &ReturnType, _error_type: &syn::Path) -> syn::Result<Type> {
+    let ReturnType::Type(_, ty) = output else {
+        return Err(syn::Error::new(
+            output.span(),
+            "offload handlers must return Result<T, E>",
+        ));
+    };
+    let Type::Path(type_path) = ty.as_ref() else {
+        return Err(syn::Error::new(
+            ty.span(),
+            "offload handlers must return Result<T, E>",
+        ));
+    };
+    let Some(segment) = type_path.path.segments.last() else {
+        return Err(syn::Error::new(ty.span(), "expected Result type"));
+    };
+    if segment.ident != "Result" {
+        return Err(syn::Error::new(
+            segment.ident.span(),
+            "offload handlers must return Result<T, E>",
+        ));
+    }
+    let syn::PathArguments::AngleBracketed(args) = &segment.arguments else {
+        return Err(syn::Error::new(
+            segment.arguments.span(),
+            "expected Result<T, E> with generic arguments",
+        ));
+    };
+    if args.args.len() != 2 {
+        return Err(syn::Error::new(
+            args.span(),
+            "expected Result<T, E> with exactly two type arguments",
+        ));
+    }
+    let syn::GenericArgument::Type(ok_type) = &args.args[0] else {
+        return Err(syn::Error::new(args.args[0].span(), "expected a type"));
+    };
+    Ok(ok_type.clone())
+}
+
+/// Convert `snake_case` identifier to `PascalCase`.
+fn to_pascal_case(ident: &syn::Ident) -> syn::Ident {
+    let s = ident.to_string();
+    let pascal: String = s
+        .split('_')
+        .map(|segment| {
+            let mut chars = segment.chars();
+            match chars.next() {
+                Some(c) => {
+                    let upper: String = c.to_uppercase().collect();
+                    upper + chars.as_str()
+                }
+                None => String::new(),
+            }
+        })
+        .collect();
+    syn::Ident::new(&pascal, ident.span())
+}
+
+/// Convert `PascalCase` identifier to `snake_case`.
+fn to_snake_case(ident: &syn::Ident) -> String {
+    let s = ident.to_string();
+    let mut result = String::new();
+    for (i, ch) in s.chars().enumerate() {
+        if ch.is_uppercase() {
+            if i > 0 {
+                result.push('_');
+            }
+            for lower in ch.to_lowercase() {
+                result.push(lower);
+            }
+        } else {
+            result.push(ch);
+        }
+    }
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use syn::ReturnType;
+
+    use super::*;
+
+    // -- to_pascal_case ---------------------------------------------------
+
+    #[test]
+    fn pascal_case_double_underscore() {
+        let ident = syn::Ident::new("my__op", proc_macro2::Span::call_site());
+        let result = to_pascal_case(&ident);
+        assert_eq!(result, "MyOp");
+    }
+
+    // -- extract_type_ident -----------------------------------------------
+
+    #[test]
+    fn type_ident_non_path() {
+        let ty: Type = syn::parse_str("(u8, u8)").unwrap();
+        assert!(extract_type_ident(&ty).is_err());
+    }
+
+    #[test]
+    fn type_ident_generic() {
+        let ty: Type = syn::parse_str("Foo<u8>").unwrap();
+        assert!(extract_type_ident(&ty).is_err());
+    }
+
+    #[test]
+    fn type_ident_simple_succeeds() {
+        let ty: Type = syn::parse_str("MyWorker").unwrap();
+        let ident = extract_type_ident(&ty).unwrap();
+        assert_eq!(ident, "MyWorker");
+    }
+
+    // -- extract_result_ok_type -------------------------------------------
+
+    fn parse_return_type(s: &str) -> ReturnType {
+        let func: syn::ItemFn = syn::parse_str(&format!("fn f() {s} {{}}")).unwrap();
+        func.sig.output
+    }
+
+    #[test]
+    fn result_ok_no_return_type() {
+        let error_path: syn::Path = syn::parse_str("MyError").unwrap();
+        assert!(extract_result_ok_type(&ReturnType::Default, &error_path).is_err());
+    }
+
+    #[test]
+    fn result_ok_non_path_return() {
+        let ret = parse_return_type("-> &u8");
+        let error_path: syn::Path = syn::parse_str("MyError").unwrap();
+        assert!(extract_result_ok_type(&ret, &error_path).is_err());
+    }
+
+    #[test]
+    fn result_ok_non_result_return() {
+        let ret = parse_return_type("-> Vec<u8>");
+        let error_path: syn::Path = syn::parse_str("MyError").unwrap();
+        assert!(extract_result_ok_type(&ret, &error_path).is_err());
+    }
+
+    #[test]
+    fn result_ok_wrong_arg_count() {
+        let ret = parse_return_type("-> Result<u8>");
+        let error_path: syn::Path = syn::parse_str("MyError").unwrap();
+        assert!(extract_result_ok_type(&ret, &error_path).is_err());
+    }
+
+    #[test]
+    fn result_ok_valid() {
+        let ret = parse_return_type("-> Result<u32, MyError>");
+        let error_path: syn::Path = syn::parse_str("MyError").unwrap();
+        let ok_ty = extract_result_ok_type(&ret, &error_path).unwrap();
+        assert_eq!(quote! { #ok_ty }.to_string(), "u32");
+    }
+
+    #[test]
+    fn result_ok_bare_result() {
+        let ret = parse_return_type("-> Result");
+        let error_path: syn::Path = syn::parse_str("MyError").unwrap();
+        assert!(extract_result_ok_type(&ret, &error_path).is_err());
+    }
+
+    // -- expand_offload validation -----------------------------------
+
+    fn test_args(workers: Option<usize>) -> OffloadArgs {
+        OffloadArgs {
+            error: syn::parse_str("E").unwrap(),
+            shutdown_error: syn::parse_str("E::Shutdown").unwrap(),
+            workers,
+        }
+    }
+
+    #[test]
+    fn reject_generic_impl() {
+        let item: ItemImpl = syn::parse_str("impl<T> Foo { }").unwrap();
+        assert!(expand_offload(test_args(None), item).is_err());
+    }
+
+    #[test]
+    fn reject_trait_impl() {
+        let item: ItemImpl = syn::parse_str("impl MyTrait for Foo { }").unwrap();
+        assert!(expand_offload(test_args(None), item).is_err());
+    }
+
+    #[test]
+    fn reject_zero_workers() {
+        let item: ItemImpl =
+            syn::parse_str("impl Foo { fn op() -> Result<(), E> { Ok(()) } }").unwrap();
+        assert!(expand_offload(test_args(Some(0)), item).is_err());
+    }
+
+    #[test]
+    fn reject_non_fn_item() {
+        let item: ItemImpl = syn::parse_str("impl Foo { const X: u32 = 1; }").unwrap();
+        assert!(expand_offload(test_args(None), item).is_err());
+    }
+
+    #[test]
+    fn reject_self_receiver() {
+        let item: ItemImpl =
+            syn::parse_str("impl Foo { fn op(&self) -> Result<(), E> { Ok(()) } }").unwrap();
+        assert!(expand_offload(test_args(None), item).is_err());
+    }
+
+    #[test]
+    fn reject_async_handler() {
+        let item: ItemImpl =
+            syn::parse_str("impl Foo { async fn op() -> Result<(), E> { Ok(()) } }").unwrap();
+        assert!(expand_offload(test_args(None), item).is_err());
+    }
+
+    #[test]
+    fn reject_destructured_param() {
+        let item: ItemImpl =
+            syn::parse_str("impl Foo { fn op((a, b): (u32, u32)) -> Result<(), E> { Ok(()) } }")
+                .unwrap();
+        assert!(expand_offload(test_args(None), item).is_err());
+    }
+
+    #[test]
+    fn reject_empty_impl() {
+        let item: ItemImpl = syn::parse_str("impl Foo { }").unwrap();
+        assert!(expand_offload(test_args(None), item).is_err());
+    }
+
+    // -- extract_type_ident: generic type path ----------------------------
+
+    #[test]
+    fn reject_generic_type_in_impl() {
+        let item: ItemImpl =
+            syn::parse_str("impl Foo<u8> { fn op() -> Result<(), E> { Ok(()) } }").unwrap();
+        assert!(expand_offload(test_args(None), item).is_err());
+    }
+}

--- a/crates/offload/src/lib.rs
+++ b/crates/offload/src/lib.rs
@@ -32,13 +32,13 @@
 //! # Macro attributes
 //!
 //! ```text
-//! #[offload(error = <ErrorType>, shutdown_error = <ErrorExpr>)]
+//! #[offload(error = <ErrorType>, shutdown_error = <ErrorPath>)]
 //! ```
 //!
 //! | Attribute        | Description |
 //! |------------------|-------------|
 //! | `error`          | The error type `E` used in every handler's `Result<T, E>` return type. |
-//! | `shutdown_error` | An expression of type `E` returned when the caller tries to use the worker after it has shut down (i.e., the channel is disconnected). |
+//! | `shutdown_error` | A path of type `E` returned when the caller tries to use the worker after it has shut down (i.e., the channel is disconnected). |
 //! | `workers`        | *(Optional, default `1`)* Number of worker threads to spawn. |
 //!
 //! # Handler rules
@@ -134,7 +134,7 @@ use syn::spanned::Spanned;
 struct OffloadArgs {
     /// Error type used in all `Result` return types.
     error: syn::Path,
-    /// Expression for the error produced when the worker channel disconnects.
+    /// Path for the error produced when the worker channel disconnects.
     shutdown_error: syn::Path,
     /// Number of worker threads to spawn (default: 1).
     workers: Option<usize>,
@@ -321,7 +321,7 @@ fn expand_offload(args: OffloadArgs, item: ItemImpl) -> syn::Result<TokenStream2
 
     let handler_fns = gen_handler_fns(&handlers, error_type);
     let op_enum = gen_op_enum(&enum_name, &handlers, error_type);
-    let worker_fn = gen_worker_fn(&worker_fn_name, &enum_name, &handlers);
+    let worker_fn = gen_worker_fn(&worker_fn_name, &enum_name, &handlers, shutdown_error);
     let struct_def = gen_struct_def(&struct_name, &enum_name, &struct_doc_attrs);
     let impl_block = gen_impl_block(
         &struct_name,
@@ -445,6 +445,7 @@ fn gen_worker_fn(
     worker_fn_name: &syn::Ident,
     enum_name: &syn::Ident,
     handlers: &[HandlerInfo],
+    shutdown_error: &syn::Path,
 ) -> TokenStream2 {
     let arms: Vec<_> = handlers
         .iter()
@@ -502,11 +503,17 @@ fn gen_worker_fn(
             quote! {
                 #(#other_attrs)*
                 #enum_name::#variant { #(#pattern_fields,)* __state } => {
-                    let __result = #handler_fn(#(#unpack_exprs),*);
+                    let __catch = ::std::panic::catch_unwind(
+                        ::std::panic::AssertUnwindSafe(|| #handler_fn(#(#unpack_exprs),*))
+                    );
+                    let __stored = match __catch {
+                        ::std::result::Result::Ok(__result) => #store_result,
+                        ::std::result::Result::Err(_) => ::std::result::Result::Err(#shutdown_error),
+                    };
                     #[allow(clippy::unwrap_used)]
                     let __waker = {
                         let mut __guard = __state.lock().unwrap();
-                        __guard.0 = ::std::option::Option::Some(#store_result);
+                        __guard.0 = ::std::option::Option::Some(__stored);
                         __guard.1.take()
                     };
                     if let ::std::option::Option::Some(__w) = __waker {
@@ -549,6 +556,7 @@ fn gen_struct_def(
         pub struct #struct_name {
             __tx: ::std::sync::mpsc::Sender<#enum_name>,
             __handles: ::std::vec::Vec<::std::thread::JoinHandle<()>>,
+            __shutdown: ::std::sync::atomic::AtomicBool,
         }
     }
 }
@@ -668,6 +676,9 @@ fn gen_impl_block(
                 #(#doc_attrs)*
                 #(#other_attrs)*
                 #vis async fn #name(&self, #(#async_params),*) -> Result<#ok_type, #error_type> {
+                    if self.__shutdown.load(::std::sync::atomic::Ordering::Acquire) {
+                        return ::std::result::Result::Err(#shutdown_error);
+                    }
                     let __state = ::std::sync::Arc::new(
                         ::std::sync::Mutex::new((
                             ::std::option::Option::None,
@@ -727,11 +738,17 @@ fn gen_impl_block(
                 Self {
                     __tx,
                     __handles,
+                    __shutdown: ::std::sync::atomic::AtomicBool::new(false),
                 }
             }
 
-            /// Shut down the worker thread(s).
+            /// Signal the worker thread(s) to shut down after processing any
+            /// already-queued operations. This is non-blocking — it enqueues
+            /// shutdown messages and returns immediately. Operations submitted
+            /// after this call will fail with the `shutdown_error`.
+            /// Worker threads are joined when this instance is dropped.
             pub fn shutdown(&self) {
+                self.__shutdown.store(true, ::std::sync::atomic::Ordering::Release);
                 for _ in 0..#num_workers {
                     let _ = self.__tx.send(#enum_name::__Shutdown);
                 }
@@ -750,6 +767,7 @@ fn gen_drop_impl(
     quote! {
         impl ::std::ops::Drop for #struct_name {
             fn drop(&mut self) {
+                self.__shutdown.store(true, ::std::sync::atomic::Ordering::Release);
                 for _ in 0..#num_workers {
                     let _ = self.__tx.send(#enum_name::__Shutdown);
                 }
@@ -773,6 +791,12 @@ fn extract_type_ident(ty: &Type) -> syn::Result<syn::Ident> {
             "offload requires a simple type name (not a path or generic)",
         ));
     };
+    if type_path.path.leading_colon.is_some() || type_path.path.segments.len() != 1 {
+        return Err(syn::Error::new(
+            ty.span(),
+            "offload requires a simple type name (not a path or generic)",
+        ));
+    }
     let Some(segment) = type_path.path.segments.last() else {
         return Err(syn::Error::new(ty.span(), "empty type path"));
     };
@@ -865,6 +889,7 @@ fn to_snake_case(ident: &syn::Ident) -> String {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used)]
 mod tests {
     use syn::ReturnType;
 
@@ -898,6 +923,18 @@ mod tests {
         let ty: Type = syn::parse_str("MyWorker").unwrap();
         let ident = extract_type_ident(&ty).unwrap();
         assert_eq!(ident, "MyWorker");
+    }
+
+    #[test]
+    fn type_ident_qualified_path() {
+        let ty: Type = syn::parse_str("foo::Bar").unwrap();
+        assert!(extract_type_ident(&ty).is_err());
+    }
+
+    #[test]
+    fn type_ident_leading_colon() {
+        let ty: Type = syn::parse_str("::Bar").unwrap();
+        assert!(extract_type_ident(&ty).is_err());
     }
 
     // -- extract_result_ok_type -------------------------------------------

--- a/crates/offload/tests/compile_tests.rs
+++ b/crates/offload/tests/compile_tests.rs
@@ -1,0 +1,16 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+// Trybuild is not compatible with Windows CI.
+#[cfg(target_os = "linux")]
+#[test]
+fn tests() {
+    let t = trybuild::TestCases::new();
+    t.compile_fail("tests/compile_tests/01-handler-with-self.rs");
+    t.compile_fail("tests/compile_tests/02-async-handler.rs");
+    t.compile_fail("tests/compile_tests/03-no-result-return.rs");
+    t.compile_fail("tests/compile_tests/04-empty-impl.rs");
+    t.compile_fail("tests/compile_tests/05-generic-impl.rs");
+    t.compile_fail("tests/compile_tests/06-trait-impl.rs");
+    t.compile_fail("tests/compile_tests/07-missing-error-attr.rs");
+}

--- a/crates/offload/tests/compile_tests/01-handler-with-self.rs
+++ b/crates/offload/tests/compile_tests/01-handler-with-self.rs
@@ -1,0 +1,18 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use offload::offload;
+
+#[derive(Debug)]
+enum MyError {
+    WorkerShutdown,
+}
+
+#[offload(error = MyError, shutdown_error = MyError::WorkerShutdown)]
+impl MyWorker {
+    pub fn bad(&self) -> Result<u32, MyError> {
+        Ok(42)
+    }
+}
+
+fn main() {}

--- a/crates/offload/tests/compile_tests/01-handler-with-self.stderr
+++ b/crates/offload/tests/compile_tests/01-handler-with-self.stderr
@@ -1,0 +1,5 @@
+error: offload handler functions must not take self
+  --> tests/compile_tests/01-handler-with-self.rs:13:9
+   |
+13 |     pub fn bad(&self) -> Result<u32, MyError> {
+   |         ^^

--- a/crates/offload/tests/compile_tests/02-async-handler.rs
+++ b/crates/offload/tests/compile_tests/02-async-handler.rs
@@ -1,0 +1,18 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use offload::offload;
+
+#[derive(Debug)]
+enum MyError {
+    WorkerShutdown,
+}
+
+#[offload(error = MyError, shutdown_error = MyError::WorkerShutdown)]
+impl MyWorker {
+    pub async fn bad() -> Result<u32, MyError> {
+        Ok(42)
+    }
+}
+
+fn main() {}

--- a/crates/offload/tests/compile_tests/02-async-handler.stderr
+++ b/crates/offload/tests/compile_tests/02-async-handler.stderr
@@ -1,0 +1,5 @@
+error: offload handler functions must be synchronous; the macro generates async wrappers
+  --> tests/compile_tests/02-async-handler.rs:13:9
+   |
+13 |     pub async fn bad() -> Result<u32, MyError> {
+   |         ^^^^^

--- a/crates/offload/tests/compile_tests/03-no-result-return.rs
+++ b/crates/offload/tests/compile_tests/03-no-result-return.rs
@@ -1,0 +1,18 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use offload::offload;
+
+#[derive(Debug)]
+enum MyError {
+    WorkerShutdown,
+}
+
+#[offload(error = MyError, shutdown_error = MyError::WorkerShutdown)]
+impl MyWorker {
+    pub fn bad() -> u32 {
+        42
+    }
+}
+
+fn main() {}

--- a/crates/offload/tests/compile_tests/03-no-result-return.stderr
+++ b/crates/offload/tests/compile_tests/03-no-result-return.stderr
@@ -1,0 +1,5 @@
+error: offload handlers must return Result<T, E>
+  --> tests/compile_tests/03-no-result-return.rs:13:21
+   |
+13 |     pub fn bad() -> u32 {
+   |                     ^^^

--- a/crates/offload/tests/compile_tests/04-empty-impl.rs
+++ b/crates/offload/tests/compile_tests/04-empty-impl.rs
@@ -1,0 +1,14 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use offload::offload;
+
+#[derive(Debug)]
+enum MyError {
+    WorkerShutdown,
+}
+
+#[offload(error = MyError, shutdown_error = MyError::WorkerShutdown)]
+impl MyWorker {}
+
+fn main() {}

--- a/crates/offload/tests/compile_tests/04-empty-impl.stderr
+++ b/crates/offload/tests/compile_tests/04-empty-impl.stderr
@@ -1,0 +1,5 @@
+error: offload impl block must contain at least one handler function
+  --> tests/compile_tests/04-empty-impl.rs:12:1
+   |
+12 | impl MyWorker {}
+   | ^^^^

--- a/crates/offload/tests/compile_tests/05-generic-impl.rs
+++ b/crates/offload/tests/compile_tests/05-generic-impl.rs
@@ -1,0 +1,18 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use offload::offload;
+
+#[derive(Debug)]
+enum MyError {
+    WorkerShutdown,
+}
+
+#[offload(error = MyError, shutdown_error = MyError::WorkerShutdown)]
+impl<T> MyWorker {
+    pub fn bad() -> Result<u32, MyError> {
+        Ok(42)
+    }
+}
+
+fn main() {}

--- a/crates/offload/tests/compile_tests/05-generic-impl.stderr
+++ b/crates/offload/tests/compile_tests/05-generic-impl.stderr
@@ -1,0 +1,5 @@
+error: offload does not support generic impl blocks
+  --> tests/compile_tests/05-generic-impl.rs:12:5
+   |
+12 | impl<T> MyWorker {
+   |     ^

--- a/crates/offload/tests/compile_tests/06-trait-impl.rs
+++ b/crates/offload/tests/compile_tests/06-trait-impl.rs
@@ -1,0 +1,22 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use offload::offload;
+
+#[derive(Debug)]
+enum MyError {
+    WorkerShutdown,
+}
+
+trait MyTrait {}
+
+struct MyWorker;
+
+#[offload(error = MyError, shutdown_error = MyError::WorkerShutdown)]
+impl MyTrait for MyWorker {
+    pub fn bad() -> Result<u32, MyError> {
+        Ok(42)
+    }
+}
+
+fn main() {}

--- a/crates/offload/tests/compile_tests/06-trait-impl.stderr
+++ b/crates/offload/tests/compile_tests/06-trait-impl.stderr
@@ -1,0 +1,5 @@
+error: offload does not support trait implementations
+  --> tests/compile_tests/06-trait-impl.rs:16:1
+   |
+16 | impl MyTrait for MyWorker {
+   | ^^^^

--- a/crates/offload/tests/compile_tests/07-missing-error-attr.rs
+++ b/crates/offload/tests/compile_tests/07-missing-error-attr.rs
@@ -1,0 +1,18 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use offload::offload;
+
+#[derive(Debug)]
+enum MyError {
+    WorkerShutdown,
+}
+
+#[offload(shutdown_error = MyError::WorkerShutdown)]
+impl MyWorker {
+    pub fn good() -> Result<u32, MyError> {
+        Ok(42)
+    }
+}
+
+fn main() {}

--- a/crates/offload/tests/compile_tests/07-missing-error-attr.stderr
+++ b/crates/offload/tests/compile_tests/07-missing-error-attr.stderr
@@ -1,0 +1,7 @@
+error: Missing field `error`
+  --> tests/compile_tests/07-missing-error-attr.rs:11:1
+   |
+11 | #[offload(shutdown_error = MyError::WorkerShutdown)]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: this error originates in the attribute macro `offload` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/crates/offload/tests/integration.rs
+++ b/crates/offload/tests/integration.rs
@@ -1,0 +1,518 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Integration tests for the `offload` proc macro.
+//!
+//! These tests exercise the macro with various parameter types and verify
+//! that the generated struct, async methods, and worker thread work correctly.
+
+use std::fmt;
+use std::future::Future;
+use std::pin::pin;
+use std::task::Context;
+use std::task::Poll;
+use std::task::Waker;
+
+use offload::offload;
+
+/// Spin-polling block_on. The generated futures return `Pending` until the
+/// worker thread completes the operation, then `Ready` on a subsequent poll.
+/// `Waker::noop()` means no wake notification, so we yield and re-poll.
+fn block_on<T>(fut: impl Future<Output = T>) -> T {
+    let waker = Waker::noop();
+    let mut cx = Context::from_waker(&waker);
+    let mut fut = pin!(fut);
+    loop {
+        match fut.as_mut().poll(&mut cx) {
+            Poll::Ready(val) => return val,
+            Poll::Pending => std::thread::yield_now(),
+        }
+    }
+}
+
+// ── Shared error type ──
+
+#[derive(Debug)]
+enum TestError {
+    WorkerShutdown,
+    Failed(String),
+}
+
+impl fmt::Display for TestError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            TestError::WorkerShutdown => write!(f, "worker shutdown"),
+            TestError::Failed(msg) => write!(f, "failed: {msg}"),
+        }
+    }
+}
+
+// ── Basic: by-value params, slice params, return types ──
+
+#[offload(error = TestError, shutdown_error = TestError::WorkerShutdown)]
+impl BasicWorker {
+    pub fn add(a: usize, b: usize) -> Result<usize, TestError> {
+        Ok(a + b)
+    }
+
+    pub fn echo_bytes(data: &[u8]) -> Result<Vec<u8>, TestError> {
+        Ok(data.to_vec())
+    }
+
+    pub fn concat(a: &[u8], b: &[u8]) -> Result<Vec<u8>, TestError> {
+        let mut result = a.to_vec();
+        result.extend_from_slice(b);
+        Ok(result)
+    }
+}
+
+#[test]
+fn test_basic_by_value() {
+    let w = BasicWorker::new();
+    let result = block_on(w.add(3, 4));
+    assert_eq!(result.unwrap(), 7);
+    w.shutdown();
+}
+
+#[test]
+fn test_basic_slice_ref() {
+    let w = BasicWorker::new();
+    let data = b"hello world";
+    let result = block_on(w.echo_bytes(data));
+    assert_eq!(result.unwrap(), data);
+    w.shutdown();
+}
+
+#[test]
+fn test_basic_multiple_slices() {
+    let w = BasicWorker::new();
+    let result = block_on(w.concat(b"foo", b"bar"));
+    assert_eq!(result.unwrap(), b"foobar");
+    w.shutdown();
+}
+
+// ── Input slice -> mutable output slice, returns valid output length ──
+
+#[offload(error = TestError, shutdown_error = TestError::WorkerShutdown)]
+impl MutableOutWorker {
+    pub fn tweak_and_copy(input: &[u8], output: &mut [u8]) -> Result<usize, TestError> {
+        let count = input.len().min(output.len());
+        for (dst, src) in output.iter_mut().zip(input.iter()).take(count) {
+            *dst = src.wrapping_add(1);
+        }
+        Ok(count)
+    }
+}
+
+#[test]
+fn test_input_slice_to_mutable_output_slice() {
+    let w = MutableOutWorker::new();
+    let mut out = [0u8; 8];
+
+    let len = block_on(w.tweak_and_copy(b"hello", &mut out)).unwrap();
+    assert_eq!(len, 5);
+    assert_eq!(&out[..len], b"ifmmp");
+    assert_eq!(&out[len..], &[0, 0, 0]);
+
+    w.shutdown();
+}
+
+// ── Option params ──
+
+#[offload(error = TestError, shutdown_error = TestError::WorkerShutdown)]
+impl OptionWorker {
+    pub fn optional_slice(data: &[u8], prefix: Option<&[u8]>) -> Result<Vec<u8>, TestError> {
+        let mut result = Vec::new();
+        if let Some(p) = prefix {
+            result.extend_from_slice(p);
+        }
+        result.extend_from_slice(data);
+        Ok(result)
+    }
+
+    pub fn optional_mut_slice(input: &[u8], output: Option<&mut [u8]>) -> Result<usize, TestError> {
+        if let Some(out) = output {
+            let count = input.len().min(out.len());
+            for (dst, src) in out.iter_mut().zip(input.iter()).take(count) {
+                *dst = src.wrapping_add(1);
+            }
+            Ok(count)
+        } else {
+            Ok(0)
+        }
+    }
+}
+
+#[test]
+fn test_option_slice_some() {
+    let w = OptionWorker::new();
+    let result = block_on(w.optional_slice(b"world", Some(b"hello ")));
+    assert_eq!(result.unwrap(), b"hello world");
+    w.shutdown();
+}
+
+#[test]
+fn test_option_slice_none() {
+    let w = OptionWorker::new();
+    let result = block_on(w.optional_slice(b"alone", None));
+    assert_eq!(result.unwrap(), b"alone");
+    w.shutdown();
+}
+
+#[test]
+fn test_option_mut_slice_some() {
+    let w = OptionWorker::new();
+    let mut out = [0u8; 8];
+
+    let len = block_on(w.optional_mut_slice(b"hello", Some(&mut out))).unwrap();
+    assert_eq!(len, 5);
+    assert_eq!(&out[..len], b"ifmmp");
+    assert_eq!(&out[len..], &[0, 0, 0]);
+
+    w.shutdown();
+}
+
+#[test]
+fn test_option_mut_slice_none() {
+    let w = OptionWorker::new();
+    let len = block_on(w.optional_mut_slice(b"hello", None)).unwrap();
+    assert_eq!(len, 0);
+    w.shutdown();
+}
+
+// ── Reference-to-non-slice (e.g., &String, &MyEnum) ──
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[allow(dead_code)]
+enum Mode {
+    Upper,
+    Lower,
+}
+
+#[offload(error = TestError, shutdown_error = TestError::WorkerShutdown)]
+impl RefWorker {
+    pub fn transform(mode: &Mode, data: &[u8]) -> Result<Vec<u8>, TestError> {
+        let s = std::str::from_utf8(data).map_err(|e| TestError::Failed(e.to_string()))?;
+        let result = match mode {
+            Mode::Upper => s.to_uppercase(),
+            Mode::Lower => s.to_lowercase(),
+        };
+        Ok(result.into_bytes())
+    }
+
+    pub fn optional_transform(data: &[u8], mode: Option<&Mode>) -> Result<Vec<u8>, TestError> {
+        let s = std::str::from_utf8(data).map_err(|e| TestError::Failed(e.to_string()))?;
+        let result = match mode {
+            Some(Mode::Upper) => s.to_uppercase(),
+            Some(Mode::Lower) => s.to_lowercase(),
+            None => s.to_string(),
+        };
+        Ok(result.into_bytes())
+    }
+}
+
+#[test]
+fn test_ref_non_slice() {
+    let w = RefWorker::new();
+    // &Mode in the handler becomes Mode by value in the async method
+    let result = block_on(w.transform(Mode::Upper, b"hello"));
+    assert_eq!(result.unwrap(), b"HELLO");
+    w.shutdown();
+}
+
+#[test]
+fn test_option_ref_some() {
+    let w = RefWorker::new();
+    // Option<&Mode> in the handler becomes Option<Mode> by value in the async method
+    let result = block_on(w.optional_transform(b"heLLo", Some(Mode::Lower)));
+    assert_eq!(result.unwrap(), b"hello");
+    w.shutdown();
+}
+
+#[test]
+fn test_option_ref_none() {
+    let w = RefWorker::new();
+    let result = block_on(w.optional_transform(b"Hello", None));
+    assert_eq!(result.unwrap(), b"Hello");
+    w.shutdown();
+}
+
+// ── Tuple return type ──
+
+#[offload(error = TestError, shutdown_error = TestError::WorkerShutdown)]
+impl TupleWorker {
+    pub fn split_at(data: &[u8], pos: usize) -> Result<(Vec<u8>, Vec<u8>), TestError> {
+        if pos > data.len() {
+            return Err(TestError::Failed("pos out of range".into()));
+        }
+        Ok((data[..pos].to_vec(), data[pos..].to_vec()))
+    }
+}
+
+#[test]
+fn test_tuple_return() {
+    let w = TupleWorker::new();
+    let (left, right) = block_on(w.split_at(b"helloworld", 5)).unwrap();
+    assert_eq!(left, b"hello");
+    assert_eq!(right, b"world");
+    w.shutdown();
+}
+
+// ── Error propagation ──
+
+#[offload(error = TestError, shutdown_error = TestError::WorkerShutdown)]
+impl ErrorWorker {
+    pub fn failing_op(should_fail: bool) -> Result<u32, TestError> {
+        if should_fail {
+            Err(TestError::Failed("intentional failure".into()))
+        } else {
+            Ok(42)
+        }
+    }
+}
+
+#[test]
+fn test_error_propagated() {
+    let w = ErrorWorker::new();
+    let ok = block_on(w.failing_op(false));
+    assert_eq!(ok.unwrap(), 42);
+
+    let err = block_on(w.failing_op(true));
+    assert!(err.is_err());
+    let msg = format!("{}", err.unwrap_err());
+    assert!(msg.contains("intentional failure"));
+    w.shutdown();
+}
+
+// ── Drop shuts down worker ──
+
+#[test]
+fn test_drop_shuts_down() {
+    let w = ErrorWorker::new();
+    let ok = block_on(w.failing_op(false));
+    assert_eq!(ok.unwrap(), 42);
+    drop(w);
+    // If Drop didn't work, the thread would leak and the test process would hang.
+}
+
+// ── Bool return type ──
+
+#[offload(error = TestError, shutdown_error = TestError::WorkerShutdown)]
+impl BoolWorker {
+    pub fn is_even(n: usize) -> Result<bool, TestError> {
+        Ok(n % 2 == 0)
+    }
+}
+
+#[test]
+fn test_bool_return() {
+    let w = BoolWorker::new();
+    assert!(block_on(w.is_even(4)).unwrap());
+    assert!(!block_on(w.is_even(7)).unwrap());
+    w.shutdown();
+}
+
+// ── Multiple operations in sequence ──
+
+#[test]
+fn test_multiple_operations_sequence() {
+    let w = BasicWorker::new();
+    for i in 0..10 {
+        let result = block_on(w.add(i, i));
+        assert_eq!(result.unwrap(), i * 2);
+    }
+    w.shutdown();
+}
+
+// ── Future yields Pending before Ready ──
+
+#[test]
+fn test_future_is_not_immediately_ready() {
+    let w = SingleThreadSlowWorker::new();
+    let mut saw_pending = false;
+    for _ in 0..10 {
+        let waker = Waker::noop();
+        let mut cx = Context::from_waker(&waker);
+        let mut fut = pin!(w.slow_add_single(1, 2));
+        if let Poll::Pending = fut.as_mut().poll(&mut cx) {
+            saw_pending = true;
+            // Spin until ready so the worker processes the op before next iteration.
+            loop {
+                match fut.as_mut().poll(&mut cx) {
+                    Poll::Ready(val) => {
+                        assert_eq!(val.unwrap(), 3);
+                        break;
+                    }
+                    Poll::Pending => std::thread::yield_now(),
+                }
+            }
+        }
+    }
+    assert!(
+        saw_pending,
+        "expected at least one Pending across 10 iterations"
+    );
+    w.shutdown();
+}
+
+// ── 20 parallel async calls ──
+
+#[test]
+fn test_parallel_async_calls() {
+    let w = BasicWorker::new();
+    let waker = Waker::noop();
+    let mut cx = Context::from_waker(&waker);
+
+    let mut futs: Vec<_> = (0..20).map(|i| Box::pin(w.add(i, i))).collect();
+    let mut results: Vec<Option<Result<usize, TestError>>> = (0..20).map(|_| None).collect();
+
+    loop {
+        let mut all_done = true;
+        for (idx, fut) in futs.iter_mut().enumerate() {
+            if results[idx].is_some() {
+                continue;
+            }
+            match fut.as_mut().poll(&mut cx) {
+                Poll::Ready(val) => results[idx] = Some(val),
+                Poll::Pending => all_done = false,
+            }
+        }
+        if all_done {
+            break;
+        }
+        std::thread::yield_now();
+    }
+
+    for i in 0..20 {
+        assert_eq!(results[i].as_ref().unwrap().as_ref().unwrap(), &(i * 2));
+    }
+    w.shutdown();
+}
+
+// ── Shutdown then use returns WorkerShutdown ──
+
+#[test]
+fn test_use_after_shutdown() {
+    let w = BasicWorker::new();
+    w.shutdown();
+    // Give the worker thread a moment to process the shutdown.
+    std::thread::sleep(std::time::Duration::from_millis(50));
+    let result = block_on(w.add(1, 2));
+    assert!(result.is_err());
+}
+
+// ── Multi-threaded worker ──
+
+#[offload(error = TestError, shutdown_error = TestError::WorkerShutdown, workers = 1)]
+impl SingleThreadSlowWorker {
+    pub fn slow_add_single(a: usize, b: usize) -> Result<usize, TestError> {
+        std::thread::sleep(std::time::Duration::from_millis(50));
+        Ok(a + b)
+    }
+}
+
+#[test]
+fn test_single_worker_sequential_throughput() {
+    // With 1 worker and 50ms per op, 4 concurrent ops must take at least 200ms.
+    let w = SingleThreadSlowWorker::new();
+    let waker = Waker::noop();
+    let mut cx = Context::from_waker(&waker);
+
+    let mut futs: Vec<_> = (0..4).map(|i| Box::pin(w.slow_add_single(i, i))).collect();
+    let mut results: Vec<Option<Result<usize, TestError>>> = (0..4).map(|_| None).collect();
+
+    let start = std::time::Instant::now();
+    loop {
+        let mut all_done = true;
+        for (idx, fut) in futs.iter_mut().enumerate() {
+            if results[idx].is_some() {
+                continue;
+            }
+            match fut.as_mut().poll(&mut cx) {
+                Poll::Ready(val) => results[idx] = Some(val),
+                Poll::Pending => all_done = false,
+            }
+        }
+        if all_done {
+            break;
+        }
+        std::thread::yield_now();
+    }
+    let elapsed = start.elapsed();
+
+    for i in 0..4 {
+        assert_eq!(results[i].as_ref().unwrap().as_ref().unwrap(), &(i * 2));
+    }
+    // 4 ops at 50ms each on 1 worker = at least 200ms sequential.
+    assert!(
+        elapsed >= std::time::Duration::from_millis(200),
+        "expected sequential execution (~200ms) but finished in {elapsed:?}"
+    );
+    w.shutdown();
+}
+
+#[offload(error = TestError, shutdown_error = TestError::WorkerShutdown, workers = 10)]
+impl MultiThreadWorker {
+    pub fn slow_add(a: usize, b: usize) -> Result<usize, TestError> {
+        std::thread::sleep(std::time::Duration::from_millis(50));
+        Ok(a + b)
+    }
+}
+
+#[test]
+fn test_multi_thread_basic() {
+    let w = MultiThreadWorker::new();
+    let result = block_on(w.slow_add(10, 20));
+    assert_eq!(result.unwrap(), 30);
+    w.shutdown();
+}
+
+#[test]
+fn test_multi_thread_parallel_throughput() {
+    // With 10 workers and 50ms per op, 10 concurrent ops should complete in
+    // roughly 50ms rather than 500ms.
+    let w = MultiThreadWorker::new();
+    let waker = Waker::noop();
+    let mut cx = Context::from_waker(&waker);
+
+    let mut futs: Vec<_> = (0..10).map(|i| Box::pin(w.slow_add(i, i))).collect();
+    let mut results: Vec<Option<Result<usize, TestError>>> = (0..10).map(|_| None).collect();
+
+    let start = std::time::Instant::now();
+    loop {
+        let mut all_done = true;
+        for (idx, fut) in futs.iter_mut().enumerate() {
+            if results[idx].is_some() {
+                continue;
+            }
+            match fut.as_mut().poll(&mut cx) {
+                Poll::Ready(val) => results[idx] = Some(val),
+                Poll::Pending => all_done = false,
+            }
+        }
+        if all_done {
+            break;
+        }
+        std::thread::yield_now();
+    }
+    let elapsed = start.elapsed();
+
+    for i in 0..10 {
+        assert_eq!(results[i].as_ref().unwrap().as_ref().unwrap(), &(i * 2));
+    }
+    // 10 ops at 50ms each sequentially = 500ms.  With 10 workers should be ~50ms.
+    // Use a generous upper bound to avoid flaky tests.
+    assert!(
+        elapsed < std::time::Duration::from_millis(180),
+        "expected parallel execution but took {elapsed:?}"
+    );
+    w.shutdown();
+}
+
+#[test]
+fn test_multi_thread_drop_shuts_down() {
+    let w = MultiThreadWorker::new();
+    let _ = block_on(w.slow_add(1, 1));
+    drop(w);
+    // If Drop didn't shut down all threads, the test process would hang.
+}

--- a/crates/offload/tests/integration.rs
+++ b/crates/offload/tests/integration.rs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+#![allow(clippy::unwrap_used, clippy::disallowed_types)]
+
 //! Integration tests for the `offload` proc macro.
 //!
 //! These tests exercise the macro with various parameter types and verify
@@ -20,7 +22,7 @@ use offload::offload;
 /// `Waker::noop()` means no wake notification, so we yield and re-poll.
 fn block_on<T>(fut: impl Future<Output = T>) -> T {
     let waker = Waker::noop();
-    let mut cx = Context::from_waker(&waker);
+    let mut cx = Context::from_waker(waker);
     let mut fut = pin!(fut);
     loop {
         match fut.as_mut().poll(&mut cx) {
@@ -300,7 +302,7 @@ fn test_drop_shuts_down() {
 #[offload(error = TestError, shutdown_error = TestError::WorkerShutdown)]
 impl BoolWorker {
     pub fn is_even(n: usize) -> Result<bool, TestError> {
-        Ok(n % 2 == 0)
+        Ok(n.is_multiple_of(2))
     }
 }
 
@@ -332,9 +334,9 @@ fn test_future_is_not_immediately_ready() {
     let mut saw_pending = false;
     for _ in 0..10 {
         let waker = Waker::noop();
-        let mut cx = Context::from_waker(&waker);
+        let mut cx = Context::from_waker(waker);
         let mut fut = pin!(w.slow_add_single(1, 2));
-        if let Poll::Pending = fut.as_mut().poll(&mut cx) {
+        if fut.as_mut().poll(&mut cx).is_pending() {
             saw_pending = true;
             // Spin until ready so the worker processes the op before next iteration.
             loop {
@@ -361,7 +363,7 @@ fn test_future_is_not_immediately_ready() {
 fn test_parallel_async_calls() {
     let w = BasicWorker::new();
     let waker = Waker::noop();
-    let mut cx = Context::from_waker(&waker);
+    let mut cx = Context::from_waker(waker);
 
     let mut futs: Vec<_> = (0..20).map(|i| Box::pin(w.add(i, i))).collect();
     let mut results: Vec<Option<Result<usize, TestError>>> = (0..20).map(|_| None).collect();
@@ -383,8 +385,8 @@ fn test_parallel_async_calls() {
         std::thread::yield_now();
     }
 
-    for i in 0..20 {
-        assert_eq!(results[i].as_ref().unwrap().as_ref().unwrap(), &(i * 2));
+    for (i, result) in results.iter().enumerate() {
+        assert_eq!(result.as_ref().unwrap().as_ref().unwrap(), &(i * 2));
     }
     w.shutdown();
 }
@@ -395,8 +397,7 @@ fn test_parallel_async_calls() {
 fn test_use_after_shutdown() {
     let w = BasicWorker::new();
     w.shutdown();
-    // Give the worker thread a moment to process the shutdown.
-    std::thread::sleep(std::time::Duration::from_millis(50));
+    // The shutdown flag is set immediately — no sleep needed.
     let result = block_on(w.add(1, 2));
     assert!(result.is_err());
 }
@@ -416,7 +417,7 @@ fn test_single_worker_sequential_throughput() {
     // With 1 worker and 50ms per op, 4 concurrent ops must take at least 200ms.
     let w = SingleThreadSlowWorker::new();
     let waker = Waker::noop();
-    let mut cx = Context::from_waker(&waker);
+    let mut cx = Context::from_waker(waker);
 
     let mut futs: Vec<_> = (0..4).map(|i| Box::pin(w.slow_add_single(i, i))).collect();
     let mut results: Vec<Option<Result<usize, TestError>>> = (0..4).map(|_| None).collect();
@@ -440,8 +441,8 @@ fn test_single_worker_sequential_throughput() {
     }
     let elapsed = start.elapsed();
 
-    for i in 0..4 {
-        assert_eq!(results[i].as_ref().unwrap().as_ref().unwrap(), &(i * 2));
+    for (i, result) in results.iter().enumerate() {
+        assert_eq!(result.as_ref().unwrap().as_ref().unwrap(), &(i * 2));
     }
     // 4 ops at 50ms each on 1 worker = at least 200ms sequential.
     assert!(
@@ -473,7 +474,7 @@ fn test_multi_thread_parallel_throughput() {
     // roughly 50ms rather than 500ms.
     let w = MultiThreadWorker::new();
     let waker = Waker::noop();
-    let mut cx = Context::from_waker(&waker);
+    let mut cx = Context::from_waker(waker);
 
     let mut futs: Vec<_> = (0..10).map(|i| Box::pin(w.slow_add(i, i))).collect();
     let mut results: Vec<Option<Result<usize, TestError>>> = (0..10).map(|_| None).collect();
@@ -497,8 +498,8 @@ fn test_multi_thread_parallel_throughput() {
     }
     let elapsed = start.elapsed();
 
-    for i in 0..10 {
-        assert_eq!(results[i].as_ref().unwrap().as_ref().unwrap(), &(i * 2));
+    for (i, result) in results.iter().enumerate() {
+        assert_eq!(result.as_ref().unwrap().as_ref().unwrap(), &(i * 2));
     }
     // 10 ops at 50ms each sequentially = 500ms.  With 10 workers should be ~50ms.
     // Use a generous upper bound to avoid flaky tests.
@@ -515,4 +516,37 @@ fn test_multi_thread_drop_shuts_down() {
     let _ = block_on(w.slow_add(1, 1));
     drop(w);
     // If Drop didn't shut down all threads, the test process would hang.
+}
+
+// ── Handler panic returns error instead of hanging ──
+
+#[offload(error = TestError, shutdown_error = TestError::WorkerShutdown)]
+impl PanicWorker {
+    pub fn panicking_op() -> Result<(), TestError> {
+        panic!("intentional panic in handler");
+    }
+
+    pub fn ok_op(x: usize) -> Result<usize, TestError> {
+        Ok(x + 1)
+    }
+}
+
+#[test]
+fn test_handler_panic_returns_error() {
+    let w = PanicWorker::new();
+    let result = block_on(w.panicking_op());
+    assert!(result.is_err());
+    assert!(matches!(result.unwrap_err(), TestError::WorkerShutdown));
+}
+
+#[test]
+fn test_worker_survives_panic() {
+    let w = PanicWorker::new();
+    // Panic should not kill the worker — subsequent ops must still work.
+    let result = block_on(w.panicking_op());
+    assert!(result.is_err());
+    assert!(matches!(result.unwrap_err(), TestError::WorkerShutdown));
+    let result = block_on(w.ok_op(41));
+    assert_eq!(result.unwrap(), 42);
+    w.shutdown();
 }


### PR DESCRIPTION
Generate async-friendly wrappers around synchronous (blocking) handler functions by executing them on one or more dedicated worker threads.

Sample usage of macro:

```rust
use offload::offload;

#[offload(error = MyError, shutdown_error = MyError::WorkerShutdown)]
impl MathWorker {
    /// Add two numbers.
    pub fn add(a: usize, b: usize) -> Result<usize, MyError> {
        Ok(a + b)
    }

    pub fn hash(data: &[u8]) -> Result<Vec<u8>, MyError> {
        // some blocking computation ...
        # Ok(data.to_vec())
    }
}
```

Generated code's usage:
```rust
let w = MathWorker::new();
let sum = w.add(3, 4).await?;      // async, runs on the worker thread
let h = w.hash(b"hello").await?;
drop(w);                            // joins the worker thread
```
