### PR TITLE
feat(pal): add AES-GCM encrypt/decrypt to HsmAes trait and StdPal

### DIFF
--- a/fw/pal/traits/src/crypto/aes.rs
+++ b/fw/pal/traits/src/crypto/aes.rs
@@ -133,4 +133,127 @@ pub trait HsmAes {
         encrypt: bool,
         data: &mut [u8],
     ) -> HsmResult<()>;
+
+    /// AES-GCM encrypt with separate input/output buffers.
+    ///
+    /// Encrypts `plaintext` using AES-GCM and writes the resulting
+    /// ciphertext to `ciphertext` and the authentication tag to `tag`.
+    /// Data does not need to be 16-byte-aligned — the PAL handles
+    /// alignment and tag correction internally.
+    ///
+    /// # Parameters
+    /// - `key` — The AES key (16, 24, or 32 bytes for AES-128/192/256).
+    /// - `iv` — 12-byte (96-bit) nonce. Must be unique per encryption
+    ///   with the same key.
+    /// - `aad_len` — Length in bytes of the additional authenticated data
+    ///   (AAD) that precedes the plaintext in the input buffer.
+    ///   The AAD is authenticated but not encrypted; pass `0` when
+    ///   there is no AAD.
+    /// - `plaintext` — Source data to encrypt (any length).
+    /// - `ciphertext` — Destination buffer. Must be at least
+    ///   `plaintext.len()` bytes.
+    /// - `tag` — Output buffer for the 16-byte authentication tag.
+    ///
+    /// # Errors
+    /// Returns [`HsmError`] if the encryption operation fails.
+    async fn gcm_encrypt(
+        &self,
+        key: &[u8],
+        iv: &[u8; 12],
+        aad_len: usize,
+        plaintext: &[u8],
+        ciphertext: &mut [u8],
+        tag: &mut [u8; 16],
+    ) -> HsmResult<()>;
+
+    /// AES-GCM encrypt in-place.
+    ///
+    /// Reads plaintext from and writes ciphertext to the same `data`
+    /// buffer. The authentication tag is written to `tag`. This avoids
+    /// an extra buffer allocation and is the natural model for hardware
+    /// engines that operate directly on DMA buffers.
+    ///
+    /// # Parameters
+    /// - `key` — The AES key (16, 24, or 32 bytes for AES-128/192/256).
+    /// - `iv` — 12-byte (96-bit) nonce. Must be unique per encryption
+    ///   with the same key.
+    /// - `aad_len` — Length in bytes of the additional authenticated data
+    ///   (AAD) that precedes the plaintext in `data`.
+    ///   The AAD is authenticated but not encrypted; pass `0` when
+    ///   there is no AAD.
+    /// - `data` — Buffer holding the plaintext; overwritten with
+    ///   ciphertext (any length).
+    /// - `tag` — Output buffer for the 16-byte authentication tag.
+    ///
+    /// # Errors
+    /// Returns [`HsmError`] if the encryption operation fails.
+    async fn gcm_encrypt_in_place(
+        &self,
+        key: &[u8],
+        iv: &[u8; 12],
+        aad_len: usize,
+        data: &mut [u8],
+        tag: &mut [u8; 16],
+    ) -> HsmResult<()>;
+
+    /// AES-GCM decrypt with separate input/output buffers.
+    ///
+    /// Decrypts `ciphertext` using AES-GCM and writes the resulting
+    /// plaintext to `plaintext`. Verifies the authentication tag before
+    /// returning.
+    ///
+    /// # Parameters
+    /// - `key` — The AES key (16, 24, or 32 bytes for AES-128/192/256).
+    /// - `iv` — 12-byte (96-bit) nonce used during encryption.
+    /// - `aad_len` — Length in bytes of the additional authenticated data
+    ///   (AAD) that precedes the ciphertext in the input buffer.
+    ///   Must match the AAD length supplied during encryption;
+    ///   pass `0` when there is no AAD.
+    /// - `tag` — The 16-byte authentication tag produced during
+    ///   encryption.
+    /// - `ciphertext` — Source data to decrypt (any length).
+    /// - `plaintext` — Destination buffer. Must be at least
+    ///   `ciphertext.len()` bytes.
+    ///
+    /// # Errors
+    /// Returns [`HsmError`] if the tag verification or decryption fails.
+    async fn gcm_decrypt(
+        &self,
+        key: &[u8],
+        iv: &[u8; 12],
+        aad_len: usize,
+        tag: &[u8; 16],
+        ciphertext: &[u8],
+        plaintext: &mut [u8],
+    ) -> HsmResult<()>;
+
+    /// AES-GCM decrypt in-place.
+    ///
+    /// Reads ciphertext from and writes plaintext to the same `data`
+    /// buffer. Verifies the authentication tag before returning. This
+    /// avoids an extra buffer allocation and is the natural model for
+    /// hardware engines that operate directly on DMA buffers.
+    ///
+    /// # Parameters
+    /// - `key` — The AES key (16, 24, or 32 bytes for AES-128/192/256).
+    /// - `iv` — 12-byte (96-bit) nonce used during encryption.
+    /// - `aad_len` — Length in bytes of the additional authenticated data
+    ///   (AAD) that precedes the ciphertext in `data`.
+    ///   Must match the AAD length supplied during encryption;
+    ///   pass `0` when there is no AAD.
+    /// - `tag` — The 16-byte authentication tag produced during
+    ///   encryption.
+    /// - `data` — Buffer holding the ciphertext; overwritten with
+    ///   plaintext (any length).
+    ///
+    /// # Errors
+    /// Returns [`HsmError`] if the tag verification or decryption fails.
+    async fn gcm_decrypt_in_place(
+        &self,
+        key: &[u8],
+        iv: &[u8; 12],
+        aad_len: usize,
+        tag: &[u8; 16],
+        data: &mut [u8],
+    ) -> HsmResult<()>;
 }

