### PR TITLE
feat(fw/pal): expand PAL crypto traits and update StdPal

### DIFF
--- a/fw/core/lib/src/ddi/get_establish_cred_encryption_key.rs
+++ b/fw/core/lib/src/ddi/get_establish_cred_encryption_key.rs
@@ -60,7 +60,7 @@ pub(crate) async fn get_establish_cred_encryption_key<'a, P: HsmPal>(
     let id_priv_key = pal.vault_key(part_id, pal.part_id_key_id(part_id)?)?;
 
     let digest = &mut fmem[..HsmHashAlgo::Sha384.digest_len()];
-    pal.hash(HsmHashAlgo::Sha384, frame.pub_key.raw, digest)
+    pal.hash(HsmHashAlgo::Sha384, frame.pub_key.raw, digest, true)
         .await?;
     pal.ecc_sign(
         HsmEccCurve::P384,

--- a/fw/core/lib/src/ddi/sha_digest.rs
+++ b/fw/core/lib/src/ddi/sha_digest.rs
@@ -49,7 +49,7 @@ pub(crate) async fn sha_digest<'a, P: HsmPal>(
     let total = encoder.position();
 
     // Compute hash directly into the reserved slice — zero copy.
-    pal.hash(algo, body.msg, frame.digest).await?;
+    pal.hash(algo, body.msg, frame.digest, true).await?;
 
     Ok(&smem[..total])
 }

--- a/fw/pal/traits/src/crypto/aes.rs
+++ b/fw/pal/traits/src/crypto/aes.rs
@@ -32,6 +32,28 @@
 
 use super::*;
 
+// ── AES-XTS data unit length ──────────────────────────────────────
+
+/// XTS data unit length.
+///
+/// Controls how the hardware segments the input into data units and
+/// increments the tweak between them. The input length must be a
+/// multiple of the selected data unit length.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum XtsDataUnitLen {
+    /// Entire input is a single data unit.
+    Full,
+
+    /// 512-byte blocks.
+    Block512,
+
+    /// 4096-byte blocks.
+    Block4K,
+
+    /// 8192-byte blocks.
+    Block8K,
+}
+
 /// Asynchronous AES operations trait.
 ///
 /// PAL implementations provide this to the core for AES key generation
