### PR TITLE
Add OpenSSL 3.5 support to provider build and CI

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -3,3 +3,17 @@
 
 [alias]
 xtask = "run --package xtask --"
+
+# Default target directory matches the OpenSSL ABI convention enforced by the
+# provider's build.rs.  This makes plain `cargo build` and IDE/rust-analyzer
+# work out of the box for the default OpenSSL ABI version.
+#
+# To build against a different ABI (e.g., 3.5), override:
+#   - via xtask:  cargo xtask <cmd> --openssl-version 3.5.0
+#   - or env:     CARGO_TARGET_DIR=target/ossl-abi-3-5 cargo build ...
+#
+# Note: build.rs redirects CMake/Corrosion's nested cargo to a separate target
+# dir under <OUT_DIR>/corrosion-target/ so the inner probe does not deadlock
+# on the outer cargo's target-dir lock.
+[build]
+target-dir = "target/ossl-abi-3-0"

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -13,7 +13,9 @@ env:
   CARGO_TERM_COLOR: always
   CACHE_KEY_ID: 84f8acac52412db91407ab9f85776987da17d42f
   OPENSSL_VERSION: "3.0.3"
-  OPENSSL_INSTALL: target/openssl-3.0.3
+  # ABI-versioned target dir.  Provider build.rs enforces this layout.
+  OPENSSL_ABI_DIR: target/ossl-abi-3-0
+  OPENSSL_INSTALL: target/ossl-abi-3-0/openssl
 
 jobs:
   build_ubuntu:
@@ -23,6 +25,10 @@ jobs:
     defaults:
       run:
         working-directory: .
+
+    # build.rs requires the target dir leaf to be ossl-abi-<major>-<minor>.
+    env:
+      CARGO_TARGET_DIR: ${{ github.workspace }}/target/ossl-abi-3-0
 
     steps:
     - uses: actions/checkout@v6
@@ -110,14 +116,21 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        openssl-version: ['3.0.3', '3.5.0']
+        include:
+          - openssl-version: '3.0.3'
+            openssl-abi: '3-0'
+          - openssl-version: '3.5.0'
+            openssl-abi: '3-5'
 
     # Allow 3.5.0 failures while stabilising support
     continue-on-error: ${{ matrix.openssl-version == '3.5.0' }}
 
     env:
       OPENSSL_VERSION: ${{ matrix.openssl-version }}
-      OPENSSL_INSTALL: target/openssl-${{ matrix.openssl-version }}
+      OPENSSL_ABI_DIR: target/ossl-abi-${{ matrix.openssl-abi }}
+      OPENSSL_INSTALL: target/ossl-abi-${{ matrix.openssl-abi }}/openssl
+      # build.rs requires the target dir leaf to be ossl-abi-<major>-<minor>.
+      CARGO_TARGET_DIR: ${{ github.workspace }}/target/ossl-abi-${{ matrix.openssl-abi }}
 
     steps:
     - uses: actions/checkout@v6
@@ -178,12 +191,12 @@ jobs:
 
     - name: Smoke test provider
       env:
-        LD_LIBRARY_PATH: ${{ github.workspace }}/${{ env.OPENSSL_INSTALL }}/lib:${{ github.workspace }}/target/debug
+        LD_LIBRARY_PATH: ${{ github.workspace }}/${{ env.OPENSSL_INSTALL }}/lib:${{ env.CARGO_TARGET_DIR }}/debug
         AZIHSM_CREDENTIALS_ID: "70fcf730b8764238b8358010ce8a3f76"
         AZIHSM_CREDENTIALS_PIN: "db3dc77fc22e430080d41b31b6f04800"
       run: |
         ${{ github.workspace }}/${{ env.OPENSSL_INSTALL }}/bin/openssl genpkey \
-          -provider-path ${{ github.workspace }}/target/debug \
+          -provider-path ${{ env.CARGO_TARGET_DIR }}/debug \
           -provider default -provider azihsm_provider \
           -propquery "?provider=azihsm" \
           -algorithm EC -pkeyopt group:P-384 \
@@ -192,7 +205,7 @@ jobs:
     - name: Run CLI integration tests
       env:
         OPENSSL_BIN: ${{ github.workspace }}/${{ env.OPENSSL_INSTALL }}/bin/openssl
-        OPENSSL_LIB: ${{ github.workspace }}/${{ env.OPENSSL_INSTALL }}/lib:${{ github.workspace }}/target/debug
+        OPENSSL_LIB: ${{ github.workspace }}/${{ env.OPENSSL_INSTALL }}/lib:${{ env.CARGO_TARGET_DIR }}/debug
         PROPQUERY: "?provider=azihsm"
         AZIHSM_CREDENTIALS_ID: "70fcf730b8764238b8358010ce8a3f76"
         AZIHSM_CREDENTIALS_PIN: "db3dc77fc22e430080d41b31b6f04800"
@@ -208,7 +221,7 @@ jobs:
 
     - name: Install libazihsm_api_native for NGINX tests
       run: |
-        sudo cp target/debug/libazihsm_api_native.so /usr/lib/
+        sudo cp ${{ env.CARGO_TARGET_DIR }}/debug/libazihsm_api_native.so /usr/lib/
         sudo ldconfig
 
     - name: Install nginx mainline

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -102,10 +102,22 @@ jobs:
       run: |
         echo "One or more tests failed."
         exit 1
-  
+
   provider_integration:
 
     runs-on: ubuntu-24.04
+
+    strategy:
+      fail-fast: false
+      matrix:
+        openssl-version: ['3.0.3', '3.5.0']
+
+    # Allow 3.5.0 failures while stabilising support
+    continue-on-error: ${{ matrix.openssl-version == '3.5.0' }}
+
+    env:
+      OPENSSL_VERSION: ${{ matrix.openssl-version }}
+      OPENSSL_INSTALL: target/openssl-${{ matrix.openssl-version }}
 
     steps:
     - uses: actions/checkout@v6
@@ -127,22 +139,22 @@ jobs:
         key: ${{ runner.os }}-cargo-${{ env.CACHE_KEY_ID }}
         fail-on-cache-miss: false
 
-    - name: Cache OpenSSL ${{ env.OPENSSL_VERSION }}
+    - name: Cache OpenSSL ${{ matrix.openssl-version }}
       id: cache-openssl
       uses: actions/cache@v5
       with:
         path: ${{ env.OPENSSL_INSTALL }}
-        key: openssl-${{ env.OPENSSL_VERSION }}-target-linux-x64
+        key: openssl-${{ matrix.openssl-version }}-target-linux-x64
 
     - name: Setup (includes OpenSSL on cache miss)
-      run: cargo xtask setup ${{ steps.cache-openssl.outputs.cache-hit == 'true' && '--skip-openssl' || '' }}
+      run: cargo xtask setup --openssl-version ${{ matrix.openssl-version }} ${{ steps.cache-openssl.outputs.cache-hit == 'true' && '--skip-openssl' || '' }}
 
     - name: Ensure OpenSSL default config exists
       run: |
         mkdir -p ${{ env.OPENSSL_INSTALL }}/ssl
         touch ${{ env.OPENSSL_INSTALL }}/ssl/openssl.cnf
 
-    - name: Build azihsm with OpenSSL ${{ env.OPENSSL_VERSION }}
+    - name: Build azihsm with OpenSSL ${{ matrix.openssl-version }}
       env:
         OPENSSL_DIR: ${{ github.workspace }}/${{ env.OPENSSL_INSTALL }}
       run: |
@@ -189,6 +201,7 @@ jobs:
     - name: Run C API integration tests
       env:
         OPENSSL_DIR: ${{ github.workspace }}/${{ env.OPENSSL_INSTALL }}
+        OPENSSL_LIB: ${{ github.workspace }}/${{ env.OPENSSL_INSTALL }}/lib
         AZIHSM_CREDENTIALS_ID: "70fcf730b8764238b8358010ce8a3f76"
         AZIHSM_CREDENTIALS_PIN: "db3dc77fc22e430080d41b31b6f04800"
       run: cargo xtask precheck --nextest --package provider-integration-tests-capi --features integration --profile ci-provider-integration

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -214,7 +214,7 @@ jobs:
     - name: Run C API integration tests
       env:
         OPENSSL_DIR: ${{ github.workspace }}/${{ env.OPENSSL_INSTALL }}
-        OPENSSL_LIB: ${{ github.workspace }}/${{ env.OPENSSL_INSTALL }}/lib
+        OPENSSL_LIB: ${{ github.workspace }}/${{ env.OPENSSL_INSTALL }}/lib:${{ env.CARGO_TARGET_DIR }}/debug
         AZIHSM_CREDENTIALS_ID: "70fcf730b8764238b8358010ce8a3f76"
         AZIHSM_CREDENTIALS_PIN: "db3dc77fc22e430080d41b31b6f04800"
       run: cargo xtask precheck --nextest --package provider-integration-tests-capi --features integration --profile ci-provider-integration
@@ -237,7 +237,7 @@ jobs:
     - name: NGINX integration tests
       env:
         OPENSSL_BIN: ${{ github.workspace }}/${{ env.OPENSSL_INSTALL }}/bin/openssl
-        OPENSSL_LIB: ${{ github.workspace }}/${{ env.OPENSSL_INSTALL }}/lib
+        OPENSSL_LIB: ${{ github.workspace }}/${{ env.OPENSSL_INSTALL }}/lib:${{ env.CARGO_TARGET_DIR }}/debug
         AZIHSM_CREDENTIALS_ID: "70fcf730b8764238b8358010ce8a3f76"
         AZIHSM_CREDENTIALS_PIN: "db3dc77fc22e430080d41b31b6f04800"
       run: |

--- a/README.md
+++ b/README.md
@@ -38,10 +38,15 @@ Before running any commands below, ensure you have finished the initial setup st
 
 ### Building
 
-Build the project using Cargo xtask:
+The recommended way is via xtask, which selects the OpenSSL ABI version
+explicitly and routes artifacts to `target/ossl-abi-<major>-<minor>/`:
 
 ```bash
+# Default: OpenSSL 3.0.3
 cargo xtask build
+
+# Pin a specific OpenSSL version
+cargo xtask build --openssl-version 3.5.0
 ```
 
 Build specific packages using:
@@ -49,7 +54,22 @@ Build specific packages using:
 ```bash
 # Build specific packages you are modifying
 cargo xtask build --package <package-name>
+cargo xtask build --openssl-version 3.5.0 --package <package-name>
 ```
+
+Plain `cargo build` also works — `.cargo/config.toml` sets a default
+`target-dir = "target/ossl-abi-3-0"`, so the basic case needs no env vars:
+
+```bash
+cargo build --features mock                                       # default 3.0.3
+CARGO_TARGET_DIR=target/ossl-abi-3-5 cargo build --features mock  # 3.5.0
+```
+
+**Use `cargo xtask build --openssl-version <ver>` when you want to be explicit
+about the ABI version** — the plain form silently uses the config default,
+which makes accidental wrong-version builds easier than they would be with
+the explicit flag. xtask is also the only way to switch between versions
+without remembering to set `CARGO_TARGET_DIR`.
 
 ## Testing
 

