### PR TITLE
Add comments to EVP_get_digestbyname calls

### DIFF
--- a/plugins/ossl_prov/src/azihsm_ossl_signature_rsa.c
+++ b/plugins/ossl_prov/src/azihsm_ossl_signature_rsa.c
@@ -696,7 +696,7 @@ static int azihsm_ossl_rsa_digest_verify_init(
     ctx->operation = 0; /* Verify */
 
     /* Get hash algorithm by name */
-    ctx->md = EVP_get_digestbyname(mdname);
+    ctx->md = EVP_get_digestbyname(mdname); // CodeQL [SM02689]  This is passed in externally by customer
     if (ctx->md == NULL)
     {
         ERR_raise(ERR_LIB_PROV, ERR_R_OPERATION_FAIL);
@@ -882,7 +882,7 @@ static int azihsm_ossl_rsa_set_ctx_params(void *sctx, const OSSL_PARAM params[])
             return OSSL_FAILURE;
         }
 
-        ctx->md = EVP_get_digestbyname(mdname);
+        ctx->md = EVP_get_digestbyname(mdname); // CodeQL [SM02689]  This is passed in externally by customer
         if (ctx->md == NULL)
         {
             ERR_raise(ERR_LIB_PROV, ERR_R_OPERATION_FAIL);
@@ -1001,7 +1001,7 @@ static int azihsm_ossl_rsa_set_ctx_params(void *sctx, const OSSL_PARAM params[])
             return OSSL_FAILURE;
         }
 
-        ctx->mgf1_md = EVP_get_digestbyname(mgf1_mdname);
+        ctx->mgf1_md = EVP_get_digestbyname(mgf1_mdname); // CodeQL [SM02689]  This is passed in externally by customer
         if (ctx->mgf1_md == NULL)
         {
             ERR_raise(ERR_LIB_PROV, ERR_R_OPERATION_FAIL);

--- a/plugins/ossl_prov/src/azihsm_ossl_signature_rsa.c
+++ b/plugins/ossl_prov/src/azihsm_ossl_signature_rsa.c
@@ -696,7 +696,13 @@ static int azihsm_ossl_rsa_digest_verify_init(
     ctx->operation = 0; /* Verify */
 
     /* Get hash algorithm by name */
-    ctx->md = EVP_get_digestbyname(mdname); // CodeQL [SM02689]  This is passed in externally by customer
+    /*
+     * CodeQL [SM02689] `mdname` comes from OpenSSL caller params, but
+     * EVP_get_digestbyname() only resolves registered digest algorithms.
+     * Unknown names return NULL here, and unsupported digests are rejected
+     * by the azihsm_ossl_evp_md_to_rsa_*_algo_id mappings below (algo.id == 0).
+     */
+    ctx->md = EVP_get_digestbyname(mdname);
     if (ctx->md == NULL)
     {
         ERR_raise(ERR_LIB_PROV, ERR_R_OPERATION_FAIL);

--- a/plugins/ossl_prov/src/azihsm_ossl_signature_rsa.c
+++ b/plugins/ossl_prov/src/azihsm_ossl_signature_rsa.c
@@ -480,9 +480,7 @@ static int azihsm_ossl_rsa_digest_sign_init(
     ctx->operation = 1; /* Sign */
 
     /* Get hash algorithm by name */
-    // CodeQL [SM02689] Parameter is externally passed by the customer and must remain for downward
-    // compatibility.
-    ctx->md = EVP_get_digestbyname(mdname);
+    ctx->md = EVP_get_digestbyname(mdname); //CodeQL [SM02689] Parameter is externally passed by the customer and must remain for downward compatibility
     if (ctx->md == NULL)
     {
         ERR_raise(ERR_LIB_PROV, ERR_R_OPERATION_FAIL);
@@ -696,9 +694,7 @@ static int azihsm_ossl_rsa_digest_verify_init(
     ctx->operation = 0; /* Verify */
 
     /* Get hash algorithm by name */
-    // CodeQL [SM02689] Parameter is externally passed by the customer and must remain for downward
-    // compatibility.
-    ctx->md = EVP_get_digestbyname(mdname);
+    ctx->md = EVP_get_digestbyname(mdname); //CodeQL [SM02689] Parameter is externally passed by the customer and must remain for downward compatibility
     if (ctx->md == NULL)
     {
         ERR_raise(ERR_LIB_PROV, ERR_R_OPERATION_FAIL);
@@ -884,9 +880,7 @@ static int azihsm_ossl_rsa_set_ctx_params(void *sctx, const OSSL_PARAM params[])
             return OSSL_FAILURE;
         }
 
-        // CodeQL [SM02689] Parameter is externally passed by the customer and must remain for
-        // downward compatibility.
-        ctx->md = EVP_get_digestbyname(mdname);
+        ctx->md = EVP_get_digestbyname(mdname); //CodeQL [SM02689] Parameter is externally passed by the customer and must remain for downward compatibility
         if (ctx->md == NULL)
         {
             ERR_raise(ERR_LIB_PROV, ERR_R_OPERATION_FAIL);
@@ -1005,9 +999,7 @@ static int azihsm_ossl_rsa_set_ctx_params(void *sctx, const OSSL_PARAM params[])
             return OSSL_FAILURE;
         }
 
-        // CodeQL [SM02689] Parameter is externally passed by the customer and must remain for
-        // downward compatibility.
-        ctx->mgf1_md = EVP_get_digestbyname(mgf1_mdname);
+        ctx->mgf1_md = EVP_get_digestbyname(mgf1_mdname); //CodeQL [SM02689] Parameter is externally passed by the customer and must remain for downward compatibility
         if (ctx->mgf1_md == NULL)
         {
             ERR_raise(ERR_LIB_PROV, ERR_R_OPERATION_FAIL);

--- a/plugins/ossl_prov/src/azihsm_ossl_signature_rsa.c
+++ b/plugins/ossl_prov/src/azihsm_ossl_signature_rsa.c
@@ -480,9 +480,9 @@ static int azihsm_ossl_rsa_digest_sign_init(
     ctx->operation = 1; /* Sign */
 
     /* Get hash algorithm by name */
-    ctx->md =
-        EVP_get_digestbyname(mdname); // CodeQL [SM02689]  This is passed in externally by customer
-                                      // and must remain in order to keep backward compatibility.
+    // CodeQL [SM02689] Parameter is externally passed by the customer and must remain for downward
+    // compatibility.
+    ctx->md = EVP_get_digestbyname(mdname);
     if (ctx->md == NULL)
     {
         ERR_raise(ERR_LIB_PROV, ERR_R_OPERATION_FAIL);
@@ -696,12 +696,8 @@ static int azihsm_ossl_rsa_digest_verify_init(
     ctx->operation = 0; /* Verify */
 
     /* Get hash algorithm by name */
-    /*
-     * CodeQL [SM02689] `mdname` comes from OpenSSL caller params, but
-     * EVP_get_digestbyname() only resolves registered digest algorithms.
-     * Unknown names return NULL here, and unsupported digests are rejected
-     * by the azihsm_ossl_evp_md_to_rsa_*_algo_id mappings below (algo.id == 0).
-     */
+    // CodeQL [SM02689] Parameter is externally passed by the customer and must remain for downward
+    // compatibility.
     ctx->md = EVP_get_digestbyname(mdname);
     if (ctx->md == NULL)
     {
@@ -888,12 +884,8 @@ static int azihsm_ossl_rsa_set_ctx_params(void *sctx, const OSSL_PARAM params[])
             return OSSL_FAILURE;
         }
 
-        /*
-         * CodeQL [SM02689] The digest name is provided via OpenSSL params, but
-         * EVP_get_digestbyname() only resolves registered digest algorithms.
-         * Unrecognized or unsupported names return NULL and are rejected by the
-         * check immediately below, so external input does not bypass validation.
-         */
+        // CodeQL [SM02689] Parameter is externally passed by the customer and must remain for
+        // downward compatibility.
         ctx->md = EVP_get_digestbyname(mdname);
         if (ctx->md == NULL)
         {
@@ -1013,10 +1005,8 @@ static int azihsm_ossl_rsa_set_ctx_params(void *sctx, const OSSL_PARAM params[])
             return OSSL_FAILURE;
         }
 
-        // CodeQL [SM02689] `mgf1_mdname` is externally provided, but only
-        // provider-supported MGF1 digests are accepted: unsupported digests
-        // fail resolution here or later validation via
-        // `azihsm_ossl_evp_md_to_mgf1_id`.
+        // CodeQL [SM02689] Parameter is externally passed by the customer and must remain for
+        // downward compatibility.
         ctx->mgf1_md = EVP_get_digestbyname(mgf1_mdname);
         if (ctx->mgf1_md == NULL)
         {

--- a/plugins/ossl_prov/src/azihsm_ossl_signature_rsa.c
+++ b/plugins/ossl_prov/src/azihsm_ossl_signature_rsa.c
@@ -1001,7 +1001,11 @@ static int azihsm_ossl_rsa_set_ctx_params(void *sctx, const OSSL_PARAM params[])
             return OSSL_FAILURE;
         }
 
-        ctx->mgf1_md = EVP_get_digestbyname(mgf1_mdname); // CodeQL [SM02689]  This is passed in externally by customer
+        // CodeQL [SM02689] `mgf1_mdname` is externally provided, but only
+        // provider-supported MGF1 digests are accepted: unsupported digests
+        // fail resolution here or later validation via
+        // `azihsm_ossl_evp_md_to_mgf1_id`.
+        ctx->mgf1_md = EVP_get_digestbyname(mgf1_mdname);
         if (ctx->mgf1_md == NULL)
         {
             ERR_raise(ERR_LIB_PROV, ERR_R_OPERATION_FAIL);

--- a/plugins/ossl_prov/src/azihsm_ossl_signature_rsa.c
+++ b/plugins/ossl_prov/src/azihsm_ossl_signature_rsa.c
@@ -882,7 +882,13 @@ static int azihsm_ossl_rsa_set_ctx_params(void *sctx, const OSSL_PARAM params[])
             return OSSL_FAILURE;
         }
 
-        ctx->md = EVP_get_digestbyname(mdname); // CodeQL [SM02689]  This is passed in externally by customer
+        /*
+         * CodeQL [SM02689] The digest name is provided via OpenSSL params, but
+         * EVP_get_digestbyname() only resolves registered digest algorithms.
+         * Unrecognized or unsupported names return NULL and are rejected by the
+         * check immediately below, so external input does not bypass validation.
+         */
+        ctx->md = EVP_get_digestbyname(mdname);
         if (ctx->md == NULL)
         {
             ERR_raise(ERR_LIB_PROV, ERR_R_OPERATION_FAIL);


### PR DESCRIPTION
Updated EVP_get_digestbyname calls to include comments indicating that the parameters are externally passed by the customer.