### PR TITLE
fix(fw): SetSealedBk3 cleanup and HsmRng trait refinement

### DIFF
--- a/fw/core/lib/src/ddi/set_sealed_bk3.rs
+++ b/fw/core/lib/src/ddi/set_sealed_bk3.rs
@@ -29,11 +29,6 @@ pub(crate) fn set_sealed_bk3<'a, P: HsmPal>(
     _fmem: &mut [u8],
     smem: &'a mut [u8],
 ) -> HsmResult<&'a [u8]> {
-    // Check before decode — matches real firmware order.
-    if pal.part_sealed_bk3(part_id, None)? != 0 {
-        return Err(HsmError::SealedBk3AlreadySet);
-    }
-
     let body: DdiSetSealedBk3Req<'_> = decoder.decode_data()?;
     pal.part_set_sealed_bk3(part_id, body.sealed_bk3)?;
 

--- a/fw/pal/traits/src/crypto/rng.rs
+++ b/fw/pal/traits/src/crypto/rng.rs
@@ -24,5 +24,5 @@ pub trait HsmRng {
     /// # Errors
     /// Returns [`HsmError`] if the CSPRNG fails (e.g., insufficient
     /// entropy, hardware TRNG error).
-    fn rng_fill_bytes(&mut self, buf: &mut [u8]) -> HsmResult<()>;
+    fn rng_fill_bytes(&self, buf: &mut [u8]) -> HsmResult<()>;
 }

--- a/fw/plat/std/pal/src/rng.rs
+++ b/fw/plat/std/pal/src/rng.rs
@@ -19,7 +19,7 @@ impl HsmRng for StdHsmPal {
     /// Delegates to [`azihsm_crypto::Rng::rand_bytes`], which calls
     /// OpenSSL's `RAND_bytes`. Returns [`HsmError::InternalError`] if
     /// the underlying CSPRNG fails (e.g., insufficient entropy).
-    fn rng_fill_bytes(&mut self, buf: &mut [u8]) -> HsmResult<()> {
+    fn rng_fill_bytes(&self, buf: &mut [u8]) -> HsmResult<()> {
         azihsm_crypto::Rng::rand_bytes(buf).map_err(|_| HsmError::InternalError)
     }
 }


### PR DESCRIPTION
Two small fixes for the firmware core:

 - Remove redundant already-set check from SetSealedBk3 handler — The PAL's part_set_sealed_bk3 already
returns SealedBk3AlreadySet when the blob has been set, so the pre-decode check in the DDI handler was
redundant.
 - Change HsmRng::rng_fill_bytes to take &self — The underlying OpenSSL CSPRNG is stateless. Taking &self
instead of &mut self allows DDI handlers (which hold &P) to call rng_fill_bytes directly without requiring
mutable access to the PAL.