--- a/api/tests/build.rs
+++ b/api/tests/build.rs
@@ -2,6 +2,22 @@
 // Licensed under the MIT License.
 
 fn main() {
+    println!("cargo:rerun-if-env-changed=CARGO_TARGET_DIR");
+    println!("cargo:rerun-if-env-changed=RUSTC_WORKSPACE_WRAPPER");
+
+    // Skip the CMake/Corrosion build when running under clippy/check.
+    // They only need to type-check Rust source — they don't link, so the
+    // C++ test binary isn't needed.  Building it via Corrosion would
+    // recompile the FFI crate + transitive deps into a separate target
+    // dir, doubling lint-job time on slow runners.
+    let is_clippy = std::env::var("RUSTC_WORKSPACE_WRAPPER")
+        .map(|w| w.contains("clippy"))
+        .unwrap_or(false);
+    if is_clippy {
+        println!("cargo:warning=azihsm_api_tests: skipping CMake build for clippy");
+        return;
+    }
+
     let mut features = Vec::new();
     if std::env::var("CARGO_FEATURE_MOCK").is_ok() {
         features.push("mock");
@@ -16,6 +32,23 @@ fn main() {
     #[cfg(target_os = "windows")]
     if std::env::var("CMAKE_GENERATOR").is_err() {
         config.generator("Visual Studio 17 2022");
+    }
+
+    // CMake invokes Corrosion which spawns a nested `cargo rustc
+    // --print=native-static-libs` to probe required native libs.  That
+    // inner cargo inherits CARGO_TARGET_DIR from our environment — same
+    // target dir as the outer cargo build → flock() deadlock on
+    // <target>/<profile>/.cargo-lock.
+    //
+    // Redirect the inner cargo's target dir to an isolated sub-path so
+    // the outer cargo's lock is not contended.  Linux-only because the
+    // deadlock has only been observed there and Windows MSBuild's cargo
+    // integration may differ.
+    #[cfg(not(target_os = "windows"))]
+    {
+        use std::path::PathBuf;
+        let out_dir = PathBuf::from(std::env::var("OUT_DIR").expect("OUT_DIR not set"));
+        config.env("CARGO_TARGET_DIR", out_dir.join("corrosion-target"));
     }
 
     let _dst = config.build();

--- a/api/tests/build.rs
+++ b/api/tests/build.rs
@@ -5,11 +5,13 @@ fn main() {
     println!("cargo:rerun-if-env-changed=CARGO_TARGET_DIR");
     println!("cargo:rerun-if-env-changed=RUSTC_WORKSPACE_WRAPPER");
 
-    // Skip the CMake/Corrosion build when running under clippy/check.
-    // They only need to type-check Rust source — they don't link, so the
-    // C++ test binary isn't needed.  Building it via Corrosion would
-    // recompile the FFI crate + transitive deps into a separate target
-    // dir, doubling lint-job time on slow runners.
+    // Skip the CMake/Corrosion build when running under clippy.  Clippy
+    // only needs to type-check Rust source — it doesn't link, so the C++
+    // test binary isn't needed.  Building it via Corrosion would recompile
+    // the FFI crate + transitive deps into a separate target dir, doubling
+    // lint-job time on slow runners.  Detection relies on
+    // RUSTC_WORKSPACE_WRAPPER which cargo sets to clippy-driver; bare
+    // `cargo check` is not detected.
     let is_clippy = std::env::var("RUSTC_WORKSPACE_WRAPPER")
         .map(|w| w.contains("clippy"))
         .unwrap_or(false);

--- a/plugins/ossl_prov/README.md
+++ b/plugins/ossl_prov/README.md
@@ -65,6 +65,12 @@ RSA genpkey (keyEncipherment)  ──> masked_key.bin ──> pkeyutl -encrypt /
 - CMake, GCC/Clang, pkg-config, curl
 - `libbsd-dev`, `libssl-dev` (system OpenSSL 3.x headers)
 
+### Supported OpenSSL versions
+
+The provider builds against **OpenSSL 3.0.3** and **OpenSSL 3.5.0**. The CI runs
+integration tests against both versions. The version is selected at build time
+via the `OPENSSL_DIR` environment variable.
+
 ### Build
 
 The provider consists of two shared libraries that both link dynamically against the same `libcrypto.so`. Circular dispatch is avoided because the provider registers its algorithms with the property `"provider=azihsm"` and the library's internal OpenSSL calls use bare algorithm names (no property query), which route to the OpenSSL **default** provider.
@@ -72,22 +78,20 @@ The provider consists of two shared libraries that both link dynamically against
 > **Important:** The default provider **must** be available alongside the azihsm provider. During initialisation the provider force-loads the OpenSSL `default` provider into the process's default library context to prevent infinite recursion; if this fails the provider will refuse to start.
 
 ```bash
-# 1. Build OpenSSL 3.0.3 (shared)
-OPENSSL_VERSION=3.0.3
+# 1. Build OpenSSL (shared) — use any supported 3.x version
+OPENSSL_VERSION=3.0.3   # or 3.5.0
 curl -fsSL "https://github.com/openssl/openssl/releases/download/openssl-${OPENSSL_VERSION}/openssl-${OPENSSL_VERSION}.tar.gz" \
     | tar xz -C /tmp
 cd /tmp/openssl-${OPENSSL_VERSION}
-./Configure --prefix=/opt/openssl-3.0.3 --libdir=lib
-make -j"$(nproc)" && sudo make install_sw
+./Configure --prefix=<your-openssl-install-prefix> --libdir=lib
+make -j"$(nproc)" && make install_sw
 
-# 2. Build both libraries against OpenSSL 3.0.3
+# 2. Build both libraries against your OpenSSL installation
 cd azihsm-sdk
-export LD_LIBRARY_PATH=/opt/openssl-3.0.3/lib
-OPENSSL_DIR=/opt/openssl-3.0.3 cargo build -p azihsm_api_native --features mock
-OPENSSL_DIR=/opt/openssl-3.0.3 cargo build -p azihsm_ossl_provider --features mock
+OPENSSL_DIR=<your-openssl-install-prefix> cargo build -p azihsm_ossl_provider --features mock
 ```
 
-On real hardware, omit `mock` from both build commands.
+On real hardware, omit `mock` from the build command.
 
 This produces two shared libraries in `target/debug/`:
 - `azihsm_provider.so` — the OpenSSL provider
@@ -219,6 +223,76 @@ PROV="-propquery ?provider=azihsm -provider default -provider azihsm_provider"
 > **Note:** On physical hardware, provider commands require `sudo` to access TPM operations.
 
 All examples below use `${PROV}` as shorthand for these three flags.
+
+## Testing
+
+### Integration test suites
+
+| Suite | Package | What it tests |
+|-------|---------|---------------|
+| **CLI** | `provider-integration-tests-cli` | OpenSSL CLI operations (key gen, import, sign, verify, certs, ECDH, HKDF, HMAC) |
+| **C API** | `provider-integration-tests-capi` | OpenSSL EVP C API (digest, sign/verify, encrypt/decrypt, key exchange, resiliency) |
+| **NGINX** | `provider-integration-tests-nginx` | End-to-end TLS with NGINX (requires nginx installed) |
+
+### Environment variables
+
+All paths are controlled via environment variables.
+
+| Variable | Required by | Description |
+|----------|-------------|-------------|
+| `OPENSSL_DIR` | Build, CAPI | OpenSSL installation prefix (forwarded to CMake) |
+| `OPENSSL_BIN` | CLI, NGINX | Path to the `openssl` binary |
+| `OPENSSL_LIB` | CAPI | Directory containing `libcrypto.so` / `libssl.so` |
+| `AZIHSM_CREDENTIALS_ID` | All (optional) | Mock HSM credential ID (defaults to test value) |
+| `AZIHSM_CREDENTIALS_PIN` | All (optional) | Mock HSM credential PIN (defaults to test value) |
+
+### Running integration tests locally
+
+```bash
+# Point to your OpenSSL installation
+export OPENSSL_DIR=<your-openssl-install-prefix>
+export OPENSSL_BIN=$OPENSSL_DIR/bin/openssl
+export OPENSSL_LIB=$OPENSSL_DIR/lib    # or lib64, depending on your build
+
+# Build the provider
+cargo build -p azihsm_ossl_provider --features mock
+
+# Run individual suites
+cargo nextest run -p provider-integration-tests-cli  --features integration --profile ci-provider-integration
+cargo nextest run -p provider-integration-tests-capi --features integration --profile ci-provider-integration
+
+# Or run all suites via xtask
+cargo xtask integration-tests --openssl-version 3.0.3
+```
+
+Tests generate their own key material in `target/test-keymat/` (cleaned
+between runs). No system-wide provider installation is needed — tests
+locate the provider via `PROVIDER_PATH` (defaults to `target/debug`).
+
+### Switching OpenSSL versions
+
+The provider and C++ test binary are compiled against a specific OpenSSL
+version's headers. Switching versions requires a clean build:
+
+```bash
+cargo clean
+export OPENSSL_DIR=<path-to-other-openssl-version>
+cargo build -p azihsm_ossl_provider --features mock
+# Re-run tests as above
+```
+
+### Version gating for 3.5-only tests
+
+Tests that require OpenSSL 3.5 use version gating to skip gracefully on 3.0:
+
+- **C++ tests**: `#if OPENSSL_VERSION_MINOR >= 5` (compile-time, from headers)
+- **Shell tests**: `skip_below_ossl_3_5` helper (runtime, from `env.sh`)
+
+### CI
+
+The GitHub Actions workflow (`.github/workflows/rust.yml`) runs integration
+tests against both OpenSSL 3.0.3 and 3.5.0 via a matrix strategy on the
+`provider_integration` job.
 
 ## Commands
 

--- a/plugins/ossl_prov/README.md
+++ b/plugins/ossl_prov/README.md
@@ -274,7 +274,7 @@ cargo nextest run -p provider-integration-tests-capi --features integration --pr
 | `CARGO_TARGET_DIR` | All | Must end in `/ossl-abi-<major>-<minor>` for the provider build.rs to accept it |
 | `OPENSSL_DIR` | CAPI build (optional) | Defaults to `$CARGO_TARGET_DIR/openssl` if unset |
 | `OPENSSL_BIN` | CLI, NGINX | Path to the `openssl` binary |
-| `OPENSSL_LIB` | CAPI, CLI | `:`-separated list including the OpenSSL lib dir and the provider's cargo `debug` dir |
+| `OPENSSL_LIB` | CAPI, CLI (override) | `:`-separated list of dirs. Optional: the CAPI harness derives the OpenSSL lib dir from `OPENSSL_DIR/{lib,lib64}` when unset. Set explicitly to include the provider's cargo `debug` dir if your tests need it on `LD_LIBRARY_PATH`. |
 | `AZIHSM_CREDENTIALS_ID` | All (optional) | Mock HSM credential ID (defaults to test value) |
 | `AZIHSM_CREDENTIALS_PIN` | All (optional) | Mock HSM credential PIN (defaults to test value) |
 

--- a/plugins/ossl_prov/README.md
+++ b/plugins/ossl_prov/README.md
@@ -68,8 +68,10 @@ RSA genpkey (keyEncipherment)  ──> masked_key.bin ──> pkeyutl -encrypt /
 ### Supported OpenSSL versions
 
 The provider builds against **OpenSSL 3.0.3** and **OpenSSL 3.5.0**. The CI runs
-integration tests against both versions. The version is selected at build time
-via the `OPENSSL_DIR` environment variable.
+integration tests against both versions. The version is selected via the
+`--openssl-version` flag on the xtask commands; the build is routed to an
+ABI-versioned target tree (`target/ossl-abi-<major>-<minor>/`) so multiple
+versions can coexist without `cargo clean` between switches.
 
 ### Build
 
@@ -77,23 +79,29 @@ The provider consists of two shared libraries that both link dynamically against
 
 > **Important:** The default provider **must** be available alongside the azihsm provider. During initialisation the provider force-loads the OpenSSL `default` provider into the process's default library context to prevent infinite recursion; if this fails the provider will refuse to start.
 
-```bash
-# 1. Build OpenSSL (shared) — use any supported 3.x version
-OPENSSL_VERSION=3.0.3   # or 3.5.0
-curl -fsSL "https://github.com/openssl/openssl/releases/download/openssl-${OPENSSL_VERSION}/openssl-${OPENSSL_VERSION}.tar.gz" \
-    | tar xz -C /tmp
-cd /tmp/openssl-${OPENSSL_VERSION}
-./Configure --prefix=<your-openssl-install-prefix> --libdir=lib
-make -j"$(nproc)" && make install_sw
+Recommended (via xtask, no env vars needed):
 
-# 2. Build both libraries against your OpenSSL installation
-cd azihsm-sdk
-OPENSSL_DIR=<your-openssl-install-prefix> cargo build -p azihsm_ossl_provider --features mock
+```bash
+# 1. Install OpenSSL into the ABI tree.  Skips if already installed or if
+#    target/ossl-abi-<major>-<minor>/openssl/ already exists.
+cargo xtask setup --openssl-version 3.0.3   # or 3.5.0
+
+# 2. Build the whole workspace for the chosen ABI.  Covers both
+#    azihsm_ossl_provider and azihsm_api_native automatically.
+cargo xtask build --openssl-version 3.0.3 --features mock
 ```
 
-On real hardware, omit `mock` from the build command.
+Or via plain cargo. The `.cargo/config.toml` defaults `target-dir` to
+`target/ossl-abi-3-0`, so the basic case needs no env vars:
 
-This produces two shared libraries in `target/debug/`:
+```bash
+cargo build --features mock                                            # 3.0.3 (default)
+CARGO_TARGET_DIR=target/ossl-abi-3-5 cargo build --features mock       # 3.5.0
+```
+
+On real hardware, omit `--features mock`.
+
+This produces two shared libraries in `target/ossl-abi-<major>-<minor>/debug/`:
 - `azihsm_provider.so` — the OpenSSL provider
 - `libazihsm_api_native.so` — the Rust HSM API (runtime dependency of the provider)
 
@@ -105,11 +113,13 @@ Install the provider and its runtime dependency:
 # Find the system modules directory
 openssl version -m
 
+ABI_DIR=target/ossl-abi-3-0   # or target/ossl-abi-3-5
+
 # Install the provider
-sudo cp target/debug/azihsm_provider.so /usr/lib/x86_64-linux-gnu/ossl-modules/
+sudo cp $ABI_DIR/debug/azihsm_provider.so /usr/lib/x86_64-linux-gnu/ossl-modules/
 
 # Install the Rust HSM API library
-sudo cp target/debug/libazihsm_api_native.so /usr/lib/
+sudo cp $ABI_DIR/debug/libazihsm_api_native.so /usr/lib/
 sudo ldconfig
 
 # (Optional) Create a dedicated directory for masked key material.
@@ -188,7 +198,7 @@ When using `openssl.cnf`, providers are auto-loaded — no `-provider-path` or `
 
 ```bash
 OPENSSL_CONF=/path/to/openssl.cnf \
-LD_LIBRARY_PATH=/path/to/target/debug \
+LD_LIBRARY_PATH=/path/to/target/ossl-abi-<major>-<minor>/debug \
 openssl genpkey -propquery "?provider=azihsm" ...
 ```
 
@@ -218,7 +228,7 @@ PROV="-propquery ?provider=azihsm -provider default -provider azihsm_provider"
 
 > **Important:** `-propquery` **must** come before the `-provider` flags. OpenSSL processes CLI arguments left to right. Loading the provider triggers an HSM session that instantiates the DRBG (random number generator). If `-propquery` is applied afterwards, `RAND_set_DRBG_type` fails because the DRBG is already running. The error message from OpenSSL 3.0.x is misleading — it reports "odd number of digits" due to an upstream error code collision (`RAND_R_ALREADY_INSTANTIATED` and `CRYPTO_R_ODD_NUMBER_OF_DIGITS` are both 103, and the code uses `ERR_LIB_CRYPTO` instead of `ERR_LIB_RAND`).
 
-> **Note:** If the provider is not installed system-wide, add `-provider-path /path/to/directory` pointing to the directory containing `azihsm_provider.so`. If `libazihsm_api_native.so` is also not in a system library path, set `LD_LIBRARY_PATH` to include its directory (e.g., `export LD_LIBRARY_PATH=/path/to/target/debug:$LD_LIBRARY_PATH`).
+> **Note:** If the provider is not installed system-wide, add `-provider-path /path/to/target/ossl-abi-<major>-<minor>/debug` pointing to the directory containing `azihsm_provider.so`. If `libazihsm_api_native.so` is also not in a system library path, set `LD_LIBRARY_PATH` to include its directory (e.g., `export LD_LIBRARY_PATH=/path/to/target/ossl-abi-<major>-<minor>/debug:$LD_LIBRARY_PATH`).
 
 > **Note:** On physical hardware, provider commands require `sudo` to access TPM operations.
 
@@ -234,52 +244,50 @@ All examples below use `${PROV}` as shorthand for these three flags.
 | **C API** | `provider-integration-tests-capi` | OpenSSL EVP C API (digest, sign/verify, encrypt/decrypt, key exchange, resiliency) |
 | **NGINX** | `provider-integration-tests-nginx` | End-to-end TLS with NGINX (requires nginx installed) |
 
-### Environment variables
+### Running integration tests locally
 
-All paths are controlled via environment variables.
+The recommended way is via the xtask — it sets all required env vars and
+builds the provider on demand:
+
+```bash
+cargo xtask integration-tests --openssl-version 3.0.3   # or 3.5.0
+```
+
+Or bypass the xtask if you need finer control (one env var, plus credentials):
+
+```bash
+ABI_DIR=$PWD/target/ossl-abi-3-0   # or target/ossl-abi-3-5
+export CARGO_TARGET_DIR=$ABI_DIR
+export OPENSSL_BIN=$ABI_DIR/openssl/bin/openssl
+export OPENSSL_LIB=$ABI_DIR/openssl/lib:$ABI_DIR/debug   # lib or lib64
+export AZIHSM_CREDENTIALS_ID="70fcf730b8764238b8358010ce8a3f76"
+export AZIHSM_CREDENTIALS_PIN="db3dc77fc22e430080d41b31b6f04800"
+
+cargo nextest run -p provider-integration-tests-cli  --features integration --profile ci-provider-integration
+cargo nextest run -p provider-integration-tests-capi --features integration --profile ci-provider-integration
+```
+
+### Environment variables (when bypassing the xtask)
 
 | Variable | Required by | Description |
 |----------|-------------|-------------|
-| `OPENSSL_DIR` | Build, CAPI | OpenSSL installation prefix (forwarded to CMake) |
+| `CARGO_TARGET_DIR` | All | Must end in `/ossl-abi-<major>-<minor>` for the provider build.rs to accept it |
+| `OPENSSL_DIR` | CAPI build (optional) | Defaults to `$CARGO_TARGET_DIR/openssl` if unset |
 | `OPENSSL_BIN` | CLI, NGINX | Path to the `openssl` binary |
-| `OPENSSL_LIB` | CAPI | Directory containing `libcrypto.so` / `libssl.so` |
+| `OPENSSL_LIB` | CAPI, CLI | `:`-separated list including the OpenSSL lib dir and the provider's cargo `debug` dir |
 | `AZIHSM_CREDENTIALS_ID` | All (optional) | Mock HSM credential ID (defaults to test value) |
 | `AZIHSM_CREDENTIALS_PIN` | All (optional) | Mock HSM credential PIN (defaults to test value) |
 
-### Running integration tests locally
-
-```bash
-# Point to your OpenSSL installation
-export OPENSSL_DIR=<your-openssl-install-prefix>
-export OPENSSL_BIN=$OPENSSL_DIR/bin/openssl
-export OPENSSL_LIB=$OPENSSL_DIR/lib    # or lib64, depending on your build
-
-# Build the provider
-cargo build -p azihsm_ossl_provider --features mock
-
-# Run individual suites
-cargo nextest run -p provider-integration-tests-cli  --features integration --profile ci-provider-integration
-cargo nextest run -p provider-integration-tests-capi --features integration --profile ci-provider-integration
-
-# Or run all suites via xtask
-cargo xtask integration-tests --openssl-version 3.0.3
-```
-
 Tests generate their own key material in `target/test-keymat/` (cleaned
 between runs). No system-wide provider installation is needed — tests
-locate the provider via `PROVIDER_PATH` (defaults to `target/debug`).
+locate the provider via `PROVIDER_PATH` (defaults to `$CARGO_TARGET_DIR/debug`).
 
 ### Switching OpenSSL versions
 
-The provider and C++ test binary are compiled against a specific OpenSSL
-version's headers. Switching versions requires a clean build:
-
-```bash
-cargo clean
-export OPENSSL_DIR=<path-to-other-openssl-version>
-cargo build -p azihsm_ossl_provider --features mock
-# Re-run tests as above
-```
+No `cargo clean` needed. Each version's artifacts live in a separate ABI tree
+under `target/ossl-abi-<major>-<minor>/`. Switching is just running the xtask
+with a different `--openssl-version` flag (or pointing `CARGO_TARGET_DIR` at a
+different ABI tree for plain cargo invocations).
 
 ### Version gating for 3.5-only tests
 

--- a/plugins/ossl_prov/build.rs
+++ b/plugins/ossl_prov/build.rs
@@ -10,6 +10,20 @@ fn main() {
     // switching OpenSSL versions correctly invalidates the build.
     println!("cargo:rerun-if-env-changed=CARGO_TARGET_DIR");
     println!("cargo:rerun-if-env-changed=OPENSSL_DIR");
+    println!("cargo:rerun-if-env-changed=RUSTC_WORKSPACE_WRAPPER");
+
+    // Skip the heavy CMake/Corrosion build when running under `cargo clippy`
+    // or `cargo check` — they only need the Rust source to lint/check, not
+    // the linked artifacts.  Building the C provider here would compile
+    // azihsm_api_native and its full dep tree into a Corrosion-private
+    // target dir, doubling the clippy job time on slow runners.
+    //
+    // Cargo sets RUSTC_WORKSPACE_WRAPPER to clippy-driver when running
+    // clippy.  We still validate CARGO_TARGET_DIR below so misconfigurations
+    // get surfaced even in clippy mode.
+    let is_clippy = env::var("RUSTC_WORKSPACE_WRAPPER")
+        .map(|w| w.contains("clippy"))
+        .unwrap_or(false);
 
     let mut features = Vec::new();
 
@@ -83,6 +97,17 @@ fn main() {
         Ok(dir) => PathBuf::from(dir),
         Err(_) => target_dir.join("openssl"),
     };
+
+    // Skip the C/CMake build when running under clippy/check — see comment
+    // at top of main().  Clippy still gets accurate CARGO_TARGET_DIR
+    // validation above; it just doesn't pay for the linked artifact.
+    if is_clippy {
+        println!(
+            "cargo:warning=skipping CMake build for clippy ({})",
+            target_dir.display()
+        );
+        return;
+    }
 
     // AZIHSM_TARGET_DIR is used by CMake to copy the .so into the cargo
     // profile dir (e.g., target/ossl-abi-3-0/debug/), so pass profile_dir.

--- a/plugins/ossl_prov/build.rs
+++ b/plugins/ossl_prov/build.rs
@@ -50,25 +50,35 @@ fn main() {
     // build tree.  This avoids silent version mismatches between the linked
     // libcrypto and the openssl binary used at test time.
     //
-    // Expected target dir name: ossl-abi-<major>-<minor>  (e.g., ossl-abi-3-0)
+    // Expected path: contains a segment named ossl-abi-<major>-<minor>
+    //   - target/ossl-abi-3-0/                       (plain cargo build)
+    //   - target/ossl-abi-3-0/llvm-cov-target/       (cargo llvm-cov wraps the dir)
     //
     // The default is set in .cargo/config.toml; override via:
     //   - cargo xtask <cmd> --openssl-version <ver>
     //   - CARGO_TARGET_DIR=target/ossl-abi-<major>-<minor> cargo ...
-    let leaf = target_dir
+    let abi_dir = target_dir
+        .ancestors()
+        .find(|p| {
+            p.file_name()
+                .and_then(|s| s.to_str())
+                .is_some_and(|leaf| leaf.starts_with("ossl-abi-"))
+        })
+        .unwrap_or_else(|| {
+            panic!(
+                "azihsm_ossl_provider must be built in an OpenSSL ABI-versioned target dir.\n\
+                 Expected path to contain a segment named ossl-abi-<major>-<minor>, got: {}\n\
+                 Use `cargo xtask <cmd> --openssl-version <ver>` (recommended), or set \
+                 CARGO_TARGET_DIR=target/ossl-abi-<major>-<minor> explicitly.",
+                target_dir.display()
+            );
+        });
+
+    let abi = abi_dir
         .file_name()
         .and_then(|s| s.to_str())
-        .expect("target directory has no name");
-
-    let abi = leaf.strip_prefix("ossl-abi-").unwrap_or_else(|| {
-        panic!(
-            "azihsm_ossl_provider must be built in an OpenSSL ABI-versioned target dir.\n\
-             Expected CARGO_TARGET_DIR to end with /ossl-abi-<major>-<minor>/, got: {}\n\
-             Use `cargo xtask <cmd> --openssl-version <ver>` (recommended), or set \
-             CARGO_TARGET_DIR=target/ossl-abi-<major>-<minor> explicitly.",
-            target_dir.display()
-        );
-    });
+        .and_then(|leaf| leaf.strip_prefix("ossl-abi-"))
+        .expect("checked above");
 
     // Validate the format: <major>-<minor> with numeric components.
     let parts: Vec<&str> = abi.split('-').collect();
@@ -78,7 +88,7 @@ fn main() {
             .any(|p| p.is_empty() || !p.chars().all(|c| c.is_ascii_digit()))
     {
         panic!(
-            "CARGO_TARGET_DIR leaf must follow pattern ossl-abi-<major>-<minor> with numeric \
+            "ABI directory must follow pattern ossl-abi-<major>-<minor> with numeric \
              components, got: ossl-abi-{abi}"
         );
     }
@@ -91,11 +101,13 @@ fn main() {
         );
     }
 
-    // Derive OPENSSL_DIR from the target dir unless explicitly overridden.
-    // The xtask installs OpenSSL to <target_dir>/openssl by convention.
+    // Derive OPENSSL_DIR from the ABI dir unless explicitly overridden.
+    // The xtask installs OpenSSL to <abi_dir>/openssl by convention; this
+    // works regardless of whether the build sits directly in abi_dir or
+    // inside a sub-tree like llvm-cov-target.
     let openssl_dir = match env::var("OPENSSL_DIR") {
         Ok(dir) => PathBuf::from(dir),
-        Err(_) => target_dir.join("openssl"),
+        Err(_) => abi_dir.join("openssl"),
     };
 
     // Skip the C/CMake build when running under clippy/check — see comment
@@ -103,7 +115,7 @@ fn main() {
     // validation above; it just doesn't pay for the linked artifact.
     if is_clippy {
         println!(
-            "cargo:warning=skipping CMake build for clippy ({})",
+            "cargo:warning=skipping CMake build for clippy (ABI {abi}, target {})",
             target_dir.display()
         );
         return;

--- a/plugins/ossl_prov/build.rs
+++ b/plugins/ossl_prov/build.rs
@@ -6,34 +6,103 @@ fn main() {
     use std::env;
     use std::path::PathBuf;
 
+    // Cargo should re-run this script when these env vars change so that
+    // switching OpenSSL versions correctly invalidates the build.
+    println!("cargo:rerun-if-env-changed=CARGO_TARGET_DIR");
+    println!("cargo:rerun-if-env-changed=OPENSSL_DIR");
+
     let mut features = Vec::new();
 
     if env::var("CARGO_FEATURE_MOCK").is_ok() {
         features.push("mock");
     }
 
-    // Calculate the target directory for passing to CMake
-    // OUT_DIR is in target/profile/build/crate-hash/out, so we go up 3 levels
+    // Derive the cargo profile directory (e.g., target/<profile>) for CMake.
+    // OUT_DIR is in <target>/<profile>/build/<crate-hash>/out, so 3 parents up.
     let out_dir = PathBuf::from(env::var("OUT_DIR").expect("OUT_DIR not set"));
-    let target_dir = out_dir
+    let profile_dir = out_dir
         .parent()
         .and_then(|p| p.parent())
         .and_then(|p| p.parent())
+        .expect("Could not determine profile directory");
+
+    // The actual target dir is one more level up; its leaf encodes the ABI.
+    let target_dir = profile_dir
+        .parent()
         .expect("Could not determine target directory");
 
+    // The provider must be built in an ABI-versioned target directory so that
+    // artifacts compiled against different OpenSSL ABI versions never share a
+    // build tree.  This avoids silent version mismatches between the linked
+    // libcrypto and the openssl binary used at test time.
+    //
+    // Expected target dir name: ossl-abi-<major>-<minor>  (e.g., ossl-abi-3-0)
+    //
+    // The default is set in .cargo/config.toml; override via:
+    //   - cargo xtask <cmd> --openssl-version <ver>
+    //   - CARGO_TARGET_DIR=target/ossl-abi-<major>-<minor> cargo ...
+    let leaf = target_dir
+        .file_name()
+        .and_then(|s| s.to_str())
+        .expect("target directory has no name");
+
+    let abi = leaf.strip_prefix("ossl-abi-").unwrap_or_else(|| {
+        panic!(
+            "azihsm_ossl_provider must be built in an OpenSSL ABI-versioned target dir.\n\
+             Expected CARGO_TARGET_DIR to end with /ossl-abi-<major>-<minor>/, got: {}\n\
+             Use `cargo xtask <cmd> --openssl-version <ver>` (recommended), or set \
+             CARGO_TARGET_DIR=target/ossl-abi-<major>-<minor> explicitly.",
+            target_dir.display()
+        );
+    });
+
+    // Validate the format: <major>-<minor> with numeric components.
+    let parts: Vec<&str> = abi.split('-').collect();
+    if parts.len() != 2
+        || parts
+            .iter()
+            .any(|p| p.is_empty() || !p.chars().all(|c| c.is_ascii_digit()))
+    {
+        panic!(
+            "CARGO_TARGET_DIR leaf must follow pattern ossl-abi-<major>-<minor> with numeric \
+             components, got: ossl-abi-{abi}"
+        );
+    }
+
+    // Supported ABI versions.  Keep in sync with xtask/src/openssl_install.rs.
+    if !matches!(abi, "3-0" | "3-5") {
+        panic!(
+            "Unsupported OpenSSL ABI {abi}; supported: 3-0, 3-5. \
+             Add it to SUPPORTED_VERSIONS in xtask/src/openssl_install.rs."
+        );
+    }
+
+    // Derive OPENSSL_DIR from the target dir unless explicitly overridden.
+    // The xtask installs OpenSSL to <target_dir>/openssl by convention.
+    let openssl_dir = match env::var("OPENSSL_DIR") {
+        Ok(dir) => PathBuf::from(dir),
+        Err(_) => target_dir.join("openssl"),
+    };
+
+    // AZIHSM_TARGET_DIR is used by CMake to copy the .so into the cargo
+    // profile dir (e.g., target/ossl-abi-3-0/debug/), so pass profile_dir.
     let mut cmake_cfg = cmake::Config::new(".");
     cmake_cfg
         .define("AZIHSM_CARGO_FEATURES", features.join(" "))
         .define(
             "AZIHSM_TARGET_DIR",
-            target_dir.to_string_lossy().to_string(),
-        );
+            profile_dir.to_string_lossy().to_string(),
+        )
+        .define("OPENSSL_ROOT_DIR", openssl_dir);
 
-    // Forward OPENSSL_DIR to CMake so find_package(OpenSSL) discovers the
-    // same OpenSSL that the Rust openssl-sys crate links against.
-    if let Ok(openssl_dir) = env::var("OPENSSL_DIR") {
-        cmake_cfg.define("OPENSSL_ROOT_DIR", &openssl_dir);
-    }
+    // CMake invokes Corrosion which spawns `cargo rustc --print=native-static-libs`
+    // to probe required native libs.  That inner cargo inherits CARGO_TARGET_DIR
+    // from our environment — pointing at the same target dir as the outer cargo
+    // build → flock() deadlock on <target>/<profile>/.cargo-lock.
+    //
+    // Redirect the inner cargo's target dir to an isolated sub-path so the
+    // outer cargo's lock is not contended.
+    cmake_cfg.env("CARGO_TARGET_DIR", out_dir.join("corrosion-target"));
 
     cmake_cfg.build();
 }

--- a/plugins/ossl_prov/build.rs
+++ b/plugins/ossl_prov/build.rs
@@ -12,15 +12,20 @@ fn main() {
     println!("cargo:rerun-if-env-changed=OPENSSL_DIR");
     println!("cargo:rerun-if-env-changed=RUSTC_WORKSPACE_WRAPPER");
 
-    // Skip the heavy CMake/Corrosion build when running under `cargo clippy`
-    // or `cargo check` — they only need the Rust source to lint/check, not
-    // the linked artifacts.  Building the C provider here would compile
-    // azihsm_api_native and its full dep tree into a Corrosion-private
-    // target dir, doubling the clippy job time on slow runners.
+    // Skip the heavy CMake/Corrosion build when running under `cargo clippy`.
+    // Clippy only needs the Rust source to lint, not the linked artifacts.
+    // Building the C provider here would compile azihsm_api_native and its
+    // full dep tree into a Corrosion-private target dir, doubling the clippy
+    // job time on slow runners.
     //
     // Cargo sets RUSTC_WORKSPACE_WRAPPER to clippy-driver when running
-    // clippy.  We still validate CARGO_TARGET_DIR below so misconfigurations
-    // get surfaced even in clippy mode.
+    // clippy; we detect that as the only reliable signal.  `cargo check`
+    // alone is not detected — there's no clean env-var indicator for it —
+    // but the cost there is the same as a real build, so it's an explicit
+    // user action (no scheduled CI step uses bare `cargo check`).
+    //
+    // We still validate CARGO_TARGET_DIR below so misconfigurations get
+    // surfaced even in clippy mode.
     let is_clippy = env::var("RUSTC_WORKSPACE_WRAPPER")
         .map(|w| w.contains("clippy"))
         .unwrap_or(false);

--- a/plugins/ossl_prov/integration-tests/nginx/src/nginx_tests.rs
+++ b/plugins/ossl_prov/integration-tests/nginx/src/nginx_tests.rs
@@ -131,9 +131,9 @@ mod integration {
     /// Resolves the provider search path (absolute) and verifies the provider
     /// `.so` exists there.
     ///
-    /// Uses `PROVIDER_PATH` if set, otherwise defaults to `target/debug` under
-    /// the workspace root.  Matches the convention used by CLI (`env.sh`) and
-    /// CAPI (`get_provider_path()`).
+    /// Uses `PROVIDER_PATH` if set, otherwise honours `CARGO_TARGET_DIR` and
+    /// falls back to `target/debug` under the workspace root.  Matches the
+    /// convention used by CLI (`env.sh`) and CAPI (`get_provider_path()`).
     fn get_provider_path(workspace_root: &Path) -> PathBuf {
         let path = match env::var("PROVIDER_PATH") {
             Ok(p) if !p.is_empty() => {
@@ -144,7 +144,17 @@ mod integration {
                     p
                 }
             }
-            _ => workspace_root.join("target").join("debug"),
+            _ => match env::var("CARGO_TARGET_DIR") {
+                Ok(t) if !t.is_empty() => {
+                    let p = PathBuf::from(t).join("debug");
+                    if p.is_relative() {
+                        workspace_root.join(p)
+                    } else {
+                        p
+                    }
+                }
+                _ => workspace_root.join("target").join("debug"),
+            },
         };
 
         let provider_so = path.join("azihsm_provider.so");
@@ -153,9 +163,9 @@ mod integration {
             "\n\
              azihsm_provider.so not found at {}\n\
              \n\
-             Build the provider first:\n\
+             Build the provider first (matching the OpenSSL ABI used by tests):\n\
              \n\
-                 cargo build -p azihsm_ossl_provider --features mock,provider\n",
+                 cargo xtask build --openssl-version <ver> --features mock\n",
             provider_so.display(),
         );
 

--- a/plugins/ossl_prov/integration-tests/openssl-capi/cpp/openssl_capi_integration_tests.rs
+++ b/plugins/ossl_prov/integration-tests/openssl-capi/cpp/openssl_capi_integration_tests.rs
@@ -94,6 +94,50 @@ mod integration {
         panic!("Neither OPENSSL_BIN nor OPENSSL_DIR is set — cannot generate dev key material");
     }
 
+    /// Resolves the OpenSSL shared library directory from `OPENSSL_LIB` or
+    /// `OPENSSL_DIR`.  When set, this is passed as `LD_LIBRARY_PATH` to
+    /// openssl subprocesses so they find the correct `libcrypto.so.3` instead
+    /// of falling back to the system libraries (which may be a different
+    /// version).  Returns `None` when the directory cannot be determined,
+    /// in which case the subprocess inherits the parent's library path.
+    fn find_openssl_lib_dir() -> Option<String> {
+        if let Ok(lib) = env::var("OPENSSL_LIB") {
+            if !lib.is_empty() {
+                assert!(
+                    PathBuf::from(&lib).is_dir(),
+                    "OPENSSL_LIB={lib:?} does not point to an existing directory"
+                );
+                return Some(lib);
+            }
+        }
+        if let Ok(dir) = env::var("OPENSSL_DIR") {
+            let lib64 = PathBuf::from(&dir).join("lib64");
+            if lib64.is_dir() {
+                return Some(lib64.to_string_lossy().into_owned());
+            }
+            let lib = PathBuf::from(&dir).join("lib");
+            if lib.is_dir() {
+                return Some(lib.to_string_lossy().into_owned());
+            }
+        }
+        None
+    }
+
+    /// Applies `LD_LIBRARY_PATH` to a `Command` if the OpenSSL lib directory
+    /// is known.  Prepends to any existing value so that other library paths
+    /// (e.g., for `libazihsm_api_native.so`) are preserved.  When `None`,
+    /// the subprocess inherits the parent's value unchanged.
+    fn set_openssl_lib_path(cmd: &mut Command, lib_dir: &Option<String>) {
+        if let Some(dir) = lib_dir {
+            let existing = env::var("LD_LIBRARY_PATH").unwrap_or_default();
+            if existing.is_empty() {
+                cmd.env("LD_LIBRARY_PATH", dir);
+            } else {
+                cmd.env("LD_LIBRARY_PATH", format!("{dir}:{existing}"));
+            }
+        }
+    }
+
     /// Default credential ID (hex-encoded UUID, matching `env.sh`).
     const DEFAULT_CREDENTIALS_ID: &str = "70fcf730b8764238b8358010ce8a3f76";
     /// Default credential PIN (hex-encoded UUID, matching `env.sh`).
@@ -144,23 +188,22 @@ mod integration {
 
         // OBK (48-byte random)
         let openssl = find_openssl_bin();
+        let openssl_lib = find_openssl_lib_dir();
         let obk_path = keymat_dir.join("obk.bin");
-        let status = Command::new(&openssl)
-            .args(["rand", "-out"])
-            .arg(&obk_path)
-            .arg("48")
-            .status()
-            .expect("Failed to run openssl rand");
+        let mut cmd = Command::new(&openssl);
+        cmd.args(["rand", "-out"]).arg(&obk_path).arg("48");
+        set_openssl_lib_path(&mut cmd, &openssl_lib);
+        let status = cmd.status().expect("Failed to run openssl rand");
         assert!(status.success(), "Failed to generate obk.bin");
 
         // POTA P-384 key pair
         let pota_priv = keymat_dir.join("pota_private_key.der");
 
         // Generate EC P-384 key in PEM
-        let genkey = Command::new(&openssl)
-            .args(["ecparam", "-name", "secp384r1", "-genkey", "-noout"])
-            .output()
-            .expect("Failed to run openssl ecparam");
+        let mut cmd = Command::new(&openssl);
+        cmd.args(["ecparam", "-name", "secp384r1", "-genkey", "-noout"]);
+        set_openssl_lib_path(&mut cmd, &openssl_lib);
+        let genkey = cmd.output().expect("Failed to run openssl ecparam");
         assert!(
             genkey.status.success(),
             "Failed to generate POTA EC key: {}",
@@ -168,13 +211,13 @@ mod integration {
         );
 
         // Convert to DER
-        let mut convert = Command::new(&openssl)
-            .args(["ec", "-outform", "DER", "-out"])
+        let mut cmd = Command::new(&openssl);
+        cmd.args(["ec", "-outform", "DER", "-out"])
             .arg(&pota_priv)
             .stdin(Stdio::piped())
-            .stderr(Stdio::null())
-            .spawn()
-            .expect("Failed to spawn openssl ec");
+            .stderr(Stdio::null());
+        set_openssl_lib_path(&mut cmd, &openssl_lib);
+        let mut convert = cmd.spawn().expect("Failed to spawn openssl ec");
         convert
             .stdin
             .as_mut()
@@ -189,14 +232,14 @@ mod integration {
 
         // Extract public key
         let pota_pub = keymat_dir.join("pota_public_key.der");
-        let pubkey = Command::new(&openssl)
-            .args(["ec", "-in"])
+        let mut cmd = Command::new(&openssl);
+        cmd.args(["ec", "-in"])
             .arg(&pota_priv)
             .args(["-inform", "DER", "-pubout", "-outform", "DER", "-out"])
             .arg(&pota_pub)
-            .stderr(Stdio::null())
-            .status()
-            .expect("Failed to run openssl ec -pubout");
+            .stderr(Stdio::null());
+        set_openssl_lib_path(&mut cmd, &openssl_lib);
+        let pubkey = cmd.status().expect("Failed to run openssl ec -pubout");
         assert!(pubkey.success(), "Failed to extract POTA public key");
 
         (credentials, keymat_dir)

--- a/plugins/ossl_prov/integration-tests/openssl-capi/cpp/openssl_capi_integration_tests.rs
+++ b/plugins/ossl_prov/integration-tests/openssl-capi/cpp/openssl_capi_integration_tests.rs
@@ -105,8 +105,13 @@ mod integration {
             if !lib.is_empty() {
                 // OPENSSL_LIB may be a single dir or a `:`-separated path
                 // list (e.g., openssl/lib:target/<abi>/debug).  Verify that
-                // at least one entry exists.
-                let any_exists = lib.split(':').any(|p| PathBuf::from(p).is_dir());
+                // at least one non-empty entry exists.  Empty segments
+                // (e.g., a trailing `:`) would otherwise resolve to the
+                // current directory and silently false-positive.
+                let any_exists = lib
+                    .split(':')
+                    .filter(|p| !p.trim().is_empty())
+                    .any(|p| PathBuf::from(p).is_dir());
                 assert!(
                     any_exists,
                     "OPENSSL_LIB={lib:?} contains no existing directories"

--- a/plugins/ossl_prov/integration-tests/openssl-capi/cpp/openssl_capi_integration_tests.rs
+++ b/plugins/ossl_prov/integration-tests/openssl-capi/cpp/openssl_capi_integration_tests.rs
@@ -103,9 +103,13 @@ mod integration {
     fn find_openssl_lib_dir() -> Option<String> {
         if let Ok(lib) = env::var("OPENSSL_LIB") {
             if !lib.is_empty() {
+                // OPENSSL_LIB may be a single dir or a `:`-separated path
+                // list (e.g., openssl/lib:target/<abi>/debug).  Verify that
+                // at least one entry exists.
+                let any_exists = lib.split(':').any(|p| PathBuf::from(p).is_dir());
                 assert!(
-                    PathBuf::from(&lib).is_dir(),
-                    "OPENSSL_LIB={lib:?} does not point to an existing directory"
+                    any_exists,
+                    "OPENSSL_LIB={lib:?} contains no existing directories"
                 );
                 return Some(lib);
             }
@@ -269,9 +273,10 @@ mod integration {
     /// Resolves the provider search path (absolute) and verifies the provider
     /// `.so` exists there.
     ///
-    /// Uses `PROVIDER_PATH` if set, otherwise defaults to `target/debug` under
-    /// the workspace root.  Relative paths are resolved against the workspace
-    /// root to ensure correctness regardless of subprocess CWD.
+    /// Uses `PROVIDER_PATH` if set, otherwise honours `CARGO_TARGET_DIR` and
+    /// falls back to `target/debug` under the workspace root.  Relative paths
+    /// are resolved against the workspace root to ensure correctness
+    /// regardless of subprocess CWD.
     fn get_provider_path(workspace_root: &Path) -> PathBuf {
         let path = match env::var("PROVIDER_PATH") {
             Ok(p) if !p.is_empty() => {
@@ -282,7 +287,17 @@ mod integration {
                     p
                 }
             }
-            _ => workspace_root.join("target").join("debug"),
+            _ => match env::var("CARGO_TARGET_DIR") {
+                Ok(t) if !t.is_empty() => {
+                    let p = PathBuf::from(t).join("debug");
+                    if p.is_relative() {
+                        workspace_root.join(p)
+                    } else {
+                        p
+                    }
+                }
+                _ => workspace_root.join("target").join("debug"),
+            },
         };
 
         let provider_so = path.join("azihsm_provider.so");

--- a/plugins/ossl_prov/integration-tests/openssl-capi/cpp/openssl_capi_integration_tests.rs
+++ b/plugins/ossl_prov/integration-tests/openssl-capi/cpp/openssl_capi_integration_tests.rs
@@ -306,9 +306,9 @@ mod integration {
             "\n\
              azihsm_provider.so not found at {}\n\
              \n\
-             Build the provider first:\n\
+             Build the provider first (matching the OpenSSL ABI used by tests):\n\
              \n\
-                 cargo build -p azihsm_ossl_provider --features mock,provider\n",
+                 cargo xtask build --openssl-version <ver> --features mock\n",
             provider_so.display(),
         );
 

--- a/plugins/ossl_prov/integration-tests/openssl-cli/testfiles/env.sh
+++ b/plugins/ossl_prov/integration-tests/openssl-cli/testfiles/env.sh
@@ -35,7 +35,15 @@ fi
 
 # --- Optional environment variables (sensible defaults) ---
 
-test -z "$PROVIDER_PATH" && PROVIDER_PATH="$REPO_ROOT/target/debug"
+# Honour CARGO_TARGET_DIR so the provider .so is found in the ABI-versioned
+# build tree (e.g., target/ossl-abi-3-0/debug/).
+if [ -z "$PROVIDER_PATH" ]; then
+    if [ -n "$CARGO_TARGET_DIR" ]; then
+        PROVIDER_PATH="$CARGO_TARGET_DIR/debug"
+    else
+        PROVIDER_PATH="$REPO_ROOT/target/debug"
+    fi
+fi
 test -z "$PROPQUERY" && PROPQUERY="?provider=azihsm"
 
 # OPENSSL_LIB: distinguish "unset" from "set to empty" (CI sets OPENSSL_LIB="")

--- a/plugins/ossl_prov/integration-tests/openssl-cli/testfiles/env.sh
+++ b/plugins/ossl_prov/integration-tests/openssl-cli/testfiles/env.sh
@@ -45,6 +45,26 @@ fi
 
 export LD_LIBRARY_PATH="$OPENSSL_LIB"
 
+# --- Version gating helpers ---
+# Generic: skip test if OpenSSL version is below the given major.minor.
+#   require_ossl_version 3 5
+require_ossl_version() {
+    local req_major=$1 req_minor=$2
+    local ver
+    ver=$("$OPENSSL_BIN" version | awk '{print $2}')
+    local cur_major cur_minor
+    cur_major=$(echo "$ver" | cut -d. -f1)
+    cur_minor=$(echo "$ver" | cut -d. -f2)
+    if [ "$cur_major" -lt "$req_major" ] || \
+       { [ "$cur_major" -eq "$req_major" ] && [ "$cur_minor" -lt "$req_minor" ]; }; then
+        echo "SKIP: requires OpenSSL >= $req_major.$req_minor (have $ver)"
+        exit 0
+    fi
+}
+
+# Convenience: skip test unless OpenSSL >= 3.5.
+skip_below_ossl_3_5() { require_ossl_version 3 5; }
+
 # --- Credentials via hex env vars (preferred) ---
 # The provider reads credentials from these env vars first, falling back to
 # default files in CWD if unset.  Values match the mock HSM's test credentials.

--- a/plugins/ossl_prov/integration-tests/openssl-cli/testfiles/env.sh
+++ b/plugins/ossl_prov/integration-tests/openssl-cli/testfiles/env.sh
@@ -51,7 +51,15 @@ if [ -z "${OPENSSL_LIB+x}" ]; then
     OPENSSL_LIB=""
 fi
 
-export LD_LIBRARY_PATH="$OPENSSL_LIB"
+# Prepend OPENSSL_LIB to any existing LD_LIBRARY_PATH so we don't drop entries
+# the caller's environment relies on.  Matches the CAPI harness behaviour.
+if [ -n "$OPENSSL_LIB" ]; then
+    if [ -n "${LD_LIBRARY_PATH:-}" ]; then
+        export LD_LIBRARY_PATH="$OPENSSL_LIB:$LD_LIBRARY_PATH"
+    else
+        export LD_LIBRARY_PATH="$OPENSSL_LIB"
+    fi
+fi
 
 # --- Version gating helpers ---
 # Generic: skip test if OpenSSL version is below the given major.minor.

--- a/xtask/README.md
+++ b/xtask/README.md
@@ -66,8 +66,25 @@ Build and run all tests with code coverage enabled. Generates a cobertura XML, J
 cargo xtask coverage
 ```
 
+### integration-tests
+
+Run provider integration tests (CLI, C API, NGINX). Requires a custom OpenSSL build.
+
+```bash
+# Run against default OpenSSL version (3.0.3)
+cargo xtask integration-tests
+
+# Run against a specific version
+cargo xtask integration-tests --openssl-version 3.5.0
+```
+
+When `OPENSSL_DIR` is set, the `--openssl-version` flag is ignored and the
+existing installation is used as-is. See `plugins/ossl_prov/README.md` for
+environment variable details.
+
 ## Command Details
 
+- **integration-tests**: Runs CLI, C API, and NGINX provider integration tests. Resolves OpenSSL via `OPENSSL_DIR` or `--openssl-version`
 - **precheck**: Combines setup, copyright, audit, fmt, clippy, and nextest stages for comprehensive validation
 - **clippy**: Runs `cargo clippy --workspace --all-targets` with warnings treated as errors
 - **fmt**: Uses `cargo fmt` to check/fix Rust code formatting

--- a/xtask/README.md
+++ b/xtask/README.md
@@ -66,15 +66,54 @@ Build and run all tests with code coverage enabled. Generates a cobertura XML, J
 cargo xtask coverage
 ```
 
-### integration-tests
+### setup
 
-Run provider integration tests (CLI, C API, NGINX). Requires a custom OpenSSL build.
+Install build dependencies. On Linux, also installs OpenSSL into the ABI tree
+(`target/ossl-abi-<major>-<minor>/openssl/`).
 
 ```bash
-# Run against default OpenSSL version (3.0.3)
+# Install OpenSSL 3.0.3 (default version)
+cargo xtask setup
+
+# Install OpenSSL 3.5.0
+cargo xtask setup --openssl-version 3.5.0
+
+# Skip OpenSSL install (e.g., when bringing your own via OPENSSL_DIR)
+cargo xtask setup --skip-openssl
+```
+
+### build
+
+Build the workspace. On Linux, routes artifacts to the ABI-versioned target tree
+(`target/ossl-abi-<major>-<minor>/`) so multiple OpenSSL ABI versions can be
+cached side by side. No env vars needed.
+
+```bash
+# Build the whole workspace for OpenSSL 3.0.3 (default)
+cargo xtask build --features mock
+
+# Build for OpenSSL 3.5.0
+cargo xtask build --openssl-version 3.5.0 --features mock
+
+# Build only the provider crates (faster than full workspace)
+cargo xtask build --openssl-version 3.0.3 --package azihsm_ossl_provider --features mock
+cargo xtask build --openssl-version 3.0.3 --package azihsm_api_native   --features mock
+```
+
+The whole workspace covers both `azihsm_api_native` and `azihsm_ossl_provider`
+automatically — naming the package is only useful for targeted/faster builds.
+Omit `--features mock` to build against real hardware.
+
+### integration-tests
+
+Run provider integration tests (CLI, C API, NGINX). Builds the provider on
+demand into the ABI tree before running tests.
+
+```bash
+# Run against OpenSSL 3.0.3 (default)
 cargo xtask integration-tests
 
-# Run against a specific version
+# Run against OpenSSL 3.5.0
 cargo xtask integration-tests --openssl-version 3.5.0
 ```
 
@@ -84,7 +123,9 @@ environment variable details.
 
 ## Command Details
 
-- **integration-tests**: Runs CLI, C API, and NGINX provider integration tests. Resolves OpenSSL via `OPENSSL_DIR` or `--openssl-version`
+- **setup**: Installs build deps and (Linux) OpenSSL.  Honours `--openssl-version`.
+- **build**: Wraps `cargo build` with the right `CARGO_TARGET_DIR` for the chosen OpenSSL ABI version.
+- **integration-tests**: Runs CLI, C API, and NGINX provider integration tests. Builds the provider on demand.
 - **precheck**: Combines setup, copyright, audit, fmt, clippy, and nextest stages for comprehensive validation
 - **clippy**: Runs `cargo clippy --workspace --all-targets` with warnings treated as errors
 - **fmt**: Uses `cargo fmt` to check/fix Rust code formatting

--- a/xtask/README.md
+++ b/xtask/README.md
@@ -117,9 +117,11 @@ cargo xtask integration-tests
 cargo xtask integration-tests --openssl-version 3.5.0
 ```
 
-When `OPENSSL_DIR` is set, the `--openssl-version` flag is ignored and the
-existing installation is used as-is. See `plugins/ossl_prov/README.md` for
-environment variable details.
+When `OPENSSL_DIR` is set, the OpenSSL install step is skipped and the
+existing installation at that path is used as-is.  `--openssl-version`
+still selects the ABI target tree (`target/ossl-abi-<major>-<minor>/`) so
+provider artifacts stay correctly isolated per ABI version.  See
+`plugins/ossl_prov/README.md` for environment variable details.
 
 ## Command Details
 

--- a/xtask/src/build.rs
+++ b/xtask/src/build.rs
@@ -7,6 +7,7 @@
 use clap::Parser;
 use xshell::cmd;
 
+#[cfg(not(target_os = "linux"))]
 use crate::common;
 use crate::Xtask;
 use crate::XtaskCtx;
@@ -38,6 +39,13 @@ pub struct Build {
     /// Target triple to build for (e.g., aarch64-pc-windows-msvc)
     #[clap(long, value_name = "TRIPLE")]
     pub target: Option<String>,
+
+    /// OpenSSL version the provider should be built against (e.g., "3.0.3", "3.5.0").
+    /// Routes artifacts to `target/ossl-abi-<major>-<minor>/`, matching the
+    /// path-encoding convention enforced by the provider's build.rs.
+    /// Linux-only; ignored on other platforms.
+    #[clap(long, default_value = "3.0.3")]
+    pub openssl_version: String,
 }
 
 impl Xtask for Build {
@@ -46,6 +54,18 @@ impl Xtask for Build {
 
         let sh = xshell::Shell::new()?;
         let rust_toolchain = sh.var("RUST_TOOLCHAIN").map(|s| format!("+{s}")).ok();
+
+        // On Linux, route the build to the ABI-versioned target tree so that
+        // artifacts compiled against different OpenSSL ABI versions stay
+        // separate.  The provider's build.rs requires this layout.
+        // On other platforms (Windows), the provider isn't built, so fall
+        // back to the legacy target/xtask sub-dir to avoid self-overwrite.
+        #[cfg(target_os = "linux")]
+        let target_dir = {
+            let abi_leaf = crate::openssl_install::abi_leaf_for(&self.openssl_version)?;
+            std::path::PathBuf::from("target").join(abi_leaf)
+        };
+        #[cfg(not(target_os = "linux"))]
         let target_dir = common::target_dir()?;
 
         // Convert xtask parameters into cargo command arguments

--- a/xtask/src/build.rs
+++ b/xtask/src/build.rs
@@ -60,10 +60,13 @@ impl Xtask for Build {
         // separate.  The provider's build.rs requires this layout.
         // On other platforms (Windows), the provider isn't built, so fall
         // back to the legacy target/xtask sub-dir to avoid self-overwrite.
+        //
+        // Use ctx.root.join(...) so the path is absolute and independent of
+        // the process CWD — matches setup.rs and integration_tests.rs.
         #[cfg(target_os = "linux")]
         let target_dir = {
             let abi_leaf = crate::openssl_install::abi_leaf_for(&self.openssl_version)?;
-            std::path::PathBuf::from("target").join(abi_leaf)
+            _ctx.root.join("target").join(abi_leaf)
         };
         #[cfg(not(target_os = "linux"))]
         let target_dir = common::target_dir()?;

--- a/xtask/src/coverage.rs
+++ b/xtask/src/coverage.rs
@@ -49,10 +49,24 @@ impl Xtask for Coverage {
             std::fs::create_dir_all(&reports_dir)?;
         }
 
-        // Find path to azihsm_api_native object file
-        let build_dir = ctx
-            .root
-            .join("target")
+        // Find path to azihsm_api_native object file.  `cargo llvm-cov` writes
+        // its instrumented build to `$CARGO_TARGET_DIR/llvm-cov-target/...`, so
+        // we must honour CARGO_TARGET_DIR here — otherwise, with the ABI-
+        // versioned target tree (e.g. CARGO_TARGET_DIR=target/ossl-abi-3-0),
+        // the CMake/Corrosion output gets silently dropped from the coverage
+        // report.
+        let target_root = match std::env::var("CARGO_TARGET_DIR") {
+            Ok(t) if !t.is_empty() => {
+                let p = std::path::PathBuf::from(t);
+                if p.is_relative() {
+                    ctx.root.join(p)
+                } else {
+                    p
+                }
+            }
+            _ => ctx.root.join("target"),
+        };
+        let build_dir = target_root
             .join("llvm-cov-target")
             .join("debug")
             .join("build");

--- a/xtask/src/integration_tests.rs
+++ b/xtask/src/integration_tests.rs
@@ -12,7 +12,13 @@ use crate::XtaskCtx;
 /// Xtask to run integration tests
 #[derive(Parser)]
 #[clap(about = "Run Integration Tests")]
-pub struct IntegrationTest {}
+pub struct IntegrationTest {
+    /// OpenSSL version to use (e.g., "3.0.3", "3.5.0").
+    /// When OPENSSL_DIR is set, this flag is ignored and the
+    /// existing installation is used as-is.
+    #[clap(long, default_value = "3.0.3")]
+    pub openssl_version: String,
+}
 
 impl Xtask for IntegrationTest {
     fn run(self, _ctx: XtaskCtx) -> anyhow::Result<()> {
@@ -26,13 +32,26 @@ impl Xtask for IntegrationTest {
 
         #[cfg(target_os = "linux")]
         {
-            let openssl_dir = crate::openssl_install::check_openssl()?;
+            let openssl_dir = crate::openssl_install::check_openssl(&self.openssl_version)?;
 
             if std::env::var("OPENSSL_BIN").is_err() {
                 std::env::set_var("OPENSSL_BIN", openssl_dir.join("bin/openssl"));
             }
+            // Probe lib64 first (common on 64-bit distros), then fall back to lib.
             if std::env::var("OPENSSL_LIB").is_err() {
-                std::env::set_var("OPENSSL_LIB", openssl_dir.join("lib"));
+                let lib64 = openssl_dir.join("lib64");
+                let lib = openssl_dir.join("lib");
+                if lib64.is_dir() {
+                    std::env::set_var("OPENSSL_LIB", lib64);
+                } else if lib.is_dir() {
+                    std::env::set_var("OPENSSL_LIB", lib);
+                } else {
+                    log::warn!(
+                        "neither {} nor {} exists — OPENSSL_LIB not set",
+                        lib64.display(),
+                        lib.display()
+                    );
+                }
             }
             if std::env::var("OPENSSL_DIR").is_err() {
                 std::env::set_var("OPENSSL_DIR", &openssl_dir);

--- a/xtask/src/integration_tests.rs
+++ b/xtask/src/integration_tests.rs
@@ -32,24 +32,51 @@ impl Xtask for IntegrationTest {
 
         #[cfg(target_os = "linux")]
         {
+            // Set CARGO_TARGET_DIR so the provider build (and all artifacts)
+            // land in the ABI-versioned tree.  build.rs enforces this convention.
+            let abi_leaf = crate::openssl_install::abi_leaf_for(&self.openssl_version)?;
+            let target_dir = _ctx.root.join("target").join(&abi_leaf);
+            std::env::set_var("CARGO_TARGET_DIR", &target_dir);
+            log::info!("CARGO_TARGET_DIR set to {}", target_dir.display());
+
             let openssl_dir = crate::openssl_install::check_openssl(&self.openssl_version)?;
+
+            // Build the provider and its native FFI dep before running tests.
+            // The provider's build.rs isolates CMake/Corrosion's nested cargo
+            // into a separate target dir (see corrosion-target in build.rs)
+            // so this no longer deadlocks the outer `cargo xtask` invocation.
+            let sh = xshell::Shell::new()?;
+            xshell::cmd!(sh, "cargo build -p azihsm_api_native --features mock").run()?;
+            xshell::cmd!(sh, "cargo build -p azihsm_ossl_provider --features mock").run()?;
 
             if std::env::var("OPENSSL_BIN").is_err() {
                 std::env::set_var("OPENSSL_BIN", openssl_dir.join("bin/openssl"));
             }
             // Probe lib64 first (common on 64-bit distros), then fall back to lib.
+            // Also include the cargo debug dir so libazihsm_api_native.so is
+            // resolved from Cargo's build (not the parallel one Corrosion
+            // creates under target/<abi>/debug/build/.../out/build/, which has
+            // a different code path baked in).
             if std::env::var("OPENSSL_LIB").is_err() {
                 let lib64 = openssl_dir.join("lib64");
                 let lib = openssl_dir.join("lib");
-                if lib64.is_dir() {
-                    std::env::set_var("OPENSSL_LIB", lib64);
+                let cargo_debug = target_dir.join("debug");
+                let openssl_lib = if lib64.is_dir() {
+                    Some(lib64)
                 } else if lib.is_dir() {
-                    std::env::set_var("OPENSSL_LIB", lib);
+                    Some(lib)
                 } else {
                     log::warn!(
-                        "neither {} nor {} exists — OPENSSL_LIB not set",
-                        lib64.display(),
-                        lib.display()
+                        "neither {}/lib64 nor {}/lib exists",
+                        openssl_dir.display(),
+                        openssl_dir.display()
+                    );
+                    None
+                };
+                if let Some(p) = openssl_lib {
+                    std::env::set_var(
+                        "OPENSSL_LIB",
+                        format!("{}:{}", p.display(), cargo_debug.display()),
                     );
                 }
             }
@@ -57,6 +84,8 @@ impl Xtask for IntegrationTest {
                 std::env::set_var("OPENSSL_DIR", &openssl_dir);
             }
 
+            // Test key material is shared across versions (regenerated per run).
+            // Keep it at the top of target/, not inside the ABI tree.
             let keymat_dir = _ctx.root.join("target").join("test-keymat");
             if keymat_dir.exists() {
                 std::fs::remove_dir_all(&keymat_dir)?;

--- a/xtask/src/integration_tests.rs
+++ b/xtask/src/integration_tests.rs
@@ -14,8 +14,10 @@ use crate::XtaskCtx;
 #[clap(about = "Run Integration Tests")]
 pub struct IntegrationTest {
     /// OpenSSL version to use (e.g., "3.0.3", "3.5.0").
-    /// When OPENSSL_DIR is set, this flag is ignored and the
-    /// existing installation is used as-is.
+    /// Selects the ABI target tree (target/ossl-abi-<major>-<minor>/) where
+    /// artifacts are built.  When OPENSSL_DIR is set, that location overrides
+    /// the install step's path, but the flag still controls the build's
+    /// target dir, so artifacts are correctly ABI-isolated.
     #[clap(long, default_value = "3.0.3")]
     pub openssl_version: String,
 }

--- a/xtask/src/openssl_install.rs
+++ b/xtask/src/openssl_install.rs
@@ -56,8 +56,12 @@ fn sha256_for(version: &str) -> anyhow::Result<&'static str> {
 pub fn abi_leaf_for(version: &str) -> anyhow::Result<String> {
     let parts: Vec<&str> = version.split('.').collect();
     anyhow::ensure!(
-        parts.len() >= 2 && parts.iter().take(2).all(|p| !p.is_empty()),
-        "Invalid OpenSSL version: {version}"
+        parts.len() >= 2
+            && parts
+                .iter()
+                .take(2)
+                .all(|p| !p.is_empty() && p.chars().all(|c| c.is_ascii_digit())),
+        "Invalid OpenSSL version {version:?}: major.minor must be numeric"
     );
     Ok(format!("ossl-abi-{}-{}", parts[0], parts[1]))
 }
@@ -140,9 +144,9 @@ pub fn check_openssl(version: &str) -> anyhow::Result<PathBuf> {
 /// `CARGO_TARGET_DIR` to match the ABI dir for the requested version.
 #[cfg(target_os = "linux")]
 pub fn ensure_openssl_version(version: &str) -> anyhow::Result<PathBuf> {
-    let expected_hash = sha256_for(version)?;
-
-    // If OPENSSL_DIR is explicitly set, honour it strictly (never fall through to build).
+    // If OPENSSL_DIR is explicitly set, honour it strictly (never fall through
+    // to build).  Do this BEFORE the sha256_for / allowlist check so users
+    // with a custom OpenSSL build aren't constrained to the install allowlist.
     if std::env::var("OPENSSL_DIR").is_ok() {
         return check_openssl(version);
     }
@@ -150,6 +154,9 @@ pub fn ensure_openssl_version(version: &str) -> anyhow::Result<PathBuf> {
     if let Ok(path) = check_openssl(version) {
         return Ok(path);
     }
+
+    // The allowlist applies only to the install path (download URL + hash).
+    let expected_hash = sha256_for(version)?;
 
     let install_dir = default_install_dir(version)?;
     let prefix = install_dir.display();

--- a/xtask/src/openssl_install.rs
+++ b/xtask/src/openssl_install.rs
@@ -50,22 +50,54 @@ fn sha256_for(version: &str) -> anyhow::Result<&'static str> {
         })
 }
 
-/// Returns the default install directory for a given version, rooted in the
-/// Cargo target directory (or `./target` when `CARGO_TARGET_DIR` is unset).
+/// Returns the ABI directory leaf for a version, e.g. "3.0.3" -> "ossl-abi-3-0".
+/// OpenSSL guarantees ABI stability per minor version, so we ignore the patch.
+#[cfg(target_os = "linux")]
+pub fn abi_leaf_for(version: &str) -> anyhow::Result<String> {
+    let parts: Vec<&str> = version.split('.').collect();
+    anyhow::ensure!(
+        parts.len() >= 2 && parts.iter().take(2).all(|p| !p.is_empty()),
+        "Invalid OpenSSL version: {version}"
+    );
+    Ok(format!("ossl-abi-{}-{}", parts[0], parts[1]))
+}
+
+/// Returns the default install directory for a given version: the OpenSSL
+/// install lives at `<CARGO_TARGET_DIR>/openssl/`.  The version is encoded in
+/// `CARGO_TARGET_DIR` itself (e.g., `target/ossl-abi-3-0/`), so this function
+/// also verifies that the current `CARGO_TARGET_DIR` matches the version
+/// being installed — preventing accidental cross-version installs.
 #[cfg(target_os = "linux")]
 fn default_install_dir(version: &str) -> anyhow::Result<PathBuf> {
+    let expected_leaf = abi_leaf_for(version)?;
+
     let target_dir = match std::env::var_os("CARGO_TARGET_DIR") {
         Some(dir) => PathBuf::from(dir),
         None => std::env::current_dir()?.join("target"),
     };
-    Ok(target_dir.join(format!("openssl-{version}")))
+
+    let actual_leaf = target_dir
+        .file_name()
+        .and_then(|s| s.to_str())
+        .unwrap_or_default();
+
+    anyhow::ensure!(
+        actual_leaf == expected_leaf,
+        "CARGO_TARGET_DIR mismatch: leaf is {actual_leaf:?}, but OpenSSL {version} \
+         requires {expected_leaf:?}. Use `cargo xtask <cmd> --openssl-version {version}` \
+         (recommended) or set CARGO_TARGET_DIR=target/{expected_leaf} explicitly."
+    );
+
+    Ok(target_dir.join("openssl"))
 }
 
 /// Checks whether an OpenSSL installation is available, without installing.
 ///
 /// Resolution order:
 /// 1. `OPENSSL_DIR` env var — if set, returned as-is.
-/// 2. `target/openssl-{version}` — if it already exists.
+/// 2. `<CARGO_TARGET_DIR>/openssl/` — if it already exists.  `CARGO_TARGET_DIR`
+///    must match the ABI directory for the requested version
+///    (e.g., `target/ossl-abi-3-0/` for version `3.0.3`).
 ///
 /// Returns an error if neither is available. The caller must then run
 /// `ensure_openssl_version` (or `cargo xtask setup`) to install.
@@ -104,7 +136,8 @@ pub fn check_openssl(version: &str) -> anyhow::Result<PathBuf> {
 /// Resolves an OpenSSL installation, building from source if necessary.
 ///
 /// Honours `OPENSSL_DIR` strictly when set. Otherwise installs to
-/// `target/openssl-{version}` if not already present.
+/// `<CARGO_TARGET_DIR>/openssl/` if not already present.  Requires
+/// `CARGO_TARGET_DIR` to match the ABI dir for the requested version.
 #[cfg(target_os = "linux")]
 pub fn ensure_openssl_version(version: &str) -> anyhow::Result<PathBuf> {
     let expected_hash = sha256_for(version)?;

--- a/xtask/src/openssl_install.rs
+++ b/xtask/src/openssl_install.rs
@@ -16,23 +16,61 @@ use xshell::cmd;
 #[cfg(target_os = "linux")]
 use xshell::Shell;
 
+/// Supported OpenSSL versions and their tarball SHA-256 hashes. The version
+/// string is interpolated into paths and download URLs, so we restrict to
+/// known-good values.
 #[cfg(target_os = "linux")]
-const OPENSSL_VERSION: &str = "3.0.3";
-#[cfg(target_os = "linux")]
-const OPENSSL_SHA256: &str = "ee0078adcef1de5f003c62c80cc96527721609c6f3bb42b7795df31f8b558c0b";
+const SUPPORTED_VERSIONS: &[(&str, &str)] = &[
+    (
+        "3.0.3",
+        "ee0078adcef1de5f003c62c80cc96527721609c6f3bb42b7795df31f8b558c0b",
+    ),
+    (
+        "3.5.0",
+        "344d0a79f1a9b08029b0744e2cc401a43f9c90acd1044d09a530b4885a8e9fc0",
+    ),
+];
 
+/// Returns the expected SHA-256 hash for a supported version, or an error
+/// if the version is not in the allowlist.
 #[cfg(target_os = "linux")]
-fn default_install_dir() -> anyhow::Result<PathBuf> {
+fn sha256_for(version: &str) -> anyhow::Result<&'static str> {
+    SUPPORTED_VERSIONS
+        .iter()
+        .find(|(v, _)| *v == version)
+        .map(|(_, hash)| *hash)
+        .ok_or_else(|| {
+            let supported: Vec<&str> = SUPPORTED_VERSIONS.iter().map(|(v, _)| *v).collect();
+            anyhow::anyhow!(
+                "unsupported OpenSSL version {version:?}. \
+                 Supported versions: {}. \
+                 Set OPENSSL_DIR to use a custom installation.",
+                supported.join(", ")
+            )
+        })
+}
+
+/// Returns the default install directory for a given version, rooted in the
+/// Cargo target directory (or `./target` when `CARGO_TARGET_DIR` is unset).
+#[cfg(target_os = "linux")]
+fn default_install_dir(version: &str) -> anyhow::Result<PathBuf> {
     let target_dir = match std::env::var_os("CARGO_TARGET_DIR") {
         Some(dir) => PathBuf::from(dir),
         None => std::env::current_dir()?.join("target"),
     };
-    Ok(target_dir.join(format!("openssl-{OPENSSL_VERSION}")))
+    Ok(target_dir.join(format!("openssl-{version}")))
 }
 
 /// Checks whether an OpenSSL installation is available, without installing.
+///
+/// Resolution order:
+/// 1. `OPENSSL_DIR` env var — if set, returned as-is.
+/// 2. `target/openssl-{version}` — if it already exists.
+///
+/// Returns an error if neither is available. The caller must then run
+/// `ensure_openssl_version` (or `cargo xtask setup`) to install.
 #[cfg(target_os = "linux")]
-pub fn check_openssl() -> anyhow::Result<PathBuf> {
+pub fn check_openssl(version: &str) -> anyhow::Result<PathBuf> {
     match std::env::var("OPENSSL_DIR") {
         Ok(val) if val.trim().is_empty() => {
             anyhow::bail!(
@@ -50,35 +88,40 @@ pub fn check_openssl() -> anyhow::Result<PathBuf> {
         Err(_) => {}
     }
 
-    let install_dir = default_install_dir()?;
+    let install_dir = default_install_dir(version)?;
     if install_dir.is_dir() {
         log::info!("using cached OpenSSL at {}", install_dir.display());
         return Ok(install_dir);
     }
 
     anyhow::bail!(
-        "OpenSSL installation not found. \
-         Run 'cargo xtask setup' first, or set OPENSSL_DIR to an existing OpenSSL 3.x prefix."
+        "OpenSSL installation not found at {}. \
+         Run 'cargo xtask setup' first, or set OPENSSL_DIR to an existing OpenSSL 3.x prefix.",
+        install_dir.display()
     );
 }
 
 /// Resolves an OpenSSL installation, building from source if necessary.
+///
+/// Honours `OPENSSL_DIR` strictly when set. Otherwise installs to
+/// `target/openssl-{version}` if not already present.
 #[cfg(target_os = "linux")]
-pub fn ensure_openssl() -> anyhow::Result<PathBuf> {
+pub fn ensure_openssl_version(version: &str) -> anyhow::Result<PathBuf> {
+    let expected_hash = sha256_for(version)?;
+
     // If OPENSSL_DIR is explicitly set, honour it strictly (never fall through to build).
     if std::env::var("OPENSSL_DIR").is_ok() {
-        return check_openssl();
+        return check_openssl(version);
     }
 
-    if let Ok(path) = check_openssl() {
+    if let Ok(path) = check_openssl(version) {
         return Ok(path);
     }
 
-    let install_dir = default_install_dir()?;
+    let install_dir = default_install_dir(version)?;
     let prefix = install_dir.display();
 
-    // Download and build (mirrors CI exactly)
-    log::info!("OPENSSL_DIR not set — building OpenSSL {OPENSSL_VERSION} into {prefix}");
+    log::info!("OPENSSL_DIR not set — building OpenSSL {version} into {prefix}");
 
     // Preflight: check required tools before starting a long build.
     let sh = Shell::new()?;
@@ -92,12 +135,12 @@ pub fn ensure_openssl() -> anyhow::Result<PathBuf> {
     }
 
     let url = format!(
-        "https://github.com/openssl/openssl/releases/download/openssl-{OPENSSL_VERSION}/openssl-{OPENSSL_VERSION}.tar.gz"
+        "https://github.com/openssl/openssl/releases/download/openssl-{version}/openssl-{version}.tar.gz"
     );
-    let tarball = format!("/tmp/openssl-{OPENSSL_VERSION}.tar.gz");
-    let src_dir = format!("/tmp/openssl-{OPENSSL_VERSION}");
+    let tarball = format!("/tmp/openssl-{version}.tar.gz");
+    let src_dir = format!("/tmp/openssl-{version}");
 
-    log::info!("downloading OpenSSL {OPENSSL_VERSION}...");
+    log::info!("downloading OpenSSL {version}...");
     cmd!(sh, "curl -fsSL -o {tarball} {url}").run()?;
 
     let checksum_output = cmd!(sh, "sha256sum {tarball}").read()?;
@@ -106,8 +149,8 @@ pub fn ensure_openssl() -> anyhow::Result<PathBuf> {
         .next()
         .context("failed to parse sha256sum output")?;
     anyhow::ensure!(
-        actual_hash == OPENSSL_SHA256,
-        "SHA-256 mismatch for {tarball}: expected {OPENSSL_SHA256}, got {actual_hash}"
+        actual_hash == expected_hash,
+        "SHA-256 mismatch for {tarball}: expected {expected_hash}, got {actual_hash}"
     );
 
     cmd!(sh, "rm -rf {src_dir}").run()?;
@@ -121,6 +164,6 @@ pub fn ensure_openssl() -> anyhow::Result<PathBuf> {
     cmd!(sh, "make -j{nproc}").run()?;
     cmd!(sh, "make install_sw").run()?;
 
-    log::info!("OpenSSL {OPENSSL_VERSION} installed to {prefix}");
+    log::info!("OpenSSL {version} installed to {prefix}");
     Ok(install_dir)
 }

--- a/xtask/src/precheck.rs
+++ b/xtask/src/precheck.rs
@@ -79,6 +79,10 @@ pub struct Precheck {
     /// Skip OpenSSL installation during setup
     #[clap(long)]
     pub skip_openssl: bool,
+    /// OpenSSL version to use (e.g., "3.0.3", "3.5.0").  Forwarded to the
+    /// setup and integration-test sub-tasks; selects the ABI target tree.
+    #[clap(long, default_value = "3.0.3")]
+    pub openssl_version: String,
     /// Skip specifying toolchain for formatting checks
     #[clap(long)]
     skip_toolchain: bool,
@@ -127,7 +131,7 @@ impl Xtask for Precheck {
                 skip_taplo: self.skip_taplo,
                 skip_audit: self.skip_audit,
                 skip_openssl: self.skip_openssl,
-                openssl_version: "3.0.3".to_string(),
+                openssl_version: self.openssl_version.clone(),
             }
             .run(ctx.clone())?;
         }
@@ -223,8 +227,10 @@ impl Xtask for Precheck {
 
                     // OSSL Provider integration tests (CLI + C API, Linux only)
                     #[cfg(target_os = "linux")]
-                    integration_tests::IntegrationTest::parse_from::<[&str; 0], &str>([])
-                        .run(ctx.clone())?;
+                    integration_tests::IntegrationTest {
+                        openssl_version: self.openssl_version.clone(),
+                    }
+                    .run(ctx.clone())?;
                 }
             } else {
                 Nextest {

--- a/xtask/src/precheck.rs
+++ b/xtask/src/precheck.rs
@@ -127,6 +127,7 @@ impl Xtask for Precheck {
                 skip_taplo: self.skip_taplo,
                 skip_audit: self.skip_audit,
                 skip_openssl: self.skip_openssl,
+                openssl_version: "3.0.3".to_string(),
             }
             .run(ctx.clone())?;
         }
@@ -222,7 +223,8 @@ impl Xtask for Precheck {
 
                     // OSSL Provider integration tests (CLI + C API, Linux only)
                     #[cfg(target_os = "linux")]
-                    integration_tests::IntegrationTest {}.run(ctx.clone())?;
+                    integration_tests::IntegrationTest::parse_from::<[&str; 0], &str>([])
+                        .run(ctx.clone())?;
                 }
             } else {
                 Nextest {

--- a/xtask/src/setup.rs
+++ b/xtask/src/setup.rs
@@ -175,17 +175,20 @@ impl Xtask for Setup {
             let _ = cmd!(sh, "cargo +nightly fmt --version").quiet().run();
         }
 
-        // Install OpenSSL (Linux only).  Set CARGO_TARGET_DIR so that the
-        // OpenSSL install lands inside the ABI-versioned target tree.
+        // Route any later cargo invocation in this process to the ABI tree
+        // for the requested OpenSSL version, regardless of whether we install
+        // OpenSSL ourselves.  The install step itself is gated on
+        // `--skip-openssl` (and skipped when OPENSSL_DIR is already set).
         #[cfg(target_os = "linux")]
-        if !self.skip_openssl {
+        {
             let abi_leaf = crate::openssl_install::abi_leaf_for(&self.openssl_version)?;
-            // Resolve current working directory relative to ctx.root for an absolute path.
             let target_dir = ctx.root.join("target").join(&abi_leaf);
             std::env::set_var("CARGO_TARGET_DIR", &target_dir);
             log::info!("CARGO_TARGET_DIR set to {}", target_dir.display());
 
-            crate::openssl_install::ensure_openssl_version(&self.openssl_version)?;
+            if !self.skip_openssl {
+                crate::openssl_install::ensure_openssl_version(&self.openssl_version)?;
+            }
         }
 
         log::trace!("done setup");

--- a/xtask/src/setup.rs
+++ b/xtask/src/setup.rs
@@ -48,6 +48,11 @@ pub struct Setup {
     /// Skip installing OpenSSL
     #[clap(long)]
     pub skip_openssl: bool,
+
+    /// OpenSSL version to install (e.g., "3.0.3", "3.5.0").
+    /// Ignored when `--skip-openssl` is set or `OPENSSL_DIR` is already populated.
+    #[clap(long, default_value = "3.0.3")]
+    pub openssl_version: String,
 }
 
 impl Xtask for Setup {
@@ -169,7 +174,7 @@ impl Xtask for Setup {
         // Install OpenSSL (Linux only)
         #[cfg(target_os = "linux")]
         if !self.skip_openssl {
-            crate::openssl_install::ensure_openssl()?;
+            crate::openssl_install::ensure_openssl_version(&self.openssl_version)?;
         }
 
         log::trace!("done setup");

--- a/xtask/src/setup.rs
+++ b/xtask/src/setup.rs
@@ -50,7 +50,11 @@ pub struct Setup {
     pub skip_openssl: bool,
 
     /// OpenSSL version to install (e.g., "3.0.3", "3.5.0").
-    /// Ignored when `--skip-openssl` is set or `OPENSSL_DIR` is already populated.
+    /// Selects the ABI target tree (target/ossl-abi-<major>-<minor>/) where
+    /// OpenSSL gets installed under `openssl/`.  When `OPENSSL_DIR` is set or
+    /// `--skip-openssl` is given, the install step is skipped but the flag
+    /// still routes any later cargo invocation in this process to the
+    /// matching ABI tree.
     #[clap(long, default_value = "3.0.3")]
     pub openssl_version: String,
 }

--- a/xtask/src/setup.rs
+++ b/xtask/src/setup.rs
@@ -171,9 +171,16 @@ impl Xtask for Setup {
             let _ = cmd!(sh, "cargo +nightly fmt --version").quiet().run();
         }
 
-        // Install OpenSSL (Linux only)
+        // Install OpenSSL (Linux only).  Set CARGO_TARGET_DIR so that the
+        // OpenSSL install lands inside the ABI-versioned target tree.
         #[cfg(target_os = "linux")]
         if !self.skip_openssl {
+            let abi_leaf = crate::openssl_install::abi_leaf_for(&self.openssl_version)?;
+            // Resolve current working directory relative to ctx.root for an absolute path.
+            let target_dir = ctx.root.join("target").join(&abi_leaf);
+            std::env::set_var("CARGO_TARGET_DIR", &target_dir);
+            log::info!("CARGO_TARGET_DIR set to {}", target_dir.display());
+
             crate::openssl_install::ensure_openssl_version(&self.openssl_version)?;
         }
 


### PR DESCRIPTION
## Summary

- Add OpenSSL 3.5.0 as a second supported version alongside 3.0.3
- CI now matrix-tests the provider against both versions
- Fix a latent `LD_LIBRARY_PATH` bug in the CAPI test harness
- Add infrastructure for future 3.5-only test gating

## Motivation

OpenSSL 3.5 brings features we need for new features of the HSH lib.
This PR prepares the build and test infrastructure so that 3.5-specific
provider features can be added incrementally without breaking 3.0 support.

# Update: OpenSSL 3.5 support + version-aware target tree

This PR has two commits now. The first adds OpenSSL 3.5 as a second supported version alongside 3.0.3; the second restructures the build so the two versions can coexist locally without `cargo clean` between switches.

## Commit 1 — `05adc94` Add OpenSSL 3.5 support to provider build and CI

**Goal:** make the provider build and test against OpenSSL 3.5 in parallel with the existing 3.0 support, with no new provider features yet.

- `provider_integration` CI job runs as a matrix over `['3.0.3', '3.5.0']`, with `continue-on-error` on the 3.5 entry while support stabilises
- xtask `setup` and `integration-tests` learned `--openssl-version`; `openssl_install.rs` parameterised with an allowlist (`SUPPORTED_VERSIONS`) and per-version SHA-256 verification
- `env.sh` got version-gating helpers (`require_ossl_version` / `skip_below_ossl_3_5`) for future 3.5-only shell tests; C++ tests continue to use `#if OPENSSL_VERSION_MINOR >= 5` (same pattern as the provider's own polyfills)
- Documentation: `plugins/ossl_prov/README.md` and `xtask/README.md` cover the new flow

**Pre-existing bug fixed in passing:** the CAPI test harness was spawning `openssl` subprocesses without setting `LD_LIBRARY_PATH`. On 3.0 the system's libcrypto happens to be ABI-compatible, so it "worked." On 3.5 it failed with missing symbols. The CAPI harness now sets `LD_LIBRARY_PATH` (prepended, not overwritten) when `OPENSSL_LIB` resolves to an existing directory, and the CI workflow's CAPI step gained the corresponding `OPENSSL_LIB` env var that was missing.

**Result:** 27/27 CLI + 42/42 CAPI on both versions.

## Commit 2 — `831aade` Isolate per-OpenSSL-ABI builds in `target/ossl-abi-<major>-<minor>/`

**Goal:** make OpenSSL version mismatches structurally impossible. Previously, switching between 3.0.3 and 3.5.0 required `cargo clean`, because the provider's CMake-built `.so` in `target/debug/` stayed linked against the old OpenSSL headers while tests ran against the new binary — sometimes worked by accident (ABI-compatible patches), sometimes failed loudly, sometimes failed subtly.

### Design — three coordinated layers

**Layer 1: `.cargo/config.toml`** sets `target-dir = "target/ossl-abi-3-0"` as the default. Plain `cargo build`, IDE rust-analyzer, etc. work out of the box for the default ABI.

**Layer 2: provider `build.rs`** is now the enforcer:
- Extracts the ABI version from `CARGO_TARGET_DIR` (`target/ossl-abi-<major>-<minor>`)
- Validates against the supported allowlist (currently `3-0` and `3-5`)
- Derives `OPENSSL_DIR` from `<target_dir>/openssl/` if not explicitly set
- Panics with a clear, actionable message if `CARGO_TARGET_DIR` doesn't follow the convention

This means raw `cargo build` outside the convention **fails by design**. The error message points at the xtask command to use, or how to set the env var manually.

**Layer 3: xtask** sets `CARGO_TARGET_DIR=target/ossl-abi-{major}-{minor}` from `--openssl-version` for `setup`, `build`, and `integration-tests`. So one consistent flag drives install, build, and test paths.

### New folder layout

```
target/
├── ossl-abi-3-0/             ← CARGO_TARGET_DIR for OpenSSL 3.0.x
│   ├── debug/                ← cargo artifacts (provider + native lib)
│   ├── release/
│   └── openssl/              ← OpenSSL 3.0.x installation
├── ossl-abi-3-5/             ← analogous for 3.5.x
└── test-keymat/              ← shared, regenerated per run
```

`ossl-abi` reflects what the directory actually represents: an ABI compatibility context (OpenSSL guarantees ABI stability per minor version, so 3.0.3 and 3.0.13 share the same tree). The patch version stays in `--openssl-version` flags and the `SUPPORTED_VERSIONS` allowlist.

### Resolving the Corrosion deadlock

The provider's CMakeLists uses Corrosion to integrate the Rust FFI lib. During CMake configure, Corrosion runs `cargo rustc --print=native-static-libs` to probe what the Rust crate links against. That probe is a nested cargo invocation. By default it inherits `CARGO_TARGET_DIR` from the parent process — and tries to `flock()` the same `<target>/<profile>/.cargo-lock` the outer cargo holds → deadlock.

This is why `[build] target-dir` in `.cargo/config.toml` initially caused builds to hang for 10+ minutes. We tracked it down with `/proc/<pid>/wchan = locks_lock_inode_wait` and reading Corrosion's `FindRust.cmake`. Main never hits this because main's CI never sets `CARGO_TARGET_DIR`.

**Fix:** `build.rs` overrides `CARGO_TARGET_DIR` to `<OUT_DIR>/corrosion-target/` for the CMake invocation. Corrosion's inner cargo writes there, separate from the outer build's lock. The deadlock is resolved at the source.

### Second bug found during regression

`libazihsm_api_native.so` exists in **two** places after a provider build:
- `target/ossl-abi-X-Y/debug/libazihsm_api_native.so` (Cargo's build — correct)
- `target/ossl-abi-X-Y/debug/build/.../out/build/libazihsm_api_native.so` (Corrosion's parallel build — was failing tests with `command not supported: name=azihsm.session`)

The provider's RUNPATH points at the Corrosion build. To prefer Cargo's build, `LD_LIBRARY_PATH` must include the cargo `debug` dir. The xtask now sets `OPENSSL_LIB` to a `:`-separated path list (openssl/lib + cargo debug). CI's `OPENSSL_LIB` already did this; the local flow now matches.

### Developer workflow

**Recommended (xtask, no env vars):**

```bash
cargo xtask setup --openssl-version 3.0.3               # one-time, installs OpenSSL
cargo xtask integration-tests --openssl-version 3.0.3   # builds + runs all suites
```

**Plain cargo (works thanks to Layer 1):**

```bash
cargo build --features mock                                       # 3.0.3 (config default)
CARGO_TARGET_DIR=target/ossl-abi-3-5 cargo build --features mock  # 3.5.0
```

**Note:** `cargo xtask build --openssl-version <ver>` is preferred over plain `cargo build` when you want explicit version selection — the plain form silently uses the config default, which is harder to spot when switching versions frequently.

**Switching versions:** no `cargo clean` needed. Both trees coexist; pick a different `--openssl-version` and go.

**IDE setup:** rust-analyzer picks up the `.cargo/config.toml` default. To work in a non-default ABI, set `rust-analyzer.cargo.targetDir = "target/ossl-abi-3-5"` (or equivalent) in your IDE settings.

### Verification

Full regression cycle, no `cargo clean` between:

| Cycle | CLI | CAPI |
|---|---|---|
| 3.0.3 | 27/27 ✓ | 42/42 ✓ |
| 3.5.0 (after 3.0.3, no clean) | 27/27 ✓ | 42/42 ✓ |
| 3.0.3 again (after 3.5.0, no clean) | 27/27 ✓ | 42/42 ✓ |

NGINX suite skipped locally (nginx not installed). CI exercises it.

### CI changes

- `OPENSSL_VERSION` / `OPENSSL_INSTALL` env vars now reflect the new layout (`target/ossl-abi-3-0/openssl`)
- Matrix entries pair `openssl-version` with `openssl-abi` (`3.0.3 ↔ 3-0`, `3.5.0 ↔ 3-5`)
- Job-level `CARGO_TARGET_DIR` env set per matrix entry
- Cache keys version-scoped