### PR TITLE
feat(fw): add GetSealedBk3 and SetSealedBk3 firmware handlers

### DIFF
--- a/ddi/lib/tests/azihsm_ddi_tests.rs
+++ b/ddi/lib/tests/azihsm_ddi_tests.rs
@@ -62,6 +62,7 @@ mod integration {
     pub mod rsa_4k_sign;
     pub mod rsa_mod_exp;
     pub mod rsa_unwrap_generated_key;
+    pub mod sealed_bk3_smoke;
     pub mod secret_hkdf_derive;
     pub mod secret_kbkdf_derive;
 }

--- a/ddi/lib/tests/integration/sealed_bk3_smoke.rs
+++ b/ddi/lib/tests/integration/sealed_bk3_smoke.rs
@@ -1,0 +1,66 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! SetSealedBk3 / GetSealedBk3 smoke tests for the emu backend.
+
+#![cfg(test)]
+
+use azihsm_ddi::*;
+use azihsm_ddi_types::*;
+use test_with_tracing::test;
+
+use super::common::*;
+
+pub fn setup(_dev: &mut <DdiTest as Ddi>::Dev, _ddi: &DdiTest, _path: &str) -> u16 {
+    0
+}
+
+pub fn cleanup(
+    _dev: &mut <DdiTest as Ddi>::Dev,
+    _ddi: &DdiTest,
+    _path: &str,
+    _setup_session_id: Option<u16>,
+) {
+}
+
+#[test]
+fn test_set_then_get_sealed_bk3() {
+    ddi_dev_test(setup, cleanup, |dev, _ddi, _path, _| {
+        let blob: Vec<u8> = (10..73u8).collect();
+
+        let set_resp = helper_set_sealed_bk3(dev, blob.clone()).unwrap();
+        assert_eq!(set_resp.hdr.op, DdiOp::SetSealedBk3);
+        assert_eq!(set_resp.hdr.status, DdiStatus::Success);
+
+        let get_resp = helper_get_sealed_bk3(dev).unwrap();
+        assert_eq!(get_resp.hdr.op, DdiOp::GetSealedBk3);
+        assert_eq!(get_resp.data.sealed_bk3.as_slice(), blob.as_slice());
+    });
+}
+
+#[test]
+fn test_set_sealed_bk3_twice_fails() {
+    ddi_dev_test(setup, cleanup, |dev, _ddi, _path, _| {
+        let blob: Vec<u8> = (10..73u8).collect();
+
+        let set_resp = helper_set_sealed_bk3(dev, blob.clone()).unwrap();
+        assert_eq!(set_resp.hdr.status, DdiStatus::Success);
+
+        let err = helper_set_sealed_bk3(dev, blob).unwrap_err();
+        assert!(matches!(
+            err,
+            DdiError::DdiStatus(DdiStatus::SealedBk3AlreadySet)
+        ));
+    });
+}
+
+#[test]
+fn test_get_sealed_bk3_before_set_fails() {
+    ddi_dev_test(setup, cleanup, |dev, _ddi, _path, _| {
+        let err = helper_get_sealed_bk3(dev).unwrap_err();
+        assert!(matches!(
+            err,
+            DdiError::DdiStatus(DdiStatus::SealedBk3NotPresent)
+        ));
+    });
+}

--- a/fw/core/lib/src/ddi/get_sealed_bk3.rs
+++ b/fw/core/lib/src/ddi/get_sealed_bk3.rs
@@ -1,0 +1,47 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! DDI GetSealedBk3 command handler.
+//!
+//! Returns the sealed BK3 blob stored on the partition, or
+//! `SealedBk3NotPresent` if none has been set.
+//!
+//! Uses the encode-frame-then-fill pattern: the response blob is
+//! filled directly into the encoder-reserved slot — zero intermediate
+//! copies.
+
+use azihsm_fw_ddi_types::get_sealed_bk3::DdiGetSealedBk3Req;
+use azihsm_fw_ddi_types::get_sealed_bk3::DdiGetSealedBk3Resp;
+
+use super::*;
+
+/// Handle DdiGetSealedBk3Cmd.
+///
+/// 1. **Body decode** — Decodes `DdiGetSealedBk3Req` (empty struct).
+///
+/// 2. **Presence check** — `sealed_bk3 len == 0` → `SealedBk3NotPresent`.
+///
+/// 3. **Response** — Encodes header + frame, fills blob in-place.
+pub(crate) fn get_sealed_bk3<'a, P: HsmPal>(
+    hdr: &DdiReqHdr,
+    decoder: &mut DdiDecoder<'_>,
+    part_id: HsmPartId,
+    pal: &P,
+    _fmem: &mut [u8],
+    smem: &'a mut [u8],
+) -> HsmResult<&'a [u8]> {
+    let _body: DdiGetSealedBk3Req = decoder.decode_data()?;
+
+    let sealed_len = pal.part_sealed_bk3(part_id, None)?;
+    if sealed_len == 0 {
+        return Err(HsmError::SealedBk3NotPresent);
+    }
+
+    let mut encoder = ddi::encode_resp_hdr(&ddi::success_hdr(hdr, DdiOp::GetSealedBk3), smem)?;
+    let frame = DdiGetSealedBk3Resp::frame(&mut encoder, sealed_len)?;
+    let total = encoder.position();
+
+    pal.part_sealed_bk3(part_id, Some(frame.sealed_bk3))?;
+
+    Ok(&smem[..total])
+}

