### PR TITLE
[build] add ValidateMembers xtask

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,8 +18,15 @@ members = [
   "crates/x509",
   "ddi/interface",
   "ddi/lib",
+  "ddi/mock",
+  "ddi/nix",
   "ddi/res_test_dev",
+  "ddi/serde/derive",
+  "ddi/serde/mbor",
+  "ddi/serde/types",
+  "ddi/sim",
   "ddi/test_helpers",
+  "ddi/win",
   "plugins/ossl_prov",
   "plugins/ossl_prov/integration-tests/nginx",
   "plugins/ossl_prov/integration-tests/openssl-capi",
@@ -104,6 +111,7 @@ spki = "0.7.3"
 syn = "2"
 test-log = "0.2.8"
 thiserror = "1.0"
+toml_edit = "0.25.11"
 tracing = "0.1"
 tracing-subscriber = "0.3.16"
 tracing-tree = "0.4.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ members = [
   "crates/resiliency_macro",
   "crates/resiliency_test_helpers",
   "crates/test_with_tracing",
+  "crates/test_with_tracing/test_with_tracing_macro",
   "crates/tpm",
   "crates/x509",
   "ddi/interface",

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -16,6 +16,7 @@ junit-parser.workspace = true
 jzon.workspace = true
 log.workspace = true
 similar = { features = ["text"], workspace = true }
+toml_edit.workspace = true
 xshell.workspace = true
 
 [lints]

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -34,6 +34,7 @@ mod openssl_install;
 mod precheck;
 mod rustup_component_add;
 mod setup;
+mod validate_members;
 
 /// Common context passed into every Xtask
 #[derive(Clone)]
@@ -77,6 +78,7 @@ enum Commands {
     Setup(setup::Setup),
     Install(install::Install),
     RustupComponentAdd(rustup_component_add::RustupComponentAdd),
+    ValidateMembers(validate_members::ValidateMembers),
 }
 
 fn main() {
@@ -118,5 +120,6 @@ fn try_main() -> anyhow::Result<()> {
         Commands::Setup(task) => task.run(ctx),
         Commands::Install(task) => task.run(ctx),
         Commands::RustupComponentAdd(task) => task.run(ctx),
+        Commands::ValidateMembers(task) => task.run(ctx),
     }
 }

--- a/xtask/src/precheck.rs
+++ b/xtask/src/precheck.rs
@@ -20,6 +20,7 @@ use crate::integration_tests;
 use crate::nextest::Nextest;
 use crate::nextest_report::NextestReport;
 use crate::setup::Setup;
+use crate::validate_members::ValidateMembers;
 use crate::Xtask;
 use crate::XtaskCtx;
 
@@ -31,6 +32,9 @@ struct Stage {
     /// Run copyright checks
     #[clap(long)]
     copyright: bool,
+    /// Run validate members checks
+    #[clap(long)]
+    validate_members: bool,
     /// Run audit checks
     #[clap(long)]
     audit: bool,
@@ -100,6 +104,7 @@ impl Xtask for Precheck {
         let stage = self.stage.unwrap_or(Stage {
             setup: true,
             copyright: true,
+            validate_members: true,
             audit: true,
             fmt: true,
             clippy: true,
@@ -135,6 +140,11 @@ impl Xtask for Precheck {
         // Run Copyright
         if stage.copyright || stage.all {
             Copyright { fix: false }.run(ctx.clone())?;
+        }
+
+        // Run ValidateMembers
+        if stage.validate_members || stage.all {
+            ValidateMembers { fix: false }.run(ctx.clone())?;
         }
 
         // Run Audit

--- a/xtask/src/validate_members.rs
+++ b/xtask/src/validate_members.rs
@@ -1,0 +1,95 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#![warn(missing_docs)]
+#![forbid(unsafe_code)]
+
+//! Xtask to validate that all path dependencies in the workspace are also listed as workspace members
+
+use std::fs;
+
+use clap::Parser;
+use toml_edit::DocumentMut;
+use toml_edit::Value;
+
+use crate::Xtask;
+use crate::XtaskCtx;
+
+/// Xtask to validate that all path dependencies in the workspace are also listed as workspace members
+#[derive(Parser)]
+#[clap(
+    about = "Validate that all path dependencies in the workspace are also listed as workspace members"
+)]
+pub struct ValidateMembers {
+    /// Attempt to fix any missing workspace members
+    #[clap(long)]
+    pub fix: bool,
+}
+
+impl Xtask for ValidateMembers {
+    fn run(self, _ctx: XtaskCtx) -> anyhow::Result<()> {
+        log::trace!("running validate_members");
+
+        // read workspace Cargo.toml and parse into toml_edit DocumentMut
+        let data: Vec<u8> = fs::read("Cargo.toml")?;
+        let data_str = std::str::from_utf8(&data)?;
+        let mut doc = data_str.parse::<DocumentMut>()?;
+
+        // get workspace members from doc
+        let members = doc["workspace"]["members"].as_array().unwrap().clone();
+        let mut member_paths: Vec<&str> = Vec::new();
+        for value in members.iter() {
+            member_paths.push(value.as_str().unwrap());
+        }
+
+        // get internal dependency paths from doc
+        let mut dep_paths: Vec<&str> = Vec::new();
+        let dep_table = doc["workspace"]["dependencies"].as_table().unwrap().clone();
+        for (_dep_str, dep_val) in dep_table.iter() {
+            if dep_val.is_inline_table() {
+                if dep_val.as_inline_table().unwrap().contains_key("path") {
+                    dep_paths.push(dep_val.as_inline_table().unwrap()["path"].as_str().unwrap());
+                }
+            }
+        }
+
+        // filter dep_paths to those not in member_paths
+        let mut non_member_paths: Vec<&str> = Vec::new();
+        for dep_path in &dep_paths {
+            if !member_paths.iter().any(|m| dep_path.starts_with(m)) {
+                non_member_paths.push(dep_path);
+            }
+        }
+
+        if self.fix {
+            // update workspace members to include any missing paths
+            let mut updated = false;
+            for dep_path in &dep_paths {
+                if !member_paths.iter().any(|m| dep_path.starts_with(m)) {
+                    log::trace!("Adding missing workspace member: {}", dep_path);
+                    doc["workspace"]["members"]
+                        .as_array_mut()
+                        .unwrap()
+                        .push(Value::from(*dep_path));
+                    updated = true;
+                }
+            }
+
+            if updated {
+                fs::write("Cargo.toml", doc.to_string())?;
+            }
+        } else {
+            if !non_member_paths.is_empty() {
+                // Error
+                Err(anyhow::anyhow!(
+                    "Workspace members missing path dependencies: {:?}",
+                    non_member_paths
+                ))?
+            }
+        }
+
+        log::trace!("done validate_members");
+
+        Ok(())
+    }
+}

--- a/xtask/src/validate_members.rs
+++ b/xtask/src/validate_members.rs
@@ -7,6 +7,7 @@
 //! Xtask to validate that all path dependencies in the workspace are also listed as workspace members
 
 use std::fs;
+use std::path::Path;
 
 use clap::Parser;
 use toml_edit::DocumentMut;
@@ -56,7 +57,10 @@ impl Xtask for ValidateMembers {
         // filter dep_paths to those not in member_paths
         let mut non_member_paths: Vec<&str> = Vec::new();
         for dep_path in &dep_paths {
-            if !member_paths.iter().any(|m| dep_path.starts_with(m)) {
+            if !member_paths
+                .iter()
+                .any(|m| Path::new(dep_path) == Path::new(m))
+            {
                 non_member_paths.push(dep_path);
             }
         }
@@ -64,15 +68,13 @@ impl Xtask for ValidateMembers {
         if self.fix {
             // update workspace members to include any missing paths
             let mut updated = false;
-            for dep_path in &dep_paths {
-                if !member_paths.iter().any(|m| dep_path.starts_with(m)) {
-                    log::trace!("Adding missing workspace member: {}", dep_path);
-                    doc["workspace"]["members"]
-                        .as_array_mut()
-                        .unwrap()
-                        .push(Value::from(*dep_path));
-                    updated = true;
-                }
+            for non_member_path in &non_member_paths {
+                log::trace!("Adding missing workspace member: {}", non_member_path);
+                doc["workspace"]["members"]
+                    .as_array_mut()
+                    .unwrap()
+                    .push(Value::from(*non_member_path));
+                updated = true;
             }
 
             if updated {

--- a/xtask/src/validate_members.rs
+++ b/xtask/src/validate_members.rs
@@ -80,14 +80,12 @@ impl Xtask for ValidateMembers {
             if updated {
                 fs::write("Cargo.toml", doc.to_string())?;
             }
-        } else {
-            if !non_member_paths.is_empty() {
-                // Error
-                Err(anyhow::anyhow!(
-                    "Workspace members missing path dependencies: {:?}",
-                    non_member_paths
-                ))?
-            }
+        } else if !non_member_paths.is_empty() {
+            // Error
+            Err(anyhow::anyhow!(
+                "Workspace members missing path dependencies: {:?}",
+                non_member_paths
+            ))?
         }
 
         log::trace!("done validate_members");


### PR DESCRIPTION
This change adds a new xtask, ValidateMembers, that will check (and optionally fix) if any internal path dependency is missing from the workspace members in the repository's root ./Cargo.toml file.