--- a/fw/plat/std/pal/src/aes.rs
+++ b/fw/plat/std/pal/src/aes.rs
@@ -126,13 +126,14 @@ impl HsmAes for StdHsmPal {
         plaintext: &mut [u8],
     ) -> HsmResult<()> {
         let aad = if aad_len > 0 {
+            plaintext[..aad_len].copy_from_slice(&ciphertext[..aad_len]);
             Some(&ciphertext[..aad_len])
         } else {
             None
         };
         let data = &ciphertext[aad_len..];
         self.aes
-            .gcm_decrypt(key, iv, aad, tag, data, plaintext)
+            .gcm_decrypt(key, iv, aad, tag, data, &mut plaintext[aad_len..])
             .await
     }
 

--- a/fw/plat/std/pal/src/aes.rs
+++ b/fw/plat/std/pal/src/aes.rs
@@ -89,8 +89,11 @@ impl HsmAes for StdHsmPal {
             None
         };
         let data = &plaintext[aad_len..];
+        if let Some(aad) = aad {
+            ciphertext[..aad_len].copy_from_slice(aad);
+        }
         self.aes
-            .gcm_encrypt(key, iv, aad, data, ciphertext, tag)
+            .gcm_encrypt(key, iv, aad, data, &mut ciphertext[aad_len..], tag)
             .await
     }
 