--- a/fw/core/lib/src/ddi/mod.rs
+++ b/fw/core/lib/src/ddi/mod.rs
@@ -6,6 +6,8 @@ pub(crate) mod get_cert_chain_info;
 pub(crate) mod get_certificate;
 pub(crate) mod get_device_info;
 pub(crate) mod get_establish_cred_encryption_key;
+pub(crate) mod get_sealed_bk3;
+pub(crate) mod set_sealed_bk3;
 pub(crate) mod sha_digest;
 
 use azihsm_fw_ddi::DdiDecoder;
@@ -18,6 +20,8 @@ pub(crate) use get_cert_chain_info::*;
 pub(crate) use get_certificate::*;
 pub(crate) use get_device_info::*;
 pub(crate) use get_establish_cred_encryption_key::*;
+pub(crate) use get_sealed_bk3::*;
+pub(crate) use set_sealed_bk3::*;
 pub(crate) use sha_digest::*;
 
 use super::*;
@@ -48,6 +52,8 @@ pub(crate) async fn dispatch<P: HsmPal>(
         DdiOp::GetEstablishCredEncryptionKey => {
             get_establish_cred_encryption_key(hdr, decoder, part_id, pal, fmem, smem).await?
         }
+        DdiOp::GetSealedBk3 => get_sealed_bk3(hdr, decoder, part_id, pal, fmem, smem)?,
+        DdiOp::SetSealedBk3 => set_sealed_bk3(hdr, decoder, part_id, pal, fmem, smem)?,
         _ => return Err(HsmError::UnsupportedCmd),
     };
     Ok(resp.len())

--- a/fw/core/lib/src/ddi/set_sealed_bk3.rs
+++ b/fw/core/lib/src/ddi/set_sealed_bk3.rs
@@ -1,0 +1,45 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! DDI SetSealedBk3 command handler.
+//!
+//! Stores the sealed BK3 blob on the partition. Returns
+//! `SealedBk3AlreadySet` if one has already been stored, or
+//! `SealedBk3TooLarge` if the blob exceeds 1024 bytes.
+
+use azihsm_fw_ddi_types::set_sealed_bk3::DdiSetSealedBk3Req;
+use azihsm_fw_ddi_types::set_sealed_bk3::DdiSetSealedBk3Resp;
+
+use super::*;
+
+/// Handle DdiSetSealedBk3Cmd.
+///
+/// 1. **Already-set check** — `sealed_bk3 len != 0` → `SealedBk3AlreadySet`.
+///
+/// 2. **Body decode** — Decodes `DdiSetSealedBk3Req` with the blob.
+///
+/// 3. **Store** — Writes the blob via the PAL (validates size internally).
+///
+/// 4. **Response** — Encodes `DdiSetSealedBk3Resp` (empty) into `smem`.
+pub(crate) fn set_sealed_bk3<'a, P: HsmPal>(
+    hdr: &DdiReqHdr,
+    decoder: &mut DdiDecoder<'_>,
+    part_id: HsmPartId,
+    pal: &P,
+    _fmem: &mut [u8],
+    smem: &'a mut [u8],
+) -> HsmResult<&'a [u8]> {
+    // Check before decode — matches real firmware order.
+    if pal.part_sealed_bk3(part_id, None)? != 0 {
+        return Err(HsmError::SealedBk3AlreadySet);
+    }
+
+    let body: DdiSetSealedBk3Req<'_> = decoder.decode_data()?;
+    pal.part_set_sealed_bk3(part_id, body.sealed_bk3)?;
+
+    let resp_hdr = ddi::success_hdr(hdr, DdiOp::SetSealedBk3);
+    let resp_data = DdiSetSealedBk3Resp {};
+
+    let len = ddi::encode_resp(&resp_hdr, &resp_data, smem)?;
+    Ok(&smem[..len])
+}

