### PR TITLE
[bug]fixed CBC padding corruption test using CBC derived key

### DIFF
--- a/api/tests/src/algo/kdf/hkdf_tests.rs
+++ b/api/tests/src/algo/kdf/hkdf_tests.rs
@@ -509,13 +509,17 @@ fn run_aes_cbc_padding_tamper_test(session: &HsmSession) {
     let iv = [0u8; 16];
     let mut enc = HsmAesCbcAlgo::with_padding(iv.to_vec()).unwrap();
 
-    let mut ct = HsmEncrypter::encrypt_vec(&mut enc, &key, b"padding test").unwrap();
+    let mut ct =
+        HsmEncrypter::encrypt_vec(&mut enc, &key, b"CBC padding with HKDF Derived Key").unwrap();
 
-    // Corrupt previous block to reliably break padding
+    // Flip C_prev[15] (= ct[len-17]) — CBC: P_last[15] = AES_dec(C_last)[15] XOR C_prev[15],
+    // so this deterministically inverts the PKCS#7 pad-length byte.
     let len = ct.len();
-    // Corrupt previous block if possible (best for breaking padding deterministically)
-    let idx = if len >= 32 { len - 16 } else { len / 2 };
-    ct[idx] ^= 0xFF;
+    assert!(
+        len >= 32,
+        "ciphertext too short to tamper with padding without risking non-determinism"
+    );
+    ct[len - 17] ^= 0xFF;
 
     let mut dec = HsmAesCbcAlgo::with_padding(iv.to_vec()).unwrap();
 


### PR DESCRIPTION
Cipher text in run_aes_cbc_padding_tamper_test is < 16 bytes which can cause a false positive for padding corruption. 
This pull request refines the AES-CBC padding tampering test to make it more deterministic and reliable. The test now uses a longer plaintext and specifically targets the PKCS#7 padding byte to ensure consistent padding errors.

Improvements to the padding tampering test:

* Updated the test plaintext in `run_aes_cbc_padding_tamper_test` to a longer message, ensuring the ciphertext is always long enough for deterministic tampering.
* Changed the tampering logic to always flip the last byte of the previous ciphertext block (`ct[len - 17]`), which reliably inverts the PKCS#7 pad-length byte and guarantees a padding error.
* Added an assertion to ensure the ciphertext is at least 32 bytes, preventing non-deterministic test failures due to short ciphertexts.