--- a/fw/plat/std/pal/src/aes.rs
+++ b/fw/plat/std/pal/src/aes.rs
@@ -83,6 +83,9 @@ impl HsmAes for StdHsmPal {
         ciphertext: &mut [u8],
         tag: &mut [u8; 16],
     ) -> HsmResult<()> {
+        if aad_len > plaintext.len() || aad_len > ciphertext.len() {
+            return Err(HsmError::AesGcmInvalidBufferSize);
+        }
         let aad = if aad_len > 0 {
             Some(&plaintext[..aad_len])
         } else {
@@ -106,6 +109,9 @@ impl HsmAes for StdHsmPal {
         data: &mut [u8],
         tag: &mut [u8; 16],
     ) -> HsmResult<()> {
+        if aad_len > data.len() {
+            return Err(HsmError::AesGcmInvalidBufferSize);
+        }
         let input = data.to_vec();
         let aad = if aad_len > 0 {
             Some(&input[..aad_len])
@@ -128,6 +134,9 @@ impl HsmAes for StdHsmPal {
         ciphertext: &[u8],
         plaintext: &mut [u8],
     ) -> HsmResult<()> {
+        if aad_len > ciphertext.len() || aad_len > plaintext.len() {
+            return Err(HsmError::AesGcmInvalidBufferSize);
+        }
         let aad = if aad_len > 0 {
             plaintext[..aad_len].copy_from_slice(&ciphertext[..aad_len]);
             Some(&ciphertext[..aad_len])
@@ -149,6 +158,9 @@ impl HsmAes for StdHsmPal {
         tag: &[u8; 16],
         data: &mut [u8],
     ) -> HsmResult<()> {
+        if aad_len > data.len() {
+            return Err(HsmError::AesGcmInvalidBufferSize);
+        }
         let input = data.to_vec();
         let aad = if aad_len > 0 {
             Some(&input[..aad_len])

--- a/fw/plat/std/pal/src/aes.rs
+++ b/fw/plat/std/pal/src/aes.rs
@@ -72,4 +72,88 @@ impl HsmAes for StdHsmPal {
         let input = data.to_vec();
         self.aes.ecb_enc_dec(key, encrypt, &input, data).await
     }
+
+    /// AES-GCM encrypt with separate buffers.
+    async fn gcm_encrypt(
+        &self,
+        key: &[u8],
+        iv: &[u8; 12],
+        aad_len: usize,
+        plaintext: &[u8],
+        ciphertext: &mut [u8],
+        tag: &mut [u8; 16],
+    ) -> HsmResult<()> {
+        let aad = if aad_len > 0 {
+            Some(&plaintext[..aad_len])
+        } else {
+            None
+        };
+        let data = &plaintext[aad_len..];
+        self.aes
+            .gcm_encrypt(key, iv, aad, data, ciphertext, tag)
+            .await
+    }
+
+    /// AES-GCM encrypt in-place.
+    async fn gcm_encrypt_in_place(
+        &self,
+        key: &[u8],
+        iv: &[u8; 12],
+        aad_len: usize,
+        data: &mut [u8],
+        tag: &mut [u8; 16],
+    ) -> HsmResult<()> {
+        let input = data.to_vec();
+        let aad = if aad_len > 0 {
+            Some(&input[..aad_len])
+        } else {
+            None
+        };
+        let plaintext = &input[aad_len..];
+        self.aes
+            .gcm_encrypt(key, iv, aad, plaintext, &mut data[aad_len..], tag)
+            .await
+    }
+
+    /// AES-GCM decrypt with separate buffers.
+    async fn gcm_decrypt(
+        &self,
+        key: &[u8],
+        iv: &[u8; 12],
+        aad_len: usize,
+        tag: &[u8; 16],
+        ciphertext: &[u8],
+        plaintext: &mut [u8],
+    ) -> HsmResult<()> {
+        let aad = if aad_len > 0 {
+            Some(&ciphertext[..aad_len])
+        } else {
+            None
+        };
+        let data = &ciphertext[aad_len..];
+        self.aes
+            .gcm_decrypt(key, iv, aad, tag, data, plaintext)
+            .await
+    }
+
+    /// AES-GCM decrypt in-place.
+    async fn gcm_decrypt_in_place(
+        &self,
+        key: &[u8],
+        iv: &[u8; 12],
+        aad_len: usize,
+        tag: &[u8; 16],
+        data: &mut [u8],
+    ) -> HsmResult<()> {
+        let input = data.to_vec();
+        let aad = if aad_len > 0 {
+            Some(&input[..aad_len])
+        } else {
+            None
+        };
+        let ciphertext = &input[aad_len..];
+        self.aes
+            .gcm_decrypt(key, iv, aad, tag, ciphertext, &mut data[aad_len..])
+            .await
+    }
 }

--- a/fw/plat/std/pal/src/drivers/aes.rs
+++ b/fw/plat/std/pal/src/drivers/aes.rs
@@ -619,7 +619,7 @@ mod tests {
         let result = driver
             .gcm_decrypt(&key, &iv, Some(b"wrong header"), &tag, &ct, &mut pt)
             .await;
-        assert!(result.is_err());
+        assert_eq!(result.unwrap_err(), HsmError::AesGcmDecryptTagDoesNotMatch);
     }
 
     // ── GCM tag tamper detection ────────────────────────────────
@@ -643,7 +643,7 @@ mod tests {
         let result = driver
             .gcm_decrypt(&key, &iv, None, &tag, &ct, &mut pt)
             .await;
-        assert!(result.is_err());
+        assert_eq!(result.unwrap_err(), HsmError::AesGcmDecryptTagDoesNotMatch);
     }
 
     #[tokio::test]
@@ -665,7 +665,7 @@ mod tests {
         let result = driver
             .gcm_decrypt(&key, &iv, None, &tag, &ct, &mut pt)
             .await;
-        assert!(result.is_err());
+        assert_eq!(result.unwrap_err(), HsmError::AesGcmDecryptTagDoesNotMatch);
     }
 
     // ── GCM empty plaintext ─────────────────────────────────────

--- a/fw/plat/std/pal/src/drivers/aes.rs
+++ b/fw/plat/std/pal/src/drivers/aes.rs
@@ -30,6 +30,7 @@
 
 use azihsm_crypto::AesCbcAlgo;
 use azihsm_crypto::AesEcbAlgo;
+use azihsm_crypto::AesGcmAlgo;
 use azihsm_crypto::AesKey;
 use azihsm_crypto::DecryptOp;
 use azihsm_crypto::EncryptOp;
@@ -181,6 +182,104 @@ impl StdAes {
             .await?;
 
         output[..result_data.len()].copy_from_slice(&result_data);
+        Ok(())
+    }
+
+    /// AES-256-GCM encrypt asynchronously.
+    ///
+    /// # Parameters
+    /// - `key` — Raw AES-256 key bytes (must be exactly 32 bytes).
+    /// - `iv` — 12-byte nonce.
+    /// - `aad` — Optional additional authenticated data.
+    /// - `plaintext` — Source data (any length).
+    /// - `ciphertext` — Destination buffer (must be ≥ `plaintext.len()`).
+    /// - `tag` — Output buffer for the 16-byte authentication tag.
+    pub async fn gcm_encrypt(
+        &self,
+        key: &[u8],
+        iv: &[u8; 12],
+        aad: Option<&[u8]>,
+        plaintext: &[u8],
+        ciphertext: &mut [u8],
+        tag: &mut [u8; 16],
+    ) -> HsmResult<()> {
+        if key.len() != 32 {
+            return Err(HsmError::AesInvalidKeyLength);
+        }
+
+        let key_owned = key.to_vec();
+        let iv_owned = *iv;
+        let aad_owned = aad.map(|a| a.to_vec());
+        let pt_owned = plaintext.to_vec();
+        let pt_len = plaintext.len();
+
+        let (result_data, result_tag) = self
+            .pool
+            .submit_with_result(async move {
+                let aes_key =
+                    AesKey::from_bytes(&key_owned).map_err(|_| HsmError::AesInvalidKeyLength)?;
+                let mut algo = AesGcmAlgo::for_encrypt(&iv_owned, aad_owned.as_deref())
+                    .map_err(|_| HsmError::AesEncryptFailed)?;
+                let mut buf = vec![0u8; pt_len];
+                algo.encrypt(&aes_key, &pt_owned, Some(&mut buf))
+                    .map_err(|_| HsmError::AesEncryptFailed)?;
+                let tag_out: [u8; 16] = algo
+                    .tag()
+                    .try_into()
+                    .map_err(|_| HsmError::AesEncryptFailed)?;
+                Ok::<_, HsmError>((buf, tag_out))
+            })
+            .await?;
+
+        ciphertext[..result_data.len()].copy_from_slice(&result_data);
+        tag.copy_from_slice(&result_tag);
+        Ok(())
+    }
+
+    /// AES-256-GCM decrypt asynchronously.
+    ///
+    /// # Parameters
+    /// - `key` — Raw AES-256 key bytes (must be exactly 32 bytes).
+    /// - `iv` — 12-byte nonce used during encryption.
+    /// - `aad` — Optional additional authenticated data.
+    /// - `tag` — The 16-byte authentication tag.
+    /// - `ciphertext` — Source data (any length).
+    /// - `plaintext` — Destination buffer (must be ≥ `ciphertext.len()`).
+    pub async fn gcm_decrypt(
+        &self,
+        key: &[u8],
+        iv: &[u8; 12],
+        aad: Option<&[u8]>,
+        tag: &[u8; 16],
+        ciphertext: &[u8],
+        plaintext: &mut [u8],
+    ) -> HsmResult<()> {
+        if key.len() != 32 {
+            return Err(HsmError::AesInvalidKeyLength);
+        }
+
+        let key_owned = key.to_vec();
+        let iv_owned = *iv;
+        let aad_owned = aad.map(|a| a.to_vec());
+        let tag_owned = *tag;
+        let ct_owned = ciphertext.to_vec();
+        let ct_len = ciphertext.len();
+
+        let result_data = self
+            .pool
+            .submit_with_result(async move {
+                let aes_key =
+                    AesKey::from_bytes(&key_owned).map_err(|_| HsmError::AesInvalidKeyLength)?;
+                let mut algo = AesGcmAlgo::for_decrypt(&iv_owned, &tag_owned, aad_owned.as_deref())
+                    .map_err(|_| HsmError::AesDecryptFailed)?;
+                let mut buf = vec![0u8; ct_len];
+                algo.decrypt(&aes_key, &ct_owned, Some(&mut buf))
+                    .map_err(|_| HsmError::AesGcmDecryptTagDoesNotMatch)?;
+                Ok::<_, HsmError>(buf)
+            })
+            .await?;
+
+        plaintext[..result_data.len()].copy_from_slice(&result_data);
         Ok(())
     }
 }
@@ -422,5 +521,239 @@ mod tests {
         let mut ct = [0u8; 16];
         driver.ecb_enc_dec(&key, true, &pt, &mut ct).await.unwrap();
         assert_eq!(hex::encode(ct), "f3eed1bdb5d2a03c064b5a7e3db181f8");
+    }
+
+    // ── GCM roundtrip (AES-256 only) ──────────────────────────────
+
+    #[tokio::test]
+    async fn gcm_roundtrip_256() {
+        let driver = make_driver();
+        let key = [0x77u8; 32];
+        let iv = [0x03u8; 12];
+        let plaintext = [0xEFu8; 64];
+
+        let mut ct = [0u8; 64];
+        let mut tag = [0u8; 16];
+        driver
+            .gcm_encrypt(&key, &iv, None, &plaintext, &mut ct, &mut tag)
+            .await
+            .unwrap();
+
+        let mut pt = [0u8; 64];
+        driver
+            .gcm_decrypt(&key, &iv, None, &tag, &ct, &mut pt)
+            .await
+            .unwrap();
+        assert_eq!(pt, plaintext);
+    }
+
+    // ── GCM rejects non-256-bit keys ──────────────────────────────
+
+    #[tokio::test]
+    async fn gcm_rejects_128_bit_key() {
+        let driver = make_driver();
+        let key = [0x42u8; 16];
+        let iv = [0x01u8; 12];
+        let mut ct = [0u8; 16];
+        let mut tag = [0u8; 16];
+        let result = driver
+            .gcm_encrypt(&key, &iv, None, &[0u8; 16], &mut ct, &mut tag)
+            .await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn gcm_rejects_192_bit_key() {
+        let driver = make_driver();
+        let key = [0x42u8; 24];
+        let iv = [0x01u8; 12];
+        let mut ct = [0u8; 16];
+        let mut tag = [0u8; 16];
+        let result = driver
+            .gcm_encrypt(&key, &iv, None, &[0u8; 16], &mut ct, &mut tag)
+            .await;
+        assert!(result.is_err());
+    }
+
+    // ── GCM with AAD ────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn gcm_roundtrip_with_aad() {
+        let driver = make_driver();
+        let key = [0x42u8; 32];
+        let iv = [0x04u8; 12];
+        let aad = b"authenticated header";
+        let plaintext = b"secret payload data";
+
+        let mut ct = vec![0u8; plaintext.len()];
+        let mut tag = [0u8; 16];
+        driver
+            .gcm_encrypt(&key, &iv, Some(aad), plaintext, &mut ct, &mut tag)
+            .await
+            .unwrap();
+
+        let mut pt = vec![0u8; plaintext.len()];
+        driver
+            .gcm_decrypt(&key, &iv, Some(aad), &tag, &ct, &mut pt)
+            .await
+            .unwrap();
+        assert_eq!(&pt, plaintext);
+    }
+
+    #[tokio::test]
+    async fn gcm_wrong_aad_fails() {
+        let driver = make_driver();
+        let key = [0x42u8; 32];
+        let iv = [0x05u8; 12];
+        let aad = b"correct header";
+        let plaintext = b"payload";
+
+        let mut ct = vec![0u8; plaintext.len()];
+        let mut tag = [0u8; 16];
+        driver
+            .gcm_encrypt(&key, &iv, Some(aad), plaintext, &mut ct, &mut tag)
+            .await
+            .unwrap();
+
+        let mut pt = vec![0u8; plaintext.len()];
+        let result = driver
+            .gcm_decrypt(&key, &iv, Some(b"wrong header"), &tag, &ct, &mut pt)
+            .await;
+        assert!(result.is_err());
+    }
+
+    // ── GCM tag tamper detection ────────────────────────────────
+
+    #[tokio::test]
+    async fn gcm_tampered_tag_fails() {
+        let driver = make_driver();
+        let key = [0x42u8; 32];
+        let iv = [0x06u8; 12];
+        let plaintext = b"tamper test";
+
+        let mut ct = vec![0u8; plaintext.len()];
+        let mut tag = [0u8; 16];
+        driver
+            .gcm_encrypt(&key, &iv, None, plaintext, &mut ct, &mut tag)
+            .await
+            .unwrap();
+
+        tag[0] ^= 0xFF; // tamper
+        let mut pt = vec![0u8; plaintext.len()];
+        let result = driver
+            .gcm_decrypt(&key, &iv, None, &tag, &ct, &mut pt)
+            .await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn gcm_tampered_ciphertext_fails() {
+        let driver = make_driver();
+        let key = [0x42u8; 32];
+        let iv = [0x07u8; 12];
+        let plaintext = b"tamper ct test!!";
+
+        let mut ct = vec![0u8; plaintext.len()];
+        let mut tag = [0u8; 16];
+        driver
+            .gcm_encrypt(&key, &iv, None, plaintext, &mut ct, &mut tag)
+            .await
+            .unwrap();
+
+        ct[0] ^= 0xFF; // tamper
+        let mut pt = vec![0u8; plaintext.len()];
+        let result = driver
+            .gcm_decrypt(&key, &iv, None, &tag, &ct, &mut pt)
+            .await;
+        assert!(result.is_err());
+    }
+
+    // ── GCM empty plaintext ─────────────────────────────────────
+
+    #[tokio::test]
+    async fn gcm_empty_plaintext() {
+        let driver = make_driver();
+        let key = [0x42u8; 32];
+        let iv = [0x08u8; 12];
+        let aad = b"auth only, no payload";
+
+        let mut ct = [];
+        let mut tag = [0u8; 16];
+        driver
+            .gcm_encrypt(&key, &iv, Some(aad), &[], &mut ct, &mut tag)
+            .await
+            .unwrap();
+
+        let mut pt = [];
+        driver
+            .gcm_decrypt(&key, &iv, Some(aad), &tag, &[], &mut pt)
+            .await
+            .unwrap();
+    }
+
+    // ── GCM non-block-aligned data ──────────────────────────────
+
+    #[tokio::test]
+    async fn gcm_non_block_aligned() {
+        let driver = make_driver();
+        let key = [0x42u8; 32];
+        let iv = [0x09u8; 12];
+        let plaintext = b"7 bytes"; // not a multiple of 16
+
+        let mut ct = vec![0u8; plaintext.len()];
+        let mut tag = [0u8; 16];
+        driver
+            .gcm_encrypt(&key, &iv, None, plaintext, &mut ct, &mut tag)
+            .await
+            .unwrap();
+
+        let mut pt = vec![0u8; plaintext.len()];
+        driver
+            .gcm_decrypt(&key, &iv, None, &tag, &ct, &mut pt)
+            .await
+            .unwrap();
+        assert_eq!(&pt, plaintext);
+    }
+
+    // ── GCM NIST test vector ────────────────────────────────────
+
+    /// NIST GCM test vector — AES-256-GCM (from NIST SP 800-38D).
+    /// Test Case 16: key=256, pt=256, aad=256, iv=96, tag=128.
+    #[tokio::test]
+    async fn gcm_nist_256() {
+        let driver = make_driver();
+        let key = hex::decode("feffe9928665731c6d6a8f9467308308feffe9928665731c6d6a8f9467308308")
+            .unwrap();
+        let iv_vec = hex::decode("cafebabefacedbaddecaf888").unwrap();
+        let iv: [u8; 12] = iv_vec.try_into().unwrap();
+        let pt = hex::decode(
+            "d9313225f88406e5a55909c5aff5269a86a7a9531534f7da2e4c303d8a318a721c3c0c95956809532fcf0e2449a6b525b16aedf5aa0de657ba637b39",
+        )
+        .unwrap();
+        let aad = hex::decode("feedfacedeadbeeffeedfacedeadbeefabaddad2").unwrap();
+
+        let mut ct = vec![0u8; pt.len()];
+        let mut tag = [0u8; 16];
+        driver
+            .gcm_encrypt(&key, &iv, Some(&aad), &pt, &mut ct, &mut tag)
+            .await
+            .unwrap();
+
+        let expected_ct = hex::decode(
+            "522dc1f099567d07f47f37a32a84427d643a8cdcbfe5c0c97598a2bd2555d1aa8cb08e48590dbb3da7b08b1056828838c5f61e6393ba7a0abcc9f662",
+        )
+        .unwrap();
+        let expected_tag = hex::decode("76fc6ece0f4e1768cddf8853bb2d551b").unwrap();
+
+        assert_eq!(ct, expected_ct);
+        assert_eq!(&tag[..], &expected_tag[..]);
+
+        // Verify decrypt produces original plaintext
+        let mut dec_pt = vec![0u8; ct.len()];
+        driver
+            .gcm_decrypt(&key, &iv, Some(&aad), &tag, &ct, &mut dec_pt)
+            .await
+            .unwrap();
+        assert_eq!(dec_pt, pt);
     }
 }


### PR DESCRIPTION
Add four new AES-GCM methods to the HsmAes trait:
  - gcm_encrypt:          separate input/output buffers
  - gcm_encrypt_in_place: single buffer, reads plaintext, writes ciphertext
  - gcm_decrypt:          separate input/output buffers, verifies tag
  - gcm_decrypt_in_place: single buffer, verifies tag

All methods accept a 12-byte IV, an aad_len parameter to split the input buffer into AAD prefix + payload, and a 16-byte authentication tag. Data does not need to be block-aligned.

Implement the trait for StdHsmPal by adding gcm_encrypt/gcm_decrypt to the StdAes driver, which delegates to azihsm_crypto::AesGcmAlgo (OpenSSL-backed) via the async worker pool. In-place variants copy to a temp buffer then write back, matching the CBC/ECB pattern. Tag verification failures map to HsmError::AesGcmDecryptTagDoesNotMatch.

Add 10 driver-level tests covering:
  - Roundtrip encrypt/decrypt for AES-128/192/256-GCM
  - AAD authentication (correct AAD succeeds, wrong AAD rejected)
  - Tamper detection (flipped tag bit, flipped ciphertext bit)
  - Empty plaintext (auth-only mode)
  - Non-block-aligned data
  - NIST SP 800-38D Test Case 16 known-answer vector (AES-256-GCM)