@@ -136,25 +158,45 @@ pub trait HsmAes {
 
     /// AES-GCM encrypt with separate input/output buffers.
     ///
-    /// Encrypts `plaintext` using AES-GCM and writes the resulting
-    /// ciphertext to `ciphertext` and the authentication tag to `tag`.
+    /// Encrypts the text portion of `plaintext` using AES-GCM and writes
+    /// the result to `ciphertext` and the authentication tag to `tag`.
     /// Data does not need to be 16-byte-aligned — the PAL handles
     /// alignment and tag correction internally.
     ///
+    /// # Buffer layout
+    ///
+    /// Both `plaintext` and `ciphertext` use the layout
+    /// `[padded_AAD | text]`, where `padded_AAD` is the AAD region
+    /// prepared according to the BCP hardware `pad_aad` convention:
+    ///
+    /// | `aad_len % 32` | Layout |
+    /// |----------------|--------|
+    /// | `== 0` | `[AAD]` — no padding |
+    /// | `1..=16` | `[zeros(16) \| AAD \| zeros(32 - 16 - rem)]` — prepend 16 zero bytes, AAD left-justified after, trail-pad to next 32 |
+    /// | `17..=31` | `[AAD \| zeros(32 - rem)]` — AAD left-justified, trail-pad to next 32 |
+    ///
+    /// The total padded AAD region is always `round_up_32(aad_len)` bytes.
+    /// When `aad_len` is `0`, no AAD region is present and `data` contains
+    /// only the text.
+    ///
+    /// The prepend-zeros rule ensures the leading GHASH block is all zeros
+    /// (transparent to the GHASH accumulator), so the AAD content occupies
+    /// the same GHASH-block positions as standard GCM. This allows the
+    /// PAL to correct the hardware tag with a simple length-field fixup.
+    ///
     /// # Parameters
-    /// - `key` — The AES key (16, 24, or 32 bytes for AES-128/192/256).
+    ///
+    /// - `key` — AES key (16, 24, or 32 bytes for AES-128/192/256).
     /// - `iv` — 12-byte (96-bit) nonce. Must be unique per encryption
     ///   with the same key.
-    /// - `aad_len` — Length in bytes of the additional authenticated data
-    ///   (AAD) that precedes the plaintext in the input buffer.
-    ///   The AAD is authenticated but not encrypted; pass `0` when
-    ///   there is no AAD.
-    /// - `plaintext` — Source data to encrypt (any length).
-    /// - `ciphertext` — Destination buffer. Must be at least
-    ///   `plaintext.len()` bytes.
+    /// - `aad_len` — **Unpadded** AAD length in bytes. The padded AAD
+    ///   region in the buffer is `round_up_32(aad_len)` bytes.
+    /// - `plaintext` — `[padded_AAD | plaintext_bytes]`.
+    /// - `ciphertext` — Destination. Must be at least `plaintext.len()`.
     /// - `tag` — Output buffer for the 16-byte authentication tag.
     ///
     /// # Errors
+    ///
     /// Returns [`HsmError`] if the encryption operation fails.
     async fn gcm_encrypt(
         &self,
@@ -173,19 +215,26 @@ pub trait HsmAes {
     /// an extra buffer allocation and is the natural model for hardware
     /// engines that operate directly on DMA buffers.
     ///
+    /// # Buffer layout
+    ///
+    /// `data` uses the layout `[padded_AAD | text]`. See
+    /// [`gcm_encrypt`](Self::gcm_encrypt) for the full `pad_aad`
+    /// convention. The padded AAD region occupies the first
+    /// `round_up_32(aad_len)` bytes; the remaining bytes are plaintext
+    /// (overwritten with ciphertext on return).
+    ///
     /// # Parameters
-    /// - `key` — The AES key (16, 24, or 32 bytes for AES-128/192/256).
+    ///
+    /// - `key` — AES key (16, 24, or 32 bytes for AES-128/192/256).
     /// - `iv` — 12-byte (96-bit) nonce. Must be unique per encryption
     ///   with the same key.
-    /// - `aad_len` — Length in bytes of the additional authenticated data
-    ///   (AAD) that precedes the plaintext in `data`.
-    ///   The AAD is authenticated but not encrypted; pass `0` when
-    ///   there is no AAD.
-    /// - `data` — Buffer holding the plaintext; overwritten with
-    ///   ciphertext (any length).
+    /// - `aad_len` — **Unpadded** AAD length in bytes.
+    /// - `data` — `[padded_AAD | plaintext]`; the text portion is
+    ///   overwritten with ciphertext.
     /// - `tag` — Output buffer for the 16-byte authentication tag.
     ///
     /// # Errors
+    ///
     /// Returns [`HsmError`] if the encryption operation fails.
     async fn gcm_encrypt_in_place(
         &self,
@@ -198,24 +247,28 @@ pub trait HsmAes {
 
     /// AES-GCM decrypt with separate input/output buffers.
     ///
-    /// Decrypts `ciphertext` using AES-GCM and writes the resulting
-    /// plaintext to `plaintext`. Verifies the authentication tag before
+    /// Decrypts the text portion of `ciphertext` using AES-GCM and writes
+    /// the result to `plaintext`. Verifies the authentication tag before
     /// returning.
     ///
+    /// # Buffer layout
+    ///
+    /// Both `ciphertext` and `plaintext` use the layout
+    /// `[padded_AAD | text]`. See [`gcm_encrypt`](Self::gcm_encrypt) for
+    /// the full `pad_aad` convention.
+    ///
     /// # Parameters
-    /// - `key` — The AES key (16, 24, or 32 bytes for AES-128/192/256).
+    ///
+    /// - `key` — AES key (16, 24, or 32 bytes for AES-128/192/256).
     /// - `iv` — 12-byte (96-bit) nonce used during encryption.
-    /// - `aad_len` — Length in bytes of the additional authenticated data
-    ///   (AAD) that precedes the ciphertext in the input buffer.
-    ///   Must match the AAD length supplied during encryption;
-    ///   pass `0` when there is no AAD.
-    /// - `tag` — The 16-byte authentication tag produced during
-    ///   encryption.
-    /// - `ciphertext` — Source data to decrypt (any length).
-    /// - `plaintext` — Destination buffer. Must be at least
-    ///   `ciphertext.len()` bytes.
+    /// - `aad_len` — **Unpadded** AAD length in bytes. Must match the
+    ///   value supplied during encryption.
+    /// - `tag` — The 16-byte authentication tag from encryption.
+    /// - `ciphertext` — `[padded_AAD | ciphertext_bytes]`.
+    /// - `plaintext` — Destination. Must be at least `ciphertext.len()`.
     ///
     /// # Errors
+    ///
     /// Returns [`HsmError`] if the tag verification or decryption fails.
     async fn gcm_decrypt(
         &self,
@@ -234,19 +287,26 @@ pub trait HsmAes {
     /// avoids an extra buffer allocation and is the natural model for
     /// hardware engines that operate directly on DMA buffers.
     ///
+    /// # Buffer layout
+    ///
+    /// `data` uses the layout `[padded_AAD | text]`. See
+    /// [`gcm_encrypt`](Self::gcm_encrypt) for the full `pad_aad`
+    /// convention. The padded AAD region occupies the first
+    /// `round_up_32(aad_len)` bytes; the remaining bytes are ciphertext
+    /// (overwritten with plaintext on return).
+    ///
     /// # Parameters
-    /// - `key` — The AES key (16, 24, or 32 bytes for AES-128/192/256).
+    ///
+    /// - `key` — AES key (16, 24, or 32 bytes for AES-128/192/256).
     /// - `iv` — 12-byte (96-bit) nonce used during encryption.
-    /// - `aad_len` — Length in bytes of the additional authenticated data
-    ///   (AAD) that precedes the ciphertext in `data`.
-    ///   Must match the AAD length supplied during encryption;
-    ///   pass `0` when there is no AAD.
-    /// - `tag` — The 16-byte authentication tag produced during
-    ///   encryption.
-    /// - `data` — Buffer holding the ciphertext; overwritten with
-    ///   plaintext (any length).
+    /// - `aad_len` — **Unpadded** AAD length in bytes. Must match the
+    ///   value supplied during encryption.
+    /// - `tag` — The 16-byte authentication tag from encryption.
+    /// - `data` — `[padded_AAD | ciphertext]`; the text portion is
+    ///   overwritten with plaintext.
     ///
     /// # Errors
+    ///
     /// Returns [`HsmError`] if the tag verification or decryption fails.
     async fn gcm_decrypt_in_place(
         &self,
@@ -254,6 +314,166 @@ pub trait HsmAes {
         iv: &[u8; 12],
         aad_len: usize,
         tag: &[u8; 16],
+        data: &mut [u8],
+    ) -> HsmResult<()>;
+
+    // ── AES Key Wrap (RFC 3394) ────────────────────────────────────
+
+    /// AES Key Wrap (RFC 3394) — wrap key data.
+    ///
+    /// Wraps `input` using the KEK `key`. The output includes an 8-byte
+    /// integrity check value (IV) prepended to the wrapped semiblocks.
+    ///
+    /// # Parameters
+    ///
+    /// - `key` — Key Encryption Key (16, 24, or 32 bytes).
+    /// - `input` — Key data to wrap. Must be ≥ 16 bytes, a multiple of 8,
+    ///   and at most 3072 bytes.
+    /// - `output` — Destination buffer. Must be at least `input.len() + 8`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`HsmError::InvalidArg`] if input constraints are violated.
+    async fn aes_kw_wrap(&self, key: &[u8], input: &[u8], output: &mut [u8]) -> HsmResult<()>;
+
+    /// AES Key Wrap (RFC 3394) — unwrap key data.
+    ///
+    /// Unwraps `input` using the KEK `key` and verifies the integrity
+    /// check value. Returns an error if the IV does not match the
+    /// default 0xA6A6A6A6A6A6A6A6 (wrong key or tampered data).
+    ///
+    /// # Parameters
+    ///
+    /// - `key` — Key Encryption Key (16, 24, or 32 bytes).
+    /// - `input` — Wrapped key data. Must be ≥ 24 bytes, a multiple of 8,
+    ///   and at most 3080 bytes.
+    /// - `output` — Destination buffer. Must be at least `input.len() - 8`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`HsmError::InvalidArg`] on bad input sizes.
+    /// Returns [`HsmError::AesUnwrapFailed`] on IV mismatch.
+    async fn aes_kw_unwrap(&self, key: &[u8], input: &[u8], output: &mut [u8]) -> HsmResult<()>;
+
+    // ── AES Key Wrap with Padding (RFC 5649) ───────────────────────
+
+    /// AES Key Wrap with Padding (RFC 5649) — wrap key data.
+    ///
+    /// Wraps `input` of any length (≥ 1 byte, ≤ 3072 bytes) using the
+    /// KEK `key`. Pads to an 8-byte boundary and uses an Alternative
+    /// Initial Value (AIV) that encodes the plaintext length.
+    ///
+    /// For padded input ≤ 8 bytes (1 semiblock), a single AES-ECB
+    /// encryption is used. Otherwise, delegates to AES-KW with the AIV.
+    ///
+    /// # Parameters
+    ///
+    /// - `key` — Key Encryption Key (16, 24, or 32 bytes).
+    /// - `input` — Key data to wrap (1..=3072 bytes, any alignment).
+    /// - `output` — Destination buffer. Must be at least
+    ///   `round_up_8(input.len()) + 8` bytes.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`HsmError::InvalidArg`] if input constraints are violated.
+    async fn aes_kwp_wrap(&self, key: &[u8], input: &[u8], output: &mut [u8]) -> HsmResult<()>;
+
+    /// AES Key Wrap with Padding (RFC 5649) — unwrap key data.
+    ///
+    /// Unwraps `input` and verifies the AIV (constant prefix + MLI).
+    /// Validates that padding bytes are all zero.
+    ///
+    /// # Parameters
+    ///
+    /// - `key` — Key Encryption Key (16, 24, or 32 bytes).
+    /// - `input` — Wrapped key data. Must be ≥ 16 bytes, a multiple of 8,
+    ///   and at most 3080 bytes.
+    /// - `output` — Destination buffer. Must be at least `input.len() - 8`.
+    ///
+    /// # Returns
+    ///
+    /// The actual plaintext length (MLI), which may be shorter than
+    /// `output.len()`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`HsmError::InvalidArg`] on bad input sizes.
+    /// Returns [`HsmError::AesUnwrapFailed`] on AIV mismatch or bad padding.
+    async fn aes_kwp_unwrap(&self, key: &[u8], input: &[u8], output: &mut [u8])
+    -> HsmResult<usize>;
+
+    // ── AES-XTS (IEEE 1619 / NIST SP 800-38E) ─────────────────────
+
+    /// Generate a random AES-256-XTS key pair (K1 || K2).
+    ///
+    /// Fills `key` with 64 random bytes and verifies K1 ≠ K2.
+    ///
+    /// # Parameters
+    /// - `key` — Output buffer. Must be exactly 64 bytes.
+    ///
+    /// # Errors
+    /// Returns [`HsmError::InvalidArg`] if `key.len() != 64`.
+    async fn aes_xts_gen_key(&self, key: &mut [u8]) -> HsmResult<()>;
+
+    /// AES-XTS encrypt with separate input/output buffers.
+    ///
+    /// # Parameters
+    /// - `key` — XTS key (64 bytes: K1\[32\] || K2\[32\]).
+    /// - `tweak` — 8-byte tweak (sector number, little-endian).
+    /// - `dul` — Data unit length mode.
+    /// - `input` — Plaintext. Must be ≥ 16 bytes, a multiple of 16,
+    ///   and a multiple of `dul` (when not [`XtsDataUnitLen::Full`]).
+    /// - `output` — Ciphertext buffer. Must be at least `input.len()`.
+    ///
+    /// # Errors
+    /// Returns [`HsmError::InvalidArg`] on invalid key/tweak/input sizes.
+    async fn aes_xts_encrypt(
+        &self,
+        key: &[u8],
+        tweak: &[u8],
+        dul: XtsDataUnitLen,
+        input: &[u8],
+        output: &mut [u8],
+    ) -> HsmResult<()>;
+
+    /// AES-XTS decrypt with separate input/output buffers.
+    ///
+    /// Same parameters and constraints as
+    /// [`aes_xts_encrypt`](Self::aes_xts_encrypt).
+    async fn aes_xts_decrypt(
+        &self,
+        key: &[u8],
+        tweak: &[u8],
+        dul: XtsDataUnitLen,
+        input: &[u8],
+        output: &mut [u8],
+    ) -> HsmResult<()>;
+
+    /// AES-XTS encrypt in-place.
+    ///
+    /// # Parameters
+    /// - `key` — XTS key (64 bytes: K1\[32\] || K2\[32\]).
+    /// - `tweak` — 8-byte tweak (sector number, little-endian).
+    /// - `dul` — Data unit length mode.
+    /// - `data` — Buffer holding plaintext; overwritten with ciphertext.
+    ///   Must be ≥ 16 bytes, a multiple of 16, and a multiple of `dul`.
+    async fn aes_xts_encrypt_in_place(
+        &self,
+        key: &[u8],
+        tweak: &[u8],
+        dul: XtsDataUnitLen,
+        data: &mut [u8],
+    ) -> HsmResult<()>;
+
+    /// AES-XTS decrypt in-place.
+    ///
+    /// Same parameters and constraints as
+    /// [`aes_xts_encrypt_in_place`](Self::aes_xts_encrypt_in_place).
+    async fn aes_xts_decrypt_in_place(
+        &self,
+        key: &[u8],
+        tweak: &[u8],
+        dul: XtsDataUnitLen,
         data: &mut [u8],
     ) -> HsmResult<()>;
 }

--- a/fw/pal/traits/src/crypto/hash.rs
+++ b/fw/pal/traits/src/crypto/hash.rs
@@ -3,16 +3,16 @@
 
 //! Cryptographic hash (digest) trait for the HSM PAL.
 //!
-//! Defines [`HashAlgo`] and the [`HsmHash`] trait that PAL implementations
-//! use to expose hardware-accelerated or software-backed hash computation.
+//! Defines [`HsmHashAlgo`], [`HsmHashState`], and the [`HsmHash`] trait that PAL
+//! implementations use to expose hardware-accelerated or software-backed hash
+//! computation.
 //!
 //! On Cortex-M7 hardware this would typically delegate to a SHA engine
 //! peripheral. On the standard (host-native) PAL it would use OpenSSL.
 //!
-//! **Status**: The trait is defined but not yet included in the [`HsmCrypto`]
-//! supertrait bound — no PAL implements it yet. It will be wired in when
-//! DDI commands that require hashing (e.g., `EccSign`, `HkdfDerive`) are
-//! implemented in `fw/core`.
+//! **Status**: This trait is part of [`HsmCrypto`] and is implemented by PALs
+//! that provide SHA digest support. Higher-level DDI commands can build on it
+//! for operations such as signing and key derivation.
 
 use super::*;
 
@@ -38,7 +38,7 @@ pub enum HsmHashAlgo {
 
 impl HsmHashAlgo {
     /// Returns the output digest length in bytes for the given algorithm.
-    pub fn digest_len(&self) -> usize {
+    pub const fn digest_len(&self) -> usize {
         match self {
             HsmHashAlgo::Sha1 => 20,
             HsmHashAlgo::Sha256 => 32,
@@ -46,26 +46,144 @@ impl HsmHashAlgo {
             HsmHashAlgo::Sha512 => 64,
         }
     }
+
+    /// Block size in bytes for the algorithm.
+    pub const fn block_len(&self) -> usize {
+        match self {
+            HsmHashAlgo::Sha1 | HsmHashAlgo::Sha256 => 64,
+            HsmHashAlgo::Sha384 | HsmHashAlgo::Sha512 => 128,
+        }
+    }
+
+    /// Working-variable state size in bytes (intermediate hash state).
+    pub const fn state_len(&self) -> usize {
+        match self {
+            HsmHashAlgo::Sha1 => 20,
+            HsmHashAlgo::Sha256 => 32,
+            HsmHashAlgo::Sha384 | HsmHashAlgo::Sha512 => 64,
+        }
+    }
+
+    /// Minimum buffer size for [`HsmHashState`]: state + block.
+    pub const fn hash_state_len(&self) -> usize {
+        self.state_len() + self.block_len()
+    }
+
+    /// Buffer size for `HsmHashState` in HMAC multi-step:
+    /// state + block (pending) + block (opad key).
+    pub const fn hmac_state_len(&self) -> usize {
+        self.state_len() + self.block_len() * 2
+    }
+
+    /// Minimum state buffer size for [`HsmKdf::mgf1`]:
+    /// `digest_len + seed_len + 4` (hash output + `seed || counter`).
+    pub const fn mgf1_state_len(&self, seed_len: usize) -> usize {
+        self.digest_len() + seed_len + 4
+    }
+
+    /// Minimum state buffer size for [`HsmKdf::x963_kdf`] and
+    /// [`HsmKdf::sp800_56a_kdf`]:
+    /// `digest_len + z_len + 4 + info_len`
+    /// (hash output + `Z || counter || info` in the largest ordering).
+    pub const fn concat_kdf_state_len(&self, z_len: usize, info_len: usize) -> usize {
+        self.digest_len() + z_len + 4 + info_len
+    }
+}
+
+/// Caller-owned hash state buffer tagged with its algorithm.
+///
+/// The buffer layout is `[state | block]`, where the first
+/// [`HsmHashAlgo::state_len`] bytes hold the SHA working variables and the next
+/// [`HsmHashAlgo::block_len`] bytes hold a partial block buffer.
+#[derive(Debug)]
+pub struct HsmHashState<'a> {
+    buf: &'a mut [u8],
+    algo: HsmHashAlgo,
+}
+
+impl<'a> HsmHashState<'a> {
+    /// Creates a new hash state wrapper.
+    pub fn new(algo: HsmHashAlgo, buf: &'a mut [u8]) -> Self {
+        debug_assert!(buf.len() >= algo.hash_state_len());
+        Self { buf, algo }
+    }
+
+    /// Returns the final digest bytes.
+    pub fn digest(&self) -> &[u8] {
+        &self.buf[..self.algo.digest_len()]
+    }
+
+    /// Returns the working-variable state portion of the buffer.
+    pub fn state(&self) -> &[u8] {
+        &self.buf[..self.algo.state_len()]
+    }
+
+    /// Returns the wrapped algorithm.
+    pub fn algo(&self) -> HsmHashAlgo {
+        self.algo
+    }
+
+    /// Returns the underlying buffer length.
+    pub fn len(&self) -> usize {
+        self.buf.len()
+    }
+
+    /// Returns whether the underlying buffer is empty.
+    pub fn is_empty(&self) -> bool {
+        self.buf.is_empty()
+    }
+
+    /// Consumes the wrapper and returns the underlying mutable buffer.
+    pub fn into_buf(self) -> &'a mut [u8] {
+        self.buf
+    }
 }
 
 /// Asynchronous hash computation trait.
-///
-/// PAL implementations provide this to the core for computing message
-/// digests. The async signature allows hardware-backed implementations
-/// to yield while a SHA engine processes data.
 pub trait HsmHash {
-    /// Compute a cryptographic hash of `data` using `algo`.
+    /// Platform-specific multi-step hash context.
+    type HashCtx<'a>
+    where
+        Self: 'a;
+
+    /// Compute a one-shot hash.
     ///
     /// # Parameters
+    /// - `algo` — Hash algorithm.
+    /// - `data` — Input message.
+    /// - `digest` — Output buffer (≥ `algo.digest_len()` bytes).
+    /// - `big_endian` — If true, big-endian (NIST standard). If false, little-endian.
+    async fn hash(
+        &self,
+        algo: HsmHashAlgo,
+        data: &[u8],
+        digest: &mut [u8],
+        big_endian: bool,
+    ) -> HsmResult<()>;
+
+    /// Begin a multi-step hash.
     ///
-    /// - `algo` — The hash algorithm to use.
-    /// - `data` — Input message bytes to hash.
-    /// - `digest` — Output buffer for the resulting digest. Must be at
-    ///   least [`HsmHashAlgo::digest_len`] bytes for the selected algorithm.
+    /// # Parameters
+    /// - `algo` — Hash algorithm.
+    /// - `state` — Working state buffer (≥ `algo.hash_state_len()` bytes).
+    async fn hash_begin<'a>(
+        &self,
+        algo: HsmHashAlgo,
+        state: HsmHashState<'a>,
+    ) -> HsmResult<Self::HashCtx<'a>>
+    where
+        Self: 'a;
+
+    /// Feed arbitrary-length data into a multi-step hash.
     ///
-    /// # Errors
-    ///
-    /// Returns [`HsmError`] if the hash computation fails (e.g., hardware
-    /// engine error).
-    async fn hash(&self, algo: HsmHashAlgo, data: &[u8], digest: &mut [u8]) -> HsmResult<()>;
+    /// Data is buffered internally. Full blocks are submitted to
+    /// hardware as they accumulate.
+    async fn hash_continue(&self, ctx: &mut Self::HashCtx<'_>, data: &[u8]) -> HsmResult<()>;
+
+    /// Finalize the hash and return the state buffer containing the digest.
+    async fn hash_finish<'a>(
+        &self,
+        ctx: Self::HashCtx<'a>,
+        big_endian: bool,
+    ) -> HsmResult<HsmHashState<'a>>;
 }

--- a/fw/pal/traits/src/crypto/hmac.rs
+++ b/fw/pal/traits/src/crypto/hmac.rs
@@ -6,9 +6,9 @@
 //! Defines the [`HsmHmac`] trait that PAL implementations use to expose
 //! HMAC key generation, signing (MAC computation), and verification.
 //!
-//! On Cortex-M7 hardware this would delegate to a dedicated HMAC engine
-//! or use the SHA engine in HMAC mode. On the standard (host-native) PAL
-//! it uses OpenSSL's HMAC implementation.
+//! On Cortex-M7 hardware this delegates to the SHA engine with software
+//! HMAC key scheduling (RFC 2104 ipad/opad). On the standard
+//! (host-native) PAL it uses OpenSSL's HMAC implementation.
 //!
 //! ## Key representation
 //!
@@ -21,6 +21,17 @@
 //! All methods take mandatory `&mut [u8]` output buffers. The caller is
 //! responsible for providing buffers of the correct size (the MAC tag
 //! length matches [`HsmHashAlgo::digest_len`] for the underlying hash).
+//!
+//! ## Multi-step API
+//!
+//! For messages that arrive in pieces, callers use
+//! [`hmac_begin`](HsmHmac::hmac_begin) /
+//! [`hmac_continue`](HsmHmac::hmac_continue) /
+//! [`hmac_finish`](HsmHmac::hmac_finish) (or
+//! [`hmac_finish_verify`](HsmHmac::hmac_finish_verify)). The caller
+//! provides an [`HsmHashState`] buffer of at least
+//! [`HsmHashAlgo::hmac_state_len`] bytes which the PAL uses to persist
+//! intermediate state between calls.
 
 use super::*;
 
@@ -30,46 +41,172 @@ use super::*;
 /// MAC computation, and MAC verification. The async signatures allow
 /// hardware-backed implementations to yield while the HMAC engine
 /// processes data.
+///
+/// Both one-shot ([`hmac_sign`](Self::hmac_sign),
+/// [`hmac_verify`](Self::hmac_verify)) and multi-step
+/// ([`hmac_begin`](Self::hmac_begin) / [`hmac_continue`](Self::hmac_continue)
+/// / [`hmac_finish`](Self::hmac_finish)) forms are provided.
 pub trait HsmHmac {
+    /// Platform-specific multi-step HMAC context.
+    ///
+    /// Created by [`hmac_begin`](Self::hmac_begin) and consumed by
+    /// [`hmac_finish`](Self::hmac_finish) or
+    /// [`hmac_finish_verify`](Self::hmac_finish_verify). Holds the
+    /// intermediate SHA state, pending partial block, and the outer key
+    /// (opad) needed for finalization.
+    type HmacCtx<'a>
+    where
+        Self: 'a;
+
     /// Generate a random HMAC key.
     ///
     /// # Parameters
-    /// - `key` — Output buffer filled with random key material. The
+    ///
+    /// - `algo` — hash algorithm that determines the recommended key
+    ///   size, though the actual key length is controlled by `key.len()`.
+    /// - `key` — output buffer filled with random key material. The
     ///   buffer length determines the key size (e.g., 32 bytes for
     ///   HMAC-SHA256, 48 for HMAC-SHA384, 64 for HMAC-SHA512).
     ///
     /// # Errors
-    /// - [`HsmError`] if RNG fails or the PCT verification fails.
-    async fn hmac_gen_key(&self, key: &mut [u8]) -> HsmResult<()>;
+    ///
+    /// Returns [`HsmError`] if RNG fails or the PCT verification fails.
+    async fn hmac_gen_key(&self, algo: HsmHashAlgo, key: &mut [u8]) -> HsmResult<()>;
 
-    /// Compute an HMAC tag (sign).
+    /// Compute an HMAC tag (sign) in a single call.
     ///
     /// # Parameters
-    /// - `key` — The HMAC key to use.
-    /// - `data` — Input message to authenticate.
-    /// - `sig` — Output buffer for the MAC tag. Must be at least
-    ///   [`HsmHashAlgo::digest_len`] bytes for the key's underlying
-    ///   hash algorithm.
+    ///
+    /// - `algo` — hash algorithm (e.g. SHA-256, SHA-512).
+    /// - `key` — the HMAC key to use.
+    /// - `data` — input message to authenticate.
+    /// - `tag` — output buffer for the MAC tag. Must be at least
+    ///   [`HsmHashAlgo::digest_len`] bytes for the chosen algorithm.
+    /// - `state` — caller-owned buffer of at least
+    ///   [`HsmHashAlgo::hmac_state_len`] bytes for intermediate state.
     ///
     /// # Errors
-    /// - [`HsmError`] if the HMAC computation fails.
-    async fn hmac_sign(&self, key: &[u8], data: &[u8], sig: &mut [u8]) -> HsmResult<()>;
-
-    /// Verify an HMAC tag.
     ///
-    /// Computes the MAC over `data` using `key` and compares it to
-    /// `sig` in constant time.
+    /// Returns [`HsmError`] if the HMAC computation fails or `tag` is
+    /// too short.
+    async fn hmac_sign<'a>(
+        &self,
+        algo: HsmHashAlgo,
+        key: &[u8],
+        data: &[u8],
+        tag: &mut [u8],
+        state: HsmHashState<'a>,
+    ) -> HsmResult<()>
+    where
+        Self: 'a;
+
+    /// Verify an HMAC tag in a single call.
     ///
     /// # Parameters
-    /// - `key` — The HMAC key to use.
-    /// - `data` — The message that was authenticated.
-    /// - `sig` — The MAC tag to verify against.
+    ///
+    /// - `algo` — hash algorithm (e.g. SHA-256, SHA-512).
+    /// - `key` — the HMAC key to use.
+    /// - `data` — the message that was authenticated.
+    /// - `tag` — the MAC tag to verify against.
+    /// - `state` — caller-owned buffer of at least
+    ///   [`HsmHashAlgo::hmac_state_len`] bytes for intermediate state.
     ///
     /// # Returns
+    ///
     /// `true` if the tag is valid, `false` if it does not match.
     ///
     /// # Errors
-    /// - [`HsmError`] if the HMAC computation itself fails (distinct
-    ///   from a tag mismatch, which returns `Ok(false)`).
-    async fn hmac_verify(&self, key: &[u8], data: &[u8], sig: &[u8]) -> HsmResult<bool>;
+    ///
+    /// Returns [`HsmError`] if the HMAC computation itself fails (distinct
+    /// from a tag mismatch, which returns `Ok(false)`).
+    async fn hmac_verify<'a>(
+        &self,
+        algo: HsmHashAlgo,
+        key: &[u8],
+        data: &[u8],
+        tag: &[u8],
+        state: HsmHashState<'a>,
+    ) -> HsmResult<bool>
+    where
+        Self: 'a;
+
+    /// Begin a multi-step HMAC computation.
+    ///
+    /// Derives the inner (ipad) and outer (opad) keys from `key` per
+    /// RFC 2104 and submits the ipad block as the first SHA input.
+    ///
+    /// # Parameters
+    ///
+    /// - `algo` — hash algorithm.
+    /// - `key` — the HMAC key. Keys longer than `algo.block_len()` are
+    ///   first hashed to `algo.digest_len()` bytes.
+    /// - `state` — caller-owned buffer that must wrap at least
+    ///   [`HsmHashAlgo::hmac_state_len`] bytes. Layout:
+    ///   `[digest(state_len) | pending_block(block_len) | opad(block_len)]`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`HsmError`] if `state` is too small.
+    async fn hmac_begin<'a>(
+        &self,
+        algo: HsmHashAlgo,
+        key: &[u8],
+        state: HsmHashState<'a>,
+    ) -> HsmResult<Self::HmacCtx<'a>>
+    where
+        Self: 'a;
+
+    /// Feed arbitrary-length data into the running HMAC computation.
+    ///
+    /// May be called zero or more times between [`hmac_begin`](Self::hmac_begin)
+    /// and [`hmac_finish`](Self::hmac_finish). Internally buffers a partial
+    /// block and submits full blocks to the SHA engine.
+    ///
+    /// # Parameters
+    ///
+    /// - `ctx` — the HMAC context returned by [`hmac_begin`](Self::hmac_begin).
+    /// - `data` — message bytes to append.
+    async fn hmac_continue(&self, ctx: &mut Self::HmacCtx<'_>, data: &[u8]) -> HsmResult<()>;
+
+    /// Finalize the inner hash and compute the outer hash to produce the
+    /// HMAC tag. Consumes the context.
+    ///
+    /// # Returns
+    ///
+    /// An [`HsmHashState`] whose [`digest()`](HsmHashState::digest) slice
+    /// contains the final MAC tag.
+    async fn hmac_finish<'a>(&self, ctx: Self::HmacCtx<'a>) -> HsmResult<HsmHashState<'a>>;
+
+    /// Finalize the HMAC and write the tag directly to `dest`.
+    ///
+    /// Like [`hmac_finish`](Self::hmac_finish), but the SHA hardware DMA
+    /// writes the outer hash digest straight into `dest` instead of the
+    /// context's state buffer. This avoids a `copy_from_slice` when the
+    /// caller needs the tag in a separate output buffer (e.g. KDF
+    /// iterations).
+    ///
+    /// # Parameters
+    ///
+    /// - `ctx` — the HMAC context to finalize (consumed).
+    /// - `dest` — output buffer of at least
+    ///   [`HsmHashAlgo::digest_len`] bytes.
+    async fn hmac_finish_into(&self, ctx: Self::HmacCtx<'_>, dest: &mut [u8]) -> HsmResult<()>;
+
+    /// Finalize and verify the MAC tag against `tag` using hardware
+    /// constant-time comparison. Consumes the context.
+    ///
+    /// # Parameters
+    ///
+    /// - `ctx` — the HMAC context to finalize.
+    /// - `tag` — the expected MAC tag to compare against.
+    ///
+    /// # Returns
+    ///
+    /// `true` if the computed tag matches, `false` otherwise.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`HsmError`] if the HMAC computation itself fails (distinct
+    /// from a tag mismatch, which returns `Ok(false)`).
+    async fn hmac_finish_verify(&self, ctx: Self::HmacCtx<'_>, tag: &[u8]) -> HsmResult<bool>;
 }

--- a/fw/pal/traits/src/crypto/kdf.rs
+++ b/fw/pal/traits/src/crypto/kdf.rs
@@ -1,15 +1,15 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-//! Key Derivation Function (KDF) traits for the HSM PAL.
+//! Key Derivation Function (KDF) and Mask Generation traits for the HSM PAL.
 //!
-//! Defines [`HkdfMode`] and the [`HsmKdf`] trait that PAL implementations
-//! use to expose HKDF (RFC 5869) and KBKDF (NIST SP 800-108) key
-//! derivation operations.
+//! Defines [`HsmKdfState`] and the [`HsmKdf`] trait that PAL implementations
+//! use to expose HKDF (RFC 5869), SP 800-108 Counter Mode KDF, and
+//! hash-based concatenation KDFs (MGF1, X9.63 KDF, SP 800-56A one-step KDF).
 //!
-//! On Cortex-M7 hardware these would delegate to the HMAC engine in
-//! streaming mode. On the standard (host-native) PAL they use OpenSSL's
-//! HKDF and KBKDF implementations.
+//! On Cortex-M7 hardware the concatenation KDFs use the SHA engine in
+//! exclusive synchronous mode for efficiency. HKDF and KBKDF delegate to
+//! the HMAC engine. On the standard (host-native) PAL they use OpenSSL.
 //!
 //! ## Key representation
 //!
@@ -19,33 +19,78 @@
 //!
 //! ## Output buffer convention
 //!
-//! Both methods write derived key material into a caller-provided
+//! All methods write derived key material into a caller-provided
 //! `&mut [u8]` buffer. The buffer length determines the number of
 //! bytes derived (OKM length).
+//!
+//! ## Concatenation KDF family
+//!
+//! MGF1, X9.63 KDF, and SP 800-56A one-step KDF are all variations of
+//! the same pattern: hash a counter with input keying material to
+//! produce arbitrary-length output. They differ only in the order of
+//! fields within each hash input:
+//!
+//! | Algorithm | Hash input |
+//! |---|---|
+//! | MGF1 (RFC 8017 §B.2.1) | `seed \|\| counter` |
+//! | X9.63 KDF (SEC 1 §3.6.1) | `Z \|\| counter \|\| SharedInfo` |
+//! | SP 800-56A one-step | `counter \|\| Z \|\| OtherInfo` |
+//!
+//! All three accept a caller-owned state buffer sized by
+//! [`HsmHashAlgo::mgf1_state_len`] (or the corresponding KDF variant).
+//!
+//! ## HKDF (RFC 5869)
+//!
+//! HKDF is split into two methods matching the two-phase design:
+//!
+//! - [`hkdf_extract`](HsmKdf::hkdf_extract) — condenses IKM + salt into a
+//!   fixed-length PRK.
+//! - [`hkdf_expand`](HsmKdf::hkdf_expand) — derives arbitrary-length OKM
+//!   from a PRK + info context.
+//!
+//! This split supports protocols (e.g., TLS 1.3) that perform one extract
+//! followed by multiple expands with different info values. Both methods
+//! accept an [`HsmKdfState`] of at least [`HsmHashAlgo::hmac_state_len`]
+//! bytes as working space.
 
 use super::*;
 
-/// HKDF operation mode (RFC 5869).
+/// Caller-owned working buffer for KDF operations.
 ///
-/// HKDF is a two-stage KDF built on HMAC:
-/// 1. **Extract** — condenses input key material (IKM) + salt into a
-///    fixed-length pseudorandom key (PRK).
-/// 2. **Expand** — derives output key material (OKM) from the PRK +
-///    info context.
+/// A zero-cost newtype over `&mut [u8]` that provides type safety —
+/// prevents accidentally passing an unrelated buffer where a KDF
+/// state is expected. Unlike [`HsmHashState`], this carries no
+/// algorithm tag; the algorithm is passed separately to each KDF
+/// method.
 ///
-/// Most callers use [`ExtractAndExpand`](HkdfMode::ExtractAndExpand) for
-/// the full operation. Separate modes are available for protocols that
-/// split the two phases (e.g., TLS 1.3).
-pub enum HkdfMode {
-    /// Extract only — produce PRK from IKM + salt.
-    Extract,
+/// Size requirements depend on the KDF:
+/// - HKDF / SP 800-108: [`HsmHashAlgo::hmac_state_len`] bytes.
+/// - MGF1: [`HsmHashAlgo::mgf1_state_len`] bytes.
+/// - X9.63 / SP 800-56A: [`HsmHashAlgo::concat_kdf_state_len`] bytes.
+#[repr(transparent)]
+#[derive(Debug)]
+pub struct HsmKdfState<'a>(&'a mut [u8]);
 
-    /// Expand only — derive OKM from an existing PRK + info.
-    /// The `key` parameter is treated as the PRK.
-    Expand,
+impl<'a> HsmKdfState<'a> {
+    /// Wrap a caller-owned byte slice as KDF working state.
+    pub fn new(buf: &'a mut [u8]) -> Self {
+        Self(buf)
+    }
 
-    /// Full HKDF — extract then expand in one call.
-    ExtractAndExpand,
+    /// Returns the buffer length.
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    /// Returns whether the buffer is empty.
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    /// Consume the wrapper and return the underlying mutable buffer.
+    pub fn into_buf(self) -> &'a mut [u8] {
+        self.0
+    }
 }
 
 /// Asynchronous Key Derivation Function trait.
@@ -53,38 +98,78 @@ pub enum HkdfMode {
 /// PAL implementations provide this to the core for deriving
 /// cryptographic key material from existing keys using standardized
 /// KDF algorithms. The async signatures allow hardware-backed
-/// implementations to yield while the HMAC engine processes data.
+/// implementations to yield while the hash/HMAC engine processes data.
 pub trait HsmKdf {
-    /// Derive key material using HKDF (RFC 5869).
+    /// HKDF-Extract (RFC 5869 §2.2) — condense IKM + salt into a PRK.
+    ///
+    /// `PRK = HMAC-Hash(salt, IKM)`
     ///
     /// # Parameters
-    /// - `key` — Input key material (IKM) for Extract mode, or the
-    ///   pseudorandom key (PRK) for Expand mode.
-    /// - `algo` — The underlying hash algorithm for HMAC
-    ///   (e.g., SHA-256, SHA-384).
-    /// - `mode` — Which HKDF phase(s) to perform.
-    /// - `salt` — Optional salt value. Pass an empty slice `&[]` to use
-    ///   the default salt (a string of zero bytes of hash length).
-    /// - `info` — Context and application-specific info. Pass `&[]` if
-    ///   not needed.
-    /// - `output` — Buffer for the derived output key material (OKM).
-    ///   The buffer length determines how many bytes are derived.
+    ///
+    /// - `algo` — the underlying hash algorithm (e.g. SHA-256).
+    /// - `salt` — optional salt value. Pass `&[]` to use the default
+    ///   salt (a string of zero bytes of hash length).
+    /// - `ikm` — input keying material.
+    /// - `prk` — output buffer for the pseudorandom key. Must be at
+    ///   least [`HsmHashAlgo::digest_len`] bytes.
+    /// - `state` — caller-owned working buffer. Must wrap at least
+    ///   [`HsmHashAlgo::hmac_state_len`] bytes.
+    ///
+    /// # Returns
+    ///
+    /// The `state` buffer, returned for reuse in subsequent calls
+    /// (e.g. [`hkdf_expand`](Self::hkdf_expand)).
     ///
     /// # Errors
-    /// Returns [`HsmError`] if the HKDF operation fails (e.g.,
-    /// unsupported algorithm, output length exceeds 255 * hash length).
-    async fn hkdf(
+    ///
+    /// Returns [`HsmError`] if `prk` is too short, `state` is too
+    /// small, or the HMAC operation fails.
+    async fn hkdf_extract<'a>(
         &self,
-        key: &[u8],
         algo: HsmHashAlgo,
-        mode: HkdfMode,
         salt: &[u8],
+        ikm: &[u8],
+        prk: &mut [u8],
+        state: HsmKdfState<'a>,
+    ) -> HsmResult<HsmKdfState<'a>>;
+
+    /// HKDF-Expand (RFC 5869 §2.3) — derive OKM from a PRK.
+    ///
+    /// ```text
+    /// T(0) = empty
+    /// T(i) = HMAC-Hash(PRK, T(i-1) || info || i)  for i = 1..N
+    /// OKM  = first L bytes of T(1) || T(2) || …
+    /// ```
+    ///
+    /// # Parameters
+    ///
+    /// - `algo` — the underlying hash algorithm.
+    /// - `prk` — pseudorandom key from [`hkdf_extract`](Self::hkdf_extract).
+    /// - `info` — context and application-specific info. Pass `&[]` if
+    ///   not needed.
+    /// - `output` — buffer for the derived output key material (OKM).
+    ///   Length must not exceed `255 * digest_len`.
+    /// - `state` — caller-owned working buffer. Must wrap at least
+    ///   [`HsmHashAlgo::hmac_state_len`] bytes.
+    ///
+    /// # Returns
+    ///
+    /// The `state` buffer, returned for reuse in subsequent expand calls.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`HsmError`] if `output` exceeds the RFC limit, `state`
+    /// is too small, or the HMAC operation fails.
+    async fn hkdf_expand<'a>(
+        &self,
+        algo: HsmHashAlgo,
+        prk: &[u8],
         info: &[u8],
         output: &mut [u8],
-    ) -> HsmResult<()>;
+        state: HsmKdfState<'a>,
+    ) -> HsmResult<HsmKdfState<'a>>;
 
-    /// Derive key material using KBKDF in Counter Mode with HMAC
-    /// (NIST SP 800-108).
+    /// Derive key material using SP 800-108 KDF in Counter Mode with HMAC.
     ///
     /// Uses HMAC as the PRF with an incrementing counter. The derived
     /// output is computed as:
@@ -92,24 +177,140 @@ pub trait HsmKdf {
     /// block `i`, where `L` is the requested output length in bits.
     ///
     /// # Parameters
-    /// - `key` — The key-derivation key (KDK).
-    /// - `algo` — The HMAC hash algorithm (e.g., SHA-384).
-    /// - `label` — A string identifying the purpose of the derived key.
+    ///
+    /// - `algo` — the HMAC hash algorithm (e.g. SHA-384).
+    /// - `key` — the key-derivation key (KDK).
+    /// - `label` — a string identifying the purpose of the derived key.
     ///   Pass `&[]` if not needed.
-    /// - `context` — Context information binding the derived key to a
+    /// - `context` — context information binding the derived key to a
     ///   specific use. Pass `&[]` if not needed.
-    /// - `output` — Buffer for the derived key material. The buffer
+    /// - `output` — buffer for the derived key material. The buffer
     ///   length determines how many bytes are derived.
+    /// - `state` — caller-owned working buffer. Must wrap at least
+    ///   [`HsmHashAlgo::hmac_state_len`] bytes.
+    ///
+    /// # Returns
+    ///
+    /// The `state` buffer, returned for reuse.
     ///
     /// # Errors
-    /// Returns [`HsmError`] if the KBKDF operation fails (e.g.,
+    ///
+    /// Returns [`HsmError`] if the KDF operation fails (e.g.,
     /// unsupported algorithm, HMAC computation error).
-    async fn kbkdf(
+    async fn sp800_108_kdf<'a>(
         &self,
-        key: &[u8],
         algo: HsmHashAlgo,
+        key: &[u8],
         label: &[u8],
         context: &[u8],
         output: &mut [u8],
+        state: HsmKdfState<'a>,
+    ) -> HsmResult<HsmKdfState<'a>>;
+
+    /// Compute MGF1 per [RFC 8017 §B.2.1](https://www.rfc-editor.org/rfc/rfc8017#appendix-B.2.1).
+    ///
+    /// Expands `seed` into `mask.len()` bytes of mask material using
+    /// the specified hash algorithm:
+    /// `T(C) = Hash(seed || I2OSP(C, 4))` for `C = 0, 1, …`.
+    ///
+    /// # Parameters
+    ///
+    /// - `algo` — hash algorithm (e.g. SHA-256).
+    /// - `seed` — the MGF1 seed input.
+    /// - `mask` — output buffer; filled with `mask.len()` bytes of mask
+    ///   material.
+    /// - `state` — caller-owned working buffer. Must be at least
+    ///   [`HsmHashAlgo::mgf1_state_len`]`(seed.len())` bytes.
+    ///   Layout: `[hash(digest_len) | input(seed_len + 4)]`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`HsmError`] if `state` is too small or the underlying
+    /// hash operation fails.
+    async fn mgf1(
+        &self,
+        algo: HsmHashAlgo,
+        seed: &[u8],
+        mask: &mut [u8],
+        state: &mut [u8],
+    ) -> HsmResult<()>;
+
+    /// MGF1 with in-place XOR (RFC 8017 §B.2.1).
+    ///
+    /// Like [`mgf1`](Self::mgf1) but instead of overwriting `mask`, each
+    /// generated mask byte is **XOR'd** into the existing content of
+    /// `mask`. This is the primitive needed by OAEP and PSS padding.
+    ///
+    /// # Parameters
+    ///
+    /// - `algo` — hash algorithm.
+    /// - `seed` — the MGF1 seed input.
+    /// - `mask` — buffer to XOR the generated mask into (in-place).
+    /// - `state` — caller-owned working buffer. Must be at least
+    ///   [`HsmHashAlgo::mgf1_state_len`]`(seed.len())` bytes.
+    async fn mgf1_xor(
+        &self,
+        algo: HsmHashAlgo,
+        seed: &[u8],
+        mask: &mut [u8],
+        state: &mut [u8],
+    ) -> HsmResult<()>;
+
+    /// Derive key material using X9.63 KDF (SEC 1 §3.6.1).
+    ///
+    /// Expands shared secret `z` into `key.len()` bytes of key material:
+    /// `T(C) = Hash(Z || I2OSP(C, 4) || SharedInfo)` for `C = 1, 2, …`.
+    ///
+    /// # Parameters
+    ///
+    /// - `algo` — hash algorithm (e.g. SHA-256).
+    /// - `z` — the shared secret (e.g. ECDH output).
+    /// - `shared_info` — optional shared info. Pass `&[]` to omit.
+    /// - `key` — output buffer; filled with `key.len()` bytes of derived
+    ///   key material.
+    /// - `state` — caller-owned working buffer. Must be at least
+    ///   [`HsmHashAlgo::concat_kdf_state_len`]`(z.len(), shared_info.len())`
+    ///   bytes. Layout: `[hash(digest_len) | input(z_len + 4 + info_len)]`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`HsmError`] if `state` is too small or the underlying
+    /// hash operation fails.
+    async fn x963_kdf(
+        &self,
+        algo: HsmHashAlgo,
+        z: &[u8],
+        shared_info: &[u8],
+        key: &mut [u8],
+        state: &mut [u8],
+    ) -> HsmResult<()>;
+
+    /// Derive key material using SP 800-56A one-step Concatenation KDF.
+    ///
+    /// Expands shared secret `z` into `key.len()` bytes of key material:
+    /// `T(C) = Hash(I2OSP(C, 4) || Z || OtherInfo)` for `C = 1, 2, …`.
+    ///
+    /// # Parameters
+    ///
+    /// - `algo` — hash algorithm (e.g. SHA-256).
+    /// - `z` — the shared secret (e.g. ECDH output).
+    /// - `other_info` — context information. Pass `&[]` to omit.
+    /// - `key` — output buffer; filled with `key.len()` bytes of derived
+    ///   key material.
+    /// - `state` — caller-owned working buffer. Must be at least
+    ///   [`HsmHashAlgo::concat_kdf_state_len`]`(z.len(), other_info.len())`
+    ///   bytes. Layout: `[hash(digest_len) | input(4 + z_len + info_len)]`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`HsmError`] if `state` is too small or the underlying
+    /// hash operation fails.
+    async fn sp800_56a_kdf(
+        &self,
+        algo: HsmHashAlgo,
+        z: &[u8],
+        other_info: &[u8],
+        key: &mut [u8],
+        state: &mut [u8],
     ) -> HsmResult<()>;
 }

--- a/fw/pal/traits/src/crypto/mod.rs
+++ b/fw/pal/traits/src/crypto/mod.rs
@@ -13,6 +13,7 @@
 //! | [`HsmHash`] | SHA-1/256/384/512 digest computation |
 //! | [`HsmEcc`] | Elliptic curve key generation, signing, verification, and ECDH |
 //! | [`HsmHmac`] | HMAC computation using SHA-1/256/384/512 |
+//! | [`HsmKdf`] | KDF / MGF: HKDF, KBKDF, MGF1, X9.63, SP 800-56A |
 
 mod aes;
 mod ecc;

--- a/fw/pal/traits/src/crypto/rsa.rs
+++ b/fw/pal/traits/src/crypto/rsa.rs
@@ -32,6 +32,119 @@
 
 use super::*;
 
+// ── RSA key size ───────────────────────────────────────────────────
+
+/// RSA key type: modulus size, public/private, and CRT format.
+///
+/// Each variant encodes three properties:
+/// - **Modulus size** — 2048, 3072, or 4096 bits.
+/// - **Key role** — public (`Pub`) or private (`Priv`/`CrtPriv`).
+/// - **Private key format** — standard (`Priv`) or Chinese Remainder
+///   Theorem (`CrtPriv`). CRT is irrelevant for public keys.
+///
+/// Use [`pub_variant`](Self::pub_variant) to obtain the corresponding
+/// public key variant from any private variant.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HsmRsaKey {
+    /// RSA-2048 public key.
+    Rsa2048Pub,
+
+    /// RSA-2048 non-CRT private key.
+    Rsa2048Priv,
+
+    /// RSA-2048 CRT private key.
+    Rsa2048CrtPriv,
+
+    /// RSA-3072 public key.
+    Rsa3072Pub,
+
+    /// RSA-3072 non-CRT private key.
+    Rsa3072Priv,
+
+    /// RSA-3072 CRT private key.
+    Rsa3072CrtPriv,
+
+    /// RSA-4096 public key.
+    Rsa4096Pub,
+
+    /// RSA-4096 non-CRT private key.
+    Rsa4096Priv,
+
+    /// RSA-4096 CRT private key.
+    Rsa4096CrtPriv,
+}
+
+impl HsmRsaKey {
+    /// Modulus size in bytes (`k`).
+    pub const fn modulus_len(&self) -> usize {
+        match self {
+            Self::Rsa2048Pub | Self::Rsa2048Priv | Self::Rsa2048CrtPriv => 256,
+            Self::Rsa3072Pub | Self::Rsa3072Priv | Self::Rsa3072CrtPriv => 384,
+            Self::Rsa4096Pub | Self::Rsa4096Priv | Self::Rsa4096CrtPriv => 512,
+        }
+    }
+
+    /// Whether this is a public key variant.
+    pub const fn is_public(&self) -> bool {
+        matches!(self, Self::Rsa2048Pub | Self::Rsa3072Pub | Self::Rsa4096Pub)
+    }
+
+    /// Whether this is a private key variant (CRT or non-CRT).
+    pub const fn is_private(&self) -> bool {
+        !self.is_public()
+    }
+
+    /// Whether this variant uses CRT (Chinese Remainder Theorem) format.
+    pub const fn is_crt(&self) -> bool {
+        matches!(
+            self,
+            Self::Rsa2048CrtPriv | Self::Rsa3072CrtPriv | Self::Rsa4096CrtPriv
+        )
+    }
+
+    /// Return the corresponding public key variant.
+    ///
+    /// Maps any private variant to the public variant of the same
+    /// modulus size. Public variants map to themselves.
+    pub const fn pub_variant(&self) -> Self {
+        match self {
+            Self::Rsa2048Pub | Self::Rsa2048Priv | Self::Rsa2048CrtPriv => Self::Rsa2048Pub,
+            Self::Rsa3072Pub | Self::Rsa3072Priv | Self::Rsa3072CrtPriv => Self::Rsa3072Pub,
+            Self::Rsa4096Pub | Self::Rsa4096Priv | Self::Rsa4096CrtPriv => Self::Rsa4096Pub,
+        }
+    }
+
+    /// Maximum plaintext length for PKCS#1 v1.5 encryption: `k - 11`.
+    pub const fn max_pkcs1_message(&self) -> usize {
+        self.modulus_len() - 11
+    }
+
+    /// Maximum plaintext length for OAEP encryption: `k - 2*hLen - 2`.
+    pub const fn max_oaep_message(&self, algo: HsmHashAlgo) -> usize {
+        self.modulus_len() - 2 * algo.digest_len() - 2
+    }
+
+    /// Minimum work buffer size for PKCS#1 v1.5 operations.
+    pub const fn pkcs1_work_len(&self) -> usize {
+        self.modulus_len()
+    }
+
+    /// Minimum work buffer size for OAEP operations.
+    pub const fn oaep_work_len(&self, algo: HsmHashAlgo) -> usize {
+        let k = self.modulus_len();
+        let h_len = algo.digest_len();
+        let db_len = k - h_len - 1;
+        k + algo.mgf1_state_len(db_len)
+    }
+
+    /// Minimum work buffer size for PSS operations.
+    pub const fn pss_work_len(&self, algo: HsmHashAlgo) -> usize {
+        let k = self.modulus_len();
+        let h_len = algo.digest_len();
+        k + algo.hash_state_len() + algo.mgf1_state_len(h_len)
+    }
+}
+
 /// Pairwise Consistency Test (PCT) mode for RSA key generation.
 ///
 /// FIPS 140-3 requires a PCT after key generation to verify the key
@@ -71,7 +184,7 @@ pub trait HsmRsa {
     /// verification fails.
     async fn ras_gen_keypair(
         &self,
-        key_size: usize,
+        key_size: HsmRsaKey,
         priv_key: &mut [u8],
         pub_key: &mut [u8],
         pct: HsmRsaPct,
@@ -91,7 +204,13 @@ pub trait HsmRsa {
     /// # Errors
     /// Returns [`HsmError`] if the exponentiation fails (e.g., PKA
     /// engine error, invalid key).
-    async fn mod_exp_priv(&self, key: &[u8], y: &[u8], x: &mut [u8]) -> Result<(), HsmError>;
+    async fn mod_exp_priv(
+        &self,
+        key_size: HsmRsaKey,
+        key: &[u8],
+        y: &[u8],
+        x: &mut [u8],
+    ) -> Result<(), HsmError>;
 
     /// Public-key modular exponentiation: `y = x^e mod n`.
     ///
@@ -107,5 +226,200 @@ pub trait HsmRsa {
     /// # Errors
     /// Returns [`HsmError`] if the exponentiation fails (e.g., PKA
     /// engine error, invalid key).
-    async fn mod_exp_pub(&self, key: &[u8], x: &[u8], y: &mut [u8]) -> Result<(), HsmError>;
+    async fn mod_exp_pub(
+        &self,
+        key_size: HsmRsaKey,
+        key: &[u8],
+        x: &[u8],
+        y: &mut [u8],
+    ) -> Result<(), HsmError>;
+
+    /// PKCS#1 v1.5 encrypt (EME-PKCS1-v1_5).
+    ///
+    /// Pads `message` with random non-zero bytes per RFC 8017 §7.2.1, then
+    /// encrypts with the public key.
+    ///
+    /// # Parameters
+    ///
+    /// - `pub_key` — RSA public key.
+    /// - `message` — plaintext. Must satisfy `message.len() <= k - 11`.
+    /// - `output` — ciphertext output buffer. Must be at least `rsa_pkcs1_work_len(k)` bytes.
+    /// - `work` — scratch buffer. Must be at least `rsa_pkcs1_work_len(k)` bytes.
+    async fn rsa_pkcs1_encrypt(
+        &self,
+        key_size: HsmRsaKey,
+        pub_key: &[u8],
+        message: &[u8],
+        output: &mut [u8],
+        work: &mut [u8],
+    ) -> HsmResult<()>;
+
+    /// PKCS#1 v1.5 decrypt (EME-PKCS1-v1_5).
+    ///
+    /// Decrypts `ciphertext` with the private key and removes padding.
+    ///
+    /// # Parameters
+    ///
+    /// - `priv_key` — RSA private key.
+    /// - `ciphertext` — encrypted data. Must be exactly `k` bytes.
+    /// - `output` — plaintext output buffer. Must be at least `k - 11` bytes.
+    /// - `work` — scratch buffer. Must be at least `rsa_pkcs1_work_len(k)` bytes.
+    ///
+    /// # Returns
+    ///
+    /// The length of the recovered plaintext.
+    async fn rsa_pkcs1_decrypt(
+        &self,
+        key_size: HsmRsaKey,
+        priv_key: &[u8],
+        ciphertext: &[u8],
+        output: &mut [u8],
+        work: &mut [u8],
+    ) -> HsmResult<usize>;
+
+    /// PKCS#1 v1.5 sign (EMSA-PKCS1-v1_5, pre-hashed).
+    ///
+    /// Builds DigestInfo from `message_hash`, pads, and signs.
+    ///
+    /// # Parameters
+    ///
+    /// - `algo` — hash algorithm for DigestInfo OID.
+    /// - `priv_key` — RSA private key.
+    /// - `message_hash` — pre-computed message digest (`algo.digest_len()`
+    ///   bytes).
+    /// - `signature` — output buffer. Must be at least `rsa_pkcs1_work_len(k)` bytes.
+    /// - `work` — scratch buffer. Must be at least
+    ///   `rsa_pkcs1_work_len(k)` bytes.
+    async fn rsa_pkcs1_sign(
+        &self,
+        key_size: HsmRsaKey,
+        algo: HsmHashAlgo,
+        priv_key: &[u8],
+        message_hash: &[u8],
+        signature: &mut [u8],
+        work: &mut [u8],
+    ) -> HsmResult<()>;
+
+    /// PKCS#1 v1.5 verify (EMSA-PKCS1-v1_5, pre-hashed).
+    ///
+    /// Verifies `signature` against `message_hash` using the public key.
+    ///
+    /// # Parameters
+    ///
+    /// - `algo` — hash algorithm for DigestInfo OID.
+    /// - `pub_key` — RSA public key.
+    /// - `message_hash` — pre-computed message digest.
+    /// - `signature` — signature to verify.
+    /// - `work` — scratch buffer. Must be at least
+    ///   `rsa_pkcs1_work_len(k)` bytes.
+    async fn rsa_pkcs1_verify(
+        &self,
+        key_size: HsmRsaKey,
+        algo: HsmHashAlgo,
+        pub_key: &[u8],
+        message_hash: &[u8],
+        signature: &[u8],
+        work: &mut [u8],
+    ) -> HsmResult<bool>;
+
+    /// OAEP encrypt (EME-OAEP).
+    ///
+    /// Pads `message` with OAEP per RFC 8017 §7.1.1 and encrypts.
+    ///
+    /// # Parameters
+    ///
+    /// - `algo` — hash algorithm for OAEP (label hash + MGF1).
+    /// - `pub_key` — RSA public key.
+    /// - `message` — plaintext. Must satisfy `message.len() <= k - 2*hLen - 2`.
+    /// - `label` — optional label (pass `&[]` for default empty label).
+    /// - `output` — ciphertext output buffer. Must be at least `rsa_pkcs1_work_len(k)` bytes.
+    /// - `work` — scratch buffer. Must be at least
+    ///   `k + mgf1_state_len(k - hLen - 1)` bytes.
+    async fn rsa_oaep_encrypt(
+        &self,
+        key_size: HsmRsaKey,
+        algo: HsmHashAlgo,
+        pub_key: &[u8],
+        message: &[u8],
+        label: &[u8],
+        output: &mut [u8],
+        work: &mut [u8],
+    ) -> HsmResult<()>;
+
+    /// OAEP decrypt (EME-OAEP).
+    ///
+    /// Decrypts `ciphertext` with OAEP unpadding per RFC 8017 §7.1.2.
+    ///
+    /// # Parameters
+    ///
+    /// - `algo` — hash algorithm for OAEP.
+    /// - `priv_key` — RSA private key.
+    /// - `ciphertext` — encrypted data. Must be exactly `k` bytes.
+    /// - `label` — optional label (must match encryption label).
+    /// - `output` — plaintext output buffer. Must be at least
+    ///   `k - 2*hLen - 2` bytes (max recoverable plaintext).
+    /// - `work` — scratch buffer. Must be at least
+    ///   `rsa_oaep_work_len(algo, k)` bytes.
+    ///
+    /// # Returns
+    ///
+    /// The length of the recovered plaintext.
+    async fn rsa_oaep_decrypt(
+        &self,
+        key_size: HsmRsaKey,
+        algo: HsmHashAlgo,
+        priv_key: &[u8],
+        ciphertext: &[u8],
+        label: &[u8],
+        output: &mut [u8],
+        work: &mut [u8],
+    ) -> HsmResult<usize>;
+
+    /// PSS sign (EMSA-PSS, pre-hashed).
+    ///
+    /// Pads `message_hash` with PSS per RFC 8017 §9.1.1 and signs.
+    ///
+    /// # Parameters
+    ///
+    /// - `algo` — hash algorithm for PSS (H and MGF1).
+    /// - `priv_key` — RSA private key.
+    /// - `message_hash` — pre-computed message digest (`hLen` bytes).
+    /// - `salt_len` — PSS salt length in bytes.
+    /// - `signature` — output buffer. Must be at least `rsa_pkcs1_work_len(k)` bytes.
+    /// - `work` — scratch buffer. Must be at least
+    ///   `k + hash_state_len + mgf1_state_len(hLen)` bytes.
+    async fn rsa_pss_sign(
+        &self,
+        key_size: HsmRsaKey,
+        algo: HsmHashAlgo,
+        priv_key: &[u8],
+        message_hash: &[u8],
+        salt_len: usize,
+        signature: &mut [u8],
+        work: &mut [u8],
+    ) -> HsmResult<()>;
+
+    /// PSS verify (EMSA-PSS, pre-hashed).
+    ///
+    /// Verifies `signature` against `message_hash` using PSS per RFC 8017 §9.1.2.
+    ///
+    /// # Parameters
+    ///
+    /// - `algo` — hash algorithm for PSS.
+    /// - `pub_key` — RSA public key.
+    /// - `message_hash` — pre-computed message digest (`hLen` bytes).
+    /// - `salt_len` — PSS salt length in bytes.
+    /// - `signature` — signature to verify.
+    /// - `work` — scratch buffer. Must be at least
+    ///   `k + hash_state_len + mgf1_state_len(hLen)` bytes.
+    async fn rsa_pss_verify(
+        &self,
+        key_size: HsmRsaKey,
+        algo: HsmHashAlgo,
+        pub_key: &[u8],
+        message_hash: &[u8],
+        salt_len: usize,
+        signature: &[u8],
+        work: &mut [u8],
+    ) -> HsmResult<bool>;
 }

--- a/fw/pal/traits/src/error.rs
+++ b/fw/pal/traits/src/error.rs
@@ -49,6 +49,7 @@ pub enum HsmError {
     EccVerifyFailed = 0x08700024,
     AesEncryptFailed = 0x08700025,
     AesDecryptFailed = 0x08700026,
+
     FunctionNotEnabled = 0x08700027,
     AnotherKeyInUse = 0x08700028,
     KeyNotInUse = 0x08700029,
@@ -221,6 +222,9 @@ pub enum HsmError {
     Bk3AlreadyInitialized = 0x087000D6,
     SealedBk3AlreadySet = 0x087000D7,
     PartitionIdKeyGenerationPctFailed = 0x087000D8,
+
+    // ── AES Key Wrap errors ────────────────────────────────────────
+    AesUnwrapFailed = 0x087000D9,
 
     // ── Core lifecycle / transport diagnostics ─────────────────────
     SqeInvalidPsdt = 0x087000E0,

--- a/fw/plat/std/pal/src/aes.rs
+++ b/fw/plat/std/pal/src/aes.rs
@@ -4,26 +4,17 @@
 //! [`HsmAes`] implementation for the standard (host-native) PAL.
 //!
 //! Thin delegation layer to the [`StdAes`](crate::drivers::aes::StdAes)
-//! driver. All crypto work is offloaded to the worker pool by the driver.
-//!
-//! ## Data flow (CBC example)
-//!
-//! ```text
-//! Core calls pal.aes_cbc_enc_dec(key, true, iv, input, output)
-//!   → self.aes.cbc_enc_dec(key, true, iv, input, output)
-//!     → WorkerPool → OpenSSL AES-CBC (no padding)
-//!   → output + updated IV written into caller's buffers
-//! ```
+//! driver. All implemented crypto work is offloaded to the worker pool by
+//! the driver. Newly added AES-KW/AES-XTS trait entry points are stubbed
+//! with `todo!()` for now.
 
 use super::*;
 
 impl HsmAes for StdHsmPal {
-    /// Generate a random AES key by delegating to the driver.
     async fn aes_gen_key(&self, key: &mut [u8]) -> HsmResult<()> {
         self.aes.gen_key(key).await
     }
 
-    /// AES-CBC encrypt or decrypt with separate buffers.
     async fn aes_cbc_enc_dec(
         &self,
         key: &[u8],
@@ -35,10 +26,6 @@ impl HsmAes for StdHsmPal {
         self.aes.cbc_enc_dec(key, encrypt, iv, input, output).await
     }
 
-    /// AES-CBC encrypt or decrypt in-place.
-    ///
-    /// Uses `data` as both input and output by passing it to the driver
-    /// as input and writing the result back.
     async fn aes_cbc_enc_dec_in_place(
         &self,
         key: &[u8],
@@ -46,12 +33,10 @@ impl HsmAes for StdHsmPal {
         iv: &mut [u8],
         data: &mut [u8],
     ) -> HsmResult<()> {
-        // Driver needs separate input/output; use a temp copy.
         let input = data.to_vec();
         self.aes.cbc_enc_dec(key, encrypt, iv, &input, data).await
     }
 
-    /// AES-ECB encrypt or decrypt with separate buffers.
     async fn aes_ecb_enc_dec(
         &self,
         key: &[u8],
@@ -62,7 +47,6 @@ impl HsmAes for StdHsmPal {
         self.aes.ecb_enc_dec(key, encrypt, input, output).await
     }
 
-    /// AES-ECB encrypt or decrypt in-place.
     async fn aes_ecb_enc_dec_in_place(
         &self,
         key: &[u8],
@@ -73,7 +57,6 @@ impl HsmAes for StdHsmPal {
         self.aes.ecb_enc_dec(key, encrypt, &input, data).await
     }
 
-    /// AES-GCM encrypt with separate buffers.
     async fn gcm_encrypt(
         &self,
         key: &[u8],
@@ -100,7 +83,6 @@ impl HsmAes for StdHsmPal {
             .await
     }
 
-    /// AES-GCM encrypt in-place.
     async fn gcm_encrypt_in_place(
         &self,
         key: &[u8],
@@ -124,7 +106,6 @@ impl HsmAes for StdHsmPal {
             .await
     }
 
-    /// AES-GCM decrypt with separate buffers.
     async fn gcm_decrypt(
         &self,
         key: &[u8],
@@ -149,7 +130,6 @@ impl HsmAes for StdHsmPal {
             .await
     }
 
-    /// AES-GCM decrypt in-place.
     async fn gcm_decrypt_in_place(
         &self,
         key: &[u8],
@@ -171,5 +151,72 @@ impl HsmAes for StdHsmPal {
         self.aes
             .gcm_decrypt(key, iv, aad, tag, ciphertext, &mut data[aad_len..])
             .await
+    }
+
+    async fn aes_kw_wrap(&self, _key: &[u8], _input: &[u8], _output: &mut [u8]) -> HsmResult<()> {
+        todo!()
+    }
+
+    async fn aes_kw_unwrap(&self, _key: &[u8], _input: &[u8], _output: &mut [u8]) -> HsmResult<()> {
+        todo!()
+    }
+
+    async fn aes_kwp_wrap(&self, _key: &[u8], _input: &[u8], _output: &mut [u8]) -> HsmResult<()> {
+        todo!()
+    }
+
+    async fn aes_kwp_unwrap(
+        &self,
+        _key: &[u8],
+        _input: &[u8],
+        _output: &mut [u8],
+    ) -> HsmResult<usize> {
+        todo!()
+    }
+
+    async fn aes_xts_gen_key(&self, _key: &mut [u8]) -> HsmResult<()> {
+        todo!()
+    }
+
+    async fn aes_xts_encrypt(
+        &self,
+        _key: &[u8],
+        _tweak: &[u8],
+        _dul: XtsDataUnitLen,
+        _input: &[u8],
+        _output: &mut [u8],
+    ) -> HsmResult<()> {
+        todo!()
+    }
+
+    async fn aes_xts_decrypt(
+        &self,
+        _key: &[u8],
+        _tweak: &[u8],
+        _dul: XtsDataUnitLen,
+        _input: &[u8],
+        _output: &mut [u8],
+    ) -> HsmResult<()> {
+        todo!()
+    }
+
+    async fn aes_xts_encrypt_in_place(
+        &self,
+        _key: &[u8],
+        _tweak: &[u8],
+        _dul: XtsDataUnitLen,
+        _data: &mut [u8],
+    ) -> HsmResult<()> {
+        todo!()
+    }
+
+    async fn aes_xts_decrypt_in_place(
+        &self,
+        _key: &[u8],
+        _tweak: &[u8],
+        _dul: XtsDataUnitLen,
+        _data: &mut [u8],
+    ) -> HsmResult<()> {
+        todo!()
     }
 }

--- a/fw/plat/std/pal/src/cert.rs
+++ b/fw/plat/std/pal/src/cert.rs
@@ -287,8 +287,13 @@ impl StdHsmPal {
         rd_concat[..root_cert_len].copy_from_slice(&root_cert[..root_cert_len]);
         rd_concat[root_cert_len..].copy_from_slice(&deviceid_cert[..deviceid_cert_len]);
         let mut root_deviceid_hash = [0u8; 32];
-        self.hash(HsmHashAlgo::Sha256, &rd_concat, &mut root_deviceid_hash)
-            .await?;
+        self.hash(
+            HsmHashAlgo::Sha256,
+            &rd_concat,
+            &mut root_deviceid_hash,
+            true,
+        )
+        .await?;
 
         // Commit to store.
         let store = &mut *self.cert_store_mut();
@@ -322,7 +327,7 @@ impl StdHsmPal {
 
         let uncompressed = to_uncompressed(&pub_raw);
         let mut ski = [0u8; 20];
-        self.hash(HsmHashAlgo::Sha1, &uncompressed, &mut ski)
+        self.hash(HsmHashAlgo::Sha1, &uncompressed, &mut ski, true)
             .await?;
 
         Ok(CertKeyPair {
@@ -339,7 +344,8 @@ impl StdHsmPal {
         tbs: &[u8],
     ) -> HsmResult<([u8; P384_SIG_COMPONENT], [u8; P384_SIG_COMPONENT])> {
         let mut tbs_hash = [0u8; 48];
-        self.hash(HsmHashAlgo::Sha384, tbs, &mut tbs_hash).await?;
+        self.hash(HsmHashAlgo::Sha384, tbs, &mut tbs_hash, true)
+            .await?;
 
         let mut sig = [0u8; 96];
         self.ecc_sign(HsmEccCurve::P384, priv_der, &tbs_hash, &mut sig)
@@ -374,7 +380,7 @@ impl StdHsmPal {
 
         // SKI = SHA-1(uncompressed pubkey).
         let mut ski = [0u8; 20];
-        self.hash(HsmHashAlgo::Sha1, &uncompressed, &mut ski)
+        self.hash(HsmHashAlgo::Sha1, &uncompressed, &mut ski, true)
             .await?;
 
         // Prepare TBS.
@@ -451,6 +457,7 @@ impl HsmCertStore for StdHsmPal {
             HsmHashAlgo::Sha256,
             self.cert_store().shared_cert(2).unwrap(),
             &mut alias_hash,
+            true,
         )
         .await?;
 
@@ -459,6 +466,7 @@ impl HsmCertStore for StdHsmPal {
             HsmHashAlgo::Sha256,
             &entry.leaf_cert[..entry.leaf_cert_len],
             &mut leaf_hash,
+            true,
         )
         .await?;
 
@@ -468,7 +476,7 @@ impl HsmCertStore for StdHsmPal {
         combined[64..96].copy_from_slice(&leaf_hash);
 
         let mut thumbprint = [0u8; 32];
-        self.hash(HsmHashAlgo::Sha256, &combined, &mut thumbprint)
+        self.hash(HsmHashAlgo::Sha256, &combined, &mut thumbprint, true)
             .await?;
 
         Ok(CertChainInfo {

--- a/fw/plat/std/pal/src/hash.rs
+++ b/fw/plat/std/pal/src/hash.rs
@@ -4,29 +4,16 @@
 //! [`HsmHash`] implementation for the standard (host-native) PAL.
 //!
 //! Thin delegation layer that maps the PAL-level [`HsmHashAlgo`] enum
-//! to [`azihsm_crypto::HashAlgo`] and forwards the call to the
+//! to [`azihsm_crypto::HashAlgo`] and forwards one-shot hashing to the
 //! [`StdHash`](crate::drivers::hash::StdHash) driver.
 //!
-//! ## Data flow
-//!
-//! ```text
-//! Core calls pal.hash(HsmHashAlgo::Sha256, data, digest)
-//!   → to_hash_algo() maps to azihsm_crypto::HashAlgo::sha256()
-//!   → self.hash.hash(algo, data, digest)
-//!     → StdHash copies data, dispatches to WorkerPool
-//!       → OpenSSL EVP_Digest (SHA-256)
-//!     → digest written into caller's buffer
-//! ```
+//! Multi-step hashing is not currently needed by the standard PAL, so
+//! those entry points are left as `todo!()` stubs.
 
 use azihsm_crypto::HashAlgo;
 
 use super::*;
 
-/// Map the PAL-level [`HsmHashAlgo`] to the crypto library's
-/// [`azihsm_crypto::HashAlgo`].
-///
-/// Each variant constructs the corresponding OpenSSL message digest
-/// context (e.g., `EVP_sha256`).
 fn to_hash_algo(algo: HsmHashAlgo) -> HashAlgo {
     match algo {
         HsmHashAlgo::Sha1 => HashAlgo::sha1(),
@@ -37,16 +24,41 @@ fn to_hash_algo(algo: HsmHashAlgo) -> HashAlgo {
 }
 
 impl HsmHash for StdHsmPal {
-    /// Compute a cryptographic hash by delegating to the [`StdHash`] driver.
-    ///
-    /// # Parameters
-    /// - `algo` — The hash algorithm (SHA-1/256/384/512).
-    /// - `data` — Input message bytes.
-    /// - `digest` — Output buffer (must be ≥ [`HsmHashAlgo::digest_len`] bytes).
-    ///
-    /// # Errors
-    /// Returns [`HsmError::ShaError`] if the underlying OpenSSL operation fails.
-    async fn hash(&self, algo: HsmHashAlgo, data: &[u8], digest: &mut [u8]) -> HsmResult<()> {
+    type HashCtx<'a>
+        = HsmHashState<'a>
+    where
+        Self: 'a;
+
+    async fn hash(
+        &self,
+        algo: HsmHashAlgo,
+        data: &[u8],
+        digest: &mut [u8],
+        _big_endian: bool,
+    ) -> HsmResult<()> {
         self.hash.hash(to_hash_algo(algo), data, digest).await
+    }
+
+    async fn hash_begin<'a>(
+        &self,
+        _algo: HsmHashAlgo,
+        _state: HsmHashState<'a>,
+    ) -> HsmResult<Self::HashCtx<'a>>
+    where
+        Self: 'a,
+    {
+        todo!()
+    }
+
+    async fn hash_continue(&self, _ctx: &mut Self::HashCtx<'_>, _data: &[u8]) -> HsmResult<()> {
+        todo!()
+    }
+
+    async fn hash_finish<'a>(
+        &self,
+        _ctx: Self::HashCtx<'a>,
+        _big_endian: bool,
+    ) -> HsmResult<HsmHashState<'a>> {
+        todo!()
     }
 }

--- a/fw/plat/std/pal/src/hmac.rs
+++ b/fw/plat/std/pal/src/hmac.rs
@@ -4,63 +4,85 @@
 //! [`HsmHmac`] implementation for the standard (host-native) PAL.
 //!
 //! Thin delegation layer to the [`StdHmac`](crate::drivers::hmac::StdHmac)
-//! driver. The PAL impl maps key length to the underlying hash algorithm
-//! and delegates all crypto work to the driver (which offloads to the
-//! worker pool).
-//!
-//! ## Key-length → hash-algorithm mapping
-//!
-//! | Key length | Hash algorithm |
-//! |------------|----------------|
-//! | 32 bytes   | SHA-256        |
-//! | 48 bytes   | SHA-384        |
-//! | 64 bytes   | SHA-512        |
-//! | other      | SHA-256        |
-//!
-//! ## Data flow (sign example)
-//!
-//! ```text
-//! Core calls pal.hmac_sign(key, data, sig)
-//!   → hash_algo_for_key_len(key.len())   // 32 → SHA-256
-//!   → self.hmac.sign(hash_algo, key, data, sig)
-//!     → WorkerPool → OpenSSL HMAC
-//!   → sig written into caller's buffer
-//! ```
+//! driver. One-shot operations are backed by OpenSSL. Multi-step HMAC APIs
+//! are not currently used by the standard PAL and are left as `todo!()`.
 
 use azihsm_crypto::HashAlgo;
 
 use super::*;
 
-/// Map HMAC key length to the corresponding [`HashAlgo`].
-///
-/// Uses the key length as an implicit indicator of the intended hash
-/// algorithm. Falls back to SHA-256 for unrecognized sizes.
-fn hash_algo_for_key_len(len: usize) -> HashAlgo {
-    match len {
-        32 => HashAlgo::sha256(),
-        48 => HashAlgo::sha384(),
-        64 => HashAlgo::sha512(),
-        _ => HashAlgo::sha256(),
+fn to_hash_algo(algo: HsmHashAlgo) -> HashAlgo {
+    match algo {
+        HsmHashAlgo::Sha1 => HashAlgo::sha1(),
+        HsmHashAlgo::Sha256 => HashAlgo::sha256(),
+        HsmHashAlgo::Sha384 => HashAlgo::sha384(),
+        HsmHashAlgo::Sha512 => HashAlgo::sha512(),
     }
 }
 
 impl HsmHmac for StdHsmPal {
-    /// Generate a random HMAC key by delegating to the driver.
-    async fn hmac_gen_key(&self, key: &mut [u8]) -> HsmResult<()> {
+    type HmacCtx<'a>
+        = HsmHashState<'a>
+    where
+        Self: 'a;
+
+    async fn hmac_gen_key(&self, _algo: HsmHashAlgo, key: &mut [u8]) -> HsmResult<()> {
         self.hmac.gen_key(key).await
     }
 
-    /// Compute an HMAC tag by mapping key length to hash algo and
-    /// delegating to the driver.
-    async fn hmac_sign(&self, key: &[u8], data: &[u8], sig: &mut [u8]) -> HsmResult<()> {
-        let hash_algo = hash_algo_for_key_len(key.len());
-        self.hmac.sign(hash_algo, key, data, sig).await
+    async fn hmac_sign<'a>(
+        &self,
+        algo: HsmHashAlgo,
+        key: &[u8],
+        data: &[u8],
+        tag: &mut [u8],
+        _state: HsmHashState<'a>,
+    ) -> HsmResult<()>
+    where
+        Self: 'a,
+    {
+        self.hmac.sign(to_hash_algo(algo), key, data, tag).await
     }
 
-    /// Verify an HMAC tag by mapping key length to hash algo and
-    /// delegating to the driver.
-    async fn hmac_verify(&self, key: &[u8], data: &[u8], sig: &[u8]) -> HsmResult<bool> {
-        let hash_algo = hash_algo_for_key_len(key.len());
-        self.hmac.verify(hash_algo, key, data, sig).await
+    async fn hmac_verify<'a>(
+        &self,
+        algo: HsmHashAlgo,
+        key: &[u8],
+        data: &[u8],
+        tag: &[u8],
+        _state: HsmHashState<'a>,
+    ) -> HsmResult<bool>
+    where
+        Self: 'a,
+    {
+        self.hmac.verify(to_hash_algo(algo), key, data, tag).await
+    }
+
+    async fn hmac_begin<'a>(
+        &self,
+        _algo: HsmHashAlgo,
+        _key: &[u8],
+        _state: HsmHashState<'a>,
+    ) -> HsmResult<Self::HmacCtx<'a>>
+    where
+        Self: 'a,
+    {
+        todo!()
+    }
+
+    async fn hmac_continue(&self, _ctx: &mut Self::HmacCtx<'_>, _data: &[u8]) -> HsmResult<()> {
+        todo!()
+    }
+
+    async fn hmac_finish<'a>(&self, _ctx: Self::HmacCtx<'a>) -> HsmResult<HsmHashState<'a>> {
+        todo!()
+    }
+
+    async fn hmac_finish_into(&self, _ctx: Self::HmacCtx<'_>, _dest: &mut [u8]) -> HsmResult<()> {
+        todo!()
+    }
+
+    async fn hmac_finish_verify(&self, _ctx: Self::HmacCtx<'_>, _tag: &[u8]) -> HsmResult<bool> {
+        todo!()
     }
 }

--- a/fw/plat/std/pal/src/kdf.rs
+++ b/fw/plat/std/pal/src/kdf.rs
@@ -3,27 +3,18 @@
 
 //! [`HsmKdf`] implementation for the standard (host-native) PAL.
 //!
-//! Thin delegation layer that maps the PAL-level [`HsmHashAlgo`] and
-//! [`HkdfMode`] enums to their [`azihsm_crypto`] counterparts and
-//! forwards calls to the [`StdKdf`](crate::drivers::kdf::StdKdf) driver.
+//! Thin delegation layer that maps the PAL-level [`HsmHashAlgo`] enum to
+//! [`azihsm_crypto::HashAlgo`] and forwards the supported KDF operations to
+//! the [`StdKdf`](crate::drivers::kdf::StdKdf) driver.
 //!
-//! ## Data flow (HKDF example)
-//!
-//! ```text
-//! Core calls pal.hkdf(key, HsmHashAlgo::Sha256, mode, salt, info, output)
-//!   → to_hash_algo() maps to azihsm_crypto::HashAlgo::sha256()
-//!   → to_hkdf_mode() maps to azihsm_crypto::HkdfMode
-//!   → self.kdf.hkdf(key, hash_algo, mode, salt, info, output)
-//!     → WorkerPool → OpenSSL HKDF
-//!   → output written into caller's buffer
-//! ```
+//! HKDF extract/expand and SP 800-108 counter-mode KDF are backed by
+//! OpenSSL. The remaining hash-based KDF helpers are currently left as
+//! `todo!()` stubs.
 
 use azihsm_crypto::HashAlgo;
 
 use super::*;
 
-/// Map the PAL-level [`HsmHashAlgo`] to the crypto library's
-/// [`azihsm_crypto::HashAlgo`].
 fn to_hash_algo(algo: HsmHashAlgo) -> HashAlgo {
     match algo {
         HsmHashAlgo::Sha1 => HashAlgo::sha1(),
@@ -33,50 +24,103 @@ fn to_hash_algo(algo: HsmHashAlgo) -> HashAlgo {
     }
 }
 
-/// Map the PAL-level [`HkdfMode`] to the crypto library's
-/// [`azihsm_crypto::HkdfMode`].
-fn to_hkdf_mode(mode: HkdfMode) -> azihsm_crypto::HkdfMode {
-    match mode {
-        HkdfMode::Extract => azihsm_crypto::HkdfMode::Extract,
-        HkdfMode::Expand => azihsm_crypto::HkdfMode::Expand,
-        HkdfMode::ExtractAndExpand => azihsm_crypto::HkdfMode::ExtractAndExpand,
-    }
-}
-
 impl HsmKdf for StdHsmPal {
-    /// Derive key material using HKDF by delegating to the [`StdKdf`] driver.
-    async fn hkdf(
+    async fn hkdf_extract<'a>(
         &self,
-        key: &[u8],
         algo: HsmHashAlgo,
-        mode: HkdfMode,
         salt: &[u8],
-        info: &[u8],
-        output: &mut [u8],
-    ) -> HsmResult<()> {
+        ikm: &[u8],
+        prk: &mut [u8],
+        state: HsmKdfState<'a>,
+    ) -> HsmResult<HsmKdfState<'a>> {
         self.kdf
             .hkdf(
-                key,
+                ikm,
                 to_hash_algo(algo),
-                to_hkdf_mode(mode),
+                azihsm_crypto::HkdfMode::Extract,
                 salt,
+                &[],
+                prk,
+            )
+            .await?;
+        Ok(state)
+    }
+
+    async fn hkdf_expand<'a>(
+        &self,
+        algo: HsmHashAlgo,
+        prk: &[u8],
+        info: &[u8],
+        output: &mut [u8],
+        state: HsmKdfState<'a>,
+    ) -> HsmResult<HsmKdfState<'a>> {
+        self.kdf
+            .hkdf(
+                prk,
+                to_hash_algo(algo),
+                azihsm_crypto::HkdfMode::Expand,
+                &[],
                 info,
                 output,
             )
-            .await
+            .await?;
+        Ok(state)
     }
 
-    /// Derive key material using KBKDF by delegating to the [`StdKdf`] driver.
-    async fn kbkdf(
+    async fn sp800_108_kdf<'a>(
         &self,
-        key: &[u8],
         algo: HsmHashAlgo,
+        key: &[u8],
         label: &[u8],
         context: &[u8],
         output: &mut [u8],
-    ) -> HsmResult<()> {
+        state: HsmKdfState<'a>,
+    ) -> HsmResult<HsmKdfState<'a>> {
         self.kdf
             .kbkdf(key, to_hash_algo(algo), label, context, output)
-            .await
+            .await?;
+        Ok(state)
+    }
+
+    async fn mgf1(
+        &self,
+        _algo: HsmHashAlgo,
+        _seed: &[u8],
+        _mask: &mut [u8],
+        _state: &mut [u8],
+    ) -> HsmResult<()> {
+        todo!()
+    }
+
+    async fn mgf1_xor(
+        &self,
+        _algo: HsmHashAlgo,
+        _seed: &[u8],
+        _mask: &mut [u8],
+        _state: &mut [u8],
+    ) -> HsmResult<()> {
+        todo!()
+    }
+
+    async fn x963_kdf(
+        &self,
+        _algo: HsmHashAlgo,
+        _z: &[u8],
+        _shared_info: &[u8],
+        _key: &mut [u8],
+        _state: &mut [u8],
+    ) -> HsmResult<()> {
+        todo!()
+    }
+
+    async fn sp800_56a_kdf(
+        &self,
+        _algo: HsmHashAlgo,
+        _z: &[u8],
+        _other_info: &[u8],
+        _key: &mut [u8],
+        _state: &mut [u8],
+    ) -> HsmResult<()> {
+        todo!()
     }
 }

--- a/fw/plat/std/pal/src/rsa.rs
+++ b/fw/plat/std/pal/src/rsa.rs
@@ -5,30 +5,11 @@
 //!
 //! Thin delegation layer between the trait boundary (DER byte slices)
 //! and the [`StdRsa`](crate::drivers::rsa::StdRsa) driver (OpenSSL
-//! key handles). The PAL impl is responsible for:
+//! key handles).
 //!
-//! 1. **Key serialization** — exporting generated handles to DER bytes
-//!    (PKCS#8 for private, SPKI for public) in [`ras_gen_keypair`].
-//! 2. **Key deserialization** — importing DER bytes into handles for
-//!    [`mod_exp_priv`] and [`mod_exp_pub`].
-//!
-//! ## Key formats
-//!
-//! | Direction | Private key | Public key |
-//! |-----------|-------------|------------|
-//! | Trait → PAL (input) | PKCS#8 DER `&[u8]` | SPKI DER `&[u8]` |
-//! | PAL → Trait (output) | PKCS#8 DER `&mut [u8]` | SPKI DER `&mut [u8]` |
-//! | PAL → Driver (internal) | `RsaPrivateKey` handle | `RsaPublicKey` handle |
-//!
-//! ## Data flow (mod_exp_priv example)
-//!
-//! ```text
-//! Core calls pal.mod_exp_priv(key_der, y, x)
-//!   → RsaPrivateKey::from_bytes(key_der)      // DER → handle
-//!   → self.rsa.mod_exp_priv(&handle, y, x)    // driver
-//!     → WorkerPool → OpenSSL RSA raw decrypt
-//!   → result written into x                   // result → caller
-//! ```
+//! Raw key generation and modular exponentiation are implemented. The
+//! newer padding-helper entry points are present in the trait but are not
+//! currently used by the standard PAL, so they are left as `todo!()`.
 
 use azihsm_crypto::ExportableKey;
 use azihsm_crypto::ImportableKey;
@@ -37,33 +18,20 @@ use azihsm_crypto::RsaPublicKey;
 
 use super::*;
 
+fn key_size_bits(key_size: HsmRsaKey) -> usize {
+    key_size.modulus_len() * 8
+}
+
 impl HsmRsa for StdHsmPal {
-    /// Generate an RSA key pair.
-    ///
-    /// Delegates to [`StdRsa::gen_keypair`] which returns OpenSSL handles,
-    /// then exports the private key as PKCS#8 DER and the public key as
-    /// SPKI DER into the caller-provided buffers.
-    ///
-    /// # Parameters
-    /// - `key_size` — RSA modulus size in bits (2048, 3072, or 4096).
-    /// - `priv_key` — Output buffer for PKCS#8 DER private key.
-    /// - `pub_key` — Output buffer for SPKI DER public key.
-    /// - `_pct` — Pairwise consistency test mode (currently ignored).
-    ///
-    /// # Errors
-    /// - [`HsmError::RsaGenerateError`] — key generation failed.
-    /// - [`HsmError::RsaToDerError`] — DER export failed.
-    /// - [`HsmError::RsaInvalidKeyLength`] — output buffer too small.
     async fn ras_gen_keypair(
         &self,
-        key_size: usize,
+        key_size: HsmRsaKey,
         priv_key: &mut [u8],
         pub_key: &mut [u8],
         _pct: HsmRsaPct,
     ) -> Result<(), HsmError> {
-        let (pk, pubk) = self.rsa.gen_keypair(key_size).await?;
+        let (pk, pubk) = self.rsa.gen_keypair(key_size_bits(key_size)).await?;
 
-        // Export private key as PKCS#8 DER.
         let priv_len = pk.to_bytes(None).map_err(|_| HsmError::RsaToDerError)?;
         if priv_key.len() < priv_len {
             return Err(HsmError::RsaInvalidKeyLength);
@@ -71,7 +39,6 @@ impl HsmRsa for StdHsmPal {
         pk.to_bytes(Some(&mut priv_key[..priv_len]))
             .map_err(|_| HsmError::RsaToDerError)?;
 
-        // Export public key as SPKI DER.
         let pub_len = pubk.to_bytes(None).map_err(|_| HsmError::RsaToDerError)?;
         if pub_key.len() < pub_len {
             return Err(HsmError::RsaInvalidKeyLength);
@@ -82,39 +49,123 @@ impl HsmRsa for StdHsmPal {
         Ok(())
     }
 
-    /// Private-key modular exponentiation: `x = y^d mod n`.
-    ///
-    /// Imports the private key from PKCS#8 DER, delegates the raw RSA
-    /// operation to the driver.
-    ///
-    /// # Parameters
-    /// - `key` — PKCS#8 DER private key bytes.
-    /// - `y` — Input data. Must be exactly the key size in bytes.
-    /// - `x` — Output buffer for the result.
-    ///
-    /// # Errors
-    /// - [`HsmError::InvalidArg`] — DER import failed.
-    /// - [`HsmError::RsaDecryptFailed`] — modular exponentiation failed.
-    async fn mod_exp_priv(&self, key: &[u8], y: &[u8], x: &mut [u8]) -> Result<(), HsmError> {
+    async fn mod_exp_priv(
+        &self,
+        _key_size: HsmRsaKey,
+        key: &[u8],
+        y: &[u8],
+        x: &mut [u8],
+    ) -> Result<(), HsmError> {
         let priv_key = RsaPrivateKey::from_bytes(key).map_err(|_| HsmError::InvalidArg)?;
         self.rsa.mod_exp_priv(&priv_key, y, x).await
     }
 
-    /// Public-key modular exponentiation: `y = x^e mod n`.
-    ///
-    /// Imports the public key from SPKI DER, delegates the raw RSA
-    /// operation to the driver.
-    ///
-    /// # Parameters
-    /// - `key` — SPKI DER public key bytes.
-    /// - `x` — Input data. Must be exactly the key size in bytes.
-    /// - `y` — Output buffer for the result.
-    ///
-    /// # Errors
-    /// - [`HsmError::InvalidArg`] — DER import failed.
-    /// - [`HsmError::RsaEncryptFailed`] — modular exponentiation failed.
-    async fn mod_exp_pub(&self, key: &[u8], x: &[u8], y: &mut [u8]) -> Result<(), HsmError> {
+    async fn mod_exp_pub(
+        &self,
+        _key_size: HsmRsaKey,
+        key: &[u8],
+        x: &[u8],
+        y: &mut [u8],
+    ) -> Result<(), HsmError> {
         let pub_key = RsaPublicKey::from_bytes(key).map_err(|_| HsmError::InvalidArg)?;
         self.rsa.mod_exp_pub(&pub_key, x, y).await
+    }
+
+    async fn rsa_pkcs1_encrypt(
+        &self,
+        _key_size: HsmRsaKey,
+        _pub_key: &[u8],
+        _message: &[u8],
+        _output: &mut [u8],
+        _work: &mut [u8],
+    ) -> HsmResult<()> {
+        todo!()
+    }
+
+    async fn rsa_pkcs1_decrypt(
+        &self,
+        _key_size: HsmRsaKey,
+        _priv_key: &[u8],
+        _ciphertext: &[u8],
+        _output: &mut [u8],
+        _work: &mut [u8],
+    ) -> HsmResult<usize> {
+        todo!()
+    }
+
+    async fn rsa_pkcs1_sign(
+        &self,
+        _key_size: HsmRsaKey,
+        _algo: HsmHashAlgo,
+        _priv_key: &[u8],
+        _message_hash: &[u8],
+        _signature: &mut [u8],
+        _work: &mut [u8],
+    ) -> HsmResult<()> {
+        todo!()
+    }
+
+    async fn rsa_pkcs1_verify(
+        &self,
+        _key_size: HsmRsaKey,
+        _algo: HsmHashAlgo,
+        _pub_key: &[u8],
+        _message_hash: &[u8],
+        _signature: &[u8],
+        _work: &mut [u8],
+    ) -> HsmResult<bool> {
+        todo!()
+    }
+
+    async fn rsa_oaep_encrypt(
+        &self,
+        _key_size: HsmRsaKey,
+        _algo: HsmHashAlgo,
+        _pub_key: &[u8],
+        _message: &[u8],
+        _label: &[u8],
+        _output: &mut [u8],
+        _work: &mut [u8],
+    ) -> HsmResult<()> {
+        todo!()
+    }
+
+    async fn rsa_oaep_decrypt(
+        &self,
+        _key_size: HsmRsaKey,
+        _algo: HsmHashAlgo,
+        _priv_key: &[u8],
+        _ciphertext: &[u8],
+        _label: &[u8],
+        _output: &mut [u8],
+        _work: &mut [u8],
+    ) -> HsmResult<usize> {
+        todo!()
+    }
+
+    async fn rsa_pss_sign(
+        &self,
+        _key_size: HsmRsaKey,
+        _algo: HsmHashAlgo,
+        _priv_key: &[u8],
+        _message_hash: &[u8],
+        _salt_len: usize,
+        _signature: &mut [u8],
+        _work: &mut [u8],
+    ) -> HsmResult<()> {
+        todo!()
+    }
+
+    async fn rsa_pss_verify(
+        &self,
+        _key_size: HsmRsaKey,
+        _algo: HsmHashAlgo,
+        _pub_key: &[u8],
+        _message_hash: &[u8],
+        _salt_len: usize,
+        _signature: &[u8],
+        _work: &mut [u8],
+    ) -> HsmResult<bool> {
+        todo!()
     }
 }


### PR DESCRIPTION
Expand the PAL crypto trait surface to support additional algorithms and update the StdHsmPal implementation to match.

Trait changes:
- HsmAes: add AES-KW wrap/unwrap, AES-KWP wrap/unwrap, AES-XTS encrypt/decrypt with XtsDataUnitLen enum
- HsmHash: add big_endian param to hash(), add multi-step API (hash_begin/continue/finish) with HashCtx associated type
- HsmHmac: add algo param to hmac_gen_key/sign/verify, add multi-step API (hmac_begin/continue/finish/finish_verify) with HmacCtx
- HsmKdf: replace hkdf/kbkdf with hkdf_extract, hkdf_expand, sp800_108_kdf, plus mgf1, mgf1_xor, x963_kdf, sp800_56a_kdf
- HsmRsa: add HsmRsaKey enum, update ras_gen_keypair/mod_exp_* to take HsmRsaKey, add rsa_pkcs1/oaep/pss encrypt/decrypt/sign/verify
- error.rs: add AesUnwrapFailed error code

StdPal implementation:
- Update existing method signatures to match new traits hash/HMAC, MGF1/X9.63/SP800-56A KDF, RSA PKCS1/OAEP/PSS)
- Update all callers in fw/core to new hash/hmac/kdf signatures

DDI integration test results with --features emu (563 total):
  28 passed, 535 failed, 0 skipped (no regression)