### PR TITLE
refactor(fw): sync remaining vendored changes

### DIFF
--- a/fw/core/ddi/mbor/types/src/lib.rs
+++ b/fw/core/ddi/mbor/types/src/lib.rs
@@ -230,8 +230,8 @@ pub enum DdiAesOp {
 
 #[open_enum]
 #[derive(Debug, Ddi, Eq, PartialEq, Clone, Copy)]
-#[repr(u32)]
 #[ddi(enumeration)]
+#[repr(u32)]
 pub enum DdiAesKeySize {
     Aes128 = 1,
     Aes192 = 2,

--- a/fw/core/lib/src/error.rs
+++ b/fw/core/lib/src/error.rs
@@ -77,15 +77,14 @@ pub(crate) trait ResultOpErrExt<T> {
 /// Extension trait for `HsmResult<T>` that preserves the original error.
 pub(crate) trait ResultOpStatusExt<T> {
     /// Log and convert to [`OpError`], keeping the original [`HsmError`].
-    fn op_status(self, tag: &str, status: u16) -> Result<T, OpError>;
+    fn op_status(self, status: u16) -> Result<T, OpError>;
 }
 
 impl<T, E: core::fmt::Debug> ResultOpErrExt<T> for Result<T, E> {
     #[inline]
-    #[allow(unused_variables)]
-    fn op_err(self, tag: &str, err: HsmError, status: u16) -> Result<T, OpError> {
-        self.map_err(|e| {
-            error!(tag, err, "{:?}", e);
+    fn op_err(self, _tag: &str, err: HsmError, status: u16) -> Result<T, OpError> {
+        self.map_err(|_e| {
+            error!(_tag, err, "{:?}", _e);
             OpError::new(err, status)
         })
     }
@@ -93,10 +92,9 @@ impl<T, E: core::fmt::Debug> ResultOpErrExt<T> for Result<T, E> {
 
 impl<T> ResultOpStatusExt<T> for HsmResult<T> {
     #[inline]
-    #[allow(unused_variables)]
-    fn op_status(self, tag: &str, status: u16) -> Result<T, OpError> {
+    fn op_status(self, status: u16) -> Result<T, OpError> {
         self.map_err(|e| {
-            error!(tag, e, "failed");
+            error!("op_status", e, "failed");
             OpError::new(e, status)
         })
     }

--- a/fw/core/lib/src/io.rs
+++ b/fw/core/lib/src/io.rs
@@ -164,12 +164,12 @@ impl<P: HsmPal> Hsm<P> {
                 Self::validate_session(&hdr, session_ctrl, session_flags, sqe_session_id)
             {
                 ddi::encode_ddi_err(hdr.op, status, resp_buf)
-                    .op_status("core", HostStatus::INTERNAL_ERROR)?
+                    .op_status(HostStatus::INTERNAL_ERROR)?
             } else {
                 match ddi::dispatch(&hdr, &mut decoder, part_id, self.pal(), fmem, resp_buf).await {
                     Ok(len) => len,
                     Err(status) => ddi::encode_ddi_err(hdr.op, status, resp_buf)
-                        .op_status("core", HostStatus::INTERNAL_ERROR)?,
+                        .op_status(HostStatus::INTERNAL_ERROR)?,
                 }
             };
 


### PR DESCRIPTION
Bring over the remaining upstream changes from the vendor crate:

- core/lib/error.rs: simplify op_status() by removing the tag parameter and hardcoding the log tag; prefix unused params with underscore in op_err()
- core/lib/io.rs: update op_status() call sites to match new signature
- core/ddi/mbor/types/lib.rs: swap attribute ordering on DdiAesKeySize (#[ddi(enumeration)] before #[repr(u32)])

DDI integration test results with --features emu (563 total):
  28 passed, 535 failed, 0 skipped (no regression)