--- a/fw/core/lib/src/op.rs
+++ b/fw/core/lib/src/op.rs
@@ -588,6 +588,8 @@ impl SessionCtrl {
             | DdiOp::GetCertChainInfo
             | DdiOp::GetCertificate
             | DdiOp::GetEstablishCredEncryptionKey
+            | DdiOp::GetSealedBk3
+            | DdiOp::SetSealedBk3
             | DdiOp::ShaDigest => Self::NoSession,
             DdiOp::OpenSession => Self::Open,
             DdiOp::CloseSession => Self::Close,

--- a/fw/pal/traits/src/part.rs
+++ b/fw/pal/traits/src/part.rs
@@ -134,4 +134,17 @@ pub trait HsmPartitionManager {
     /// Called after credential establishment or session open to ensure
     /// nonce freshness.
     fn part_nonce_refresh(&self, pid: HsmPartId) -> HsmResult<()>;
+
+    /// Returns the sealed BK3 blob for the partition.
+    ///
+    /// Pass `None` to query the size; pass `Some(buf)` to copy into `buf`.
+    /// Returns 0 if no sealed BK3 has been stored yet.
+    fn part_sealed_bk3(&self, pid: HsmPartId, out: Option<&mut [u8]>) -> HsmResult<usize>;
+
+    /// Store the sealed BK3 blob for the partition.
+    ///
+    /// # Errors
+    /// - [`HsmError::SealedBk3AlreadySet`] if already stored.
+    /// - [`HsmError::SealedBk3TooLarge`] if `data` exceeds 1024 bytes.
+    fn part_set_sealed_bk3(&self, pid: HsmPartId, data: &[u8]) -> HsmResult<()>;
 }

--- a/fw/plat/std/pal/src/part.rs
+++ b/fw/plat/std/pal/src/part.rs
@@ -61,6 +61,9 @@ pub const MAX_RESOURCES: u8 = 65;
 /// Length of the per-partition random nonce in bytes.
 const NONCE_LEN: usize = 32;
 
+/// Maximum size of the sealed BK3 blob in bytes.
+const SEALED_BK3_SIZE: usize = 512;
+
 /// Length of a partition's random identity blob in bytes.
 const PART_ID_LEN: usize = 16;
 
@@ -143,6 +146,12 @@ pub(crate) struct PartitionEntry {
 
     /// 32-byte random nonce, generated on enable and refreshable.
     pub(crate) nonce: [u8; NONCE_LEN],
+
+    /// Sealed BK3 blob — up to 512 bytes of opaque data.
+    sealed_bk3: [u8; SEALED_BK3_SIZE],
+
+    /// Length of valid data in `sealed_bk3` (0 = not yet stored).
+    sealed_bk3_len: u32,
 }
 
 impl Default for PartitionEntry {
@@ -162,6 +171,8 @@ impl Default for PartitionEntry {
             session_enc_key_id: None,
             session_enc_pub_key: [0u8; P384_PUB_KEY_LEN],
             nonce: [0u8; NONCE_LEN],
+            sealed_bk3: [0u8; SEALED_BK3_SIZE],
+            sealed_bk3_len: 0,
         }
     }
 }
@@ -340,6 +351,25 @@ impl HsmPartitionManager for StdHsmPal {
     fn part_nonce_refresh(&self, pid: HsmPartId) -> HsmResult<()> {
         let entry = self.enabled_part_mut(u8::from(pid))?;
         Rng::rand_bytes(&mut entry.nonce).map_err(|_| HsmError::InternalError)
+    }
+
+    fn part_sealed_bk3(&self, pid: HsmPartId, out: Option<&mut [u8]>) -> HsmResult<usize> {
+        let entry = self.active_part(pid)?;
+        let len = entry.sealed_bk3_len as usize;
+        copy_out(&entry.sealed_bk3[..len], out)
+    }
+
+    fn part_set_sealed_bk3(&self, pid: HsmPartId, data: &[u8]) -> HsmResult<()> {
+        let entry = self.active_part_mut(pid)?;
+        if entry.sealed_bk3_len != 0 {
+            return Err(HsmError::SealedBk3AlreadySet);
+        }
+        if data.len() > SEALED_BK3_SIZE {
+            return Err(HsmError::SealedBk3TooLarge);
+        }
+        entry.sealed_bk3[..data.len()].copy_from_slice(data);
+        entry.sealed_bk3_len = data.len() as u32;
+        Ok(())
     }
 }
 
@@ -668,5 +698,7 @@ impl StdHsmPal {
         entry.nonce.fill(0);
         entry.vault.clear();
         entry.session_table = SessionTable::new();
+        entry.sealed_bk3[..entry.sealed_bk3_len as usize].fill(0);
+        entry.sealed_bk3_len = 0;
     }
 }


### PR DESCRIPTION
Add sealed BK3 storage to the partition abstraction layer and wire GetSealedBk3/SetSealedBk3 into the firmware DDI dispatcher, matching real firmware behavior.

- Add SEALED_BK3_SIZE (512) constant and part_sealed_bk3/ part_set_sealed_bk3 methods to HsmPartitionManager trait
- Implement sealed_bk3 storage in StdHsmPal PartitionEntry with clearing on partition disable/free
- Create get_sealed_bk3.rs and set_sealed_bk3.rs DDI handlers using the encode-frame-then-fill pattern (zero intermediate copies)
- Wire both opcodes into dispatch() and SessionCtrl::from_op as NoSession commands
- Add sealed_bk3_smoke integration tests (Set+Get round-trip, double Set rejected, Get before Set rejected)

DDI integration test results with --features emu (563 total):
  28 passed, 535 failed, 0 skipped

DDI smoke test results with --features emu (6 total):
  6 passed, 0 failed, 0 skipped