### PR TITLE
feat(fw/pal): sync vendored crates and align StdPal with new PAL trait surface

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,9 @@ members = [
   "ddi/sim",
   "ddi/test_helpers",
   "ddi/win",
+  "fw/core/crypto/aes-cbc-pad",
+  "fw/core/crypto/gcm-buf",
+  "fw/core/crypto/hpke",
   "fw/core/ddi/mbor/api",
   "fw/core/ddi/mbor/codec",
   "fw/core/ddi/mbor/derive",
@@ -95,6 +98,11 @@ azihsm_fw_ddi_tbor = { path = "fw/core/ddi/tbor/codec" }
 azihsm_fw_ddi_tbor_api = { path = "fw/core/ddi/tbor/api" }
 azihsm_fw_ddi_tbor_derive = { path = "fw/core/ddi/tbor/derive" }
 azihsm_fw_ddi_tbor_types = { path = "fw/core/ddi/tbor/types" }
+
+# Firmware crates — crypto
+azihsm_fw_core_crypto_aes_cbc_pad = { path = "fw/core/crypto/aes-cbc-pad" }
+azihsm_fw_core_crypto_gcm_buf = { path = "fw/core/crypto/gcm-buf" }
+azihsm_fw_core_crypto_hpke = { path = "fw/core/crypto/hpke" }
 
 # Firmware crates — common
 azihsm_fw_hsm_core = { path = "fw/core/lib" }

--- a/fw/core/crypto/aes-cbc-pad/Cargo.toml
+++ b/fw/core/crypto/aes-cbc-pad/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+edition = "2021"
+name = "azihsm_fw_core_crypto_aes_cbc_pad"
+version = "0.1.0"
+
+[lib]
+bench = false
+doctest = false
+test = false
+
+[dependencies]
+azihsm_fw_hsm_pal_traits = { workspace = true }

--- a/fw/core/crypto/aes-cbc-pad/src/lib.rs
+++ b/fw/core/crypto/aes-cbc-pad/src/lib.rs
@@ -1,0 +1,205 @@
+// Copyright (c) Microsoft Corporation.
+
+#![no_std]
+
+//! AES-CBC with PKCS#7 padding.
+//!
+//! This crate wraps the PAL's block-aligned [`HsmAes`] CBC API so
+//! callers can encrypt arbitrary-length plaintext: [`aes_cbc_pkcs7_encrypt`]
+//! adds PKCS#7 padding before encryption, and [`aes_cbc_pkcs7_decrypt`]
+//! validates and removes it after decryption.
+//!
+//! ## PKCS#7 padding
+//!
+//! PKCS#7 always appends `pad_byte` value-`pad_byte` bytes where
+//! `pad_byte = block_len - (pt.len() % block_len)`. When the
+//! plaintext is already block-aligned the padding is a full extra
+//! block of `0x10` bytes. The unpadder rejects any tail that does
+//! not match this exact pattern with [`HsmError::AesDecryptFailed`].
+//!
+//! The crate is generic over the PAL — it only depends on the
+//! [`HsmAes`] trait, not on any concrete PAL implementation.
+
+use azihsm_fw_hsm_pal_traits::AesOp;
+use azihsm_fw_hsm_pal_traits::DmaBuf;
+use azihsm_fw_hsm_pal_traits::HsmAes;
+use azihsm_fw_hsm_pal_traits::HsmAlloc;
+use azihsm_fw_hsm_pal_traits::HsmError;
+use azihsm_fw_hsm_pal_traits::HsmIo;
+use azihsm_fw_hsm_pal_traits::HsmResult;
+
+// =============================================================================
+// Constants
+// =============================================================================
+
+/// AES block size in bytes.
+const BLOCK: usize = 16;
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+/// Compute the PKCS#7-padded ciphertext length.
+///
+/// Always grows by 1..=BLOCK bytes (PKCS#7 never produces a
+/// zero-byte pad — block-aligned inputs gain a full extra block).
+///
+/// # Parameters
+/// * `pt_len` — plaintext length in bytes.
+///
+/// # Returns
+/// * `pt_len + (BLOCK - pt_len % BLOCK)`.
+pub const fn padded_len(pt_len: usize) -> usize {
+    pt_len + BLOCK - (pt_len % BLOCK)
+}
+
+/// Apply PKCS#7 padding to the tail of a `padded_len(pt.len())` buffer.
+///
+/// Copies `pt` into `dst[..pt.len()]` and fills `dst[pt.len()..]`
+/// with the pad-byte value.
+fn apply_pkcs7_padding(dst: &mut [u8], pt: &[u8]) {
+    let padded = dst.len();
+    dst[..pt.len()].copy_from_slice(pt);
+    let pad_byte = (padded - pt.len()) as u8;
+    dst[pt.len()..padded].fill(pad_byte);
+}
+
+/// Validate PKCS#7 padding on the tail of a freshly-decrypted buffer
+/// and return the unpadded length.
+///
+/// # Parameters
+/// * `decrypted` — plaintext + padding (length is a multiple of
+///   [`BLOCK`]).
+///
+/// # Returns
+/// * `Ok(unpadded_len)` if the padding is well-formed.
+///
+/// # Errors
+/// * [`HsmError::AesDecryptFailed`] if the trailing padding bytes do
+///   not match the PKCS#7 pattern.
+fn strip_pkcs7_padding(decrypted: &[u8]) -> HsmResult<usize> {
+    let len = decrypted.len();
+    let pad_byte = decrypted[len - 1];
+    if pad_byte == 0 || pad_byte as usize > BLOCK {
+        return Err(HsmError::AesDecryptFailed);
+    }
+    let pad_start = len - pad_byte as usize;
+    if !decrypted[pad_start..len].iter().all(|&b| b == pad_byte) {
+        return Err(HsmError::AesDecryptFailed);
+    }
+    Ok(pad_start)
+}
+
+// =============================================================================
+// Public API
+// =============================================================================
+
+/// AES-CBC encrypt with PKCS#7 padding.
+///
+/// Pads `pt` to the next 16-byte boundary (always adds at least 1
+/// byte of padding) and encrypts the padded buffer with AES-CBC.
+///
+/// # Type parameters
+/// * `P` — any [`HsmAes`] PAL implementation.
+///
+/// # Parameters
+/// * `pal` — PAL providing AES-CBC.
+/// * `io` — I/O context forwarded to the PAL AES methods.
+/// * `key` — AES key (16, 24, or 32 bytes).
+/// * `iv` — 16-byte initialisation vector. Updated in place to the
+///   last ciphertext block so the caller can chain CBC sessions.
+/// * `pt` — plaintext of any length (including zero — the result is
+///   then a single full block of pad bytes).
+/// * `ct` — destination buffer; must be at least
+///   [`padded_len(pt.len())`](padded_len) bytes long.
+///
+/// # Returns
+/// * `Ok(padded_len)` — number of ciphertext bytes written to `ct`.
+///
+/// # Errors
+/// * [`HsmError::InvalidArg`] if `ct` is shorter than the padded
+///   length.
+/// * Any [`HsmError`] surfaced by the PAL's CBC engine.
+pub async fn aes_cbc_pkcs7_encrypt<P: HsmAes + HsmAlloc>(
+    pal: &P,
+    io: &impl HsmIo,
+    key: &DmaBuf,
+    iv: &mut [u8],
+    pt: &[u8],
+    ct: &mut DmaBuf,
+) -> HsmResult<usize> {
+    let padded = padded_len(pt.len());
+    if ct.len() < padded {
+        return Err(HsmError::InvalidArg);
+    }
+
+    if iv.len() != BLOCK {
+        return Err(HsmError::InvalidArg);
+    }
+
+    let work = pal.dma_alloc(io, padded)?;
+    apply_pkcs7_padding(work, pt);
+
+    let iv_in = pal.dma_alloc(io, BLOCK)?;
+    iv_in.copy_from_slice(iv);
+    let iv_out = pal.dma_alloc(io, BLOCK)?;
+    pal.aes_cbc_enc_dec_in_place(io, AesOp::Encrypt, key, work, iv_in, Some(iv_out))
+        .await?;
+    ct[..padded].copy_from_slice(work);
+    iv.copy_from_slice(iv_out);
+    Ok(padded)
+}
+
+/// AES-CBC decrypt with PKCS#7 unpadding.
+///
+/// Decrypts `ct` with AES-CBC, validates the PKCS#7 padding, and
+/// returns the unpadded plaintext length.
+///
+/// # Type parameters
+/// * `P` — any [`HsmAes`] PAL implementation.
+///
+/// # Parameters
+/// * `pal` — PAL providing AES-CBC.
+/// * `io` — I/O context forwarded to the PAL AES methods.
+/// * `key` — AES key (16, 24, or 32 bytes).
+/// * `iv` — 16-byte IV. Updated in place after decryption.
+/// * `ct` — ciphertext; must be a non-empty whole number of 16-byte
+///   blocks.
+/// * `pt` — destination buffer; must be at least `ct.len()` bytes
+///   long.
+///
+/// # Returns
+/// * `Ok(pt_len)` — number of plaintext bytes (i.e. `ct.len()` minus
+///   the validated PKCS#7 pad).
+///
+/// # Errors
+/// * [`HsmError::InvalidArg`] if `ct` is empty, not a multiple of 16
+///   bytes, or `pt` is shorter than `ct`.
+/// * [`HsmError::AesDecryptFailed`] if the recovered padding is
+///   invalid.
+/// * Any [`HsmError`] surfaced by the PAL's CBC engine.
+pub async fn aes_cbc_pkcs7_decrypt<P: HsmAes + HsmAlloc>(
+    pal: &P,
+    io: &impl HsmIo,
+    key: &DmaBuf,
+    iv: &mut [u8],
+    ct: &DmaBuf,
+    pt: &mut DmaBuf,
+) -> HsmResult<usize> {
+    let len = ct.len();
+    if len == 0 || !len.is_multiple_of(BLOCK) || pt.len() < len {
+        return Err(HsmError::InvalidArg);
+    }
+
+    if iv.len() != BLOCK {
+        return Err(HsmError::InvalidArg);
+    }
+
+    let iv_in = pal.dma_alloc(io, BLOCK)?;
+    iv_in.copy_from_slice(iv);
+    let iv_out = pal.dma_alloc(io, BLOCK)?;
+    pal.aes_cbc_enc_dec(io, AesOp::Decrypt, key, ct, iv_in, pt, Some(iv_out))
+        .await?;
+    iv.copy_from_slice(iv_out);
+    strip_pkcs7_padding(&pt[..len])
+}

--- a/fw/core/crypto/gcm-buf/Cargo.toml
+++ b/fw/core/crypto/gcm-buf/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+edition = "2021"
+name = "azihsm_fw_core_crypto_gcm_buf"
+version = "0.1.0"
+
+[lib]
+bench = false
+doctest = false
+test = false

--- a/fw/core/crypto/gcm-buf/src/lib.rs
+++ b/fw/core/crypto/gcm-buf/src/lib.rs
@@ -1,0 +1,247 @@
+// Copyright (c) Microsoft Corporation.
+
+#![no_std]
+
+//! GCM buffer layout helpers for the BCP `pad_aad` convention.
+//!
+//! The Ocelot BCP hardware accepts AES-GCM input buffers laid out as
+//! `[padded_AAD | text]`. The AAD region is padded to a multiple of
+//! 32 bytes per the table below. The prepended (or trailing) zero
+//! bytes form a GHASH-transparent block, so the real AAD content
+//! occupies the same GHASH-block positions as standard GCM.
+//!
+//! | `aad_len % 32` | Padded layout                              |
+//! |----------------|--------------------------------------------|
+//! | `0`            | `[AAD]` (no padding)                       |
+//! | `1..=16`       | `[zeros(16) ‖ AAD ‖ trail_zeros]` (prefix) |
+//! | `17..=31`      | `[AAD ‖ trail_zeros]` (trailing only)      |
+//!
+//! This crate is pure computation — no PAL traits, no hardware
+//! access, no allocations.
+
+// =============================================================================
+// Constants
+// =============================================================================
+
+/// AAD-padding granularity (bytes). Every BCP GCM submission's AAD
+/// region length is a multiple of this value.
+const AAD_PAD: usize = 32;
+
+/// Threshold at which the BCP convention switches from the "prefix
+/// 16 zeros" layout to the "trailing-only" layout. Inclusive upper
+/// bound for the prefix layout.
+const PREFIX_LAYOUT_THRESHOLD: usize = 16;
+
+// =============================================================================
+// Layout primitives
+// =============================================================================
+
+/// Layout selector for [`format_gcm_buf`] — which of the three rules
+/// in the table at the top of this module applies.
+#[derive(Clone, Copy)]
+enum AadLayout {
+    /// `aad_len == 0` — the buffer is just the text.
+    Empty,
+    /// `aad_len % 32 == 0` — AAD is copied verbatim, no padding.
+    Aligned,
+    /// `aad_len % 32 in 1..=16` — prepend 16 zero bytes, then AAD,
+    /// then trailing zeros to the next 32 boundary.
+    Prefix16,
+    /// `aad_len % 32 in 17..=31` — AAD verbatim, then trailing zeros
+    /// to the next 32 boundary.
+    Trailing,
+}
+
+impl AadLayout {
+    /// Pick the right layout for an unpadded AAD length.
+    const fn from_len(aad_len: usize) -> Self {
+        if aad_len == 0 {
+            return Self::Empty;
+        }
+        match aad_len % AAD_PAD {
+            0 => Self::Aligned,
+            1..=PREFIX_LAYOUT_THRESHOLD => Self::Prefix16,
+            _ => Self::Trailing,
+        }
+    }
+}
+
+// =============================================================================
+// Public API
+// =============================================================================
+
+/// Compute the padded AAD region size in bytes.
+///
+/// The result is always a multiple of 32 (or 0 when `aad_len == 0`).
+///
+/// # Parameters
+/// * `aad_len` — unpadded AAD length supplied by the caller.
+///
+/// # Returns
+/// * The padded AAD-region length per the [layout
+///   table](self#padded-layout-table).
+pub const fn padded_aad_len(aad_len: usize) -> usize {
+    match AadLayout::from_len(aad_len) {
+        AadLayout::Empty => 0,
+        AadLayout::Aligned => aad_len,
+        AadLayout::Prefix16 => (16 + aad_len).next_multiple_of(AAD_PAD),
+        AadLayout::Trailing => aad_len.next_multiple_of(AAD_PAD),
+    }
+}
+
+/// Total buffer size needed for one GCM encrypt/decrypt operation
+/// (`padded_aad ‖ text`).
+///
+/// # Parameters
+/// * `aad_len` — unpadded AAD length.
+/// * `text_len` — plaintext or ciphertext length.
+///
+/// # Returns
+/// * `padded_aad_len(aad_len) + text_len`.
+pub const fn gcm_buf_len(aad_len: usize, text_len: usize) -> usize {
+    padded_aad_len(aad_len) + text_len
+}
+
+/// Format AAD and text into a GCM buffer using the BCP `pad_aad`
+/// convention.
+///
+/// Writes `[padded_aad | text]` into `buf` and returns the unpadded
+/// `aad_len` value the caller should pass to `gcm_encrypt` /
+/// `gcm_decrypt`.
+///
+/// # Parameters
+/// * `aad` — additional authenticated data (any length, may be
+///   empty).
+/// * `text` — plaintext or ciphertext.
+/// * `buf` — destination; must be at least
+///   [`gcm_buf_len(aad.len(), text.len())`](gcm_buf_len) bytes.
+///
+/// # Returns
+/// * `aad.len()` — pass this verbatim to the GCM API.
+///
+/// # Panics
+/// * Panics if `buf` is too small.
+pub fn format_gcm_buf(aad: &[u8], text: &[u8], buf: &mut [u8]) -> usize {
+    let aad_len = aad.len();
+    let padded = padded_aad_len(aad_len);
+    let total = padded + text.len();
+    assert!(buf.len() >= total, "gcm buf too small");
+
+    match AadLayout::from_len(aad_len) {
+        AadLayout::Empty => {
+            // No AAD region — `padded` is 0, so `buf[..text.len()]`
+            // is the full output.
+            buf[..text.len()].copy_from_slice(text);
+        }
+        AadLayout::Aligned => {
+            buf[..aad_len].copy_from_slice(aad);
+        }
+        AadLayout::Prefix16 => {
+            // Prepend 16 zero bytes, then AAD, then trailing zeros
+            // up to `padded`.
+            buf[..16].fill(0);
+            buf[16..16 + aad_len].copy_from_slice(aad);
+            buf[16 + aad_len..padded].fill(0);
+        }
+        AadLayout::Trailing => {
+            // AAD left-justified, trailing zeros up to `padded`.
+            buf[..aad_len].copy_from_slice(aad);
+            buf[aad_len..padded].fill(0);
+        }
+    }
+
+    // Append text after the padded AAD region.
+    buf[padded..total].copy_from_slice(text);
+
+    aad_len
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn padded_len_zero() {
+        assert_eq!(padded_aad_len(0), 0);
+    }
+
+    #[test]
+    fn padded_len_small() {
+        // 13 % 32 = 13 ≤ 16 → prepend 16 + 13 = 29 → round to 32
+        assert_eq!(padded_aad_len(13), 32);
+    }
+
+    #[test]
+    fn padded_len_16() {
+        // 16 % 32 = 16 ≤ 16 → prepend 16 + 16 = 32
+        assert_eq!(padded_aad_len(16), 32);
+    }
+
+    #[test]
+    fn padded_len_20() {
+        // 20 % 32 = 20 > 16 → trail-pad 20 → 32
+        assert_eq!(padded_aad_len(20), 32);
+    }
+
+    #[test]
+    fn padded_len_32() {
+        // 32 % 32 = 0 → no padding
+        assert_eq!(padded_aad_len(32), 32);
+    }
+
+    #[test]
+    fn padded_len_48() {
+        // 48 % 32 = 16 ≤ 16 → prepend 16 + 48 = 64
+        assert_eq!(padded_aad_len(48), 64);
+    }
+
+    #[test]
+    fn padded_len_50() {
+        // 50 % 32 = 18 > 16 → trail-pad 50 → 64
+        assert_eq!(padded_aad_len(50), 64);
+    }
+
+    #[test]
+    fn padded_len_64() {
+        // 64 % 32 = 0 → no padding
+        assert_eq!(padded_aad_len(64), 64);
+    }
+
+    #[test]
+    fn format_no_aad() {
+        let text = [0xAA; 16];
+        let mut buf = [0u8; 16];
+        let aad_len = format_gcm_buf(&[], &text, &mut buf);
+        assert_eq!(aad_len, 0);
+        assert_eq!(buf, text);
+    }
+
+    #[test]
+    fn format_aligned_aad() {
+        let aad = [0xBB; 32];
+        let text = [0xCC; 8];
+        let mut buf = [0u8; 40];
+        let aad_len = format_gcm_buf(&aad, &text, &mut buf);
+        assert_eq!(aad_len, 32);
+        assert_eq!(&buf[..32], &aad);
+        assert_eq!(&buf[32..40], &text);
+    }
+
+    #[test]
+    fn format_prepend_zeros() {
+        let aad = [0xDD; 13];
+        let text = [0xEE; 4];
+        let padded = padded_aad_len(13); // 32
+        let mut buf = [0xFFu8; 36];
+        let aad_len = format_gcm_buf(&aad, &text, &mut buf);
+        assert_eq!(aad_len, 13);
+        // First 16 bytes are zeros (prepended).
+        assert_eq!(&buf[..16], &[0u8; 16]);
+        // Then AAD.
+        assert_eq!(&buf[16..29], &aad);
+        // Trail zeros.
+        assert_eq!(&buf[29..padded], &[0u8; 3]);
+        // Then text.
+        assert_eq!(&buf[padded..padded + 4], &text);
+    }
+}

--- a/fw/core/crypto/hpke/Cargo.toml
+++ b/fw/core/crypto/hpke/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+edition = "2021"
+name = "azihsm_fw_core_crypto_hpke"
+version = "0.1.0"
+
+[lib]
+bench = false
+doctest = false
+test = false
+
+[dependencies]
+azihsm_fw_core_crypto_aes_cbc_pad = { path = "../aes-cbc-pad" }
+azihsm_fw_core_crypto_gcm_buf = { path = "../gcm-buf" }
+azihsm_fw_hsm_pal_traits = { workspace = true }

--- a/fw/core/crypto/hpke/src/aead.rs
+++ b/fw/core/crypto/hpke/src/aead.rs
@@ -1,0 +1,543 @@
+// Copyright (c) Microsoft Corporation.
+
+//! HPKE AEAD seal / open — dispatches to AES-256-GCM or
+//! AES-256-CBC + HMAC depending on the chosen [`HpkeSuite`].
+//!
+//! ## Output layouts
+//!
+//! | Suite type | Layout                                |
+//! |------------|---------------------------------------|
+//! | GCM        | `ct[pt.len()] ‖ tag[16]`              |
+//! | CBC-HMAC   | `iv[16] ‖ ciphertext[padded] ‖ tag[Nt]` |
+//!
+//! ## CBC-HMAC details
+//!
+//! The CBC variants use the FIPS-compliant key sizing scheme defined
+//! in [`HpkeSuite`]:
+//!
+//! ```text
+//! key       = MAC_KEY[Nh] ‖ ENC_KEY[32]
+//! tag_len   = Nh / 2          (HMAC truncated to half the hash)
+//! mac_input = aad ‖ iv ‖ ciphertext ‖ I2OSP(aad.len() * 8, 8)
+//! ```
+//!
+//! Encryption uses encrypt-then-MAC; decryption verifies the MAC
+//! before unpadding so a tag mismatch never reveals padding-oracle
+//! information.
+
+use azihsm_fw_hsm_pal_traits::HsmAlloc;
+use azihsm_fw_hsm_pal_traits::HsmCrypto;
+use azihsm_fw_hsm_pal_traits::HsmError;
+use azihsm_fw_hsm_pal_traits::HsmHashAlgo;
+use azihsm_fw_hsm_pal_traits::HsmIo;
+use azihsm_fw_hsm_pal_traits::HsmResult;
+use azihsm_fw_hsm_pal_traits::HsmScopedAlloc;
+
+use crate::helpers::dma_copy_in;
+use crate::suite::HpkeSuite;
+
+// =============================================================================
+// Constants
+// =============================================================================
+
+/// AES-256-GCM tag length in bytes.
+const GCM_TAG_LEN: usize = 16;
+
+/// CBC IV length in bytes (= one AES block).
+const CBC_IV_LEN: usize = 16;
+
+/// Maximum SHA digest length supported (SHA-512). Used to size the
+/// stack-allocated full-tag buffer used in the CBC paths.
+const MAX_DIGEST_LEN: usize = 64;
+
+// =============================================================================
+// Public dispatch
+// =============================================================================
+
+/// AEAD Seal: encrypt + authenticate. Dispatches on
+/// [`HpkeSuite::is_cbc`].
+///
+/// # Type parameters
+///
+/// * `P` — any [`HsmCrypto`] PAL implementation.
+///
+/// # Parameters
+///
+/// * `pal` — PAL providing AES / HMAC.
+/// * `io` — caller's I/O context (per-IO scope).
+/// * `suite` — HPKE ciphersuite (selects AES-GCM vs AES-CBC + HMAC).
+/// * `key` — AEAD key (`Nk` bytes — see [`HpkeSuite::nk`]).
+/// * `base_nonce` — for GCM: 12-byte nonce.  For CBC: ignored (the
+///   PAL generates a random IV per call).
+/// * `aad` — additional authenticated data (may be empty).
+/// * `pt` — plaintext to encrypt.
+/// * `ct` — destination buffer; sized per the
+///   [output-layouts table](self#output-layouts).
+/// * `alloc` — scoped allocator used for HMAC scratch in the CBC
+///   path (unused on GCM).
+///
+/// # Returns
+///
+/// * `Ok(ct_len)` — bytes written to `ct`
+///   (`pt.len() + 16` for GCM; `16 + padded(pt.len()) + Nt` for CBC).
+/// * `Err(HsmError::InvalidArg)` — length-constraint violation
+///   (nonce / key / output-buffer size).
+/// * `Err(HsmError)` — propagated from the AES, HMAC, or RNG
+///   driver.
+pub async fn seal<'a, P>(
+    pal: &P,
+    io: &impl HsmIo,
+    suite: HpkeSuite,
+    key: &[u8],
+    base_nonce: &[u8],
+    aad: &[u8],
+    pt: &[u8],
+    ct: &mut [u8],
+    alloc: &'a impl HsmScopedAlloc,
+) -> HsmResult<usize>
+where
+    P: HsmCrypto + HsmAlloc + 'a,
+{
+    if suite.is_cbc() {
+        seal_cbc(pal, io, suite, key, aad, pt, ct, alloc).await
+    } else {
+        seal_gcm(pal, io, key, base_nonce, aad, pt, ct, alloc).await
+    }
+}
+
+/// AEAD Open: decrypt + verify. Dispatches on [`HpkeSuite::is_cbc`].
+///
+/// # Type parameters
+///
+/// * `P` — any [`HsmCrypto`] PAL implementation.
+///
+/// # Parameters
+///
+/// * `pal` — PAL providing AES / HMAC.
+/// * `io` — caller's I/O context (per-IO scope).
+/// * `suite` — HPKE ciphersuite.
+/// * `key` — AEAD key.
+/// * `base_nonce` — for GCM: 12-byte nonce.  For CBC: ignored (IV
+///   is read from `ct`).
+/// * `aad` — additional authenticated data.
+/// * `ct` — sealed buffer.
+/// * `pt` — destination for plaintext.
+/// * `alloc` — scoped allocator used for HMAC scratch in the CBC
+///   path (unused on GCM).
+///
+/// # Returns
+///
+/// * `Ok(pt_len)` — number of plaintext bytes written to `pt`.
+/// * `Err(HsmError::InvalidArg)` — length-constraint violation.
+/// * `Err(HsmError::AesGcmDecryptTagDoesNotMatch)` — GCM
+///   authentication tag mismatch.
+/// * `Err(HsmError::AesDecryptFailed)` — CBC HMAC tag mismatch or
+///   PKCS#7 padding error.
+/// * `Err(HsmError)` — propagated from the AES or HMAC driver.
+pub async fn open<'a, P>(
+    pal: &P,
+    io: &impl HsmIo,
+    suite: HpkeSuite,
+    key: &[u8],
+    base_nonce: &[u8],
+    aad: &[u8],
+    ct: &[u8],
+    pt: &mut [u8],
+    alloc: &'a impl HsmScopedAlloc,
+) -> HsmResult<usize>
+where
+    P: HsmCrypto + HsmAlloc + 'a,
+{
+    if suite.is_cbc() {
+        open_cbc(pal, io, suite, key, aad, ct, pt, alloc).await
+    } else {
+        open_gcm(pal, io, key, base_nonce, aad, ct, pt, alloc).await
+    }
+}
+
+// =============================================================================
+// AES-GCM
+// =============================================================================
+
+/// AES-256-GCM seal.
+///
+/// # Returns
+///
+/// * `Ok(pt.len() + 16)` — bytes written (`ciphertext ‖ tag`).
+/// * `Err(HsmError::InvalidArg)` — `nonce.len() != 12` or
+///   `ct.len() < pt.len() + 16`.
+/// * `Err(HsmError)` — propagated from `gcm_encrypt`.
+async fn seal_gcm<'a, P>(
+    pal: &P,
+    io: &impl HsmIo,
+    key: &[u8],
+    nonce: &[u8],
+    aad: &[u8],
+    pt: &[u8],
+    ct: &mut [u8],
+    alloc: &'a impl HsmScopedAlloc,
+) -> HsmResult<usize>
+where
+    P: HsmCrypto + 'a,
+{
+    let key_dma = dma_copy_in(alloc, key)?;
+    let nonce_dma = dma_copy_in(alloc, nonce)?;
+
+    if aad.is_empty() {
+        // No AAD — simple path, no buffer formatting needed.
+        let ct_len = pt.len() + GCM_TAG_LEN;
+        if ct.len() < ct_len {
+            return Err(HsmError::InvalidArg);
+        }
+        let pt_dma = dma_copy_in(alloc, pt)?;
+        let ct_scratch = alloc.dma_alloc(pt.len())?;
+        let tag_dma = alloc.dma_alloc(GCM_TAG_LEN)?;
+        pal.gcm_encrypt(io, key_dma, nonce_dma, 0, pt_dma, ct_scratch, tag_dma)
+            .await?;
+        ct[..pt.len()].copy_from_slice(ct_scratch);
+        ct[pt.len()..ct_len].copy_from_slice(tag_dma);
+        Ok(ct_len)
+    } else {
+        // Non-empty AAD — format [padded_aad | pt] into ct, encrypt in-place.
+        let buf_len = azihsm_fw_core_crypto_gcm_buf::gcm_buf_len(aad.len(), pt.len());
+        let ct_len = buf_len + GCM_TAG_LEN;
+        if ct.len() < ct_len {
+            return Err(HsmError::InvalidArg);
+        }
+        let aad_len = azihsm_fw_core_crypto_gcm_buf::format_gcm_buf(aad, pt, &mut ct[..buf_len]);
+        let work = alloc.dma_alloc(buf_len)?;
+        let tag_dma = alloc.dma_alloc(GCM_TAG_LEN)?;
+        work.copy_from_slice(&ct[..buf_len]);
+        pal.gcm_encrypt_in_place(io, key_dma, nonce_dma, aad_len, work, tag_dma)
+            .await?;
+        ct[..buf_len].copy_from_slice(work);
+        // Move text portion (after padded AAD) to front, append tag.
+        let padded = azihsm_fw_core_crypto_gcm_buf::padded_aad_len(aad.len());
+        let text_len = buf_len - padded;
+        ct.copy_within(padded..buf_len, 0);
+        ct[text_len..text_len + GCM_TAG_LEN].copy_from_slice(tag_dma);
+        Ok(text_len + GCM_TAG_LEN)
+    }
+}
+
+/// AES-256-GCM open.
+///
+/// # Returns
+///
+/// * `Ok(ct.len() - 16)` — bytes written to `pt`.
+/// * `Err(HsmError::InvalidArg)` — length-constraint violation.
+/// * `Err(HsmError::AesGcmDecryptTagDoesNotMatch)` — tag mismatch.
+/// * `Err(HsmError)` — propagated from `gcm_decrypt`.
+async fn open_gcm<'a, P>(
+    pal: &P,
+    io: &impl HsmIo,
+    key: &[u8],
+    nonce: &[u8],
+    aad: &[u8],
+    ct: &[u8],
+    pt: &mut [u8],
+    alloc: &'a impl HsmScopedAlloc,
+) -> HsmResult<usize>
+where
+    P: HsmCrypto + 'a,
+{
+    if ct.len() < GCM_TAG_LEN {
+        return Err(HsmError::InvalidArg);
+    }
+    let pt_len = ct.len() - GCM_TAG_LEN;
+    let tag = &ct[pt_len..];
+    let key_dma = dma_copy_in(alloc, key)?;
+    let nonce_dma = dma_copy_in(alloc, nonce)?;
+    let tag_dma = dma_copy_in(alloc, tag)?;
+
+    if aad.is_empty() {
+        if pt.len() < pt_len {
+            return Err(HsmError::InvalidArg);
+        }
+        let ct_dma = dma_copy_in(alloc, &ct[..pt_len])?;
+        let pt_scratch = alloc.dma_alloc(pt_len)?;
+        pal.gcm_decrypt(io, key_dma, nonce_dma, 0, tag_dma, ct_dma, pt_scratch)
+            .await?;
+        pt[..pt_len].copy_from_slice(pt_scratch);
+        Ok(pt_len)
+    } else {
+        // Format [padded_aad | ciphertext] into pt (used as work buffer),
+        // decrypt in-place, then move plaintext to front.
+        let buf_len = azihsm_fw_core_crypto_gcm_buf::gcm_buf_len(aad.len(), pt_len);
+        if pt.len() < buf_len {
+            return Err(HsmError::InvalidArg);
+        }
+        let aad_len =
+            azihsm_fw_core_crypto_gcm_buf::format_gcm_buf(aad, &ct[..pt_len], &mut pt[..buf_len]);
+        let work = alloc.dma_alloc(buf_len)?;
+        work.copy_from_slice(&pt[..buf_len]);
+        pal.gcm_decrypt_in_place(io, key_dma, nonce_dma, aad_len, tag_dma, work)
+            .await?;
+        pt[..buf_len].copy_from_slice(work);
+        // Move decrypted text (after padded AAD) to front.
+        let padded = azihsm_fw_core_crypto_gcm_buf::padded_aad_len(aad.len());
+        pt.copy_within(padded..buf_len, 0);
+        Ok(pt_len)
+    }
+}
+
+// =============================================================================
+// AES-CBC + HMAC
+// =============================================================================
+
+/// AES-256-CBC + HMAC seal.
+///
+/// Generates a random IV, encrypts with PKCS#7 padding, then computes
+/// the encrypt-then-MAC tag over `aad ‖ iv ‖ ciphertext ‖
+/// I2OSP(aad_bits, 8)`.
+///
+/// # Returns
+///
+/// * `Ok(ct_len)` — `16 + padded(pt.len()) + Nt` bytes written.
+/// * `Err(HsmError::InvalidArg)` — the key length disagrees with
+///   the suite or `ct` is too small.
+/// * `Err(HsmError::NotEnoughSpace)` — allocator scope too small
+///   for HMAC state.
+/// * `Err(HsmError)` — propagated from the RNG, AES-CBC, or HMAC
+///   driver.
+async fn seal_cbc<'a, P>(
+    pal: &P,
+    io: &impl HsmIo,
+    suite: HpkeSuite,
+    key: &[u8],
+    aad: &[u8],
+    pt: &[u8],
+    ct: &mut [u8],
+    alloc: &'a impl HsmScopedAlloc,
+) -> HsmResult<usize>
+where
+    P: HsmCrypto + HsmAlloc + 'a,
+{
+    let cbc = CbcParams::from_suite(suite, key)?;
+    let padded = azihsm_fw_core_crypto_aes_cbc_pad::padded_len(pt.len());
+    let ct_len = CBC_IV_LEN + padded + cbc.tag_len;
+    if ct.len() < ct_len {
+        return Err(HsmError::InvalidArg);
+    }
+
+    // Generate the IV in place at the front of `ct`, then keep a
+    // mutable copy for the AES-CBC engine which advances it.
+    pal.rng_fill_bytes(io, &mut ct[..CBC_IV_LEN])?;
+    let mut iv_copy = [0u8; CBC_IV_LEN];
+    iv_copy.copy_from_slice(&ct[..CBC_IV_LEN]);
+
+    // Encrypt plaintext into the middle slot.
+    let key_dma = dma_copy_in(alloc, cbc.enc_key)?;
+    let ct_scratch = alloc.dma_alloc(padded)?;
+    azihsm_fw_core_crypto_aes_cbc_pad::aes_cbc_pkcs7_encrypt(
+        pal,
+        io,
+        key_dma,
+        &mut iv_copy,
+        pt,
+        ct_scratch,
+    )
+    .await?;
+    ct[CBC_IV_LEN..CBC_IV_LEN + padded].copy_from_slice(ct_scratch);
+
+    // MAC over [aad || iv || ciphertext || aad_len_bits_be64].
+    // Split `ct` into the three disjoint sections so we can borrow
+    // the IV + ciphertext immutably while writing the tag mutably.
+    let (iv_section, body) = ct[..ct_len].split_at_mut(CBC_IV_LEN);
+    let (ciphertext_section, tag_section) = body.split_at_mut(padded);
+    compute_hmac_into(
+        pal,
+        io,
+        cbc.hash,
+        cbc.mac_key,
+        aad,
+        iv_section,
+        ciphertext_section,
+        tag_section,
+        cbc.tag_len,
+        alloc,
+    )
+    .await?;
+
+    Ok(ct_len)
+}
+
+/// AES-256-CBC + HMAC open.
+///
+/// Verifies the MAC first (encrypt-then-MAC), then decrypts and
+/// unpads.  A tag mismatch returns [`HsmError::AesDecryptFailed`]
+/// before any padding bytes are inspected, eliminating the
+/// padding-oracle.
+///
+/// # Returns
+///
+/// * `Ok(pt_len)` — number of plaintext bytes written after PKCS#7
+///   unpadding.
+/// * `Err(HsmError::InvalidArg)` — length-constraint violation.
+/// * `Err(HsmError::AesDecryptFailed)` — HMAC tag mismatch or
+///   PKCS#7 unpadding error.
+/// * `Err(HsmError::NotEnoughSpace)` — allocator scope too small
+///   for HMAC state.
+/// * `Err(HsmError)` — propagated from the AES-CBC or HMAC driver.
+async fn open_cbc<'a, P>(
+    pal: &P,
+    io: &impl HsmIo,
+    suite: HpkeSuite,
+    key: &[u8],
+    aad: &[u8],
+    ct: &[u8],
+    pt: &mut [u8],
+    alloc: &'a impl HsmScopedAlloc,
+) -> HsmResult<usize>
+where
+    P: HsmCrypto + HsmAlloc + 'a,
+{
+    let cbc = CbcParams::from_suite(suite, key)?;
+    if ct.len() < CBC_IV_LEN + CBC_IV_LEN + cbc.tag_len {
+        return Err(HsmError::InvalidArg);
+    }
+
+    let enc_len = ct.len() - CBC_IV_LEN - cbc.tag_len;
+    let iv = &ct[..CBC_IV_LEN];
+    let ciphertext = &ct[CBC_IV_LEN..CBC_IV_LEN + enc_len];
+    let received_tag = &ct[CBC_IV_LEN + enc_len..];
+
+    // Verify MAC first (encrypt-then-MAC pattern).
+    let mut computed_tag = [0u8; MAX_DIGEST_LEN];
+    compute_hmac_into(
+        pal,
+        io,
+        cbc.hash,
+        cbc.mac_key,
+        aad,
+        iv,
+        ciphertext,
+        &mut computed_tag[..cbc.tag_len],
+        cbc.tag_len,
+        alloc,
+    )
+    .await?;
+
+    if computed_tag[..cbc.tag_len] != *received_tag {
+        return Err(HsmError::AesDecryptFailed);
+    }
+
+    // Decrypt + unpad.
+    let mut iv_copy = [0u8; CBC_IV_LEN];
+    iv_copy.copy_from_slice(iv);
+    let key_dma = dma_copy_in(alloc, cbc.enc_key)?;
+    let ct_dma = dma_copy_in(alloc, ciphertext)?;
+    let pt_scratch = alloc.dma_alloc(ciphertext.len())?;
+    let pt_len = azihsm_fw_core_crypto_aes_cbc_pad::aes_cbc_pkcs7_decrypt(
+        pal,
+        io,
+        key_dma,
+        &mut iv_copy,
+        ct_dma,
+        pt_scratch,
+    )
+    .await?;
+    pt[..pt_len].copy_from_slice(&pt_scratch[..pt_len]);
+    Ok(pt_len)
+}
+
+/// Per-suite CBC/HMAC parameters borrowed from a caller-supplied key.
+struct CbcParams<'a> {
+    /// Hash algorithm for the HMAC (= suite hash).
+    hash: HsmHashAlgo,
+    /// Truncated tag length in bytes (`Nh / 2`).
+    tag_len: usize,
+    /// HMAC key prefix of `key`.
+    mac_key: &'a [u8],
+    /// AES-CBC key suffix of `key`.
+    enc_key: &'a [u8],
+}
+
+impl<'a> CbcParams<'a> {
+    /// Validate `key.len()` against the suite's `MAC_KEY ‖ ENC_KEY`
+    /// layout and return borrowed slices for each half.
+    ///
+    /// # Returns
+    ///
+    /// * `Ok(params)` — split `(mac_key, enc_key)` plus the suite's
+    ///   hash algorithm and truncated tag length.
+    /// * `Err(HsmError::InvalidArg)` — `key.len() != mac_key_len +
+    ///   enc_key_len`.
+    fn from_suite(suite: HpkeSuite, key: &'a [u8]) -> HsmResult<Self> {
+        let mac_key_len = suite.cbc_mac_key_len();
+        let enc_key_len = suite.cbc_enc_key_len();
+        if key.len() != mac_key_len + enc_key_len {
+            return Err(HsmError::InvalidArg);
+        }
+        Ok(Self {
+            hash: suite.aead_hash(),
+            tag_len: suite.nt(),
+            mac_key: &key[..mac_key_len],
+            enc_key: &key[mac_key_len..],
+        })
+    }
+}
+
+/// Compute `HMAC(mac_key, aad ‖ iv ‖ ciphertext ‖ I2OSP(aad_bits, 8))`
+/// and write the truncated tag into `dest`.
+///
+/// Shared by [`seal_cbc`] (which writes the tag straight into the
+/// output buffer) and [`open_cbc`] (which writes it into a stack
+/// buffer for constant-time comparison).
+///
+/// # Parameters
+///
+/// * `pal` — PAL providing the HMAC engine.
+/// * `io` — caller's I/O context (per-IO scope).
+/// * `algo` — hash algorithm.
+/// * `mac_key` — HMAC key (full hash output length).
+/// * `aad` — additional authenticated data (may be empty).
+/// * `iv` — 16-byte AES-CBC IV.
+/// * `ciphertext` — already-encrypted CBC body.
+/// * `dest` — destination for the truncated tag; must be at least
+///   `tag_len` bytes.
+/// * `tag_len` — number of leading HMAC output bytes to copy.
+/// * `alloc` — scoped allocator backing the HMAC state buffer.
+///
+/// # Returns
+///
+/// * `Ok(())` — `dest[..tag_len]` populated.
+/// * `Err(HsmError::NotEnoughSpace)` — allocator scope too small.
+/// * `Err(HsmError)` — propagated from the HMAC engine.
+async fn compute_hmac_into<'a, P>(
+    pal: &P,
+    io: &impl HsmIo,
+    algo: HsmHashAlgo,
+    mac_key: &[u8],
+    aad: &[u8],
+    iv: &[u8],
+    ciphertext: &[u8],
+    dest: &mut [u8],
+    tag_len: usize,
+    alloc: &'a impl HsmScopedAlloc,
+) -> HsmResult<()>
+where
+    P: HsmCrypto + 'a,
+{
+    let aad_len_bits = (aad.len() as u64 * 8).to_be_bytes();
+    let hash_len = algo.digest_len();
+
+    let full_tag = alloc.dma_alloc_zeroed(hash_len)?;
+    let mac_key_dma = dma_copy_in(alloc, mac_key)?;
+
+    let mut ctx = pal.hmac_begin(io, algo, mac_key_dma, alloc).await?;
+    if !aad.is_empty() {
+        let aad_dma = dma_copy_in(alloc, aad)?;
+        pal.hmac_continue(io, &mut ctx, aad_dma).await?;
+    }
+    let iv_dma = dma_copy_in(alloc, iv)?;
+    let ct_dma = dma_copy_in(alloc, ciphertext)?;
+    let len_dma = dma_copy_in(alloc, &aad_len_bits)?;
+    pal.hmac_continue(io, &mut ctx, iv_dma).await?;
+    pal.hmac_continue(io, &mut ctx, ct_dma).await?;
+    pal.hmac_continue(io, &mut ctx, len_dma).await?;
+    pal.hmac_finish_into(io, ctx, full_tag).await?;
+
+    dest[..tag_len].copy_from_slice(&full_tag[..tag_len]);
+    Ok(())
+}

--- a/fw/core/crypto/hpke/src/error.rs
+++ b/fw/core/crypto/hpke/src/error.rs
@@ -1,0 +1,23 @@
+// Copyright (c) Microsoft Corporation.
+
+//! HPKE error types.
+//!
+//! Currently a placeholder — HPKE operations surface
+//! [`azihsm_fw_hsm_pal_traits::HsmError`] directly via [`HsmResult`]
+//! returns, since every error in the crate is forwarded from the
+//! underlying PAL traits ([`HsmEcc`], [`HsmCrypto`], [`HsmKdf`],
+//! [`HsmHmac`], [`HsmRng`]) without any HPKE-specific failure modes.
+//!
+//! A dedicated `HpkeError` enum will be introduced if/when the crate
+//! gains failure modes that cannot be expressed as PAL errors (for
+//! example RFC 9180 single-shot input length checks that should be
+//! distinct from generic [`HsmError::InvalidArg`]).
+//!
+//! [`HsmError`]: azihsm_fw_hsm_pal_traits::HsmError
+//! [`HsmError::InvalidArg`]: azihsm_fw_hsm_pal_traits::HsmError::InvalidArg
+//! [`HsmResult`]: azihsm_fw_hsm_pal_traits::HsmResult
+//! [`HsmEcc`]: azihsm_fw_hsm_pal_traits::HsmEcc
+//! [`HsmCrypto`]: azihsm_fw_hsm_pal_traits::HsmCrypto
+//! [`HsmKdf`]: azihsm_fw_hsm_pal_traits::HsmKdf
+//! [`HsmHmac`]: azihsm_fw_hsm_pal_traits::HsmHmac
+//! [`HsmRng`]: azihsm_fw_hsm_pal_traits::HsmRng

--- a/fw/core/crypto/hpke/src/helpers.rs
+++ b/fw/core/crypto/hpke/src/helpers.rs
@@ -1,0 +1,23 @@
+// Copyright (c) Microsoft Corporation.
+
+//! Internal helpers shared across HPKE submodules.
+
+use azihsm_fw_hsm_pal_traits::DmaBuf;
+use azihsm_fw_hsm_pal_traits::HsmResult;
+use azihsm_fw_hsm_pal_traits::HsmScopedAlloc;
+
+/// Allocate a DMA-accessible buffer and copy `src` into it.
+///
+/// Many HPKE callers pass plain `&[u8]` slices that originate from
+/// the host wire (or from non-DMA stack buffers); the underlying
+/// crypto traits now require `&DmaBuf` for any data touched by the
+/// hardware engines. This helper centralizes the copy.
+#[inline]
+pub(crate) fn dma_copy_in<'a>(
+    alloc: &'a impl HsmScopedAlloc,
+    src: &[u8],
+) -> HsmResult<&'a mut DmaBuf> {
+    let buf = alloc.dma_alloc(src.len())?;
+    buf.copy_from_slice(src);
+    Ok(buf)
+}

--- a/fw/core/crypto/hpke/src/kdf.rs
+++ b/fw/core/crypto/hpke/src/kdf.rs
@@ -1,0 +1,179 @@
+// Copyright (c) Microsoft Corporation.
+
+//! HPKE LabeledExtract and LabeledExpand (RFC 9180 §4).
+//!
+//! These are thin wrappers that prepend HPKE domain-separation labels
+//! before calling the PAL's HKDF Extract/Expand:
+//!
+//! ```text
+//! labeled_ikm  = "HPKE-v1" || suite_id || label || ikm
+//! labeled_info = I2OSP(L, 2) || "HPKE-v1" || suite_id || label || info
+//! ```
+//!
+//! Both helpers assemble their labelled buffer from the caller's
+//! [`HsmScopedAlloc`], while the PAL allocates any internal HKDF scratch
+//! per call.
+
+use azihsm_fw_hsm_pal_traits::DmaBuf;
+use azihsm_fw_hsm_pal_traits::HsmAlloc;
+use azihsm_fw_hsm_pal_traits::HsmHashAlgo;
+use azihsm_fw_hsm_pal_traits::HsmIo;
+use azihsm_fw_hsm_pal_traits::HsmKdf;
+use azihsm_fw_hsm_pal_traits::HsmResult;
+use azihsm_fw_hsm_pal_traits::HsmScopedAlloc;
+
+use crate::helpers::dma_copy_in;
+
+// =============================================================================
+// Constants
+// =============================================================================
+
+/// HPKE version string prepended to every labelled input (RFC 9180 §4).
+const HPKE_V1: &[u8] = b"HPKE-v1";
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+/// Allocate a buffer from `alloc`, concatenate `parts` into it, and
+/// return the filled slice.
+///
+/// The returned buffer is scoped to the surrounding PAL allocation
+/// region and is released automatically when that alloc ends.
+fn concat_alloc<'a>(parts: &[&[u8]], alloc: &'a impl HsmScopedAlloc) -> HsmResult<&'a mut DmaBuf> {
+    let total: usize = parts.iter().map(|p| p.len()).sum();
+    let dst = alloc.dma_alloc(total)?;
+    let mut pos = 0;
+    for part in parts {
+        dst[pos..pos + part.len()].copy_from_slice(part);
+        pos += part.len();
+    }
+    Ok(dst)
+}
+
+// =============================================================================
+// Labelled Extract / Expand
+// =============================================================================
+
+/// HPKE `LabeledExtract` (RFC 9180 §4):
+///
+/// ```text
+/// labeled_ikm = "HPKE-v1" || suite_id || label || ikm
+/// PRK         = Extract(salt, labeled_ikm)
+/// ```
+///
+/// Allocates `labeled_ikm` and the output scratch from `alloc`,
+/// while the PAL allocates its internal HKDF scratch per call.
+///
+/// # Type parameters
+///
+/// * `P` — any [`HsmKdf`] PAL implementation.
+///
+/// # Parameters
+///
+/// * `pal` — PAL providing the underlying HKDF.
+/// * `io` — caller's I/O context (per-IO scope).
+/// * `algo` — hash algorithm used by HKDF (selects `Nh`).
+/// * `suite_id` — HPKE suite identifier (`"HPKE" || I2OSP(kem_id,
+///   2) || …`, opaque to this function).
+/// * `salt` — HKDF salt (may be empty).
+/// * `label` — context-specific label (e.g. `b"eae_prk"`).
+/// * `ikm` — input keying material.
+/// * `prk_out` — destination buffer for the pseudo-random key;
+///   must be at least `algo.digest_len()` bytes.  Only the leading
+///   `digest_len` bytes are written.
+/// * `alloc` — scoped allocator used for the labelled input buffer
+///   and output scratch.
+///
+/// # Returns
+///
+/// * `Ok(())` — `prk_out[..digest_len]` populated.
+/// * `Err(HsmError::NotEnoughSpace)` — one of the required scoped
+///   allocations could not be satisfied.
+/// * `Err(HsmError)` — propagated from
+///   [`HsmKdf::hkdf_extract`].
+pub async fn labeled_extract<'a, P>(
+    pal: &P,
+    io: &impl HsmIo,
+    algo: HsmHashAlgo,
+    suite_id: &[u8],
+    salt: &[u8],
+    label: &[u8],
+    ikm: &[u8],
+    prk_out: &mut [u8],
+    alloc: &'a impl HsmScopedAlloc,
+) -> HsmResult<()>
+where
+    P: HsmKdf + HsmAlloc + 'a,
+{
+    let labeled_ikm = concat_alloc(&[HPKE_V1, suite_id, label, ikm], alloc)?;
+    let salt_dma = dma_copy_in(alloc, salt)?;
+    let prk_scratch = alloc.dma_alloc(prk_out.len())?;
+    pal.hkdf_extract(io, algo, salt_dma, labeled_ikm, prk_scratch)
+        .await?;
+    prk_out.copy_from_slice(prk_scratch);
+    Ok(())
+}
+
+/// HPKE `LabeledExpand` (RFC 9180 §4):
+///
+/// ```text
+/// labeled_info = I2OSP(L, 2) || "HPKE-v1" || suite_id || label || info
+/// out          = Expand(prk, labeled_info, L)
+/// ```
+///
+/// Allocates `labeled_info` and the output scratch from `alloc`,
+/// while the PAL allocates its internal HKDF scratch per call.
+///
+/// # Type parameters
+///
+/// * `P` — any [`HsmKdf`] PAL implementation.
+///
+/// # Parameters
+///
+/// * `pal` — PAL providing the underlying HKDF.
+/// * `io` — caller's I/O context (per-IO scope).
+/// * `algo` — hash algorithm used by HKDF.
+/// * `suite_id` — HPKE suite identifier.
+/// * `prk` — pseudo-random key from a prior
+///   [`labeled_extract`] call.
+/// * `label` — context-specific label (e.g. `b"shared_secret"`).
+/// * `info` — application-specific context bytes (may be empty).
+/// * `out` — destination buffer; `L = out.len()` is encoded as a
+///   2-byte big-endian prefix in `labeled_info`.  RFC 9180 caps
+///   `L` at `255 * Nh`.
+/// * `alloc` — scoped allocator used for the labelled input buffer
+///   and output scratch.
+///
+/// # Returns
+///
+/// * `Ok(())` — `out` filled with the derived key bytes.
+/// * `Err(HsmError::InvalidArg)` — `out.len() > 255 * Nh`
+///   (propagated from `hkdf_expand`).
+/// * `Err(HsmError::NotEnoughSpace)` — one of the required scoped
+///   allocations could not be satisfied.
+/// * `Err(HsmError)` — propagated from
+///   [`HsmKdf::hkdf_expand`].
+pub async fn labeled_expand<'a, P>(
+    pal: &P,
+    io: &impl HsmIo,
+    algo: HsmHashAlgo,
+    suite_id: &[u8],
+    prk: &[u8],
+    label: &[u8],
+    info: &[u8],
+    out: &mut [u8],
+    alloc: &'a impl HsmScopedAlloc,
+) -> HsmResult<()>
+where
+    P: HsmKdf + HsmAlloc + 'a,
+{
+    let l_bytes = (out.len() as u16).to_be_bytes();
+    let prk_dma = dma_copy_in(alloc, prk)?;
+    let labeled_info = concat_alloc(&[&l_bytes, HPKE_V1, suite_id, label, info], alloc)?;
+    let out_scratch = alloc.dma_alloc(out.len())?;
+    pal.hkdf_expand(io, algo, prk_dma, labeled_info, out_scratch)
+        .await?;
+    out.copy_from_slice(out_scratch);
+    Ok(())
+}

--- a/fw/core/crypto/hpke/src/kem.rs
+++ b/fw/core/crypto/hpke/src/kem.rs
@@ -1,0 +1,377 @@
+// Copyright (c) Microsoft Corporation.
+
+//! DHKEM (RFC 9180 §4.1) — Encap / Decap and their Auth variants.
+//!
+//! All four entry points produce a [`HpkeSuite::nsecret`]-byte
+//! shared secret via:
+//!
+//! 1. One ECDH (or two for Auth) using either an ephemeral keypair
+//!    (Encap / AuthEncap) or the recipient's static private key
+//!    (Decap / AuthDecap).
+//! 2. A `kem_context` made up of `enc ‖ pk_r` (Base) or
+//!    `enc ‖ pk_r ‖ pk_s` (Auth).
+//! 3. The shared `ExtractAndExpand` step that maps `(dh, kem_context)`
+//!    to the final shared secret via [`labeled_extract`] +
+//!    [`labeled_expand`].
+//!
+//! Each public function allocates its intermediate buffers from the
+//! caller's [`HsmScopedAlloc`], then funnels through
+//! [`extract_and_expand`].
+//!
+//! [`labeled_extract`]: crate::kdf::labeled_extract
+//! [`labeled_expand`]: crate::kdf::labeled_expand
+
+use azihsm_fw_hsm_pal_traits::DmaBuf;
+use azihsm_fw_hsm_pal_traits::HsmAlloc;
+use azihsm_fw_hsm_pal_traits::HsmCrypto;
+use azihsm_fw_hsm_pal_traits::HsmEccPct;
+use azihsm_fw_hsm_pal_traits::HsmIo;
+use azihsm_fw_hsm_pal_traits::HsmResult;
+use azihsm_fw_hsm_pal_traits::HsmScopedAlloc;
+
+use crate::helpers::dma_copy_in;
+use crate::kdf;
+use crate::suite::HpkeSuite;
+
+// =============================================================================
+// kem_context layout
+// =============================================================================
+
+/// Fill `dst` with the HPKE `kem_context` value:
+///
+/// * If `pk_s` is `None`: `enc ‖ pk_r` (Base modes).
+/// * If `pk_s` is `Some(_)`: `enc ‖ pk_r ‖ pk_s` (Auth modes).
+///
+/// # Parameters
+/// * `dst` — destination buffer of `npk * (2 + auth as usize)` bytes.
+/// * `enc` — serialised ephemeral / received public key (`Npk` bytes).
+/// * `pk_r` — recipient public key (`Npk` bytes).
+/// * `pk_s` — sender public key for Auth modes (`Npk` bytes), `None`
+///   for Base modes.
+fn build_kem_context(dst: &mut [u8], enc: &[u8], pk_r: &[u8], pk_s: Option<&[u8]>) {
+    let npk = pk_r.len();
+    dst[..npk].copy_from_slice(enc);
+    dst[npk..2 * npk].copy_from_slice(pk_r);
+    if let Some(pk_s) = pk_s {
+        dst[2 * npk..3 * npk].copy_from_slice(pk_s);
+    }
+}
+
+fn alloc_bytes(len: usize, alloc: &impl HsmScopedAlloc) -> HsmResult<&mut DmaBuf> {
+    alloc.dma_alloc(len)
+}
+
+// =============================================================================
+// Public entry points
+// =============================================================================
+
+/// DHKEM Encap (Base mode).
+///
+/// Generates an ephemeral keypair, derives `dh = DH(skE, pkR)`, and
+/// runs `ExtractAndExpand(dh, enc ‖ pkR)`.
+///
+/// # Type parameters
+///
+/// * `P` — any [`HsmCrypto`] PAL implementation.
+///
+/// # Parameters
+///
+/// * `pal` — PAL providing ECC + HKDF.
+/// * `io` — caller's I/O context (per-IO scope).
+/// * `suite` — HPKE ciphersuite.
+/// * `pk_r` — recipient public key (`Npk` bytes).
+/// * `enc` — output: encapsulated key (`Nenc` bytes).
+/// * `shared_secret` — output: KEM shared secret (`Nsecret`
+///   bytes).
+/// * `alloc` — scoped allocator used for the ephemeral keypair,
+///   intermediate buffers, and internal HKDF / HMAC state.
+///
+/// # Returns
+///
+/// * `Ok(())` — `enc` and `shared_secret` populated.
+/// * `Err(HsmError::NotEnoughSpace)` — allocator scope too small.
+/// * `Err(HsmError)` — propagated from the ECC keypair / ECDH /
+///   HKDF calls.
+pub async fn encap<'a, P>(
+    pal: &P,
+    io: &impl HsmIo,
+    suite: HpkeSuite,
+    pk_r: &[u8],
+    enc: &mut [u8],
+    shared_secret: &mut [u8],
+    alloc: &'a impl HsmScopedAlloc,
+) -> HsmResult<()>
+where
+    P: HsmCrypto + HsmAlloc + 'a,
+{
+    let curve = suite.kem_curve();
+    let nsk = suite.nsk();
+    let npk = suite.npk();
+    let ndh = suite.ndh();
+
+    let keygen_buf = alloc_bytes(nsk + npk, alloc)?;
+    let (sk_e, pk_e) = pal
+        .ecc_gen_keypair(io, curve, keygen_buf, HsmEccPct::None)
+        .await?;
+
+    let dh = alloc_bytes(ndh, alloc)?;
+    let pk_r_dma = dma_copy_in(alloc, pk_r)?;
+    pal.ecdh_derive(io, curve, sk_e, pk_r_dma, dh).await?;
+
+    enc[..npk].copy_from_slice(pk_e);
+
+    let kem_context = alloc_bytes(npk * 2, alloc)?;
+    build_kem_context(kem_context, &enc[..npk], pk_r, None);
+
+    extract_and_expand(pal, io, suite, dh, kem_context, shared_secret, alloc).await
+}
+
+/// DHKEM Decap (Base mode).
+///
+/// Derives `dh = DH(skR, pkE)` and runs
+/// `ExtractAndExpand(dh, enc ‖ pkR)`.
+///
+/// # Parameters
+///
+/// * `pal` — PAL providing ECC + HKDF.
+/// * `io` — caller's I/O context (per-IO scope).
+/// * `suite` — HPKE ciphersuite.
+/// * `enc` — encapsulated key from sender (`Nenc` bytes).
+/// * `sk_r` — recipient private key.
+/// * `pk_r` — recipient public key.
+/// * `shared_secret` — output: KEM shared secret.
+/// * `alloc` — scoped allocator used for the DH buffer,
+///   intermediate context, and internal HKDF / HMAC state.
+///
+/// # Returns
+///
+/// * `Ok(())` — `shared_secret` populated.
+/// * `Err(HsmError::NotEnoughSpace)` — allocator scope too small.
+/// * `Err(HsmError)` — propagated from the ECDH / HKDF calls.
+pub async fn decap<'a, P>(
+    pal: &P,
+    io: &impl HsmIo,
+    suite: HpkeSuite,
+    enc: &[u8],
+    sk_r: &[u8],
+    pk_r: &[u8],
+    shared_secret: &mut [u8],
+    alloc: &'a impl HsmScopedAlloc,
+) -> HsmResult<()>
+where
+    P: HsmCrypto + HsmAlloc + 'a,
+{
+    let curve = suite.kem_curve();
+    let npk = suite.npk();
+    let ndh = suite.ndh();
+
+    let pk_e = &enc[..npk];
+
+    let dh = alloc_bytes(ndh, alloc)?;
+    let sk_r_dma = dma_copy_in(alloc, sk_r)?;
+    let pk_e_dma = dma_copy_in(alloc, pk_e)?;
+    pal.ecdh_derive(io, curve, sk_r_dma, pk_e_dma, dh).await?;
+
+    let kem_context = alloc_bytes(npk * 2, alloc)?;
+    build_kem_context(kem_context, &enc[..npk], pk_r, None);
+
+    extract_and_expand(pal, io, suite, dh, kem_context, shared_secret, alloc).await
+}
+
+/// DHKEM AuthEncap.
+///
+/// Generates an ephemeral keypair, derives both
+/// `dh1 = DH(skE, pkR)` and `dh2 = DH(skS, pkR)`, then runs
+/// `ExtractAndExpand(dh1 ‖ dh2, enc ‖ pkR ‖ pkS)`.
+///
+/// # Parameters
+///
+/// * `pal` — PAL providing ECC + HKDF.
+/// * `io` — caller's I/O context (per-IO scope).
+/// * `suite` — HPKE ciphersuite.
+/// * `pk_r` — recipient public key.
+/// * `sk_s` — sender private key.
+/// * `pk_s` — sender public key.
+/// * `enc` — output: encapsulated key.
+/// * `shared_secret` — output: KEM shared secret.
+/// * `alloc` — scoped allocator used for the ephemeral keypair,
+///   DH buffers, intermediate context, and internal HKDF / HMAC
+///   state.
+///
+/// # Returns
+///
+/// * `Ok(())` — `enc` and `shared_secret` populated.
+/// * `Err(HsmError::NotEnoughSpace)` — allocator scope too small.
+/// * `Err(HsmError)` — propagated from the ECC keypair / ECDH /
+///   HKDF calls.
+pub async fn auth_encap<'a, P>(
+    pal: &P,
+    io: &impl HsmIo,
+    suite: HpkeSuite,
+    pk_r: &[u8],
+    sk_s: &[u8],
+    pk_s: &[u8],
+    enc: &mut [u8],
+    shared_secret: &mut [u8],
+    alloc: &'a impl HsmScopedAlloc,
+) -> HsmResult<()>
+where
+    P: HsmCrypto + HsmAlloc + 'a,
+{
+    let curve = suite.kem_curve();
+    let nsk = suite.nsk();
+    let npk = suite.npk();
+    let ndh = suite.ndh();
+
+    let keygen_buf = alloc_bytes(nsk + npk, alloc)?;
+    let (sk_e, pk_e) = pal
+        .ecc_gen_keypair(io, curve, keygen_buf, HsmEccPct::None)
+        .await?;
+
+    let dh = alloc_bytes(ndh * 2, alloc)?;
+    let pk_r_dma = dma_copy_in(alloc, pk_r)?;
+    let sk_s_dma = dma_copy_in(alloc, sk_s)?;
+    pal.ecdh_derive(io, curve, sk_e, pk_r_dma, &mut dh[..ndh])
+        .await?;
+    pal.ecdh_derive(io, curve, sk_s_dma, pk_r_dma, &mut dh[ndh..])
+        .await?;
+
+    enc[..npk].copy_from_slice(pk_e);
+
+    let kem_context = alloc_bytes(npk * 3, alloc)?;
+    build_kem_context(kem_context, &enc[..npk], pk_r, Some(pk_s));
+
+    extract_and_expand(pal, io, suite, dh, kem_context, shared_secret, alloc).await
+}
+
+/// DHKEM AuthDecap.
+///
+/// Derives both `dh1 = DH(skR, pkE)` and `dh2 = DH(skR, pkS)`, then
+/// runs `ExtractAndExpand(dh1 ‖ dh2, enc ‖ pkR ‖ pkS)`.
+///
+/// # Parameters
+///
+/// * `pal` — PAL providing ECC + HKDF.
+/// * `io` — caller's I/O context (per-IO scope).
+/// * `suite` — HPKE ciphersuite.
+/// * `enc` — encapsulated key from sender.
+/// * `sk_r` — recipient private key.
+/// * `pk_r` — recipient public key.
+/// * `pk_s` — sender public key (used to authenticate the
+///   encapsulation).
+/// * `shared_secret` — output: KEM shared secret.
+/// * `alloc` — scoped allocator used for the DH buffers,
+///   intermediate context, and internal HKDF / HMAC state.
+///
+/// # Returns
+///
+/// * `Ok(())` — `shared_secret` populated.
+/// * `Err(HsmError::NotEnoughSpace)` — allocator scope too small.
+/// * `Err(HsmError)` — propagated from the ECDH / HKDF calls.
+pub async fn auth_decap<'a, P>(
+    pal: &P,
+    io: &impl HsmIo,
+    suite: HpkeSuite,
+    enc: &[u8],
+    sk_r: &[u8],
+    pk_r: &[u8],
+    pk_s: &[u8],
+    shared_secret: &mut [u8],
+    alloc: &'a impl HsmScopedAlloc,
+) -> HsmResult<()>
+where
+    P: HsmCrypto + HsmAlloc + 'a,
+{
+    let curve = suite.kem_curve();
+    let npk = suite.npk();
+    let ndh = suite.ndh();
+
+    let pk_e = &enc[..npk];
+
+    let dh = alloc_bytes(ndh * 2, alloc)?;
+    let sk_r_dma = dma_copy_in(alloc, sk_r)?;
+    let pk_e_dma = dma_copy_in(alloc, pk_e)?;
+    let pk_s_dma = dma_copy_in(alloc, pk_s)?;
+    pal.ecdh_derive(io, curve, sk_r_dma, pk_e_dma, &mut dh[..ndh])
+        .await?;
+    pal.ecdh_derive(io, curve, sk_r_dma, pk_s_dma, &mut dh[ndh..])
+        .await?;
+
+    let kem_context = alloc_bytes(npk * 3, alloc)?;
+    build_kem_context(kem_context, &enc[..npk], pk_r, Some(pk_s));
+
+    extract_and_expand(pal, io, suite, dh, kem_context, shared_secret, alloc).await
+}
+
+// =============================================================================
+// ExtractAndExpand
+// =============================================================================
+
+/// `ExtractAndExpand(dh, kem_context) → shared_secret`
+///
+/// ```text
+/// eae_prk       = LabeledExtract("",         "eae_prk",      dh)
+/// shared_secret = LabeledExpand (eae_prk,   "shared_secret", kem_context, Nsecret)
+/// ```
+///
+/// # Parameters
+///
+/// * `pal` — PAL providing HKDF.
+/// * `io` — caller's I/O context (per-IO scope).
+/// * `suite` — HPKE ciphersuite.
+/// * `dh` — concatenated ECDH output(s).
+/// * `kem_context` — `enc ‖ pkR` (Base) or `enc ‖ pkR ‖ pkS`
+///   (Auth).
+/// * `shared_secret` — output: `Nsecret` bytes.
+/// * `alloc` — scoped allocator used for the intermediate `eae_prk`
+///   and internal HKDF / HMAC state.
+///
+/// # Returns
+///
+/// * `Ok(())` — `shared_secret` populated.
+/// * `Err(HsmError::NotEnoughSpace)` — allocator scope too small.
+/// * `Err(HsmError)` — propagated from the HKDF Extract / Expand
+///   calls.
+async fn extract_and_expand<'a, P>(
+    pal: &P,
+    io: &impl HsmIo,
+    suite: HpkeSuite,
+    dh: &[u8],
+    kem_context: &[u8],
+    shared_secret: &mut [u8],
+    alloc: &'a impl HsmScopedAlloc,
+) -> HsmResult<()>
+where
+    P: HsmCrypto + HsmAlloc + 'a,
+{
+    let algo = suite.kem_hash();
+    let nh = suite.nh();
+    let kem_suite_id = suite.kem_suite_id();
+
+    let eae_prk = alloc_bytes(nh, alloc)?;
+    kdf::labeled_extract(
+        pal,
+        io,
+        algo,
+        &kem_suite_id,
+        &[],
+        b"eae_prk",
+        dh,
+        eae_prk,
+        alloc,
+    )
+    .await?;
+
+    kdf::labeled_expand(
+        pal,
+        io,
+        algo,
+        &kem_suite_id,
+        eae_prk,
+        b"shared_secret",
+        kem_context,
+        shared_secret,
+        alloc,
+    )
+    .await
+}

--- a/fw/core/crypto/hpke/src/lib.rs
+++ b/fw/core/crypto/hpke/src/lib.rs
@@ -1,0 +1,79 @@
+// Copyright (c) Microsoft Corporation.
+
+#![no_std]
+#![allow(clippy::too_many_arguments)]
+
+//! Hybrid Public Key Encryption (HPKE — RFC 9180), single-shot API.
+//!
+//! Supports all four HPKE modes (Base / PSK / Auth / AuthPSK) across
+//! six ciphersuites built from three KEMs and two AEAD primitives:
+//!
+//! | KEM          | KDF          | AEAD                    |
+//! |--------------|--------------|-------------------------|
+//! | DHKEM(P-256) | HKDF-SHA-256 | AES-256-GCM             |
+//! | DHKEM(P-256) | HKDF-SHA-256 | AES-256-CBC-HMAC-SHA-256 |
+//! | DHKEM(P-384) | HKDF-SHA-384 | AES-256-GCM             |
+//! | DHKEM(P-384) | HKDF-SHA-384 | AES-256-CBC-HMAC-SHA-384 |
+//! | DHKEM(P-521) | HKDF-SHA-512 | AES-256-GCM             |
+//! | DHKEM(P-521) | HKDF-SHA-512 | AES-256-CBC-HMAC-SHA-512 |
+//!
+//! See [`HpkeSuite`] for the full enum and per-suite size constants.
+//!
+//! ## API surface
+//!
+//! Each HPKE mode exposes a `seal_*` and `open_*` pair that takes a
+//! caller-owned [`SealRequest`] / [`OpenRequest`]:
+//!
+//! | Mode    | Seal              | Open              |
+//! |---------|-------------------|-------------------|
+//! | Base    | [`seal_base`]     | [`open_base`]     |
+//! | PSK     | [`seal_psk`]      | [`open_psk`]      |
+//! | Auth    | [`seal_auth`]     | [`open_auth`]     |
+//! | AuthPSK | [`seal_auth_psk`] | [`open_auth_psk`] |
+//!
+//! Two Base-mode export helpers are also exported:
+//! [`send_export_base`] (sender side, runs Encap) and
+//! [`receive_export_base`] (receiver side, runs Decap).
+//!
+//! ## Scoped-allocation contract
+//!
+//! Every entry point takes an [`azihsm_fw_hsm_pal_traits::HsmScopedAlloc`]
+//! and allocates its intermediate buffers from that alloc. Internal
+//! helpers request only the slices they need, and the PAL frees them
+//! automatically when the outer alloc returns.
+//!
+//! ## Internal modules
+//!
+//! * `aead` — AES-GCM / AES-CBC-HMAC seal & open dispatch.
+//! * `kdf` — RFC 9180 §4 LabeledExtract / LabeledExpand.
+//! * `kem` — DHKEM Encap / Decap and their Auth variants.
+//! * `ops` — public seal / open / export entry points.
+//! * `schedule` — RFC 9180 §5.1 key schedule.
+//! * `suite` — [`HpkeSuite`] enum and per-suite constants.
+//! * `error` — placeholder; HPKE currently surfaces
+//!   [`azihsm_fw_hsm_pal_traits::HsmError`] directly.
+
+mod aead;
+mod error;
+mod helpers;
+mod kdf;
+mod kem;
+mod ops;
+mod schedule;
+mod suite;
+
+pub use ops::open_auth;
+pub use ops::open_auth_psk;
+pub use ops::open_base;
+pub use ops::open_psk;
+pub use ops::receive_export_base;
+pub use ops::seal_auth;
+pub use ops::seal_auth_psk;
+pub use ops::seal_base;
+pub use ops::seal_psk;
+pub use ops::send_export_base;
+pub use ops::AuthParams;
+pub use ops::OpenRequest;
+pub use ops::PskParams;
+pub use ops::SealRequest;
+pub use suite::HpkeSuite;

--- a/fw/core/crypto/hpke/src/ops.rs
+++ b/fw/core/crypto/hpke/src/ops.rs
@@ -1,0 +1,683 @@
+// Copyright (c) Microsoft Corporation.
+
+//! HPKE single-shot seal / open / export operations (RFC 9180 §6).
+//!
+//! All four HPKE modes (Base / PSK / Auth / AuthPSK) reduce to the
+//! same three steps:
+//!
+//! 1. **KEM** — encapsulate or decapsulate a `Nsecret`-byte shared
+//!    secret using the recipient's public key (and the sender's own
+//!    keypair for Auth modes).
+//! 2. **Key schedule** — derive an AEAD `key` and a `base_nonce` from
+//!    the shared secret, the application info, and the optional PSK
+//!    (RFC 9180 §5.1).
+//! 3. **AEAD** — seal or open with `key`/`base_nonce` against the
+//!    caller-supplied AAD and plaintext/ciphertext.
+//!
+//! [`seal`] and [`open`] perform the full pipeline under a single
+//! caller-provided [`HsmScopedAlloc`]. The eight thin wrappers
+//! ([`seal_base`], [`open_psk`], …) match the trait-level naming
+//! convention of the HSM core and select the right [`Mode`] /
+//! [`AuthInputs`] / [`PskInputs`] arguments.
+//!
+//! ## Buffer layout invariants
+//!
+//! Each helper allocates only the intermediates it needs from `alloc`:
+//! a KEM shared secret, then AEAD key + base nonce, then any
+//! key-schedule / KDF formatting buffers. The scoped allocator frees the
+//! whole tree when the public call returns.
+
+use azihsm_fw_hsm_pal_traits::DmaBuf;
+use azihsm_fw_hsm_pal_traits::HsmAlloc;
+use azihsm_fw_hsm_pal_traits::HsmCrypto;
+use azihsm_fw_hsm_pal_traits::HsmIo;
+use azihsm_fw_hsm_pal_traits::HsmResult;
+use azihsm_fw_hsm_pal_traits::HsmScopedAlloc;
+
+use crate::aead;
+use crate::kdf;
+use crate::kem;
+use crate::schedule;
+use crate::suite::HpkeSuite;
+
+// =============================================================================
+// HPKE mode (RFC 9180 §5.1 Table 1)
+// =============================================================================
+
+/// HPKE operating mode (RFC 9180 §5.1 Table 1).
+///
+/// Encoded as a single byte at byte 0 of the key-schedule context.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+enum Mode {
+    Base = 0x00,
+    Psk = 0x01,
+    Auth = 0x02,
+    AuthPsk = 0x03,
+}
+
+// =============================================================================
+// Request / parameter structs
+// =============================================================================
+
+/// Common parameters for an HPKE seal (encrypt) operation.
+#[derive(Debug)]
+pub struct SealRequest<'a> {
+    /// HPKE ciphersuite.
+    pub suite: HpkeSuite,
+    /// Recipient public key (`Npk` bytes).
+    pub pk_r: &'a [u8],
+    /// Application-supplied info (may be empty).
+    pub info: &'a [u8],
+    /// Additional authenticated data (may be empty).
+    pub aad: &'a [u8],
+    /// Plaintext to encrypt.
+    pub pt: &'a [u8],
+    /// Output: encapsulated key (`Nenc` bytes).
+    pub enc: &'a mut [u8],
+    /// Output: ciphertext.
+    pub ct: &'a mut [u8],
+}
+
+/// Common parameters for an HPKE open (decrypt) operation.
+#[derive(Debug)]
+pub struct OpenRequest<'a> {
+    /// HPKE ciphersuite.
+    pub suite: HpkeSuite,
+    /// Recipient private key (`Nsk` bytes).
+    pub sk_r: &'a [u8],
+    /// Recipient public key (`Npk` bytes).
+    pub pk_r: &'a [u8],
+    /// Encapsulated key from the sender (`Nenc` bytes).
+    pub enc: &'a [u8],
+    /// Application-supplied info — must equal the sender's value.
+    pub info: &'a [u8],
+    /// Additional authenticated data — must equal the sender's value.
+    pub aad: &'a [u8],
+    /// Ciphertext to decrypt.
+    pub ct: &'a [u8],
+    /// Output: recovered plaintext.
+    pub pt: &'a mut [u8],
+}
+
+/// Pre-shared key parameters for [`seal_psk`] / [`open_psk`] and
+/// [`seal_auth_psk`] / [`open_auth_psk`].
+#[derive(Debug)]
+pub struct PskParams<'a> {
+    /// Pre-shared key (≥ 32 bytes of entropy recommended by RFC 9180).
+    pub psk: &'a [u8],
+    /// PSK identifier.
+    pub psk_id: &'a [u8],
+}
+
+/// Sender authentication parameters for [`seal_auth`] /
+/// [`seal_auth_psk`] (sender side only — the recipient passes
+/// `auth_pk_s` directly to [`open_auth`] / [`open_auth_psk`]).
+#[derive(Debug)]
+pub struct AuthParams<'a> {
+    /// Sender private key.
+    pub sk_s: &'a [u8],
+    /// Sender public key.
+    pub pk_s: &'a [u8],
+}
+
+// =============================================================================
+// Internal driver
+// =============================================================================
+
+/// PSK inputs threaded into [`Mode::Psk`] / [`Mode::AuthPsk`] calls.
+/// Equivalent to a flattened `Option<PskParams>` (empty slices mean
+/// "no PSK").
+#[derive(Default, Clone, Copy)]
+struct PskInputs<'a> {
+    psk: &'a [u8],
+    psk_id: &'a [u8],
+}
+
+impl<'a> From<Option<&'a PskParams<'a>>> for PskInputs<'a> {
+    fn from(p: Option<&'a PskParams<'a>>) -> Self {
+        match p {
+            Some(p) => Self {
+                psk: p.psk,
+                psk_id: p.psk_id,
+            },
+            None => Self::default(),
+        }
+    }
+}
+
+/// Sender-authentication inputs threaded into [`Mode::Auth`] /
+/// [`Mode::AuthPsk`] encap calls.
+#[derive(Clone, Copy)]
+struct AuthInputs<'a> {
+    sk_s: &'a [u8],
+    pk_s: &'a [u8],
+}
+
+fn alloc_bytes(len: usize, alloc: &impl HsmScopedAlloc) -> HsmResult<&mut DmaBuf> {
+    alloc.dma_alloc(len)
+}
+
+/// Run the key schedule on `ss`, then AEAD-seal `pt → ct`.
+async fn seal_finish<'a, P>(
+    pal: &P,
+    io: &impl HsmIo,
+    suite: HpkeSuite,
+    mode: Mode,
+    ss: &mut [u8],
+    info: &[u8],
+    psk: PskInputs<'_>,
+    aad: &[u8],
+    pt: &[u8],
+    ct: &mut [u8],
+    alloc: &'a impl HsmScopedAlloc,
+) -> HsmResult<usize>
+where
+    P: HsmCrypto + HsmAlloc + 'a,
+{
+    let key = alloc_bytes(suite.nk(), alloc)?;
+    let nonce = alloc_bytes(suite.nn(), alloc)?;
+    schedule::key_schedule(
+        pal, io, suite, mode as u8, ss, info, psk.psk, psk.psk_id, key, nonce, alloc,
+    )
+    .await?;
+    aead::seal(pal, io, suite, key, nonce, aad, pt, ct, alloc).await
+}
+
+/// Run the key schedule on `ss`, then AEAD-open `ct → pt`.
+async fn open_finish<'a, P>(
+    pal: &P,
+    io: &impl HsmIo,
+    suite: HpkeSuite,
+    mode: Mode,
+    ss: &mut [u8],
+    info: &[u8],
+    psk: PskInputs<'_>,
+    aad: &[u8],
+    ct: &[u8],
+    pt: &mut [u8],
+    alloc: &'a impl HsmScopedAlloc,
+) -> HsmResult<usize>
+where
+    P: HsmCrypto + HsmAlloc + 'a,
+{
+    let key = alloc_bytes(suite.nk(), alloc)?;
+    let nonce = alloc_bytes(suite.nn(), alloc)?;
+    schedule::key_schedule(
+        pal, io, suite, mode as u8, ss, info, psk.psk, psk.psk_id, key, nonce, alloc,
+    )
+    .await?;
+    aead::open(pal, io, suite, key, nonce, aad, ct, pt, alloc).await
+}
+
+/// Unified seal driver used by every mode-specific wrapper.
+///
+/// Allocates the `Nsecret`-byte KEM shared secret from `alloc`, runs
+/// encapsulation to populate it, then passes it to [`seal_finish`].
+async fn seal<'a, P>(
+    pal: &P,
+    io: &impl HsmIo,
+    req: &mut SealRequest<'_>,
+    mode: Mode,
+    auth: Option<&AuthInputs<'_>>,
+    psk: PskInputs<'_>,
+    alloc: &'a impl HsmScopedAlloc,
+) -> HsmResult<usize>
+where
+    P: HsmCrypto + HsmAlloc + 'a,
+{
+    let ss = alloc_bytes(req.suite.nsecret(), alloc)?;
+    match auth {
+        None => kem::encap(pal, io, req.suite, req.pk_r, req.enc, ss, alloc).await?,
+        Some(a) => {
+            kem::auth_encap(
+                pal, io, req.suite, req.pk_r, a.sk_s, a.pk_s, req.enc, ss, alloc,
+            )
+            .await?;
+        }
+    }
+    seal_finish(
+        pal, io, req.suite, mode, ss, req.info, psk, req.aad, req.pt, req.ct, alloc,
+    )
+    .await
+}
+
+/// Unified open driver used by every mode-specific wrapper.
+async fn open<'a, P>(
+    pal: &P,
+    io: &impl HsmIo,
+    req: &mut OpenRequest<'_>,
+    mode: Mode,
+    auth_pk_s: Option<&[u8]>,
+    psk: PskInputs<'_>,
+    alloc: &'a impl HsmScopedAlloc,
+) -> HsmResult<usize>
+where
+    P: HsmCrypto + HsmAlloc + 'a,
+{
+    let ss = alloc_bytes(req.suite.nsecret(), alloc)?;
+    match auth_pk_s {
+        None => kem::decap(pal, io, req.suite, req.enc, req.sk_r, req.pk_r, ss, alloc).await?,
+        Some(pk_s) => {
+            kem::auth_decap(
+                pal, io, req.suite, req.enc, req.sk_r, req.pk_r, pk_s, ss, alloc,
+            )
+            .await?;
+        }
+    }
+    open_finish(
+        pal, io, req.suite, mode, ss, req.info, psk, req.aad, req.ct, req.pt, alloc,
+    )
+    .await
+}
+
+// =============================================================================
+// Mode-specific public entry points
+// =============================================================================
+
+/// HPKE Base-mode seal: encrypt to the recipient's public key.
+///
+/// # Type parameters
+///
+/// * `P` — any [`HsmCrypto`] PAL implementation.
+///
+/// # Parameters
+///
+/// * `pal` — PAL providing all crypto primitives.
+/// * `io` — caller's I/O context (per-IO scope).
+/// * `req` — input/output buffers; see [`SealRequest`].
+/// * `alloc` — scoped allocator owning every HPKE intermediate.
+///
+/// # Returns
+///
+/// * `Ok(ct_len)` — ciphertext bytes written to `req.ct`.
+/// * `Err(HsmError::InvalidArg)` — buffer-size violation.
+/// * `Err(HsmError::NotEnoughSpace)` — allocator scope too small.
+/// * `Err(HsmError)` — propagated from the KEM, key schedule, or
+///   AEAD step.
+pub async fn seal_base<'a, P>(
+    pal: &P,
+    io: &impl HsmIo,
+    req: &mut SealRequest<'_>,
+    alloc: &'a impl HsmScopedAlloc,
+) -> HsmResult<usize>
+where
+    P: HsmCrypto + HsmAlloc + 'a,
+{
+    seal(pal, io, req, Mode::Base, None, PskInputs::default(), alloc).await
+}
+
+/// HPKE Base-mode open: decrypt with the recipient's private key.
+///
+/// # Parameters
+///
+/// * `pal` — PAL providing all crypto primitives.
+/// * `io` — caller's I/O context (per-IO scope).
+/// * `req` — input/output buffers; see [`OpenRequest`].
+/// * `alloc` — scoped allocator owning every HPKE intermediate.
+///
+/// # Returns
+///
+/// * `Ok(pt_len)` — plaintext bytes written to `req.pt`.
+/// * `Err(HsmError::InvalidArg)` — buffer-size violation.
+/// * `Err(HsmError::NotEnoughSpace)` — allocator scope too small.
+/// * `Err(HsmError::AesGcmDecryptTagDoesNotMatch)` — AEAD tag
+///   mismatch (GCM suites).
+/// * `Err(HsmError::AesDecryptFailed)` — AEAD tag mismatch (CBC
+///   suites).
+/// * `Err(HsmError)` — propagated from the KEM, key schedule, or
+///   AEAD step.
+pub async fn open_base<'a, P>(
+    pal: &P,
+    io: &impl HsmIo,
+    req: &mut OpenRequest<'_>,
+    alloc: &'a impl HsmScopedAlloc,
+) -> HsmResult<usize>
+where
+    P: HsmCrypto + HsmAlloc + 'a,
+{
+    open(pal, io, req, Mode::Base, None, PskInputs::default(), alloc).await
+}
+
+/// HPKE PSK-mode seal: encrypt with PSK authentication.
+///
+/// # Parameters
+///
+/// * `pal` — PAL providing all crypto primitives.
+/// * `io` — caller's I/O context (per-IO scope).
+/// * `req` — input/output buffers.
+/// * `psk` — pre-shared key + identifier.
+/// * `alloc` — scoped allocator owning every HPKE intermediate.
+///
+/// # Returns
+///
+/// Same shape as [`seal_base`].
+pub async fn seal_psk<'a, P>(
+    pal: &P,
+    io: &impl HsmIo,
+    req: &mut SealRequest<'_>,
+    psk: &PskParams<'_>,
+    alloc: &'a impl HsmScopedAlloc,
+) -> HsmResult<usize>
+where
+    P: HsmCrypto + HsmAlloc + 'a,
+{
+    seal(pal, io, req, Mode::Psk, None, Some(psk).into(), alloc).await
+}
+
+/// HPKE PSK-mode open: decrypt with PSK authentication.
+///
+/// # Parameters
+///
+/// * `pal` — PAL providing all crypto primitives.
+/// * `io` — caller's I/O context (per-IO scope).
+/// * `req` — input/output buffers.
+/// * `psk` — pre-shared key + identifier; must equal the sender's.
+/// * `alloc` — scoped allocator owning every HPKE intermediate.
+///
+/// # Returns
+///
+/// Same shape as [`open_base`].
+pub async fn open_psk<'a, P>(
+    pal: &P,
+    io: &impl HsmIo,
+    req: &mut OpenRequest<'_>,
+    psk: &PskParams<'_>,
+    alloc: &'a impl HsmScopedAlloc,
+) -> HsmResult<usize>
+where
+    P: HsmCrypto + HsmAlloc + 'a,
+{
+    open(pal, io, req, Mode::Psk, None, Some(psk).into(), alloc).await
+}
+
+/// HPKE Auth-mode seal: encrypt with sender-key authentication.
+///
+/// # Parameters
+///
+/// * `pal` — PAL providing all crypto primitives.
+/// * `io` — caller's I/O context (per-IO scope).
+/// * `req` — input/output buffers.
+/// * `auth` — sender keypair used to authenticate the
+///   encapsulation.
+/// * `alloc` — scoped allocator owning every HPKE intermediate.
+///
+/// # Returns
+///
+/// Same shape as [`seal_base`].
+pub async fn seal_auth<'a, P>(
+    pal: &P,
+    io: &impl HsmIo,
+    req: &mut SealRequest<'_>,
+    auth: &AuthParams<'_>,
+    alloc: &'a impl HsmScopedAlloc,
+) -> HsmResult<usize>
+where
+    P: HsmCrypto + HsmAlloc + 'a,
+{
+    let auth_inputs = AuthInputs {
+        sk_s: auth.sk_s,
+        pk_s: auth.pk_s,
+    };
+    seal(
+        pal,
+        io,
+        req,
+        Mode::Auth,
+        Some(&auth_inputs),
+        PskInputs::default(),
+        alloc,
+    )
+    .await
+}
+
+/// HPKE Auth-mode open: decrypt with sender-key authentication.
+///
+/// # Parameters
+///
+/// * `pal` — PAL providing all crypto primitives.
+/// * `io` — caller's I/O context (per-IO scope).
+/// * `req` — input/output buffers.
+/// * `auth_pk_s` — sender's public key (used to verify the
+///   authenticated encapsulation).
+/// * `alloc` — scoped allocator owning every HPKE intermediate.
+///
+/// # Returns
+///
+/// Same shape as [`open_base`].
+pub async fn open_auth<'a, P>(
+    pal: &P,
+    io: &impl HsmIo,
+    req: &mut OpenRequest<'_>,
+    auth_pk_s: &[u8],
+    alloc: &'a impl HsmScopedAlloc,
+) -> HsmResult<usize>
+where
+    P: HsmCrypto + HsmAlloc + 'a,
+{
+    open(
+        pal,
+        io,
+        req,
+        Mode::Auth,
+        Some(auth_pk_s),
+        PskInputs::default(),
+        alloc,
+    )
+    .await
+}
+
+/// HPKE AuthPSK-mode seal: encrypt with both sender-key and PSK
+/// authentication.
+///
+/// # Parameters
+///
+/// * `pal` — PAL providing all crypto primitives.
+/// * `io` — caller's I/O context (per-IO scope).
+/// * `req` — input/output buffers.
+/// * `auth` — sender keypair.
+/// * `psk` — pre-shared key + identifier.
+/// * `alloc` — scoped allocator owning every HPKE intermediate.
+///
+/// # Returns
+///
+/// Same shape as [`seal_base`].
+pub async fn seal_auth_psk<'a, P>(
+    pal: &P,
+    io: &impl HsmIo,
+    req: &mut SealRequest<'_>,
+    auth: &AuthParams<'_>,
+    psk: &PskParams<'_>,
+    alloc: &'a impl HsmScopedAlloc,
+) -> HsmResult<usize>
+where
+    P: HsmCrypto + HsmAlloc + 'a,
+{
+    let auth_inputs = AuthInputs {
+        sk_s: auth.sk_s,
+        pk_s: auth.pk_s,
+    };
+    seal(
+        pal,
+        io,
+        req,
+        Mode::AuthPsk,
+        Some(&auth_inputs),
+        Some(psk).into(),
+        alloc,
+    )
+    .await
+}
+
+/// HPKE AuthPSK-mode open: decrypt with both sender-key and PSK
+/// authentication.
+///
+/// # Parameters
+///
+/// * `pal` — PAL providing all crypto primitives.
+/// * `io` — caller's I/O context (per-IO scope).
+/// * `req` — input/output buffers.
+/// * `auth_pk_s` — sender's public key.
+/// * `psk` — pre-shared key + identifier; must equal the sender's.
+/// * `alloc` — scoped allocator owning every HPKE intermediate.
+///
+/// # Returns
+///
+/// Same shape as [`open_base`].
+pub async fn open_auth_psk<'a, P>(
+    pal: &P,
+    io: &impl HsmIo,
+    req: &mut OpenRequest<'_>,
+    auth_pk_s: &[u8],
+    psk: &PskParams<'_>,
+    alloc: &'a impl HsmScopedAlloc,
+) -> HsmResult<usize>
+where
+    P: HsmCrypto + HsmAlloc + 'a,
+{
+    open(
+        pal,
+        io,
+        req,
+        Mode::AuthPsk,
+        Some(auth_pk_s),
+        Some(psk).into(),
+        alloc,
+    )
+    .await
+}
+
+// =============================================================================
+// Export operations (Base mode only)
+// =============================================================================
+
+/// Sender-side derivation of an HPKE export key (Base mode).
+///
+/// Performs encap + the Base-mode key-schedule export step, then
+/// `LabeledExpand`s the exporter secret with `exporter_context` to
+/// produce `exported.len()` derived bytes.
+///
+/// # Parameters
+///
+/// * `pal` — PAL providing all crypto primitives.
+/// * `io` — caller's I/O context (per-IO scope).
+/// * `suite` — HPKE ciphersuite.
+/// * `pk_r` — recipient public key.
+/// * `info` — application-supplied info; must equal the
+///   receiver's.
+/// * `exporter_context` — context bytes mixed into the final
+///   export; must equal the receiver's.
+/// * `enc` — output: encapsulated key (`Nenc` bytes).
+/// * `exported` — output: derived key bytes.
+/// * `alloc` — scoped allocator owning every HPKE intermediate.
+///
+/// # Returns
+///
+/// * `Ok(())` — `enc` and `exported` populated.
+/// * `Err(HsmError::NotEnoughSpace)` — allocator scope too small.
+/// * `Err(HsmError)` — propagated from the KEM, key schedule, or
+///   HKDF.
+pub async fn send_export_base<'a, P>(
+    pal: &P,
+    io: &impl HsmIo,
+    suite: HpkeSuite,
+    pk_r: &[u8],
+    info: &[u8],
+    exporter_context: &[u8],
+    enc: &mut [u8],
+    exported: &mut [u8],
+    alloc: &'a impl HsmScopedAlloc,
+) -> HsmResult<()>
+where
+    P: HsmCrypto + HsmAlloc + 'a,
+{
+    let ss = alloc_bytes(suite.nsecret(), alloc)?;
+    kem::encap(pal, io, suite, pk_r, enc, ss, alloc).await?;
+    export_finish(pal, io, suite, ss, info, exporter_context, exported, alloc).await
+}
+
+/// Receiver-side derivation of an HPKE export key (Base mode).
+///
+/// # Parameters
+///
+/// * `pal` — PAL providing all crypto primitives.
+/// * `io` — caller's I/O context (per-IO scope).
+/// * `suite` — HPKE ciphersuite.
+/// * `sk_r` — recipient private key.
+/// * `pk_r` — recipient public key.
+/// * `enc` — encapsulated key from sender.
+/// * `info` — application-supplied info; must equal the sender's.
+/// * `exporter_context` — context bytes mixed into the final
+///   export; must equal the sender's.
+/// * `exported` — output: derived key bytes.
+/// * `alloc` — scoped allocator owning every HPKE intermediate.
+///
+/// # Returns
+///
+/// * `Ok(())` — `exported` populated.
+/// * `Err(HsmError::NotEnoughSpace)` — allocator scope too small.
+/// * `Err(HsmError)` — propagated from the KEM, key schedule, or
+///   HKDF.
+pub async fn receive_export_base<'a, P>(
+    pal: &P,
+    io: &impl HsmIo,
+    suite: HpkeSuite,
+    sk_r: &[u8],
+    pk_r: &[u8],
+    enc: &[u8],
+    info: &[u8],
+    exporter_context: &[u8],
+    exported: &mut [u8],
+    alloc: &'a impl HsmScopedAlloc,
+) -> HsmResult<()>
+where
+    P: HsmCrypto + HsmAlloc + 'a,
+{
+    let ss = alloc_bytes(suite.nsecret(), alloc)?;
+    kem::decap(pal, io, suite, enc, sk_r, pk_r, ss, alloc).await?;
+    export_finish(pal, io, suite, ss, info, exporter_context, exported, alloc).await
+}
+
+/// Run the Base-mode export key schedule, then expand the exporter
+/// secret with `exporter_context`. Shared by [`send_export_base`] and
+/// [`receive_export_base`].
+async fn export_finish<'a, P>(
+    pal: &P,
+    io: &impl HsmIo,
+    suite: HpkeSuite,
+    ss: &mut [u8],
+    info: &[u8],
+    exporter_context: &[u8],
+    exported: &mut [u8],
+    alloc: &'a impl HsmScopedAlloc,
+) -> HsmResult<()>
+where
+    P: HsmCrypto + HsmAlloc + 'a,
+{
+    let exp_secret = alloc_bytes(suite.nh(), alloc)?;
+    schedule::key_schedule_export(
+        pal,
+        io,
+        suite,
+        Mode::Base as u8,
+        ss,
+        info,
+        &[],
+        &[],
+        exp_secret,
+        alloc,
+    )
+    .await?;
+    kdf::labeled_expand(
+        pal,
+        io,
+        suite.kdf_hash(),
+        &suite.hpke_suite_id(),
+        exp_secret,
+        b"sec",
+        exporter_context,
+        exported,
+        alloc,
+    )
+    .await
+}

--- a/fw/core/crypto/hpke/src/schedule.rs
+++ b/fw/core/crypto/hpke/src/schedule.rs
@@ -1,0 +1,300 @@
+// Copyright (c) Microsoft Corporation.
+
+//! HPKE key schedule (RFC 9180 §5.1).
+//!
+//! Both [`key_schedule`] and [`key_schedule_export`] start by deriving
+//! `secret`, the `key_schedule_context` (`KSC`), and the per-suite
+//! `hpke_suite_id` from the shared inputs. They then diverge:
+//!
+//! * [`key_schedule`] expands `secret` into the AEAD `key` and
+//!   `base_nonce`.
+//! * [`key_schedule_export`] expands `secret` into the export
+//!   `exporter_secret`.
+//!
+//! The shared prefix lives in [`derive_secret_and_ksc`] so the two
+//! public entry points stay short and the slice arithmetic does not
+//! get duplicated.
+
+use azihsm_fw_hsm_pal_traits::DmaBuf;
+use azihsm_fw_hsm_pal_traits::HsmAlloc;
+use azihsm_fw_hsm_pal_traits::HsmCrypto;
+use azihsm_fw_hsm_pal_traits::HsmHashAlgo;
+use azihsm_fw_hsm_pal_traits::HsmIo;
+use azihsm_fw_hsm_pal_traits::HsmResult;
+use azihsm_fw_hsm_pal_traits::HsmScopedAlloc;
+
+use crate::kdf;
+use crate::suite::HpkeSuite;
+
+// =============================================================================
+// Shared key-schedule prefix
+// =============================================================================
+
+/// Outputs of [`derive_secret_and_ksc`] borrowed from the scoped allocator.
+struct ScheduleState<'a> {
+    /// Hash algorithm used by HKDF.
+    algo: HsmHashAlgo,
+    /// Cached HPKE suite identifier.
+    suite_id: [u8; 10],
+    /// `secret = LabeledExtract(shared_secret, "secret", psk)` (`Nh` bytes).
+    secret: &'a [u8],
+    /// `key_schedule_context = mode || psk_id_hash || info_hash`
+    /// (`1 + 2*Nh` bytes).
+    ksc: &'a [u8],
+}
+
+fn alloc_bytes(len: usize, alloc: &impl HsmScopedAlloc) -> HsmResult<&mut DmaBuf> {
+    alloc.dma_alloc(len)
+}
+
+/// Compute the shared `(secret, ksc)` pair used by every HPKE key
+/// schedule (export and AEAD).
+///
+/// Allocates `psk_id_hash`, `info_hash`, `ksc`, and `secret` from
+/// `alloc` and returns the shared `secret` / `ksc` pair used by
+/// both key-schedule entry points.
+///
+/// # Parameters
+///
+/// * `pal` — PAL providing HKDF / HMAC.
+/// * `io` — caller's I/O context (per-IO scope).
+/// * `suite` — HPKE ciphersuite.
+/// * `mode` — RFC 9180 §5.1 mode byte (Base, PSK, Auth, AuthPSK).
+/// * `shared_secret` — KEM output (`Nsecret` bytes).
+/// * `info` — application-supplied info (may be empty).
+/// * `psk` — pre-shared key (empty for non-PSK modes).
+/// * `psk_id` — PSK identifier (empty for non-PSK modes).
+/// * `alloc` — scoped allocator used for the intermediate buffers
+///   and internal HKDF / HMAC state.
+///
+/// # Returns
+///
+/// * `Ok(state)` — [`ScheduleState`] borrowing slices from `alloc`.
+/// * `Err(HsmError::NotEnoughSpace)` — allocator scope too small.
+/// * `Err(HsmError)` — propagated from the HKDF Extract calls.
+async fn derive_secret_and_ksc<'a, P>(
+    pal: &P,
+    io: &impl HsmIo,
+    suite: HpkeSuite,
+    mode: u8,
+    shared_secret: &[u8],
+    info: &[u8],
+    psk: &[u8],
+    psk_id: &[u8],
+    alloc: &'a impl HsmScopedAlloc,
+) -> HsmResult<ScheduleState<'a>>
+where
+    P: HsmCrypto + HsmAlloc + 'a,
+{
+    let algo = suite.kdf_hash();
+    let nh = suite.nh();
+    let suite_id = suite.hpke_suite_id();
+
+    let psk_id_hash = alloc_bytes(nh, alloc)?;
+    kdf::labeled_extract(
+        pal,
+        io,
+        algo,
+        &suite_id,
+        &[],
+        b"psk_id_hash",
+        psk_id,
+        psk_id_hash,
+        alloc,
+    )
+    .await?;
+
+    let info_hash = alloc_bytes(nh, alloc)?;
+    kdf::labeled_extract(
+        pal,
+        io,
+        algo,
+        &suite_id,
+        &[],
+        b"info_hash",
+        info,
+        info_hash,
+        alloc,
+    )
+    .await?;
+
+    let ksc = alloc_bytes(1 + 2 * nh, alloc)?;
+    ksc[0] = mode;
+    ksc[1..1 + nh].copy_from_slice(psk_id_hash);
+    ksc[1 + nh..].copy_from_slice(info_hash);
+
+    let secret = alloc_bytes(nh, alloc)?;
+    kdf::labeled_extract(
+        pal,
+        io,
+        algo,
+        &suite_id,
+        shared_secret,
+        b"secret",
+        psk,
+        secret,
+        alloc,
+    )
+    .await?;
+
+    Ok(ScheduleState {
+        algo,
+        suite_id,
+        secret: &*secret,
+        ksc: &*ksc,
+    })
+}
+
+// =============================================================================
+// Public entry points
+// =============================================================================
+
+/// Derive the AEAD `key` and `base_nonce` from `shared_secret +
+/// info`.
+///
+/// Implements the RFC 9180 §5.1 KeySchedule for all four modes —
+/// the `mode` / `psk` / `psk_id` parameters select Base, PSK, Auth,
+/// or AuthPSK.  For Base / Auth modes pass empty `psk` / `psk_id`.
+///
+/// # Type parameters
+///
+/// * `P` — any [`HsmCrypto`] PAL implementation.
+///
+/// # Parameters
+///
+/// * `pal` — PAL providing HKDF / HMAC.
+/// * `io` — caller's I/O context (per-IO scope).
+/// * `suite` — HPKE ciphersuite.
+/// * `mode` — RFC 9180 §5.1 mode byte (`0x00..=0x03`).
+/// * `shared_secret` — KEM output (`Nsecret` bytes).
+/// * `info` — application-supplied info.
+/// * `psk` — pre-shared key (empty for Base / Auth modes).
+/// * `psk_id` — PSK identifier (empty for Base / Auth modes).
+/// * `key` — output: AEAD key (`Nk` bytes).
+/// * `base_nonce` — output: AEAD base nonce (`Nn` bytes).
+/// * `alloc` — scoped allocator used for intermediate buffers and
+///   the internal HKDF / HMAC state.
+///
+/// # Returns
+///
+/// * `Ok(())` — `key` and `base_nonce` populated.
+/// * `Err(HsmError::NotEnoughSpace)` — allocator scope too small.
+/// * `Err(HsmError)` — propagated from the HKDF Extract / Expand
+///   calls.
+pub async fn key_schedule<'a, P>(
+    pal: &P,
+    io: &impl HsmIo,
+    suite: HpkeSuite,
+    mode: u8,
+    shared_secret: &[u8],
+    info: &[u8],
+    psk: &[u8],
+    psk_id: &[u8],
+    key: &mut [u8],
+    base_nonce: &mut [u8],
+    alloc: &'a impl HsmScopedAlloc,
+) -> HsmResult<()>
+where
+    P: HsmCrypto + HsmAlloc + 'a,
+{
+    let st = derive_secret_and_ksc(
+        pal,
+        io,
+        suite,
+        mode,
+        shared_secret,
+        info,
+        psk,
+        psk_id,
+        alloc,
+    )
+    .await?;
+
+    // key = LabeledExpand(secret, "key", ksc, Nk)
+    kdf::labeled_expand(
+        pal,
+        io,
+        st.algo,
+        &st.suite_id,
+        st.secret,
+        b"key",
+        st.ksc,
+        key,
+        alloc,
+    )
+    .await?;
+
+    // base_nonce = LabeledExpand(secret, "base_nonce", ksc, Nn)
+    kdf::labeled_expand(
+        pal,
+        io,
+        st.algo,
+        &st.suite_id,
+        st.secret,
+        b"base_nonce",
+        st.ksc,
+        base_nonce,
+        alloc,
+    )
+    .await
+}
+
+/// Derive an `exporter_secret` from `shared_secret + info`.
+///
+/// Same algorithm as [`key_schedule`] but stops after the secret /
+/// KSC step and emits a single `LabeledExpand` for the export
+/// secret.
+///
+/// # Parameters
+///
+/// Same as [`key_schedule`] except `exporter_secret` replaces
+/// `key` / `base_nonce` and is `Nh` bytes.  `alloc` provides the
+/// intermediate buffers and internal HKDF / HMAC state.
+///
+/// # Returns
+///
+/// * `Ok(())` — `exporter_secret` populated.
+/// * `Err(HsmError::NotEnoughSpace)` — allocator scope too small.
+/// * `Err(HsmError)` — propagated from the HKDF Extract / Expand
+///   calls.
+pub async fn key_schedule_export<'a, P>(
+    pal: &P,
+    io: &impl HsmIo,
+    suite: HpkeSuite,
+    mode: u8,
+    shared_secret: &[u8],
+    info: &[u8],
+    psk: &[u8],
+    psk_id: &[u8],
+    exporter_secret: &mut [u8],
+    alloc: &'a impl HsmScopedAlloc,
+) -> HsmResult<()>
+where
+    P: HsmCrypto + HsmAlloc + 'a,
+{
+    let st = derive_secret_and_ksc(
+        pal,
+        io,
+        suite,
+        mode,
+        shared_secret,
+        info,
+        psk,
+        psk_id,
+        alloc,
+    )
+    .await?;
+
+    kdf::labeled_expand(
+        pal,
+        io,
+        st.algo,
+        &st.suite_id,
+        st.secret,
+        b"exp",
+        st.ksc,
+        exporter_secret,
+        alloc,
+    )
+    .await
+}

--- a/fw/core/crypto/hpke/src/suite.rs
+++ b/fw/core/crypto/hpke/src/suite.rs
@@ -1,0 +1,337 @@
+// Copyright (c) Microsoft Corporation.
+
+//! HPKE ciphersuite definitions and per-suite size constants.
+//!
+//! Six ciphersuites are exposed as a single [`HpkeSuite`] enum. Three
+//! of them are RFC 9180 standard combinations (DHKEM(P-N) + HKDF + AES-
+//! 256-GCM); the other three substitute AES-256-CBC + HMAC for the
+//! AEAD step using a private-use AEAD identifier (`0xFFFF`) and a
+//! FIPS-compliant key sizing scheme.
+//!
+//! ## CBC-HMAC key layout
+//!
+//! For the CBC variants the AEAD key concatenates the MAC key (size =
+//! hash output length per SP 800-107) and the AES encryption key
+//! (always 32 bytes for AES-256):
+//!
+//! | Suite      | `MAC_KEY` | `ENC_KEY` | Total `Nk` | Tag `Nt` |
+//! |------------|-----------|-----------|------------|----------|
+//! | P-256/CBC  | 32        | 32        | 64         | 16       |
+//! | P-384/CBC  | 48        | 32        | 80         | 24       |
+//! | P-521/CBC  | 64        | 32        | 96         | 32       |
+//!
+//! The tag is HMAC truncated to half the hash output.
+//!
+//! ## Internal representation
+//!
+//! Every per-suite quantity is derived from two orthogonal selectors —
+//! the [`KemKind`] (curve / hash family) and an `is_cbc` flag. This
+//! avoids the original `match` ladder in every accessor and keeps the
+//! per-curve constants in a single [`KEM_TABLE`] entry.
+
+use azihsm_fw_hsm_pal_traits::HsmEccCurve;
+use azihsm_fw_hsm_pal_traits::HsmHashAlgo;
+
+// =============================================================================
+// HpkeSuite enum
+// =============================================================================
+
+/// HPKE ciphersuite.
+///
+/// All suites use AES-256. The CBC variants use AES-256-CBC + HMAC
+/// with FIPS-compliant MAC key lengths (= full hash output, per
+/// SP 800-107).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[allow(clippy::upper_case_acronyms)]
+pub enum HpkeSuite {
+    /// DHKEM(P-256, HKDF-SHA256), HKDF-SHA256, AES-256-GCM.
+    DHKemP256Sha256Aes256Gcm,
+
+    /// DHKEM(P-256, HKDF-SHA256), HKDF-SHA256, AES-256-CBC-HMAC-SHA256.
+    DHKemP256Sha256Aes256Cbc,
+
+    /// DHKEM(P-384, HKDF-SHA384), HKDF-SHA384, AES-256-GCM.
+    DHKemP384Sha384Aes256Gcm,
+
+    /// DHKEM(P-384, HKDF-SHA384), HKDF-SHA384, AES-256-CBC-HMAC-SHA384.
+    DHKemP384Sha384Aes256Cbc,
+
+    /// DHKEM(P-521, HKDF-SHA512), HKDF-SHA512, AES-256-GCM.
+    DHKemP521Sha512Aes256Gcm,
+
+    /// DHKEM(P-521, HKDF-SHA512), HKDF-SHA512, AES-256-CBC-HMAC-SHA512.
+    DHKemP521Sha512Aes256Cbc,
+}
+
+// =============================================================================
+// Internal KEM table
+// =============================================================================
+
+/// Per-curve KEM/KDF parameters. The CBC vs GCM differences are
+/// handled separately in [`HpkeSuite`] accessors.
+#[derive(Clone, Copy)]
+struct KemEntry {
+    /// IANA KEM identifier (RFC 9180 §7.1).
+    kem_id: u16,
+    /// IANA KDF identifier (RFC 9180 §7.2).
+    kdf_id: u16,
+    /// Underlying NIST curve.
+    curve: HsmEccCurve,
+    /// HKDF / KEM hash algorithm.
+    hash: HsmHashAlgo,
+    /// Hash output length in bytes (`Nh`).
+    nh: usize,
+    /// HSM-format public-key length in bytes (`Npk = Nenc`,
+    /// `x ‖ y` with HSM 4-byte alignment for P-521).
+    npk: usize,
+    /// HSM-format private-key length in bytes (`Nsk`).
+    nsk: usize,
+    /// Raw ECDH shared-secret length in bytes (`Ndh = curve byte size`).
+    ndh: usize,
+}
+
+/// Curve-family selector. The integer value is the index into
+/// [`KEM_TABLE`].
+#[derive(Clone, Copy)]
+enum KemKind {
+    P256 = 0,
+    P384 = 1,
+    P521 = 2,
+}
+
+/// One entry per [`KemKind`].
+const KEM_TABLE: [KemEntry; 3] = [
+    KemEntry {
+        kem_id: 0x0010,
+        kdf_id: 0x0001,
+        curve: HsmEccCurve::P256,
+        hash: HsmHashAlgo::Sha256,
+        nh: 32,
+        npk: 64,
+        nsk: 32,
+        ndh: 32,
+    },
+    KemEntry {
+        kem_id: 0x0011,
+        kdf_id: 0x0002,
+        curve: HsmEccCurve::P384,
+        hash: HsmHashAlgo::Sha384,
+        nh: 48,
+        npk: 96,
+        nsk: 48,
+        ndh: 48,
+    },
+    KemEntry {
+        kem_id: 0x0012,
+        kdf_id: 0x0003,
+        curve: HsmEccCurve::P521,
+        hash: HsmHashAlgo::Sha512,
+        nh: 64,
+        // P-521 uses 4-byte aligned HSM wire format → 68-byte coords.
+        npk: 136,
+        nsk: 68,
+        // Raw ECDH x-coordinate is 66 bytes (NOT the HSM-padded size).
+        ndh: 66,
+    },
+];
+
+/// IANA AEAD identifier for AES-256-GCM (RFC 9180 §7.3).
+const AEAD_ID_GCM: u16 = 0x0002;
+
+/// Private-use AEAD identifier this crate assigns to AES-256-CBC + HMAC.
+const AEAD_ID_CBC: u16 = 0xFFFF;
+
+/// AES-256 encryption key length used by every CBC suite.
+const AES256_KEY_LEN: usize = 32;
+
+/// AES-CBC IV / GCM nonce sizes.
+const CBC_IV_LEN: usize = 16;
+const GCM_NONCE_LEN: usize = 12;
+
+/// AES-256-GCM tag size.
+const GCM_TAG_LEN: usize = 16;
+
+// =============================================================================
+// HpkeSuite accessors
+// =============================================================================
+
+impl HpkeSuite {
+    /// Decompose the suite into its `(KemKind, is_cbc)` selector pair.
+    ///
+    /// # Returns
+    /// * `(kind, is_cbc)` — `kind` indexes into [`KEM_TABLE`] and
+    ///   `is_cbc` selects the AEAD variant.
+    const fn parts(&self) -> (KemKind, bool) {
+        match self {
+            Self::DHKemP256Sha256Aes256Gcm => (KemKind::P256, false),
+            Self::DHKemP256Sha256Aes256Cbc => (KemKind::P256, true),
+            Self::DHKemP384Sha384Aes256Gcm => (KemKind::P384, false),
+            Self::DHKemP384Sha384Aes256Cbc => (KemKind::P384, true),
+            Self::DHKemP521Sha512Aes256Gcm => (KemKind::P521, false),
+            Self::DHKemP521Sha512Aes256Cbc => (KemKind::P521, true),
+        }
+    }
+
+    /// Borrow the per-curve [`KemEntry`] backing this suite.
+    const fn entry(&self) -> &'static KemEntry {
+        let (kind, _) = self.parts();
+        &KEM_TABLE[kind as usize]
+    }
+
+    // ── IANA identifiers ──────────────────────────────────────────
+
+    /// Returns the IANA KEM identifier (RFC 9180 §7.1).
+    pub const fn kem_id(&self) -> u16 {
+        self.entry().kem_id
+    }
+
+    /// Returns the IANA KDF identifier (RFC 9180 §7.2).
+    pub const fn kdf_id(&self) -> u16 {
+        self.entry().kdf_id
+    }
+
+    /// Returns the IANA AEAD identifier (RFC 9180 §7.3, plus the
+    /// private-use value for the CBC variants).
+    pub const fn aead_id(&self) -> u16 {
+        if self.is_cbc() {
+            AEAD_ID_CBC
+        } else {
+            AEAD_ID_GCM
+        }
+    }
+
+    /// `true` for the AES-256-CBC + HMAC variants, `false` for GCM.
+    pub const fn is_cbc(&self) -> bool {
+        let (_, is_cbc) = self.parts();
+        is_cbc
+    }
+
+    // ── Crypto algorithm selectors ────────────────────────────────
+
+    /// NIST curve used by the KEM.
+    pub const fn kem_curve(&self) -> HsmEccCurve {
+        self.entry().curve
+    }
+
+    /// Hash algorithm used by KEM, KDF, and AEAD HMAC.
+    pub const fn kdf_hash(&self) -> HsmHashAlgo {
+        self.entry().hash
+    }
+
+    /// Hash algorithm used by the KEM (always equal to [`Self::kdf_hash`]).
+    pub const fn kem_hash(&self) -> HsmHashAlgo {
+        self.kdf_hash()
+    }
+
+    /// Hash algorithm used by the CBC-HMAC AEAD (always equal to
+    /// [`Self::kdf_hash`]).
+    pub const fn aead_hash(&self) -> HsmHashAlgo {
+        self.kdf_hash()
+    }
+
+    // ── Size constants ────────────────────────────────────────────
+
+    /// AEAD key length in bytes (`Nk`).
+    ///
+    /// * GCM: 32 bytes (AES-256 key).
+    /// * CBC: `mac_key_len + 32` bytes (`MAC_KEY ‖ ENC_KEY`).
+    pub const fn nk(&self) -> usize {
+        if self.is_cbc() {
+            self.cbc_mac_key_len() + AES256_KEY_LEN
+        } else {
+            AES256_KEY_LEN
+        }
+    }
+
+    /// AEAD nonce / IV length in bytes (`Nn`).
+    ///
+    /// * GCM: 12 (96-bit IV).
+    /// * CBC: 16 (one AES block).
+    pub const fn nn(&self) -> usize {
+        if self.is_cbc() {
+            CBC_IV_LEN
+        } else {
+            GCM_NONCE_LEN
+        }
+    }
+
+    /// KDF hash output length in bytes (`Nh`).
+    pub const fn nh(&self) -> usize {
+        self.entry().nh
+    }
+
+    /// AEAD tag length in bytes (`Nt`).
+    ///
+    /// * GCM: always 16.
+    /// * CBC: HMAC truncated to `Nh / 2`.
+    pub const fn nt(&self) -> usize {
+        if self.is_cbc() {
+            self.nh() / 2
+        } else {
+            GCM_TAG_LEN
+        }
+    }
+
+    /// KEM public-key length in bytes (`Npk = Nenc`).
+    ///
+    /// Uses the HSM `x ‖ y` wire format (no `0x04` prefix). P-521
+    /// coordinates are padded to 4-byte alignment by the HSM PAL.
+    pub const fn npk(&self) -> usize {
+        self.entry().npk
+    }
+
+    /// KEM encapsulated-key length in bytes (`Nenc`). Same as
+    /// [`Self::npk`] for DHKEM.
+    pub const fn nenc(&self) -> usize {
+        self.npk()
+    }
+
+    /// KEM private-key length in bytes (`Nsk`). P-521 uses 68 bytes
+    /// (4-byte aligned HSM wire format).
+    pub const fn nsk(&self) -> usize {
+        self.entry().nsk
+    }
+
+    /// KEM shared-secret length in bytes (`Nsecret = Nh`).
+    pub const fn nsecret(&self) -> usize {
+        self.nh()
+    }
+
+    /// Raw ECDH shared-secret length in bytes (`Ndh`).
+    ///
+    /// This is the curve byte size, NOT the HSM-padded size. P-521
+    /// raw x-coordinate is 66 bytes.
+    pub const fn ndh(&self) -> usize {
+        self.entry().ndh
+    }
+
+    /// CBC-HMAC MAC key length = full hash output length (FIPS
+    /// SP 800-107 compliant).
+    pub const fn cbc_mac_key_len(&self) -> usize {
+        self.nh()
+    }
+
+    /// CBC-HMAC encryption-key length (always 32 for AES-256).
+    pub const fn cbc_enc_key_len(&self) -> usize {
+        AES256_KEY_LEN
+    }
+
+    // ── Suite-id construction ─────────────────────────────────────
+
+    /// KEM suite identifier: `concat("KEM", I2OSP(kem_id, 2))` = 5 bytes.
+    pub const fn kem_suite_id(&self) -> [u8; 5] {
+        let id = self.kem_id().to_be_bytes();
+        [b'K', b'E', b'M', id[0], id[1]]
+    }
+
+    /// HPKE suite identifier: `concat("HPKE", kem_id, kdf_id, aead_id)`
+    /// = 10 bytes.
+    pub const fn hpke_suite_id(&self) -> [u8; 10] {
+        let kem = self.kem_id().to_be_bytes();
+        let kdf = self.kdf_id().to_be_bytes();
+        let aead = self.aead_id().to_be_bytes();
+        [
+            b'H', b'P', b'K', b'E', kem[0], kem[1], kdf[0], kdf[1], aead[0], aead[1],
+        ]
+    }
+}

--- a/fw/core/ddi/mbor/api/src/encoder.rs
+++ b/fw/core/ddi/mbor/api/src/encoder.rs
@@ -10,32 +10,17 @@ pub struct DdiEncoder;
 impl DdiEncoder {
     /// Encode `hdr` (key 0) and `data` (key 1) into `out`.
     /// Returns the number of bytes written.
-    pub fn encode_parts<H: MborEncode + MborLen, D: MborEncode + MborLen>(
+    pub fn encode_parts<H: MborEncode, D: MborEncode>(
         hdr: H,
         data: D,
         out: &mut [u8],
     ) -> HsmResult<usize> {
-        // Pre-compute total length
-        let mut acc = MborLenAccumulator::default();
-        MborMap(2).mbor_len(&mut acc);
-        0u8.mbor_len(&mut acc);
-        hdr.mbor_len(&mut acc);
-        1u8.mbor_len(&mut acc);
-        data.mbor_len(&mut acc);
-        let total = acc.len();
-
-        // Single bounds check
-        if total > out.len() {
-            return Err(HsmError::DdiEncodeFailed);
-        }
-
-        let mut encoder = MborEncoder::new_trusted(out);
+        let mut encoder = MborEncoder::new(out);
         MborMap(2).mbor_encode(&mut encoder)?;
         0u8.mbor_encode(&mut encoder)?;
         hdr.mbor_encode(&mut encoder)?;
         1u8.mbor_encode(&mut encoder)?;
         data.mbor_encode(&mut encoder)?;
-
-        Ok(total)
+        Ok(encoder.position())
     }
 }

--- a/fw/core/ddi/mbor/codec/src/encode.rs
+++ b/fw/core/ddi/mbor/codec/src/encode.rs
@@ -250,6 +250,58 @@ impl<'a> MborEncoder<'a> {
 
         Ok(slice)
     }
+
+    /// Like [`encode_reserve`](Self::encode_reserve), but returns the byte
+    /// range of the reserved data region inside the encoder's buffer
+    /// instead of a mutable slice into it.
+    ///
+    /// Used by the `reserve()` codegen to record per-field offsets in a
+    /// layout struct without producing a borrow that would alias the
+    /// encoder. Combined with a later `from_layout(buf, &layout)` call,
+    /// this lets a caller fill the reserved regions across an `await`
+    /// without keeping the encoder alive.
+    pub fn reserve_offset(
+        &mut self,
+        data_len: usize,
+        pad: u8,
+    ) -> Result<core::ops::Range<usize>, MborEncodeError> {
+        let pad = BYTES_PAD_MASK & pad;
+        let total = 1 + 2 + pad as usize + data_len;
+
+        #[cfg(not(feature = "trusted-encode"))]
+        {
+            if self.trusted {
+                debug_assert!(
+                    total + self.pos <= self.buffer.len(),
+                    "trusted reserve_offset overflow",
+                );
+            } else if total + self.pos > self.buffer.len() {
+                return Err(MborEncodeError::BufferOverflow);
+            }
+        }
+        #[cfg(feature = "trusted-encode")]
+        debug_assert!(
+            total + self.pos <= self.buffer.len(),
+            "trusted reserve_offset overflow",
+        );
+
+        self.buffer[self.pos] = BYTES_MARKER | pad;
+        self.pos += 1;
+
+        let len_be = (data_len as u16).to_be_bytes();
+        self.buffer[self.pos] = len_be[0];
+        self.buffer[self.pos + 1] = len_be[1];
+        self.pos += 2;
+
+        for _ in 0..pad {
+            self.buffer[self.pos] = 0;
+            self.pos += 1;
+        }
+
+        let start = self.pos;
+        self.pos += data_len;
+        Ok(start..start + data_len)
+    }
 }
 
 #[cfg(test)]

--- a/fw/core/ddi/mbor/codec/src/lib.rs
+++ b/fw/core/ddi/mbor/codec/src/lib.rs
@@ -7,6 +7,7 @@ mod decode;
 mod encode;
 mod len;
 
+pub use azihsm_fw_hsm_pal_traits::DmaBuf;
 pub use decode::MborDecode;
 pub use decode::MborDecodeError;
 pub use decode::MborDecoder;
@@ -69,6 +70,12 @@ pub trait MborFrameable {
     /// reservable byte-slice field (including nested frames).
     type Frame<'a>;
 
+    /// Layout struct mirroring [`Frame`](Self::Frame), but recording each
+    /// reservable region as an offset range within the encoder's buffer
+    /// instead of a borrow. Produced by [`mbor_reserve`](Self::mbor_reserve)
+    /// and consumed by [`mbor_from_layout`](Self::mbor_from_layout).
+    type Layout;
+
     /// Encode MBOR structure (map header, field IDs, inline primitives)
     /// and reserve mutable slots for byte-slice fields.
     ///
@@ -78,6 +85,32 @@ pub trait MborFrameable {
         encoder: &mut MborEncoder<'a>,
         params: Self::FrameParams,
     ) -> Result<Self::Frame<'a>, MborEncodeError>;
+
+    /// Like [`mbor_frame`](Self::mbor_frame), but returns a layout
+    /// recording where each reservable region was written instead of
+    /// borrowing those regions. Used to defer fill across an `await` or
+    /// other point where holding a borrow of the buffer is inconvenient.
+    fn mbor_reserve(
+        encoder: &mut MborEncoder<'_>,
+        params: Self::FrameParams,
+    ) -> Result<Self::Layout, MborEncodeError>;
+
+    /// Materialize a [`Frame`](Self::Frame) from a previously recorded
+    /// [`Layout`](Self::Layout).
+    ///
+    /// # Safety
+    ///
+    /// `buf_ptr` must point to the start of the same buffer that was
+    /// passed to the encoder when [`mbor_reserve`](Self::mbor_reserve)
+    /// produced `layout`, and that buffer must be at least as long as
+    /// the largest `end` recorded in `layout`. The caller must also
+    /// ensure no other live `&mut` references alias any byte covered by
+    /// `layout`'s recorded ranges for the lifetime `'a`.
+    #[allow(unsafe_code)]
+    unsafe fn mbor_from_layout<'a>(
+        buf_ptr: *mut u8,
+        layout: &Self::Layout,
+    ) -> Self::Frame<'a>;
 }
 
 // ── Wire-format constants (identical to `ddi/serde/mbor`) ──────────────

--- a/fw/core/ddi/mbor/derive/src/frame.rs
+++ b/fw/core/ddi/mbor/derive/src/frame.rs
@@ -6,7 +6,7 @@
 //! For structs that contain byte-slice fields or `#[ddi(frame)]` children,
 //! this module generates:
 //!
-//! * A companion **`<Struct>Frame<'a>`** struct whose fields are `&'a mut [u8]`
+//! * A companion **`<Struct>Frame<'a>`** struct whose fields are `&'a mut DmaBuf`
 //!   slices (for direct byte-slice fields) or nested `<Child>Frame<'a>` structs
 //!   (for `#[ddi(frame)]` children).
 //! * A **`<Struct>FrameParams`** struct that bundles the parameters for
@@ -46,6 +46,7 @@ pub(crate) fn struct_frame(ddi: &DdiStruct) -> syn::Result<proc_macro2::TokenStr
     let ident = &ddi.ident;
     let frame_ident = format_ident!("{}Frame", ident);
     let params_ident = format_ident!("{}FrameParams", ident);
+    let layout_ident = format_ident!("{}Layout", ident);
 
     // FrameParams needs lifetime parameters when Normal (non-frame)
     // fields carry borrowed data (e.g., `DdiTargetKeyProperties<'a>`).
@@ -74,8 +75,26 @@ pub(crate) fn struct_frame(ddi: &DdiStruct) -> syn::Result<proc_macro2::TokenStr
                     pub #name: <#ty as azihsm_fw_ddi_mbor::MborFrameable>::Frame<'a>
                 }
             } else {
-                // Direct slice: &'a mut [u8].
-                quote! { pub #name: &'a mut [u8] }
+                // Direct slice: &'a mut DmaBuf.
+                quote! { pub #name: &'a mut azihsm_fw_ddi_mbor::DmaBuf }
+            }
+        })
+        .collect::<Vec<_>>();
+
+    // ── Layout struct fields ─────────────────────────────────────────
+    let layout_fields = ddi
+        .fields
+        .iter()
+        .filter(|f| is_frameable_field(f))
+        .map(|f| {
+            let name = &f.ident;
+            if f.frame {
+                let ty = strip_lifetime(&f.ty);
+                quote! {
+                    pub #name: <#ty as azihsm_fw_ddi_mbor::MborFrameable>::Layout
+                }
+            } else {
+                quote! { pub #name: core::ops::Range<usize> }
             }
         })
         .collect::<Vec<_>>();
@@ -143,6 +162,15 @@ pub(crate) fn struct_frame(ddi: &DdiStruct) -> syn::Result<proc_macro2::TokenStr
         .map(frame_encode_field)
         .collect::<Vec<_>>();
 
+    // ── reserve() body — mirrors frame_body but uses reserve_offset
+    //    for slice fields and mbor_reserve for nested frames.
+    let reserve_body = ddi
+        .fields
+        .iter()
+        .filter(|f| !f.opt)
+        .map(reserve_encode_field)
+        .collect::<Vec<_>>();
+
     // ── Frame struct construction ─────────────────────────────────────
     let frame_init = ddi
         .fields
@@ -151,6 +179,37 @@ pub(crate) fn struct_frame(ddi: &DdiStruct) -> syn::Result<proc_macro2::TokenStr
         .map(|f| {
             let name = &f.ident;
             quote! { #name }
+        })
+        .collect::<Vec<_>>();
+
+    // ── Layout struct construction (used by reserve()) ────────────────
+    let layout_init = frame_init.clone();
+
+    // ── from_layout() body — rebuild Frame from buf_ptr + Layout.
+    let from_layout_fields = ddi
+        .fields
+        .iter()
+        .filter(|f| is_frameable_field(f))
+        .map(|f| {
+            let name = &f.ident;
+            if f.frame {
+                let ty = strip_lifetime(&f.ty);
+                quote! {
+                    let #name = <#ty as azihsm_fw_ddi_mbor::MborFrameable>::mbor_from_layout(
+                        buf_ptr,
+                        &layout.#name,
+                    );
+                }
+            } else {
+                quote! {
+                    let #name = azihsm_fw_ddi_mbor::DmaBuf::from_raw_mut(
+                        core::slice::from_raw_parts_mut(
+                            buf_ptr.add(layout.#name.start),
+                            layout.#name.end - layout.#name.start,
+                        )
+                    );
+                }
+            }
         })
         .collect::<Vec<_>>();
 
@@ -176,6 +235,7 @@ pub(crate) fn struct_frame(ddi: &DdiStruct) -> syn::Result<proc_macro2::TokenStr
             })
             .collect::<Vec<_>>();
         let frameable_call_args = frameable_destructure.clone();
+        let reserve_call_args = frameable_destructure.clone();
 
         // Use <'_> for structs with lifetimes, bare ident for others.
         let self_ty = if lifetimes.is_empty() {
@@ -188,6 +248,7 @@ pub(crate) fn struct_frame(ddi: &DdiStruct) -> syn::Result<proc_macro2::TokenStr
             impl azihsm_fw_ddi_mbor::MborFrameable for #self_ty {
                 type FrameParams = #params_ident;
                 type Frame<'a> = #frame_ident<'a>;
+                type Layout = #layout_ident;
 
                 fn mbor_frame<'a>(
                     encoder: &mut azihsm_fw_ddi_mbor::MborEncoder<'a>,
@@ -195,6 +256,22 @@ pub(crate) fn struct_frame(ddi: &DdiStruct) -> syn::Result<proc_macro2::TokenStr
                 ) -> Result<Self::Frame<'a>, azihsm_fw_ddi_mbor::MborEncodeError> {
                     let #params_ident { #(#frameable_destructure,)* } = params;
                     #ident::frame(encoder, #(#frameable_call_args,)*)
+                }
+
+                fn mbor_reserve(
+                    encoder: &mut azihsm_fw_ddi_mbor::MborEncoder<'_>,
+                    params: Self::FrameParams,
+                ) -> Result<Self::Layout, azihsm_fw_ddi_mbor::MborEncodeError> {
+                    let #params_ident { #(#frameable_destructure,)* } = params;
+                    #ident::reserve(encoder, #(#reserve_call_args,)*)
+                }
+
+                #[allow(unsafe_code)]
+                unsafe fn mbor_from_layout<'a>(
+                    buf_ptr: *mut u8,
+                    layout: &Self::Layout,
+                ) -> Self::Frame<'a> {
+                    #ident::from_layout_raw(buf_ptr, layout)
                 }
             }
         }
@@ -218,6 +295,17 @@ pub(crate) fn struct_frame(ddi: &DdiStruct) -> syn::Result<proc_macro2::TokenStr
             #(#params_fields,)*
         }
 
+        /// Layout describing where each reservable field of
+        /// [`#frame_ident`] sits inside the encoder's output buffer.
+        ///
+        /// Produced by [`reserve()`](#ident::reserve) and consumed by
+        /// [`from_layout()`](#ident::from_layout) to materialize a
+        /// [`#frame_ident`] without holding the encoder borrow alive
+        /// across an `await`.
+        pub struct #layout_ident {
+            #(#layout_fields,)*
+        }
+
         impl #ident<'_> {
             /// Write MBOR structure and return mutable slices / nested
             /// frames for in-place fill.
@@ -235,6 +323,68 @@ pub(crate) fn struct_frame(ddi: &DdiStruct) -> syn::Result<proc_macro2::TokenStr
                 Ok(#frame_ident {
                     #(#frame_init,)*
                 })
+            }
+
+            /// Like [`frame()`](Self::frame), but records each reservable
+            /// region's offset range in a [`#layout_ident`] instead of
+            /// returning borrows. Pair with [`from_layout()`](Self::from_layout)
+            /// to materialize the frame later.
+            pub fn reserve<'a>(
+                encoder: &mut azihsm_fw_ddi_mbor::MborEncoder<'_>,
+                #(#frame_params,)*
+            ) -> Result<#layout_ident, azihsm_fw_ddi_mbor::MborEncodeError> {
+                use azihsm_fw_ddi_mbor::MborEncode;
+
+                let cnt = #field_cnt as azihsm_fw_ddi_mbor::MborId;
+                azihsm_fw_ddi_mbor::MborMap(cnt).mbor_encode(encoder)?;
+
+                #(#reserve_body)*
+
+                Ok(#layout_ident {
+                    #(#layout_init,)*
+                })
+            }
+
+            /// Materialize a [`#frame_ident`] from a buffer and a layout
+            /// produced by [`reserve()`](Self::reserve).
+            ///
+            /// `buf` must be the same buffer (or the encoder's underlying
+            /// buffer) used when `layout` was produced. Otherwise the
+            /// returned frame's slices will alias unrelated memory.
+            #[allow(unsafe_code)]
+            pub fn from_layout<'a>(
+                buf: &'a mut azihsm_fw_ddi_mbor::DmaBuf,
+                layout: &#layout_ident,
+            ) -> #frame_ident<'a> {
+                // SAFETY: `layout` was produced by `reserve()` writing into
+                // a buffer of which `buf` is the same buffer (or a longer
+                // prefix). `reserve()` only ever advances the encoder
+                // cursor, so all recorded ranges are non-overlapping and
+                // within the buffer's bounds.
+                unsafe { Self::from_layout_raw(buf.as_mut_ptr(), layout) }
+            }
+
+            /// Raw-pointer variant of [`from_layout()`](Self::from_layout)
+            /// used by the [`MborFrameable`] impl to recurse into nested
+            /// frames without re-borrowing the parent buffer.
+            ///
+            /// # Safety
+            ///
+            /// `buf_ptr` must point to the start of the same buffer used
+            /// when `layout` was produced, the buffer must be at least
+            /// as long as the largest `end` recorded in `layout`, and no
+            /// other live `&mut` references may alias any byte covered by
+            /// `layout`'s recorded ranges for the lifetime `'a`.
+            #[doc(hidden)]
+            #[allow(unsafe_code)]
+            pub unsafe fn from_layout_raw<'a>(
+                buf_ptr: *mut u8,
+                layout: &#layout_ident,
+            ) -> #frame_ident<'a> {
+                #(#from_layout_fields)*
+                #frame_ident {
+                    #(#frame_init,)*
+                }
             }
         }
 
@@ -270,6 +420,57 @@ fn frame_encode_field(f: &DdiStructField) -> proc_macro2::TokenStream {
                 (#id).mbor_encode(encoder)?;
                 let pad = #pad_expr;
                 let #name = encoder.encode_reserve(#len_name, pad)?;
+                // SAFETY: `encoder` was constructed from a `&mut DmaBuf`, so
+                // the slice it returned is itself DMA-accessible.
+                let #name = unsafe { azihsm_fw_ddi_mbor::DmaBuf::from_raw_mut(#name) };
+            }
+        }
+        DdiStructFieldKind::Array => {
+            quote! {
+                (#id).mbor_encode(encoder)?;
+                azihsm_fw_ddi_mbor::MborByteSlice(&#name).mbor_encode(encoder)?;
+            }
+        }
+        DdiStructFieldKind::Normal => {
+            quote! {
+                (#id).mbor_encode(encoder)?;
+                #name.mbor_encode(encoder)?;
+            }
+        }
+    }
+}
+
+/// Generate the reserve encode body for a single non-optional field.
+///
+/// Mirrors [`frame_encode_field`] but uses [`reserve_offset`] for slice
+/// fields (returning a byte range) and [`mbor_reserve`] for nested
+/// frames (returning the child's [`Layout`]).
+fn reserve_encode_field(f: &DdiStructField) -> proc_macro2::TokenStream {
+    let id = f.id;
+    let name = &f.ident;
+
+    if f.frame {
+        let ty = strip_lifetime(&f.ty);
+        return quote! {
+            (#id).mbor_encode(encoder)?;
+            let #name = <#ty as azihsm_fw_ddi_mbor::MborFrameable>::mbor_reserve(
+                encoder, #name,
+            )?;
+        };
+    }
+
+    match f.kind {
+        DdiStructFieldKind::Slice => {
+            let len_name = format_ident!("{}_len", name);
+            let pad_expr = if f.len.is_some() {
+                quote! { 0 }
+            } else {
+                quote! { azihsm_fw_ddi_mbor::pad4(encoder.position() as u32 + 3) as u8 }
+            };
+            quote! {
+                (#id).mbor_encode(encoder)?;
+                let pad = #pad_expr;
+                let #name = encoder.reserve_offset(#len_name, pad)?;
             }
         }
         DdiStructFieldKind::Array => {

--- a/fw/core/ddi/tbor/derive/src/codegen_enc.rs
+++ b/fw/core/ddi/tbor/derive/src/codegen_enc.rs
@@ -33,7 +33,7 @@ pub fn gen_encoder_and_frame(schema: &Schema) -> TokenStream {
     let layout = TocLayout::compute(&schema.fields);
 
     let toc_count_expr = build_toc_count_expr(&layout, &schema.fields);
-    let (marker_defs, state_markers) = gen_state_markers(schema, vis);
+    let (marker_defs, state_markers) = gen_state_markers(schema);
     let s0 = &state_markers[0];
     let encoder_alias = format_ident!("{}Encoder", schema.name);
 
@@ -99,8 +99,8 @@ fn build_toc_count_expr(layout: &TocLayout, fields: &[SchemaField]) -> TokenStre
 /// (`FooS0`, `FooS1`, …, `FooSN`).
 fn gen_state_markers(
     schema: &Schema,
-    vis: &syn::Visibility,
 ) -> (Vec<TokenStream>, Vec<syn::Ident>) {
+    let vis = &schema.vis;
     let n_fields = schema.fields.len();
     let state_markers: Vec<_> = (0..=n_fields)
         .map(|i| format_ident!("{}S{}", schema.name, i))

--- a/fw/core/ddi/tbor/derive/src/codegen_view.rs
+++ b/fw/core/ddi/tbor/derive/src/codegen_view.rs
@@ -241,7 +241,7 @@ fn gen_validation(schema: &Schema) -> TokenStream {
 
     let type_checks = gen_type_checks(schema, &layout);
     let padding_checks = gen_padding_checks(&layout);
-    let len_checks = gen_len_checks(schema, &layout, &header_len_val);
+    let len_checks = gen_len_checks(schema, &layout);
 
     quote! {
         let raw = #parse_call;
@@ -329,8 +329,12 @@ fn gen_padding_checks(layout: &TocLayout) -> Vec<TokenStream> {
 fn gen_len_checks(
     schema: &Schema,
     layout: &TocLayout,
-    header_len_val: &TokenStream,
 ) -> Vec<TokenStream> {
+    let header_len_val = match schema.kind {
+        MessageKind::Request { .. } => quote! { azihsm_fw_ddi_tbor::REQ_HEADER_LEN },
+        MessageKind::Response => quote! { azihsm_fw_ddi_tbor::RESP_HEADER_LEN },
+        MessageKind::Fields => unreachable!(),
+    };
     schema
         .fields
         .iter()

--- a/fw/core/lib/src/ddi/get_api_rev.rs
+++ b/fw/core/lib/src/ddi/get_api_rev.rs
@@ -5,7 +5,7 @@
 //!
 //! Validates the request (rev must be None, body must be empty),
 //! builds a response with the supported API revision range, and
-//! MBOR-encodes it into `smem`.
+//! MBOR-encodes it into a heap-allocated response buffer.
 
 use super::*;
 
@@ -21,13 +21,13 @@ use super::*;
 ///    trailing bytes.
 ///
 /// 3. **Response** — Encodes `DdiGetApiRevCmdResp` with min/max API
-///    revision into `smem`.
-pub(crate) fn get_api_rev<'a>(
-    hdr: &DdiReqHdr,
+///    revision into a heap-allocated response buffer.
+pub(crate) fn get_api_rev<'p, P: HsmPal>(
+    pal: &'p P,
+    io: &impl HsmIo,
     decoder: &mut DdiDecoder<'_>,
-    _fmem: &mut [u8],
-    smem: &'a mut [u8],
-) -> HsmResult<&'a [u8]> {
+    hdr: &DdiReqHdr,
+) -> HsmResult<&'p DmaBuf> {
     // GetApiRev is the bootstrap command — rev must not be set.
     if hdr.rev.is_some() {
         return Err(HsmError::UnsupportedRevision);
@@ -42,7 +42,9 @@ pub(crate) fn get_api_rev<'a>(
         max: DdiApiRev { major: 1, minor: 0 },
     };
 
-    let len = ddi::encode_resp(&ddi::success_hdr(hdr, DdiOp::GetApiRev), &resp_data, smem)?;
+    let resp = pal.dma_alloc_var(io, |buf| {
+        ddi::encode_resp(&ddi::success_hdr(hdr, DdiOp::GetApiRev), &resp_data, buf)
+    })?;
 
-    Ok(&smem[..len])
+    Ok(resp)
 }

--- a/fw/core/lib/src/ddi/get_cert_chain_info.rs
+++ b/fw/core/lib/src/ddi/get_cert_chain_info.rs
@@ -15,29 +15,29 @@ use super::*;
 ///
 /// 1. **Body decode** — Decodes `DdiGetCertChainInfoReq { slot_id }`.
 ///
-/// 2. **Response** — Calls `pal.get_cert_chain_info(part_id, slot_id)`,
+/// 2. **Response** — Calls `pal.get_cert_chain_info(io, io.pid(), slot_id)`,
 ///    encodes `DdiGetCertChainInfoResp { num_certs, thumbprint }`.
-pub(crate) async fn get_cert_chain_info<'a, P: HsmPal>(
-    hdr: &DdiReqHdr,
+pub(crate) async fn get_cert_chain_info<'p, P: HsmPal>(
+    pal: &'p P,
+    io: &impl HsmIo,
     decoder: &mut DdiDecoder<'_>,
-    part_id: HsmPartId,
-    pal: &P,
-    _fmem: &mut [u8],
-    smem: &'a mut [u8],
-) -> HsmResult<&'a [u8]> {
+    hdr: &DdiReqHdr,
+) -> HsmResult<&'p DmaBuf> {
     let body: DdiGetCertChainInfoReq = decoder.decode_data()?;
 
-    let info = pal.get_cert_chain_info(part_id, body.slot_id).await?;
+    let info = pal.get_cert_chain_info(io, io.pid(), body.slot_id).await?;
 
     let resp_data = DdiGetCertChainInfoResp {
         num_certs: info.count,
         thumbprint: &info.thumbprint,
     };
 
-    let len = ddi::encode_resp(
-        &ddi::success_hdr(hdr, DdiOp::GetCertChainInfo),
-        &resp_data,
-        smem,
-    )?;
-    Ok(&smem[..len])
+    let resp = pal.dma_alloc_var(io, |buf| {
+        ddi::encode_resp(
+            &ddi::success_hdr(hdr, DdiOp::GetCertChainInfo),
+            &resp_data,
+            buf,
+        )
+    })?;
+    Ok(resp)
 }

--- a/fw/core/lib/src/ddi/get_certificate.rs
+++ b/fw/core/lib/src/ddi/get_certificate.rs
@@ -17,30 +17,33 @@ use azihsm_fw_ddi_mbor_types::get_certificate::DdiGetCertificateResp;
 use super::*;
 
 /// Handle DdiGetCertificateCmd.
-pub(crate) async fn get_certificate<'a, P: HsmPal>(
-    hdr: &DdiReqHdr,
+pub(crate) async fn get_certificate<'p, P: HsmPal>(
+    pal: &'p P,
+    io: &impl HsmIo,
     decoder: &mut DdiDecoder<'_>,
-    part_id: HsmPartId,
-    pal: &P,
-    _fmem: &mut [u8],
-    smem: &'a mut [u8],
-) -> HsmResult<&'a [u8]> {
+    hdr: &DdiReqHdr,
+) -> HsmResult<&'p DmaBuf> {
     let body: DdiGetCertificateReq = decoder.decode_data()?;
 
     // Query cert size (no copy).
     let len = pal
-        .get_cert(part_id, body.slot_id, body.cert_id, None)
+        .get_cert(io, io.pid(), body.slot_id, body.cert_id, None)
         .await?;
 
-    // Encode header + frame, reserving space for cert data.
-    let resp_hdr = ddi::success_hdr(hdr, DdiOp::GetCertificate);
-    let mut encoder = ddi::encode_resp_hdr(&resp_hdr, smem)?;
-    let frame = DdiGetCertificateResp::frame(&mut encoder, len)?;
-    let total = encoder.position();
+    // Reserve the response inside a closure (encoder borrow ends with the
+    // closure), recording where the cert slot landed in a layout returned
+    // as the closure's owned out-value. After the closure, rebind the
+    // layout against the populated buffer to fill the slot.
+    let (resp, layout) = pal.dma_alloc_var_with(io, |buf| {
+        let mut encoder = ddi::encode_resp_hdr(&ddi::success_hdr(hdr, DdiOp::GetCertificate), buf)?;
+        let layout = DdiGetCertificateResp::reserve(&mut encoder, len)?;
+        Ok((encoder.position(), layout))
+    })?;
 
-    // Fill the reserved slice in-place.
-    pal.get_cert(part_id, body.slot_id, body.cert_id, Some(frame.certificate))
+    let frame = DdiGetCertificateResp::from_layout(resp, &layout);
+
+    pal.get_cert(io, io.pid(), body.slot_id, body.cert_id, Some(frame.certificate))
         .await?;
 
-    Ok(&smem[..total])
+    Ok(resp)
 }

--- a/fw/core/lib/src/ddi/get_device_info.rs
+++ b/fw/core/lib/src/ddi/get_device_info.rs
@@ -17,27 +17,26 @@ use super::*;
 /// 2. **Response** — Encodes `DdiGetDeviceInfoResp` with device kind,
 ///    table count, and FIPS status. Echoes `hdr.rev` back in the
 ///    response header.
-pub(crate) fn get_device_info<'a, P: HsmPal>(
-    hdr: &DdiReqHdr,
+pub(crate) fn get_device_info<'p, P: HsmPal>(
+    pal: &'p P,
+    io: &impl HsmIo,
     decoder: &mut DdiDecoder<'_>,
-    part_id: HsmPartId,
-    pal: &P,
-    _fmem: &mut [u8],
-    smem: &'a mut [u8],
-) -> HsmResult<&'a [u8]> {
+    hdr: &DdiReqHdr,
+) -> HsmResult<&'p DmaBuf> {
     let _body: DdiGetDeviceInfoReq = decoder.decode_data()?;
 
     let resp_data = DdiGetDeviceInfoResp {
         kind: DdiDeviceKind::Physical,
-        tables: pal.part_res_count(part_id).unwrap_or(0),
+        tables: pal.part_res_count(io).unwrap_or(0),
         fips_approved: false,
     };
 
-    let len = ddi::encode_resp(
-        &ddi::success_hdr(hdr, DdiOp::GetDeviceInfo),
-        &resp_data,
-        smem,
-    )?;
-
-    Ok(&smem[..len])
+    let resp = pal.dma_alloc_var(io, |buf| {
+        ddi::encode_resp(
+            &ddi::success_hdr(hdr, DdiOp::GetDeviceInfo),
+            &resp_data,
+            buf,
+        )
+    })?;
+    Ok(resp)
 }

--- a/fw/core/lib/src/ddi/get_establish_cred_encryption_key.rs
+++ b/fw/core/lib/src/ddi/get_establish_cred_encryption_key.rs
@@ -18,51 +18,52 @@ use azihsm_fw_ddi_mbor_types::DdiPublicKeyFrameParams;
 use super::*;
 
 /// Handle DdiGetEstablishCredEncryptionKeyCmd.
-pub(crate) async fn get_establish_cred_encryption_key<'a, P: HsmPal>(
-    hdr: &DdiReqHdr,
+pub(crate) async fn get_establish_cred_encryption_key<'p, P: HsmPal>(
+    pal: &'p P,
+    io: &impl HsmIo,
     decoder: &mut DdiDecoder<'_>,
-    part_id: HsmPartId,
-    pal: &P,
-    fmem: &mut [u8],
-    smem: &'a mut [u8],
-) -> HsmResult<&'a [u8]> {
+    hdr: &DdiReqHdr,
+) -> HsmResult<&'p DmaBuf> {
     let _body: DdiGetEstablishCredEncryptionKeyReq = decoder.decode_data()?;
 
     // Key must exist (not yet consumed by EstablishCredential).
-    pal.part_establish_cred_key_id(part_id)?
+    pal.part_establish_cred_key_id(io)?
         .ok_or(HsmError::KeyNotFound)?;
 
     // Query sizes, then encode header + frame with reserved slots.
-    let pub_key_len = pal.part_establish_cred_pub_key(part_id, None)?;
-    let nonce_len = pal.part_nonce(part_id, None)?;
+    let pub_key_len = pal.part_establish_cred_pub_key(io, None)?;
+    let nonce_len = pal.part_nonce(io, None)?;
 
-    let mut encoder = ddi::encode_resp_hdr(
-        &ddi::success_hdr(hdr, DdiOp::GetEstablishCredEncryptionKey),
-        smem,
-    )?;
-    let frame = DdiGetEstablishCredEncryptionKeyResp::frame(
-        &mut encoder,
-        DdiPublicKeyFrameParams {
-            raw_len: pub_key_len,
-            key_kind: DdiKeyType::Ecc384Public,
-        },
-        nonce_len,
-        HsmEccCurve::P384.sig_len(),
-    )?;
-    let total = encoder.position();
+    let digest = pal.dma_alloc(io, HsmHashAlgo::Sha384.digest_len())?;
+    let id_priv_key = pal.vault_key(io, pal.part_id_key_id(io)?)?;
+
+    let (resp, layout) = pal.dma_alloc_var_with(io, |buf| {
+        let mut encoder = ddi::encode_resp_hdr(
+            &ddi::success_hdr(hdr, DdiOp::GetEstablishCredEncryptionKey),
+            buf,
+        )?;
+        let layout = DdiGetEstablishCredEncryptionKeyResp::reserve(
+            &mut encoder,
+            DdiPublicKeyFrameParams {
+                raw_len: pub_key_len,
+                key_kind: DdiKeyType::Ecc384Public,
+            },
+            nonce_len,
+            HsmEccCurve::P384.sig_len(),
+        )?;
+        Ok((encoder.position(), layout))
+    })?;
+    let frame = DdiGetEstablishCredEncryptionKeyResp::from_layout(resp, &layout);
 
     // Fill public key and nonce in-place.
-    pal.part_establish_cred_pub_key(part_id, Some(frame.pub_key.raw))?;
-    pal.part_nonce(part_id, Some(frame.nonce))?;
+    pal.part_establish_cred_pub_key(io, Some(frame.pub_key.raw))?;
+    pal.part_nonce(io, Some(frame.nonce))?;
 
     // Hash pub key, then sign directly into the signature slot.
-    // Digest goes in fmem to keep the async future small.
-    let id_priv_key = pal.vault_key(part_id, pal.part_id_key_id(part_id)?)?;
-
-    let digest = &mut fmem[..HsmHashAlgo::Sha384.digest_len()];
-    pal.hash(HsmHashAlgo::Sha384, frame.pub_key.raw, digest, true)
+    pal.hash(io, HsmHashAlgo::Sha384, frame.pub_key.raw, digest, true)
         .await?;
     pal.ecc_sign(
+        io,
         HsmEccCurve::P384,
         id_priv_key,
         digest,
@@ -70,5 +71,5 @@ pub(crate) async fn get_establish_cred_encryption_key<'a, P: HsmPal>(
     )
     .await?;
 
-    Ok(&smem[..total])
+    Ok(resp)
 }

--- a/fw/core/lib/src/ddi/get_sealed_bk3.rs
+++ b/fw/core/lib/src/ddi/get_sealed_bk3.rs
@@ -22,26 +22,26 @@ use super::*;
 /// 2. **Presence check** — `sealed_bk3 len == 0` → `SealedBk3NotPresent`.
 ///
 /// 3. **Response** — Encodes header + frame, fills blob in-place.
-pub(crate) fn get_sealed_bk3<'a, P: HsmPal>(
-    hdr: &DdiReqHdr,
+pub(crate) fn get_sealed_bk3<'p, P: HsmPal>(
+    pal: &'p P,
+    io: &impl HsmIo,
     decoder: &mut DdiDecoder<'_>,
-    part_id: HsmPartId,
-    pal: &P,
-    _fmem: &mut [u8],
-    smem: &'a mut [u8],
-) -> HsmResult<&'a [u8]> {
+    hdr: &DdiReqHdr,
+) -> HsmResult<&'p DmaBuf> {
     let _body: DdiGetSealedBk3Req = decoder.decode_data()?;
 
-    let sealed_len = pal.part_sealed_bk3(part_id, None)?;
+    let sealed_len = pal.part_sealed_bk3(io, None)?;
     if sealed_len == 0 {
         return Err(HsmError::SealedBk3NotPresent);
     }
 
-    let mut encoder = ddi::encode_resp_hdr(&ddi::success_hdr(hdr, DdiOp::GetSealedBk3), smem)?;
-    let frame = DdiGetSealedBk3Resp::frame(&mut encoder, sealed_len)?;
-    let total = encoder.position();
+    let resp = pal.dma_alloc_var(io, |buf| {
+        let mut encoder = ddi::encode_resp_hdr(&ddi::success_hdr(hdr, DdiOp::GetSealedBk3), buf)?;
+        let frame = DdiGetSealedBk3Resp::frame(&mut encoder, sealed_len)?;
+        let total = encoder.position();
+        pal.part_sealed_bk3(io, Some(frame.sealed_bk3))?;
+        Ok(total)
+    })?;
 
-    pal.part_sealed_bk3(part_id, Some(frame.sealed_bk3))?;
-
-    Ok(&smem[..total])
+    Ok(resp)
 }

--- a/fw/core/lib/src/ddi/mod.rs
+++ b/fw/core/lib/src/ddi/mod.rs
@@ -28,72 +28,51 @@ use super::*;
 
 /// Dispatch a DDI command to its handler.
 ///
-/// Returns the response length on success, or a [`HsmError`] on
-/// failure. The caller wraps failures in a DDI error response.
+/// Returns the encoded response slice on success, or a [`HsmError`] on
+/// failure. The slice borrows from `pal`'s per-IO allocator and is
+/// valid until the IO completes.
 ///
 /// This function is `async` because `GetCertificate` calls into
 /// `HsmCertStore::get_cert` which is async.
-pub(crate) async fn dispatch<P: HsmPal>(
-    hdr: &DdiReqHdr,
+pub(crate) async fn dispatch<'p, P: HsmPal>(
+    pal: &'p P,
+    io: &impl HsmIo,
     decoder: &mut DdiDecoder<'_>,
-    part_id: HsmPartId,
-    pal: &P,
-    fmem: &mut [u8],
-    smem: &mut [u8],
-) -> HsmResult<usize> {
-    let resp = match hdr.op {
-        DdiOp::GetApiRev => get_api_rev(hdr, decoder, fmem, smem)?,
-        DdiOp::GetDeviceInfo => get_device_info(hdr, decoder, part_id, pal, fmem, smem)?,
-        DdiOp::GetCertChainInfo => {
-            get_cert_chain_info(hdr, decoder, part_id, pal, fmem, smem).await?
-        }
-        DdiOp::GetCertificate => get_certificate(hdr, decoder, part_id, pal, fmem, smem).await?,
-        DdiOp::ShaDigest => sha_digest(hdr, decoder, part_id, pal, fmem, smem).await?,
+    hdr: &DdiReqHdr,
+) -> HsmResult<&'p DmaBuf> {
+    match hdr.op {
+        DdiOp::GetApiRev => get_api_rev(pal, io, decoder, hdr),
+        DdiOp::GetDeviceInfo => get_device_info(pal, io, decoder, hdr),
+        DdiOp::GetCertChainInfo => get_cert_chain_info(pal, io, decoder, hdr).await,
+        DdiOp::GetCertificate => get_certificate(pal, io, decoder, hdr).await,
+        DdiOp::ShaDigest => sha_digest(pal, io, decoder, hdr).await,
         DdiOp::GetEstablishCredEncryptionKey => {
-            get_establish_cred_encryption_key(hdr, decoder, part_id, pal, fmem, smem).await?
+            get_establish_cred_encryption_key(pal, io, decoder, hdr).await
         }
-        DdiOp::GetSealedBk3 => get_sealed_bk3(hdr, decoder, part_id, pal, fmem, smem)?,
-        DdiOp::SetSealedBk3 => set_sealed_bk3(hdr, decoder, part_id, pal, fmem, smem)?,
-        _ => return Err(HsmError::UnsupportedCmd),
-    };
-    Ok(resp.len())
+        DdiOp::GetSealedBk3 => get_sealed_bk3(pal, io, decoder, hdr),
+        DdiOp::SetSealedBk3 => set_sealed_bk3(pal, io, decoder, hdr),
+        _ => Err(HsmError::UnsupportedCmd),
+    }
 }
 
-/// Encode a DDI response (header + data) with a single upfront bounds check.
+/// Encode a DDI response (header + data) in a single pass.
 ///
-/// Computes the total encoded length via [`MborLen`], checks it fits in
-/// `smem`, then encodes with no per-field bounds checks. Returns the
-/// encoded length, or [`HsmError::DdiEncodeFailed`] if the buffer is
-/// too small.
+/// The caller supplies a destination buffer (typically from
+/// [`HsmAlloc::alloc_all`](azihsm_fw_hsm_pal_traits::HsmAlloc::alloc_all));
+/// this helper encodes directly into it and returns the number of bytes
+/// written.
 pub(crate) fn encode_resp<H, D>(hdr: &H, data: &D, smem: &mut [u8]) -> HsmResult<usize>
 where
-    H: MborEncode + MborLen,
-    D: MborEncode + MborLen,
+    H: MborEncode,
+    D: MborEncode,
 {
-    // Pre-compute total length
-    let mut acc = MborLenAccumulator::default();
-    MborMap(2).mbor_len(&mut acc); // outer Map(2)
-    0u8.mbor_len(&mut acc); // key=0
-    hdr.mbor_len(&mut acc); // header map
-    1u8.mbor_len(&mut acc); // key=1
-    data.mbor_len(&mut acc); // data map
-    let total = acc.len();
-
-    // Single bounds check
-    if total > smem.len() {
-        return Err(HsmError::DdiEncodeFailed);
-    }
-
-    // Encode — trusted mode: single upfront bounds check means
-    // per-field checks are redundant.
-    let mut encoder = MborEncoder::new_trusted(smem);
+    let mut encoder = MborEncoder::new(smem);
     MborMap(2).mbor_encode(&mut encoder)?;
     0u8.mbor_encode(&mut encoder)?;
     hdr.mbor_encode(&mut encoder)?;
     1u8.mbor_encode(&mut encoder)?;
     data.mbor_encode(&mut encoder)?;
-
-    Ok(total)
+    Ok(encoder.position())
 }
 
 /// Encode the DDI response header and outer framing, returning the encoder
@@ -105,18 +84,7 @@ pub(crate) fn encode_resp_hdr<'a>(
     hdr: &DdiRespHdr,
     smem: &'a mut [u8],
 ) -> HsmResult<MborEncoder<'a>> {
-    // Pre-compute header framing length
-    let mut acc = MborLenAccumulator::default();
-    MborMap(2).mbor_len(&mut acc);
-    0u8.mbor_len(&mut acc);
-    hdr.mbor_len(&mut acc);
-    1u8.mbor_len(&mut acc);
-
-    if acc.len() > smem.len() {
-        return Err(HsmError::DdiEncodeFailed);
-    }
-
-    let mut encoder = MborEncoder::new_trusted(smem);
+    let mut encoder = MborEncoder::new(smem);
     MborMap(2).mbor_encode(&mut encoder)?;
     0u8.mbor_encode(&mut encoder)?;
     hdr.mbor_encode(&mut encoder)?;

--- a/fw/core/lib/src/ddi/set_sealed_bk3.rs
+++ b/fw/core/lib/src/ddi/set_sealed_bk3.rs
@@ -20,21 +20,21 @@ use super::*;
 ///
 /// 3. **Store** — Writes the blob via the PAL (validates size internally).
 ///
-/// 4. **Response** — Encodes `DdiSetSealedBk3Resp` (empty) into `smem`.
-pub(crate) fn set_sealed_bk3<'a, P: HsmPal>(
-    hdr: &DdiReqHdr,
+/// 4. **Response** — Encodes `DdiSetSealedBk3Resp` (empty) into a
+///    heap-allocated response buffer.
+pub(crate) fn set_sealed_bk3<'p, P: HsmPal>(
+    pal: &'p P,
+    io: &impl HsmIo,
     decoder: &mut DdiDecoder<'_>,
-    part_id: HsmPartId,
-    pal: &P,
-    _fmem: &mut [u8],
-    smem: &'a mut [u8],
-) -> HsmResult<&'a [u8]> {
+    hdr: &DdiReqHdr,
+) -> HsmResult<&'p DmaBuf> {
     let body: DdiSetSealedBk3Req<'_> = decoder.decode_data()?;
-    pal.part_set_sealed_bk3(part_id, body.sealed_bk3)?;
+    pal.part_set_sealed_bk3(io, body.sealed_bk3)?;
 
     let resp_hdr = ddi::success_hdr(hdr, DdiOp::SetSealedBk3);
     let resp_data = DdiSetSealedBk3Resp {};
 
-    let len = ddi::encode_resp(&resp_hdr, &resp_data, smem)?;
-    Ok(&smem[..len])
+    let resp = pal.dma_alloc_var(io, |buf| ddi::encode_resp(&resp_hdr, &resp_data, buf))?;
+
+    Ok(resp)
 }

--- a/fw/core/lib/src/ddi/sha_digest.rs
+++ b/fw/core/lib/src/ddi/sha_digest.rs
@@ -29,27 +29,26 @@ fn to_hsm_hash_algo(ddi: DdiHashAlgorithm) -> HsmResult<HsmHashAlgo> {
 }
 
 /// Handle DdiShaDigestCmd.
-pub(crate) async fn sha_digest<'a, P: HsmPal>(
-    hdr: &DdiReqHdr,
+pub(crate) async fn sha_digest<'p, P: HsmPal>(
+    pal: &'p P,
+    io: &impl HsmIo,
     decoder: &mut DdiDecoder<'_>,
-    _part_id: HsmPartId,
-    pal: &P,
-    _fmem: &mut [u8],
-    smem: &'a mut [u8],
-) -> HsmResult<&'a [u8]> {
+    hdr: &DdiReqHdr,
+) -> HsmResult<&'p DmaBuf> {
     let body: DdiShaDigestReq<'_> = decoder.decode_data()?;
 
     let algo = to_hsm_hash_algo(body.sha_mode)?;
     let digest_len = algo.digest_len();
 
-    // Encode header + frame, reserving space for the digest.
-    let resp_hdr = ddi::success_hdr(hdr, DdiOp::ShaDigest);
-    let mut encoder = ddi::encode_resp_hdr(&resp_hdr, smem)?;
-    let frame = DdiShaDigestResp::frame(&mut encoder, digest_len)?;
-    let total = encoder.position();
-
-    // Compute hash directly into the reserved slice — zero copy.
-    pal.hash(algo, body.msg, frame.digest, true).await?;
-
-    Ok(&smem[..total])
+    let (resp, layout) = pal.dma_alloc_var_with(io, |buf| {
+        let resp_hdr = ddi::success_hdr(hdr, DdiOp::ShaDigest);
+        let mut encoder = ddi::encode_resp_hdr(&resp_hdr, buf)?;
+        let layout = DdiShaDigestResp::reserve(&mut encoder, digest_len)?;
+        Ok((encoder.position(), layout))
+    })?;
+    let frame = DdiShaDigestResp::from_layout(resp, &layout);
+    let msg_dma = pal.dma_alloc(io, body.msg.len())?;
+    msg_dma.copy_from_slice(body.msg);
+    pal.hash(io, algo, msg_dma, frame.digest, true).await?;
+    Ok(resp)
 }

--- a/fw/core/lib/src/error.rs
+++ b/fw/core/lib/src/error.rs
@@ -36,6 +36,8 @@ impl HostStatus {
     pub const DMA_TXN_ERROR: u16 = 0x0C6;
 
     pub const REQ_HDR_DECODE_ERR: u16 = 0x0C8;
+
+    pub const ALLOC_ERR: u16 = 0x0C9;
 }
 
 // ── OpError: pairs HsmError (for logging) with host status (for CQE) ─

--- a/fw/core/lib/src/io.rs
+++ b/fw/core/lib/src/io.rs
@@ -47,64 +47,30 @@ impl<P: HsmPal> Hsm<P> {
     /// writes session fields and status to the CQE before completion.
     pub async fn handle_io(&self, mut io: P::Io) {
         // Gate on partition state — drop IOs for non-enabled partitions.
-        {
-            let pid = io.pid();
-            let enabled = self
-                .pal()
-                .part_state(pid)
-                .is_ok_and(|s| s == PartState::Enabled);
-            if !enabled {
-                debug!("core", "dropping IO for disabled partition {:?}", pid);
-                if let Err(_e) = self.pal().drop_io(io).await {
-                    error!("core", HsmError::DropIoFailure, "drop_io failed: {:?}", _e);
-                }
-                return;
+        if !self.partition_enabled(&io) {
+            debug!("core", "dropping IO for disabled partition {:?}", io.pid());
+            if let Err(_e) = self.pal().drop_io(io).await {
+                error!("core", HsmError::DropIoFailure, "drop_io failed: {:?}", _e);
             }
+            return;
         }
 
-        // Populate CQE header fields before dispatch
-        {
-            let sqe = Sqe::from(io.sqe());
-            let cmd_id = sqe.cmd_id();
-            let sq_id = io.queue_id();
-            let cqe = io.cqe();
-            let mut cqe = Cqe::from(cqe);
-            cqe.clear();
-            cqe.set_cmd_id(cmd_id);
-            cqe.set_sq_id(sq_id);
-        }
+        // Single SQE parse — extract all fields once, populate CQE, validate,
+        // and dispatch.
+        let (op, validated) = Self::init_cqe_from_sqe(&mut io);
 
-        // Inline opcode dispatch — eliminates one async state machine
-        // level, saving ~16 bytes per task and ~20 instructions per poll.
-        let op_result = {
-            let sqe = Sqe::from(io.sqe());
-            if let Err(e) = sqe.validate() {
-                Err(e)
-            } else {
-                match sqe.op() {
-                    OP_GENERIC => self.handle_generic_op(&mut io).await,
-                    OP_FLUSH => self.handle_flush_op(&mut io).await,
-                    _ => Err(OpError::new(
-                        HsmError::UnsupportedCmd,
-                        HostStatus::INVALID_COMMAND_OPCODE,
-                    )),
-                }
-            }
+        let op_result = match validated {
+            Err(e) => Err(e),
+            Ok(()) => match op {
+                OP_GENERIC => self.handle_generic_op(&mut io).await,
+                OP_FLUSH => self.handle_flush_op(&mut io).await,
+                _ => Err(OpError::new(
+                    HsmError::UnsupportedCmd,
+                    HostStatus::INVALID_COMMAND_OPCODE,
+                )),
+            },
         };
-        match op_result {
-            Ok(status) => {
-                let cqe = io.cqe();
-                let mut cqe = Cqe::from(cqe);
-                cqe.set_dw0(CqeDw0::from(status.cqe_dw0_session).with_dst_len(status.resp_len));
-                cqe.set_dw1(CqeDw1::from(status.cqe_dw1));
-            }
-            Err(e) => {
-                let cqe = io.cqe();
-                let mut cqe = Cqe::from(cqe);
-                cqe.set_status(e.status);
-                error!("core", e.err, "handle_op failed");
-            }
-        }
+        Self::finalize_cqe(&mut io, op_result);
 
         if let Err(_e) = self.pal().complete_io(io).await {
             error!(
@@ -116,6 +82,45 @@ impl<P: HsmPal> Hsm<P> {
         }
     }
 
+    /// Returns `true` if the partition for this IO is enabled.
+    #[inline]
+    fn partition_enabled(&self, io: &P::Io) -> bool {
+        self.pal().part_state(io)
+            .is_ok_and(|s| s == PartState::Enabled)
+    }
+
+    /// Parses the SQE once, populates the CQE header, and returns the
+    /// op code along with the SQE-validation result.
+    #[inline]
+    fn init_cqe_from_sqe(io: &mut P::Io) -> (u16, Result<(), OpError>) {
+        let (cmd_id, op, validated) = {
+            let sqe = Sqe::from(io.sqe());
+            (sqe.cmd_id(), sqe.op(), sqe.validate())
+        };
+        let sq_id = io.queue_id();
+        let mut cqe = Cqe::from(io.cqe());
+        cqe.clear();
+        cqe.set_cmd_id(cmd_id);
+        cqe.set_sq_id(sq_id);
+        (op, validated)
+    }
+
+    /// Writes the final CQE status from the dispatch result.
+    #[inline]
+    fn finalize_cqe(io: &mut P::Io, op_result: Result<HsmOpStatus, OpError>) {
+        let mut cqe = Cqe::from(io.cqe());
+        match op_result {
+            Ok(status) => {
+                cqe.set_dw0(CqeDw0::from(status.cqe_dw0_session).with_dst_len(status.resp_len));
+                cqe.set_dw1(CqeDw1::from(status.cqe_dw1));
+            }
+            Err(e) => {
+                cqe.set_status(e.status);
+                error!("core", e.err, "handle_op failed");
+            }
+        }
+    }
+
     /// Handles an [`OP_GENERIC`] IO command.
     ///
     /// **Phase 1 (pre-decode)** — SQE validation, inbound DMA, header
@@ -124,32 +129,31 @@ impl<P: HsmPal> Hsm<P> {
     /// **Phase 2 (post-decode)** — Session validation, DDI dispatch.
     /// Errors → DDI error response DMA'd to host, CQE Success.
     async fn handle_generic_op(&self, io: &mut P::Io) -> Result<HsmOpStatus, OpError> {
-        let sqe = io.sqe();
-        let sqe = Sqe::from(sqe);
-        sqe.validate_generic_op()?;
-
-        let part_id = io.pid();
-        let src_len = sqe.src_len() as usize;
+        let params = Self::decode_generic_sqe(io)?;
+        let split = params.src_len.next_multiple_of(4);
+        let req_buf = self
+            .pal()
+            .dma_alloc(&*io, split)
+            .op_status(HostStatus::ALLOC_ERR)?;
 
         // ── Phase 1: inbound DMA (yield 1) ─────────────────────────
-        {
-            let src_addr = sqe.src_prp1();
-            let (_, smem) = io.mem();
-            self.copy_host_to_mem(part_id, src_addr, &mut smem[..src_len])
-                .await?;
-        }
+        self.pal()
+            .copy_mem_from_host(
+                &*io,
+                params.src_addr,
+                &mut req_buf[..params.src_len],
+                true,
+            )
+            .await
+            .op_err(
+                "core",
+                HsmError::FailedToStartDmaTransaction,
+                HostStatus::DMA_TXN_ERROR,
+            )?;
 
         // ── Phase 2: decode + validate + dispatch (no yield) ───────
-        // All Phase 2 locals scoped so they die before yield 2.
-        let (resp_len, session_ctrl) = {
-            let session_flags = Sqe::from(io.sqe()).session_flags();
-            let sqe_session_id = Sqe::from(io.sqe()).session_id();
-
-            let (fmem, smem) = io.mem();
-            let split = src_len.next_multiple_of(4);
-            let (req_padded, resp_buf) = smem.split_at_mut(split);
-            let req = &req_padded[..src_len];
-
+        let (resp, session_ctrl) = {
+            let req = &req_buf[..params.src_len];
             let mut decoder = DdiDecoder::new(req);
             let hdr: DdiReqHdr = decoder.decode_hdr().op_err(
                 "core",
@@ -159,42 +163,58 @@ impl<P: HsmPal> Hsm<P> {
 
             let session_ctrl = SessionCtrl::from_op(hdr.op);
 
-            // Session hijack protection
-            let resp_len = if let Err(status) =
-                Self::validate_session(&hdr, session_ctrl, session_flags, sqe_session_id)
-            {
-                ddi::encode_ddi_err(hdr.op, status, resp_buf)
-                    .op_status(HostStatus::INTERNAL_ERROR)?
-            } else {
-                match ddi::dispatch(&hdr, &mut decoder, part_id, self.pal(), fmem, resp_buf).await {
-                    Ok(len) => len,
-                    Err(status) => ddi::encode_ddi_err(hdr.op, status, resp_buf)
-                        .op_status(HostStatus::INTERNAL_ERROR)?,
-                }
+            let dispatch_result = match Self::validate_session(
+                &hdr,
+                session_ctrl,
+                params.session_flags,
+                params.sqe_session_id,
+            ) {
+                Ok(()) => ddi::dispatch(self.pal(), &*io, &mut decoder, &hdr).await,
+                Err(e) => Err(e),
             };
 
-            (resp_len, session_ctrl)
+            let resp: &DmaBuf = dispatch_result.or_else(|status| {
+                self.pal()
+                    .dma_alloc_var(&*io, |buf| ddi::encode_ddi_err(hdr.op, status, buf))
+                    .op_status(HostStatus::INTERNAL_ERROR)
+                    .map(|b| &*b)
+            })?;
+
+            (resp, session_ctrl)
         };
 
+        let resp_len = resp.len();
+
         // ── Outbound DMA (yield 2) ─────────────────────────────────
-        {
-            let dst_addr = Sqe::from(io.sqe()).dst_prp1();
-            let (_, smem) = io.mem();
-            let split = src_len.next_multiple_of(4);
-            let resp = &smem[split..split + resp_len];
-            self.copy_mem_to_host(part_id, resp, dst_addr).await?;
-        }
+        self.pal()
+            .copy_mem_to_host(&*io, resp, params.dst_addr, true)
+            .await
+            .op_err(
+                "core",
+                HsmError::FailedToStartDmaTransaction,
+                HostStatus::DMA_TXN_ERROR,
+            )?;
 
         Ok(HsmOpStatus::new(resp_len, session_ctrl, None, None, false))
     }
 
+    /// Validates the SQE for an [`OP_GENERIC`] IO command and extracts
+    /// the fields used by [`Self::handle_generic_op`].
+    #[inline]
+    fn decode_generic_sqe(io: &P::Io) -> Result<GenericSqeParams, OpError> {
+        let sqe = Sqe::from(io.sqe());
+        sqe.validate_generic_op()?;
+        Ok(GenericSqeParams {
+            src_len: sqe.src_len() as usize,
+            src_addr: sqe.src_prp1(),
+            dst_addr: sqe.dst_prp1(),
+            session_flags: sqe.session_flags(),
+            sqe_session_id: sqe.session_id(),
+        })
+    }
+
     /// Validate SQE session flags against the decoded DDI header.
-    ///
-    /// Three rules for session hijack protection:
-    ///
-    /// 1. SQE `session_ctrl` must match the DDI op's expected kind.
-    /// 2. `ctrl`/`id_valid` combinations must be consistent.
-    /// 3. SQE `session_id` must match DDI header `sess_id`.
+    #[inline(always)]
     fn validate_session(
         hdr: &DdiReqHdr,
         expected: SessionCtrl,
@@ -228,38 +248,6 @@ impl<P: HsmPal> Hsm<P> {
         Ok(())
     }
 
-    async fn copy_host_to_mem(
-        &self,
-        part_id: HsmPartId,
-        src_prp: HsmDmaAddr,
-        dest: &mut [u8],
-    ) -> Result<(), OpError> {
-        self.pal()
-            .copy_mem_from_host(part_id, src_prp, dest, true)
-            .await
-            .op_err(
-                "core",
-                HsmError::FailedToStartDmaTransaction,
-                HostStatus::DMA_TXN_ERROR,
-            )
-    }
-
-    async fn copy_mem_to_host(
-        &self,
-        part_id: HsmPartId,
-        src: &[u8],
-        dst_prp: HsmDmaAddr,
-    ) -> Result<(), OpError> {
-        self.pal()
-            .copy_mem_to_host(part_id, src, dst_prp, true)
-            .await
-            .op_err(
-                "core",
-                HsmError::FailedToStartDmaTransaction,
-                HostStatus::DMA_TXN_ERROR,
-            )
-    }
-
     /// Handles an [`OP_FLUSH`] IO command.
     ///
     /// Returns [`HsmError::IoChannelUnknownOp`] — flush is not yet supported.
@@ -269,4 +257,13 @@ impl<P: HsmPal> Hsm<P> {
             HostStatus::INVALID_COMMAND_OPCODE,
         ))
     }
+}
+
+/// Fields extracted from a validated [`OP_GENERIC`] SQE.
+struct GenericSqeParams {
+    src_len: usize,
+    src_addr: HsmDmaAddr,
+    dst_addr: HsmDmaAddr,
+    session_flags: SessionFlags,
+    sqe_session_id: u16,
 }

--- a/fw/pal/traits/src/alloc.rs
+++ b/fw/pal/traits/src/alloc.rs
@@ -1,0 +1,582 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Per-IO memory allocator trait.
+//!
+//! Defines the [`HsmAlloc`] PAL trait and the
+//! [`HsmScopedAlloc`] handle that callers receive inside an
+//! allocation scope.  The trait is the entry point for every
+//! firmware-side scratch allocation: DMA staging buffers, crypto
+//! state, hash contexts, KDF working memory, DDI response framing.
+//!
+//! ## Memory pools
+//!
+//! Each IO has access to two distinct pools, chosen implicitly by
+//! method name:
+//!
+//! - **NonDma** — fast, tightly-coupled DTCM (~2 KB).  Reached via
+//!   [`alloc`](HsmAlloc::alloc), [`alloc_zeroed`](HsmAlloc::alloc_zeroed),
+//!   [`alloc_val`](HsmAlloc::alloc_val), and the matching methods on
+//!   [`HsmScopedAlloc`].  Use for small, CPU-only state where DTCM
+//!   latency matters: SHA/HMAC contexts, KDF scratch, structs that
+//!   never touch a DMA engine.
+//!
+//! - **Dma** — larger, slower SRAM (~8 KB).  Reached via
+//!   [`dma_alloc`](HsmAlloc::dma_alloc),
+//!   [`dma_alloc_zeroed`](HsmAlloc::dma_alloc_zeroed),
+//!   [`dma_alloc_var`](HsmAlloc::dma_alloc_var),
+//!   [`dma_alloc_var_with`](HsmAlloc::dma_alloc_var_with), and the
+//!   matching methods on [`HsmScopedAlloc`].  Use for any buffer
+//!   that is the source or destination of a GDMA/SHA/AES transfer,
+//!   plus large staging buffers (DDI request/response framing,
+//!   certificate streaming).
+//!
+//! All allocations are 4-byte aligned.  All sizes are honored
+//! exactly — there is no rounding past the alignment requirement.
+//!
+//! ## Lifetime model
+//!
+//! Allocations come in two lifetime flavors:
+//!
+//! - **Scoped** — made through an
+//!   [`HsmScopedAlloc`] handle inside
+//!   [`alloc_scoped`](HsmAlloc::alloc_scoped) /
+//!   [`alloc_scoped_async`](HsmAlloc::alloc_scoped_async).  Every
+//!   buffer is freed when the closure returns; the borrow lives only
+//!   inside the closure body.  This is the common path for short-
+//!   lived crypto scratch.
+//!
+//! - **IO-scoped** — made directly on the PAL via
+//!   [`dma_alloc`](HsmAlloc::dma_alloc) / friends.  The borrow lives
+//!   for the rest of the IO and survives across `await` points,
+//!   which is required for buffers that bracket a DMA descriptor
+//!   yield (e.g. the inbound/outbound DMA staging buffer in
+//!   `handle_generic_op`).
+//!
+//! ## Errors
+//!
+//! Every fallible method returns [`HsmError::NotEnoughSpace`] when
+//! the underlying bump allocator's watermark cannot satisfy the
+//! request.  This is the *only* error any allocator method
+//! produces; other errors are propagated only through user closures
+//! ([`dma_alloc_var`](HsmAlloc::dma_alloc_var) etc.).
+//!
+//! ## Example
+//!
+//! ```ignore
+//! // Scoped: all allocations freed on closure return.
+//! pal.alloc_scoped(io, |a| {
+//!     let scratch = a.alloc(384)?;     // NonDma DTCM
+//!     let dma_buf = a.dma_alloc(256)?; // Dma SRAM
+//!     // ... use buffers ...
+//!     Ok::<_, HsmError>(())
+//! })?;
+//!
+//! // IO-scoped: lives across await points.
+//! let staging = pal.dma_alloc(io, 512)?;
+//! pal.copy_mem_from_host(io, src_addr, staging, true).await?;
+//! ```
+
+use core::ops::AsyncFnOnce;
+
+use super::*;
+
+// ── DmaBuf ────────────────────────────────────────────────────────
+
+/// A byte slice guaranteed to reside in DMA-accessible memory.
+///
+/// `DmaBuf` is a `#[repr(transparent)]` newtype over `[u8]`. The
+/// only way to construct one is via the unsafe `from_raw` /
+/// `from_raw_mut` helpers, which the PAL allocator uses to brand
+/// SRAM-backed buffers handed out by `dma_alloc`. Everywhere a
+/// `&DmaBuf` or `&mut DmaBuf` is required, the type system proves
+/// the bytes live in a region the GDMA / SHA / AES engines can
+/// reach.
+///
+/// `DmaBuf` `Deref`s to `[u8]`, so all read-only slice operations
+/// (length, iteration, `as_ptr`) work transparently. Mutable
+/// access goes through `DerefMut`.
+#[repr(transparent)]
+pub struct DmaBuf {
+    inner: [u8],
+}
+
+impl DmaBuf {
+    /// Brands a borrowed `[u8]` as DMA-accessible.
+    ///
+    /// # Safety
+    ///
+    /// `buf` must point into a memory region that the platform's
+    /// DMA engines (GDMA, SHA, AES, etc.) can address. The PAL
+    /// allocator is the only place this should be called with
+    /// freshly allocated SRAM. Outside the PAL, prefer constructing
+    /// sub-views of an existing `DmaBuf` via indexing.
+    #[doc(hidden)]
+    #[inline(always)]
+    pub unsafe fn from_raw(buf: &[u8]) -> &Self {
+        unsafe { &*(buf as *const [u8] as *const DmaBuf) }
+    }
+
+    /// Mutable equivalent of [`DmaBuf::from_raw`].
+    ///
+    /// # Safety
+    ///
+    /// Same requirements as [`DmaBuf::from_raw`].
+    #[doc(hidden)]
+    #[inline(always)]
+    pub unsafe fn from_raw_mut(buf: &mut [u8]) -> &mut Self {
+        unsafe { &mut *(buf as *mut [u8] as *mut DmaBuf) }
+    }
+
+    /// Splits this `DmaBuf` into two `DmaBuf` views at `mid`.
+    ///
+    /// Both halves remain DMA-accessible because they are
+    /// sub-views of an existing `DmaBuf`.
+    #[inline(always)]
+    pub fn split_at(&self, mid: usize) -> (&DmaBuf, &DmaBuf) {
+        let (a, b) = self.inner.split_at(mid);
+        unsafe { (DmaBuf::from_raw(a), DmaBuf::from_raw(b)) }
+    }
+
+    /// Mutable equivalent of [`DmaBuf::split_at`].
+    #[inline(always)]
+    pub fn split_at_mut(&mut self, mid: usize) -> (&mut DmaBuf, &mut DmaBuf) {
+        let (a, b) = self.inner.split_at_mut(mid);
+        unsafe { (DmaBuf::from_raw_mut(a), DmaBuf::from_raw_mut(b)) }
+    }
+}
+
+impl core::ops::Deref for DmaBuf {
+    type Target = [u8];
+    #[inline(always)]
+    fn deref(&self) -> &[u8] {
+        &self.inner
+    }
+}
+
+impl core::ops::DerefMut for DmaBuf {
+    #[inline(always)]
+    fn deref_mut(&mut self) -> &mut [u8] {
+        &mut self.inner
+    }
+}
+
+impl core::fmt::Debug for DmaBuf {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "DmaBuf({} bytes)", self.inner.len())
+    }
+}
+
+impl core::ops::Index<usize> for DmaBuf {
+    type Output = u8;
+    #[inline(always)]
+    fn index(&self, i: usize) -> &u8 {
+        &self.inner[i]
+    }
+}
+
+impl core::ops::IndexMut<usize> for DmaBuf {
+    #[inline(always)]
+    fn index_mut(&mut self, i: usize) -> &mut u8 {
+        &mut self.inner[i]
+    }
+}
+
+impl core::ops::Index<core::ops::Range<usize>> for DmaBuf {
+    type Output = DmaBuf;
+    #[inline(always)]
+    fn index(&self, r: core::ops::Range<usize>) -> &DmaBuf {
+        unsafe { DmaBuf::from_raw(&self.inner[r]) }
+    }
+}
+
+impl core::ops::IndexMut<core::ops::Range<usize>> for DmaBuf {
+    #[inline(always)]
+    fn index_mut(&mut self, r: core::ops::Range<usize>) -> &mut DmaBuf {
+        unsafe { DmaBuf::from_raw_mut(&mut self.inner[r]) }
+    }
+}
+
+impl core::ops::Index<core::ops::RangeTo<usize>> for DmaBuf {
+    type Output = DmaBuf;
+    #[inline(always)]
+    fn index(&self, r: core::ops::RangeTo<usize>) -> &DmaBuf {
+        unsafe { DmaBuf::from_raw(&self.inner[r]) }
+    }
+}
+
+impl core::ops::IndexMut<core::ops::RangeTo<usize>> for DmaBuf {
+    #[inline(always)]
+    fn index_mut(&mut self, r: core::ops::RangeTo<usize>) -> &mut DmaBuf {
+        unsafe { DmaBuf::from_raw_mut(&mut self.inner[r]) }
+    }
+}
+
+impl core::ops::Index<core::ops::RangeFrom<usize>> for DmaBuf {
+    type Output = DmaBuf;
+    #[inline(always)]
+    fn index(&self, r: core::ops::RangeFrom<usize>) -> &DmaBuf {
+        unsafe { DmaBuf::from_raw(&self.inner[r]) }
+    }
+}
+
+impl core::ops::IndexMut<core::ops::RangeFrom<usize>> for DmaBuf {
+    #[inline(always)]
+    fn index_mut(&mut self, r: core::ops::RangeFrom<usize>) -> &mut DmaBuf {
+        unsafe { DmaBuf::from_raw_mut(&mut self.inner[r]) }
+    }
+}
+
+impl core::ops::Index<core::ops::RangeFull> for DmaBuf {
+    type Output = DmaBuf;
+    #[inline(always)]
+    fn index(&self, _: core::ops::RangeFull) -> &DmaBuf {
+        self
+    }
+}
+
+impl core::ops::IndexMut<core::ops::RangeFull> for DmaBuf {
+    #[inline(always)]
+    fn index_mut(&mut self, _: core::ops::RangeFull) -> &mut DmaBuf {
+        self
+    }
+}
+
+// ── Scoped allocation handle ──────────────────────────────────────
+
+/// Handle to allocations whose lifetime is bounded by an
+/// [`alloc_scoped`](HsmAlloc::alloc_scoped) /
+/// [`alloc_scoped_async`](HsmAlloc::alloc_scoped_async) closure.
+///
+/// Every method on this trait mirrors the corresponding direct
+/// method on [`HsmAlloc`], minus the `io` parameter — the IO is
+/// captured implicitly by the scope.  All buffers handed out by a
+/// scoped handle are freed atomically when the enclosing closure
+/// returns.
+pub trait HsmScopedAlloc {
+    /// Allocates `size` bytes of uninitialised memory from the
+    /// NonDma (DTCM) pool.
+    ///
+    /// Contents of the returned slice are unspecified.
+    ///
+    /// # Parameters
+    ///
+    /// - `size` — number of bytes to allocate.
+    ///
+    /// # Returns
+    ///
+    /// - `Ok(&mut [u8])` — slice of length exactly `size`, 4-byte
+    ///   aligned.
+    /// - `Err(HsmError::NotEnoughSpace)` — the NonDma pool cannot
+    ///   satisfy the request.
+    fn alloc(&self, size: usize) -> HsmResult<&mut [u8]>;
+
+    /// Allocates `size` bytes from the NonDma (DTCM) pool and
+    /// zero-fills them.
+    ///
+    /// # Parameters
+    ///
+    /// - `size` — number of bytes to allocate.
+    ///
+    /// # Returns
+    ///
+    /// - `Ok(&mut [u8])` — zero-initialised slice of length `size`.
+    /// - `Err(HsmError::NotEnoughSpace)` — pool exhausted.
+    fn alloc_zeroed(&self, size: usize) -> HsmResult<&mut [u8]>;
+
+    /// Allocates space for a `T` from the NonDma (DTCM) pool and
+    /// moves `value` into it.
+    ///
+    /// # Type Parameters
+    ///
+    /// - `T` — `Sized`. The allocation is `core::mem::size_of::<T>()`
+    ///   bytes; alignment is the standard 4-byte allocator alignment
+    ///   (matches `T`'s alignment for all `T` with `align_of::<T>()
+    ///   <= 4`).
+    ///
+    /// # Parameters
+    ///
+    /// - `value` — `T` to be moved into the allocation.
+    ///
+    /// # Returns
+    ///
+    /// - `Ok(&mut T)` — exclusive reference to the freshly placed
+    ///   value.
+    /// - `Err(HsmError::NotEnoughSpace)` — pool exhausted.
+    fn alloc_val<T: Sized>(&self, value: T) -> HsmResult<&mut T>;
+
+    /// Allocates `size` bytes of uninitialised memory from the Dma
+    /// (SRAM) pool.
+    ///
+    /// # Parameters
+    ///
+    /// - `size` — number of bytes to allocate.
+    ///
+    /// # Returns
+    ///
+    /// - `Ok(&mut [u8])` — DMA-capable slice of length exactly
+    ///   `size`, 4-byte aligned.  Suitable as a GDMA/SHA/AES
+    ///   endpoint.
+    /// - `Err(HsmError::NotEnoughSpace)` — the Dma pool cannot
+    ///   satisfy the request.
+    fn dma_alloc(&self, size: usize) -> HsmResult<&mut DmaBuf>;
+
+    /// Allocates `size` bytes from the Dma (SRAM) pool and
+    /// zero-fills them.
+    ///
+    /// # Parameters
+    ///
+    /// - `size` — number of bytes to allocate.
+    ///
+    /// # Returns
+    ///
+    /// - `Ok(&mut [u8])` — zero-initialised DMA-capable slice.
+    /// - `Err(HsmError::NotEnoughSpace)` — pool exhausted.
+    fn dma_alloc_zeroed(&self, size: usize) -> HsmResult<&mut DmaBuf>;
+}
+
+// ── Public allocator trait ────────────────────────────────────────
+
+/// Per-IO scratch memory allocator.
+///
+/// Concrete PALs implement this trait by carving each IO's slot out
+/// of two static heaps (NonDma / Dma) and handing out bump-allocated
+/// slices via [`HsmScopedAlloc`] (scope-bounded) or directly
+/// (IO-bounded).
+///
+/// **Allocation methods** (the same set is mirrored on
+/// [`HsmScopedAlloc`] without the `io` argument):
+///
+/// | NonDma (DTCM) | Dma (SRAM) |
+/// |---------------|------------|
+/// | [`alloc`](Self::alloc) | [`dma_alloc`](Self::dma_alloc) |
+/// | [`alloc_zeroed`](Self::alloc_zeroed) | [`dma_alloc_zeroed`](Self::dma_alloc_zeroed) |
+/// | [`alloc_val`](Self::alloc_val) | — |
+///
+/// **Dma-only** (long-lived, variable-size, populated via closure):
+///
+/// | Method | Description |
+/// |--------|-------------|
+/// | [`dma_alloc_var`](Self::dma_alloc_var) | Hand out the rest of Dma to a closure, shrink to the closure's reported length |
+/// | [`dma_alloc_var_with`](Self::dma_alloc_var_with) | Same, plus return an owned `T` alongside the buffer |
+///
+/// **Scoping**:
+///
+/// | Method | Description |
+/// |--------|-------------|
+/// | [`alloc_scoped`](Self::alloc_scoped) | Synchronous scope; all scope allocations freed on return |
+/// | [`alloc_scoped_async`](Self::alloc_scoped_async) | Async scope; same lifetime semantics across awaits |
+pub trait HsmAlloc {
+    /// PAL-specific scoped allocator handle.
+    ///
+    /// The associated lifetime ties the handle to the enclosing
+    /// scope so allocations cannot escape it.
+    type Scoped<'a>: HsmScopedAlloc
+    where
+        Self: 'a;
+
+    // ── NonDma (DTCM) ─────────────────────────────────────────
+
+    /// Allocates `size` bytes of uninitialised memory from `io`'s
+    /// NonDma pool.
+    ///
+    /// The borrow lives for the rest of the IO and survives across
+    /// `await` points.  Use this when the buffer must outlive a
+    /// scope (rare for NonDma; most NonDma allocations are scoped).
+    ///
+    /// # Parameters
+    ///
+    /// - `io` — caller's I/O context (selects the per-IO heap slot).
+    /// - `size` — number of bytes to allocate.
+    ///
+    /// # Returns
+    ///
+    /// - `Ok(&mut [u8])` — slice of length exactly `size`, 4-byte
+    ///   aligned.
+    /// - `Err(HsmError::NotEnoughSpace)` — pool exhausted.
+    fn alloc(&self, io: &impl HsmIo, size: usize) -> HsmResult<&mut [u8]>;
+
+    /// Allocates `size` bytes from `io`'s NonDma pool and
+    /// zero-fills them.
+    ///
+    /// # Parameters
+    ///
+    /// - `io` — caller's I/O context.
+    /// - `size` — number of bytes to allocate.
+    ///
+    /// # Returns
+    ///
+    /// - `Ok(&mut [u8])` — zero-initialised slice.
+    /// - `Err(HsmError::NotEnoughSpace)` — pool exhausted.
+    fn alloc_zeroed(&self, io: &impl HsmIo, size: usize) -> HsmResult<&mut [u8]>;
+
+    /// Allocates space for a `T` on `io`'s NonDma pool and moves
+    /// `value` into it.
+    ///
+    /// # Type Parameters
+    ///
+    /// - `T` — `Sized`. Allocation size is
+    ///   `core::mem::size_of::<T>()`; alignment is the standard
+    ///   4-byte allocator alignment.
+    ///
+    /// # Parameters
+    ///
+    /// - `io` — caller's I/O context.
+    /// - `value` — `T` to be moved into the allocation.
+    ///
+    /// # Returns
+    ///
+    /// - `Ok(&mut T)` — exclusive reference to the placed value.
+    /// - `Err(HsmError::NotEnoughSpace)` — pool exhausted.
+    fn alloc_val<T: Sized>(&self, io: &impl HsmIo, value: T) -> HsmResult<&mut T>;
+
+    // ── Dma (SRAM) ────────────────────────────────────────────
+
+    /// Allocates `size` bytes of uninitialised memory from `io`'s
+    /// Dma pool.
+    ///
+    /// The borrow lives for the rest of the IO and survives across
+    /// `await` points — the canonical use is staging a host↔device
+    /// DMA transfer that yields between request submission and
+    /// completion.
+    ///
+    /// # Parameters
+    ///
+    /// - `io` — caller's I/O context.
+    /// - `size` — number of bytes to allocate.
+    ///
+    /// # Returns
+    ///
+    /// - `Ok(&mut [u8])` — DMA-capable slice of length exactly
+    ///   `size`, 4-byte aligned.
+    /// - `Err(HsmError::NotEnoughSpace)` — pool exhausted.
+    fn dma_alloc(&self, io: &impl HsmIo, size: usize) -> HsmResult<&mut DmaBuf>;
+
+    /// Allocates `size` bytes from `io`'s Dma pool and zero-fills
+    /// them.
+    ///
+    /// # Parameters
+    ///
+    /// - `io` — caller's I/O context.
+    /// - `size` — number of bytes to allocate.
+    ///
+    /// # Returns
+    ///
+    /// - `Ok(&mut [u8])` — zero-initialised DMA-capable slice.
+    /// - `Err(HsmError::NotEnoughSpace)` — pool exhausted.
+    fn dma_alloc_zeroed(&self, io: &impl HsmIo, size: usize) -> HsmResult<&mut DmaBuf>;
+
+    /// Variable-size DMA allocation populated by a closure.
+    ///
+    /// Hands `f` the *entire* remaining Dma watermark as a mutable
+    /// slice.  `f` writes a prefix of unknown length and returns the
+    /// number of bytes it actually populated.  The allocation is
+    /// then shrunk to that length and the unused tail is returned to
+    /// the pool.
+    ///
+    /// Used wherever a buffer's exact size is only known after the
+    /// fact — for example, MBOR encoding of a DDI response.
+    ///
+    /// # Type Parameters
+    ///
+    /// - `F` — `FnOnce(&mut [u8]) -> HsmResult<usize>`.  The closure
+    ///   may return any [`HsmError`]; the allocator only contributes
+    ///   [`HsmError::NotEnoughSpace`] of its own.
+    ///
+    /// # Parameters
+    ///
+    /// - `io` — caller's I/O context.
+    /// - `f` — populates a prefix and returns its length in bytes.
+    ///   The returned length must be ≤ the slice the closure
+    ///   received.
+    ///
+    /// # Returns
+    ///
+    /// - `Ok(&mut [u8])` — slice trimmed to the length returned by
+    ///   `f`.
+    /// - `Err(HsmError::NotEnoughSpace)` — Dma pool was empty before
+    ///   `f` ran.
+    /// - `Err(e)` — propagated unchanged from `f`.
+    fn dma_alloc_var<F>(&self, io: &impl HsmIo, f: F) -> HsmResult<&mut DmaBuf>
+    where
+        F: FnOnce(&mut [u8]) -> HsmResult<usize>;
+
+    /// Like [`dma_alloc_var`](Self::dma_alloc_var) but `f` returns
+    /// an owned `T` alongside the populated length.
+    ///
+    /// Useful when the closure needs to communicate something else
+    /// to the caller in addition to the buffer length — for example,
+    /// a parsed length field, a derived `usize` count, or a small
+    /// struct describing the encoded layout.
+    ///
+    /// # Type Parameters
+    ///
+    /// - `F` — `FnOnce(&mut [u8]) -> HsmResult<(usize, T)>`.
+    /// - `T` — owned value produced by the closure.
+    ///
+    /// # Parameters
+    ///
+    /// - `io` — caller's I/O context.
+    /// - `f` — populates a prefix and returns `(prefix_len, value)`.
+    ///   `prefix_len` must be ≤ the slice the closure received.
+    ///
+    /// # Returns
+    ///
+    /// - `Ok((&mut [u8], T))` — trimmed slice plus the closure's
+    ///   value.
+    /// - `Err(HsmError::NotEnoughSpace)` — Dma pool empty before
+    ///   `f` ran.
+    /// - `Err(e)` — propagated unchanged from `f`.
+    fn dma_alloc_var_with<F, T>(&self, io: &impl HsmIo, f: F) -> HsmResult<(&mut DmaBuf, T)>
+    where
+        F: FnOnce(&mut [u8]) -> HsmResult<(usize, T)>;
+
+    // ── Scoping ───────────────────────────────────────────────
+
+    /// Runs `f` with an [`HsmScopedAlloc`] handle and frees every
+    /// allocation made through that handle when `f` returns.
+    ///
+    /// Scopes may nest; nested scopes see the parent's watermark
+    /// and roll back to it on return.  Allocations made through the
+    /// outer PAL trait (e.g. [`dma_alloc`](Self::dma_alloc)) are
+    /// **not** freed by scope exit.
+    ///
+    /// # Type Parameters
+    ///
+    /// - `R` — value returned by `f` and forwarded to the caller.
+    ///
+    /// # Parameters
+    ///
+    /// - `io` — caller's I/O context.
+    /// - `f` — closure that performs scoped allocations through the
+    ///   provided handle.
+    ///
+    /// # Returns
+    ///
+    /// Whatever `f` returned (`R`); `f` is expected to encode any
+    /// fallibility into `R` itself (typically `R = HsmResult<…>`).
+    fn alloc_scoped<R>(&self, io: &impl HsmIo, f: impl FnOnce(&Self::Scoped<'_>) -> R) -> R;
+
+    /// Async variant of [`alloc_scoped`](Self::alloc_scoped).
+    ///
+    /// Scope semantics are identical: the watermark rolls back when
+    /// `f`'s future completes, regardless of how many `await` points
+    /// it contained.
+    ///
+    /// # Type Parameters
+    ///
+    /// - `R` — value returned by `f`'s future.
+    /// - `F` — `for<'a> AsyncFnOnce(&'a Self::Scoped<'a>) -> R`.
+    ///
+    /// # Parameters
+    ///
+    /// - `io` — caller's I/O context.
+    /// - `f` — async closure that performs scoped allocations.
+    ///
+    /// # Returns
+    ///
+    /// Whatever `f` returned (`R`).
+    async fn alloc_scoped_async<R, F>(&self, io: &impl HsmIo, f: F) -> R
+    where
+        F: for<'a> AsyncFnOnce(&'a Self::Scoped<'a>) -> R;
+}

--- a/fw/pal/traits/src/cert.rs
+++ b/fw/pal/traits/src/cert.rs
@@ -3,66 +3,129 @@
 
 //! Certificate store types and traits.
 //!
-//! Defines the [`CertificateStore`] trait for retrieving certificate chains
-//! associated with partition/slot pairs.
+//! Defines the [`HsmCertStore`] trait used by DDI handlers
+//! (`get_cert_chain_info`, `get_certificate`) to read per-partition
+//! certificate chains.  Each partition can hold multiple chains
+//! addressed by a `slot_id` (e.g. slot 0 = identity chain, slot 1 =
+//! attestation chain — exact slot mapping is platform-defined).
+//!
+//! ## Storage model
+//!
+//! A *chain* is an ordered list of DER-encoded X.509 certificates,
+//! conventionally arranged leaf-first.  The store reports two pieces
+//! of metadata per chain via [`CertChainInfo`]:
+//!
+//! - the chain length (`count`), and
+//! - the SHA-256 thumbprint of the leaf certificate.
+//!
+//! Individual certificates are streamed one at a time through
+//! [`HsmCertStore::get_cert`] using the standard query/copy pattern.
+//!
+//! ## Addressing
+//!
+//! Every method takes both an [`HsmIo`] handle and an explicit
+//! [`HsmPartId`].  Unlike most PAL traits, the partition is *not*
+//! resolved from `io.pid()` here: the cert store is read by core
+//! partition-management paths that need to inspect *another*
+//! partition's chains (for example, returning the host's own
+//! identity-cert metadata in a query that arrived on partition 0).
+//! The [`HsmIo`] handle is still passed for per-IO scope (allocator,
+//! logging, throttling).
 
 use super::*;
 
-/// Metadata about a certificate chain for a partition slot.
+/// Metadata for a single certificate chain.
+///
+/// Returned by [`HsmCertStore::get_cert_chain_info`].  The
+/// thumbprint lets the host detect chain rotation without
+/// downloading every certificate.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct CertChainInfo {
     /// Number of certificates in the chain.
+    ///
+    /// Indices passed to [`HsmCertStore::get_cert`] must satisfy
+    /// `idx < count`.
     pub count: u8,
 
-    /// SHA-256 thumbprint of the leaf certificate.
+    /// SHA-256 thumbprint of the leaf certificate (DER bytes).
+    ///
+    /// Computed once at chain-load time and cached; reading it does
+    /// not invoke the SHA accelerator.
     pub thumbprint: [u8; 32],
 }
 
-/// Certificate store interface.
+/// Per-partition certificate store interface.
 ///
-/// Provides methods for retrieving certificate chains for partitions.
+/// Both methods are `async` so PAL implementations can stream
+/// certificate bytes from non-volatile storage (flash, eMMC) without
+/// blocking the core's IO loop.  Implementations backed by RAM may
+/// resolve immediately; callers should still treat the await as
+/// potentially yielding.
 pub trait HsmCertStore {
-    /// Returns the certificate chain information for the given partition and slot.
+    /// Returns metadata for the certificate chain at
+    /// `(part_id, slot_id)`.
+    ///
+    /// Cheap query that lets the host decide whether to fetch
+    /// individual certificates; performs no buffer allocation.
     ///
     /// # Parameters
     ///
-    /// - `part_id` — Partition index.
-    /// - `slot_id` — Slot index.
+    /// - `io` — caller's I/O context (per-IO scope).
+    /// - `part_id` — partition whose chain is being queried (not
+    ///   necessarily `io.pid()`).
+    /// - `slot_id` — chain slot within the partition.  Valid range
+    ///   is platform-defined; the standard PAL currently treats this
+    ///   as advisory.
     ///
     /// # Returns
     ///
-    /// A [`CertChainInfo`] containing the chain length and leaf thumbprint.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`HsmError`] if the partition or slot index is invalid.
+    /// - `Ok(info)` — populated [`CertChainInfo`].
+    /// - `Err(HsmError::InvalidArg)` — `part_id` or `slot_id` is out
+    ///   of range, or the partition has no chain installed at this
+    ///   slot.
+    /// - `Err(HsmError)` — propagated from the underlying storage
+    ///   driver.
     async fn get_cert_chain_info(
         &self,
+        io: &impl HsmIo,
         part_id: HsmPartId,
         slot_id: u8,
     ) -> HsmResult<CertChainInfo>;
 
-    /// Reads a certificate from the chain into the provided buffer.
+    /// Reads one certificate from a chain, optionally copying its
+    /// bytes into a caller-supplied buffer.
+    ///
+    /// Follows the standard query/copy pattern used elsewhere in the
+    /// PAL: pass `cert = None` to obtain the certificate's size
+    /// without copying, then call again with `cert = Some(buf)` to
+    /// perform the copy.  Both calls return the same canonical
+    /// length.
     ///
     /// # Parameters
     ///
-    /// - `part_id` — Partition identifier.
-    /// - `slot_id` — Slot index.
-    /// - `idx` — Zero-based index of the certificate within the chain.
-    /// - `cert` — When `Some`, output buffer to receive the certificate bytes.
-    ///   When `None`, only the certificate length is returned (size query).
+    /// - `io` — caller's I/O context (per-IO scope).
+    /// - `part_id` — partition whose chain is being read.
+    /// - `slot_id` — chain slot within the partition.
+    /// - `idx` — zero-based certificate index; must satisfy
+    ///   `idx < CertChainInfo::count` for the same `(part_id,
+    ///   slot_id)`.  By convention `idx == 0` is the leaf and the
+    ///   last index is the root.
+    /// - `cert` — `None` to query the size, or `Some(buf)` to copy
+    ///   the DER-encoded certificate into `buf[..size]`.  `buf.len()`
+    ///   must be ≥ size.
     ///
     /// # Returns
     ///
-    /// The number of bytes that were (or would be) written to `cert`.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`HsmError`] if the partition index, slot index, or certificate
-    /// index is invalid, or if `cert` is `Some` but too small for the
-    /// certificate being read.
+    /// - `Ok(size)` — number of bytes that were (or would be)
+    ///   written.
+    /// - `Err(HsmError::InvalidArg)` — `part_id`, `slot_id`, or
+    ///   `idx` is out of range, or `cert = Some(buf)` and
+    ///   `buf.len() < size`.
+    /// - `Err(HsmError)` — propagated from the underlying storage
+    ///   driver.
     async fn get_cert(
         &self,
+        io: &impl HsmIo,
         part_id: HsmPartId,
         slot_id: u8,
         idx: u8,

--- a/fw/pal/traits/src/crypto/aes.rs
+++ b/fw/pal/traits/src/crypto/aes.rs
@@ -11,21 +11,21 @@
 //!
 //! ## Key representation
 //!
-//! All key parameters are plain `&[u8]` byte slices containing the raw
-//! AES key material. Each PAL implementation is responsible for parsing
-//! them into whatever internal representation it needs.
+//! DMA-facing AES operations take [`DmaBuf`] inputs/outputs for any bytes
+//! touched directly by the hardware engine (keys, IVs, payloads, tags,
+//! tweaks). Random key-generation outputs remain plain `&mut [u8]` so
+//! callers can write into either slices or DMA buffers via deref.
 //!
 //! ## Encrypt / decrypt unification
 //!
-//! CBC and ECB methods take a `encrypt: bool` flag instead of having
-//! separate `_encrypt` / `_decrypt` methods. `true` = encrypt,
-//! `false` = decrypt. This reduces trait surface and matches the
-//! hardware register model where a single direction bit selects the
-//! operation.
+//! CBC and ECB methods take an [`AesOp`] selector instead of having
+//! separate `_encrypt` / `_decrypt` methods. This reduces trait
+//! surface while keeping the operation direction explicit at the call
+//! site.
 //!
 //! ## In-place variants
 //!
-//! Methods suffixed `_in_place` operate on a single `&mut [u8]` buffer,
+//! Methods suffixed `_in_place` operate on a single `&mut DmaBuf` buffer,
 //! reading input and writing output to the same memory. This avoids an
 //! extra buffer allocation and is the natural model for hardware engines
 //! that operate directly on DMA buffers.
@@ -54,106 +54,155 @@ pub enum XtsDataUnitLen {
     Block8K,
 }
 
+/// AES encrypt/decrypt operation selector.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AesOp {
+    /// Encrypt the input.
+    Encrypt,
+
+    /// Decrypt the input.
+    Decrypt,
+}
+
 /// Asynchronous AES operations trait.
 ///
 /// PAL implementations provide this to the core for AES key generation
 /// and block cipher operations. The async signatures allow hardware-backed
 /// implementations to yield while the AES engine processes data.
+///
+/// All methods take `io` as their second parameter so callers can forward
+/// the operation-scoped [`HsmIo`] context through the PAL crypto stack.
 pub trait HsmAes {
     /// Generate a random AES key.
     ///
     /// # Parameters
-    /// - `key` — Output buffer filled with random key material. The
-    ///   buffer length determines the key size:
-    ///   - 16 bytes → AES-128
-    ///   - 24 bytes → AES-192
-    ///   - 32 bytes → AES-256
     ///
-    /// # Errors
-    /// Returns [`HsmError`] if the RNG fails.
-    async fn aes_gen_key(&self, key: &mut [u8]) -> HsmResult<()>;
+    /// - `io` — caller's I/O context (per-IO scope).
+    /// - `key` — output buffer; entirely filled with random bytes.
+    ///   Buffer length determines key size: 16 / 24 / 32 bytes for
+    ///   AES-128 / 192 / 256 respectively.
+    ///
+    /// # Returns
+    ///
+    /// - `Ok(())` — `key` populated.
+    /// - `Err(HsmError::InvalidArg)` — `key.len()` is not 16, 24, or 32.
+    /// - `Err(HsmError)` — propagated from the CSPRNG.
+    async fn aes_gen_key(&self, io: &impl HsmIo, key: &mut [u8]) -> HsmResult<()>;
 
-    /// AES-CBC encrypt or decrypt with separate input/output buffers.
+    /// AES-CBC encrypt or decrypt with separate input / output buffers.
     ///
     /// # Parameters
-    /// - `key` — The AES key.
-    /// - `encrypt` — `true` for encryption, `false` for decryption.
-    /// - `iv` — 16-byte initialization vector. Updated in-place to the
-    ///   last ciphertext block after the operation, enabling chaining
-    ///   across multiple calls.
-    /// - `input` — Source data. Must be a multiple of 16 bytes.
-    /// - `output` — Destination buffer. Must be at least `input.len()`
-    ///   bytes.
     ///
-    /// # Errors
-    /// Returns [`HsmError`] if the cipher operation fails.
+    /// - `io` — caller's I/O context (per-IO scope).
+    /// - `op` — [`AesOp::Encrypt`] or [`AesOp::Decrypt`].
+    /// - `key` — AES key (16 / 24 / 32 bytes).
+    /// - `input` — source bytes; length must be a multiple of 16.
+    /// - `iv_in` — 16-byte IV used for this request.
+    /// - `output` — destination; must be at least `input.len()` bytes.
+    /// - `iv_out` — optional destination for the updated chaining IV.
+    ///
+    /// # Returns
+    ///
+    /// - `Ok(())` — `output[..input.len()]` populated and `iv_out`
+    ///   updated when provided.
+    /// - `Err(HsmError::InvalidArg)` — buffer-size or alignment
+    ///   violation.
+    /// - `Err(HsmError)` — AES driver failure.
     async fn aes_cbc_enc_dec(
         &self,
-        key: &[u8],
-        encrypt: bool,
-        iv: &mut [u8],
-        input: &[u8],
-        output: &mut [u8],
+        io: &impl HsmIo,
+        op: AesOp,
+        key: &DmaBuf,
+        input: &DmaBuf,
+        iv_in: &DmaBuf,
+        output: &mut DmaBuf,
+        iv_out: Option<&mut DmaBuf>,
     ) -> HsmResult<()>;
 
     /// AES-CBC encrypt or decrypt in-place.
     ///
-    /// Reads from and writes to the same `data` buffer. The IV is
-    /// updated in-place for chaining.
+    /// Identical to [`aes_cbc_enc_dec`](Self::aes_cbc_enc_dec) but the
+    /// transform is applied to a single buffer.  This avoids a second
+    /// allocation and is the natural shape for hardware engines that
+    /// operate directly on DMA buffers.
     ///
     /// # Parameters
-    /// - `key` — The AES key.
-    /// - `encrypt` — `true` for encryption, `false` for decryption.
-    /// - `iv` — 16-byte initialization vector (updated in-place).
-    /// - `data` — Buffer holding the input; overwritten with the output.
-    ///   Must be a multiple of 16 bytes.
     ///
-    /// # Errors
-    /// Returns [`HsmError`] if the cipher operation fails.
+    /// - `io` — caller's I/O context (per-IO scope).
+    /// - `op` — [`AesOp::Encrypt`] or [`AesOp::Decrypt`].
+    /// - `key` — AES key (16 / 24 / 32 bytes).
+    /// - `data` — input on entry, output on return; length must
+    ///   be a multiple of 16.
+    /// - `iv_in` — 16-byte IV used for this request.
+    /// - `iv_out` — optional destination for the updated chaining IV.
+    ///
+    /// # Returns
+    ///
+    /// - `Ok(())` — `data` overwritten with the result and `iv_out`
+    ///   updated when provided.
+    /// - `Err(HsmError::InvalidArg)` — buffer-size or alignment
+    ///   violation.
+    /// - `Err(HsmError)` — AES driver failure.
     async fn aes_cbc_enc_dec_in_place(
         &self,
-        key: &[u8],
-        encrypt: bool,
-        iv: &mut [u8],
-        data: &mut [u8],
+        io: &impl HsmIo,
+        op: AesOp,
+        key: &DmaBuf,
+        data: &mut DmaBuf,
+        iv_in: &DmaBuf,
+        iv_out: Option<&mut DmaBuf>,
     ) -> HsmResult<()>;
 
-    /// AES-ECB encrypt or decrypt with separate input/output buffers.
+    /// AES-ECB encrypt or decrypt with separate input / output
+    /// buffers.
     ///
     /// # Parameters
-    /// - `key` — The AES key.
-    /// - `encrypt` — `true` for encryption, `false` for decryption.
-    /// - `input` — Source block(s). Must be a multiple of 16 bytes.
-    /// - `output` — Destination buffer. Must be at least `input.len()`
+    ///
+    /// - `io` — caller's I/O context (per-IO scope).
+    /// - `op` — [`AesOp::Encrypt`] or [`AesOp::Decrypt`].
+    /// - `key` — AES key (16 / 24 / 32 bytes).
+    /// - `input` — source block(s); length must be a multiple of
+    ///   16.
+    /// - `output` — destination; must be at least `input.len()`
     ///   bytes.
     ///
-    /// # Errors
-    /// Returns [`HsmError`] if the cipher operation fails.
+    /// # Returns
+    ///
+    /// - `Ok(())` — `output[..input.len()]` populated.
+    /// - `Err(HsmError::InvalidArg)` — buffer-size or alignment
+    ///   violation.
+    /// - `Err(HsmError)` — AES driver failure.
     async fn aes_ecb_enc_dec(
         &self,
-        key: &[u8],
-        encrypt: bool,
-        input: &[u8],
-        output: &mut [u8],
+        io: &impl HsmIo,
+        op: AesOp,
+        key: &DmaBuf,
+        input: &DmaBuf,
+        output: &mut DmaBuf,
     ) -> HsmResult<()>;
 
     /// AES-ECB encrypt or decrypt in-place.
     ///
-    /// Reads from and writes to the same `data` buffer.
-    ///
     /// # Parameters
-    /// - `key` — The AES key.
-    /// - `encrypt` — `true` for encryption, `false` for decryption.
-    /// - `data` — Buffer holding the input; overwritten with the output.
-    ///   Must be a multiple of 16 bytes.
     ///
-    /// # Errors
-    /// Returns [`HsmError`] if the cipher operation fails.
+    /// - `io` — caller's I/O context (per-IO scope).
+    /// - `op` — [`AesOp::Encrypt`] or [`AesOp::Decrypt`].
+    /// - `key` — AES key (16 / 24 / 32 bytes).
+    /// - `data` — input on entry, output on return; length must
+    ///   be a multiple of 16.
+    ///
+    /// # Returns
+    ///
+    /// - `Ok(())` — `data` overwritten with the result.
+    /// - `Err(HsmError::InvalidArg)` — buffer-size or alignment
+    ///   violation.
+    /// - `Err(HsmError)` — AES driver failure.
     async fn aes_ecb_enc_dec_in_place(
         &self,
-        key: &[u8],
-        encrypt: bool,
-        data: &mut [u8],
+        io: &impl HsmIo,
+        op: AesOp,
+        key: &DmaBuf,
+        data: &mut DmaBuf,
     ) -> HsmResult<()>;
 
     /// AES-GCM encrypt with separate input/output buffers.
@@ -186,6 +235,7 @@ pub trait HsmAes {
     ///
     /// # Parameters
     ///
+    /// - `io` — caller's I/O context (per-IO scope).
     /// - `key` — AES key (16, 24, or 32 bytes for AES-128/192/256).
     /// - `iv` — 12-byte (96-bit) nonce. Must be unique per encryption
     ///   with the same key.
@@ -195,17 +245,22 @@ pub trait HsmAes {
     /// - `ciphertext` — Destination. Must be at least `plaintext.len()`.
     /// - `tag` — Output buffer for the 16-byte authentication tag.
     ///
-    /// # Errors
+    /// # Returns
     ///
-    /// Returns [`HsmError`] if the encryption operation fails.
+    /// - `Ok(())` — `ciphertext[..plaintext.len()]` populated, `tag`
+    ///   set.
+    /// - `Err(HsmError::InvalidArg)` — buffer-size violation, IV not
+    ///   12 bytes, or AAD layout malformed.
+    /// - `Err(HsmError)` — AES driver failure.
     async fn gcm_encrypt(
         &self,
-        key: &[u8],
-        iv: &[u8; 12],
+        io: &impl HsmIo,
+        key: &DmaBuf,
+        iv: &DmaBuf,
         aad_len: usize,
-        plaintext: &[u8],
-        ciphertext: &mut [u8],
-        tag: &mut [u8; 16],
+        plaintext: &DmaBuf,
+        ciphertext: &mut DmaBuf,
+        tag: &mut DmaBuf,
     ) -> HsmResult<()>;
 
     /// AES-GCM encrypt in-place.
@@ -225,6 +280,7 @@ pub trait HsmAes {
     ///
     /// # Parameters
     ///
+    /// - `io` — caller's I/O context (per-IO scope).
     /// - `key` — AES key (16, 24, or 32 bytes for AES-128/192/256).
     /// - `iv` — 12-byte (96-bit) nonce. Must be unique per encryption
     ///   with the same key.
@@ -233,16 +289,20 @@ pub trait HsmAes {
     ///   overwritten with ciphertext.
     /// - `tag` — Output buffer for the 16-byte authentication tag.
     ///
-    /// # Errors
+    /// # Returns
     ///
-    /// Returns [`HsmError`] if the encryption operation fails.
+    /// - `Ok(())` — `data` text portion overwritten, `tag` set.
+    /// - `Err(HsmError::InvalidArg)` — buffer-size violation, IV not
+    ///   12 bytes, or AAD layout malformed.
+    /// - `Err(HsmError)` — AES driver failure.
     async fn gcm_encrypt_in_place(
         &self,
-        key: &[u8],
-        iv: &[u8; 12],
+        io: &impl HsmIo,
+        key: &DmaBuf,
+        iv: &DmaBuf,
         aad_len: usize,
-        data: &mut [u8],
-        tag: &mut [u8; 16],
+        data: &mut DmaBuf,
+        tag: &mut DmaBuf,
     ) -> HsmResult<()>;
 
     /// AES-GCM decrypt with separate input/output buffers.
@@ -259,6 +319,7 @@ pub trait HsmAes {
     ///
     /// # Parameters
     ///
+    /// - `io` — caller's I/O context (per-IO scope).
     /// - `key` — AES key (16, 24, or 32 bytes for AES-128/192/256).
     /// - `iv` — 12-byte (96-bit) nonce used during encryption.
     /// - `aad_len` — **Unpadded** AAD length in bytes. Must match the
@@ -267,17 +328,24 @@ pub trait HsmAes {
     /// - `ciphertext` — `[padded_AAD | ciphertext_bytes]`.
     /// - `plaintext` — Destination. Must be at least `ciphertext.len()`.
     ///
-    /// # Errors
+    /// # Returns
     ///
-    /// Returns [`HsmError`] if the tag verification or decryption fails.
+    /// - `Ok(())` — tag verified and `plaintext[..ciphertext.len()]`
+    ///   populated.
+    /// - `Err(HsmError::InvalidArg)` — buffer-size violation or AAD
+    ///   layout malformed.
+    /// - `Err(HsmError::AesGcmTagMismatch)` — authentication tag
+    ///   does not match.
+    /// - `Err(HsmError)` — AES driver failure.
     async fn gcm_decrypt(
         &self,
-        key: &[u8],
-        iv: &[u8; 12],
+        io: &impl HsmIo,
+        key: &DmaBuf,
+        iv: &DmaBuf,
         aad_len: usize,
-        tag: &[u8; 16],
-        ciphertext: &[u8],
-        plaintext: &mut [u8],
+        tag: &DmaBuf,
+        ciphertext: &DmaBuf,
+        plaintext: &mut DmaBuf,
     ) -> HsmResult<()>;
 
     /// AES-GCM decrypt in-place.
@@ -297,6 +365,7 @@ pub trait HsmAes {
     ///
     /// # Parameters
     ///
+    /// - `io` — caller's I/O context (per-IO scope).
     /// - `key` — AES key (16, 24, or 32 bytes for AES-128/192/256).
     /// - `iv` — 12-byte (96-bit) nonce used during encryption.
     /// - `aad_len` — **Unpadded** AAD length in bytes. Must match the
@@ -305,175 +374,255 @@ pub trait HsmAes {
     /// - `data` — `[padded_AAD | ciphertext]`; the text portion is
     ///   overwritten with plaintext.
     ///
-    /// # Errors
+    /// # Returns
     ///
-    /// Returns [`HsmError`] if the tag verification or decryption fails.
+    /// - `Ok(())` — tag verified, `data` text portion overwritten
+    ///   with plaintext.
+    /// - `Err(HsmError::InvalidArg)` — buffer-size violation or AAD
+    ///   layout malformed.
+    /// - `Err(HsmError::AesGcmTagMismatch)` — authentication tag
+    ///   does not match (`data` is left in an unspecified state).
+    /// - `Err(HsmError)` — AES driver failure.
     async fn gcm_decrypt_in_place(
         &self,
-        key: &[u8],
-        iv: &[u8; 12],
+        io: &impl HsmIo,
+        key: &DmaBuf,
+        iv: &DmaBuf,
         aad_len: usize,
-        tag: &[u8; 16],
-        data: &mut [u8],
+        tag: &DmaBuf,
+        data: &mut DmaBuf,
     ) -> HsmResult<()>;
 
     // ── AES Key Wrap (RFC 3394) ────────────────────────────────────
 
     /// AES Key Wrap (RFC 3394) — wrap key data.
     ///
-    /// Wraps `input` using the KEK `key`. The output includes an 8-byte
-    /// integrity check value (IV) prepended to the wrapped semiblocks.
+    /// Wraps `input` under the KEK `key`.  The output prepends the
+    /// 8-byte default integrity check value
+    /// `0xA6A6A6A6A6A6A6A6` to the wrapped semiblocks.
     ///
     /// # Parameters
     ///
-    /// - `key` — Key Encryption Key (16, 24, or 32 bytes).
-    /// - `input` — Key data to wrap. Must be ≥ 16 bytes, a multiple of 8,
-    ///   and at most 3072 bytes.
-    /// - `output` — Destination buffer. Must be at least `input.len() + 8`.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`HsmError::InvalidArg`] if input constraints are violated.
-    async fn aes_kw_wrap(&self, key: &[u8], input: &[u8], output: &mut [u8]) -> HsmResult<()>;
-
-    /// AES Key Wrap (RFC 3394) — unwrap key data.
-    ///
-    /// Unwraps `input` using the KEK `key` and verifies the integrity
-    /// check value. Returns an error if the IV does not match the
-    /// default 0xA6A6A6A6A6A6A6A6 (wrong key or tampered data).
-    ///
-    /// # Parameters
-    ///
-    /// - `key` — Key Encryption Key (16, 24, or 32 bytes).
-    /// - `input` — Wrapped key data. Must be ≥ 24 bytes, a multiple of 8,
-    ///   and at most 3080 bytes.
-    /// - `output` — Destination buffer. Must be at least `input.len() - 8`.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`HsmError::InvalidArg`] on bad input sizes.
-    /// Returns [`HsmError::AesUnwrapFailed`] on IV mismatch.
-    async fn aes_kw_unwrap(&self, key: &[u8], input: &[u8], output: &mut [u8]) -> HsmResult<()>;
-
-    // ── AES Key Wrap with Padding (RFC 5649) ───────────────────────
-
-    /// AES Key Wrap with Padding (RFC 5649) — wrap key data.
-    ///
-    /// Wraps `input` of any length (≥ 1 byte, ≤ 3072 bytes) using the
-    /// KEK `key`. Pads to an 8-byte boundary and uses an Alternative
-    /// Initial Value (AIV) that encodes the plaintext length.
-    ///
-    /// For padded input ≤ 8 bytes (1 semiblock), a single AES-ECB
-    /// encryption is used. Otherwise, delegates to AES-KW with the AIV.
-    ///
-    /// # Parameters
-    ///
-    /// - `key` — Key Encryption Key (16, 24, or 32 bytes).
-    /// - `input` — Key data to wrap (1..=3072 bytes, any alignment).
-    /// - `output` — Destination buffer. Must be at least
-    ///   `round_up_8(input.len()) + 8` bytes.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`HsmError::InvalidArg`] if input constraints are violated.
-    async fn aes_kwp_wrap(&self, key: &[u8], input: &[u8], output: &mut [u8]) -> HsmResult<()>;
-
-    /// AES Key Wrap with Padding (RFC 5649) — unwrap key data.
-    ///
-    /// Unwraps `input` and verifies the AIV (constant prefix + MLI).
-    /// Validates that padding bytes are all zero.
-    ///
-    /// # Parameters
-    ///
-    /// - `key` — Key Encryption Key (16, 24, or 32 bytes).
-    /// - `input` — Wrapped key data. Must be ≥ 16 bytes, a multiple of 8,
-    ///   and at most 3080 bytes.
-    /// - `output` — Destination buffer. Must be at least `input.len() - 8`.
+    /// - `io` — caller's I/O context (per-IO scope).
+    /// - `key` — Key Encryption Key (16 / 24 / 32 bytes).
+    /// - `input` — plaintext key material.  Must be ≥ 16 bytes,
+    ///   a multiple of 8, and at most 3072 bytes.
+    /// - `output` — destination; must be at least
+    ///   `input.len() + 8` bytes.
     ///
     /// # Returns
     ///
-    /// The actual plaintext length (MLI), which may be shorter than
-    /// `output.len()`.
+    /// - `Ok(())` — `output[..input.len() + 8]` populated.
+    /// - `Err(HsmError::InvalidArg)` — size or alignment
+    ///   constraints violated.
+    /// - `Err(HsmError)` — AES driver failure.
+    async fn aes_kw_wrap(
+        &self,
+        io: &impl HsmIo,
+        key: &DmaBuf,
+        input: &DmaBuf,
+        output: &mut DmaBuf,
+    ) -> HsmResult<()>;
+
+    /// AES Key Wrap (RFC 3394) — unwrap key data.
     ///
-    /// # Errors
+    /// Unwraps `input` under the KEK `key` and verifies the
+    /// integrity check value matches the default `0xA6A6…`.
     ///
-    /// Returns [`HsmError::InvalidArg`] on bad input sizes.
-    /// Returns [`HsmError::AesUnwrapFailed`] on AIV mismatch or bad padding.
-    async fn aes_kwp_unwrap(&self, key: &[u8], input: &[u8], output: &mut [u8])
-    -> HsmResult<usize>;
+    /// # Parameters
+    ///
+    /// - `io` — caller's I/O context (per-IO scope).
+    /// - `key` — Key Encryption Key (16 / 24 / 32 bytes).
+    /// - `input` — wrapped key data.  Must be ≥ 24 bytes,
+    ///   a multiple of 8, and at most 3080 bytes.
+    /// - `output` — destination; must be at least
+    ///   `input.len() - 8` bytes.
+    ///
+    /// # Returns
+    ///
+    /// - `Ok(())` — `output[..input.len() - 8]` populated.
+    /// - `Err(HsmError::InvalidArg)` — size or alignment
+    ///   constraints violated.
+    /// - `Err(HsmError::AesUnwrapFailed)` — IV mismatch (wrong
+    ///   key or tampered ciphertext).
+    /// - `Err(HsmError)` — AES driver failure.
+    async fn aes_kw_unwrap(
+        &self,
+        io: &impl HsmIo,
+        key: &DmaBuf,
+        input: &DmaBuf,
+        output: &mut DmaBuf,
+    ) -> HsmResult<()>;
+
+    // ── AES Key Wrap with Padding (RFC 5649) ───────────────────────
+
+    /// AES Key Wrap with Padding (RFC 5649) — wrap key data of any
+    /// length.
+    ///
+    /// Pads `input` to an 8-byte boundary and uses an Alternative
+    /// Initial Value (AIV) that encodes the plaintext length.
+    /// Padded payloads of one semiblock use a single AES-ECB pass;
+    /// longer payloads delegate to AES-KW with the AIV.
+    ///
+    /// # Parameters
+    ///
+    /// - `io` — caller's I/O context (per-IO scope).
+    /// - `key` — Key Encryption Key (16 / 24 / 32 bytes).
+    /// - `input` — plaintext (1..=3072 bytes, any alignment).
+    /// - `output` — destination; must be at least
+    ///   `round_up_8(input.len()) + 8` bytes.
+    ///
+    /// # Returns
+    ///
+    /// - `Ok(())` — wrapped output populated.
+    /// - `Err(HsmError::InvalidArg)` — size constraints violated.
+    /// - `Err(HsmError)` — AES driver failure.
+    async fn aes_kwp_wrap(
+        &self,
+        io: &impl HsmIo,
+        key: &DmaBuf,
+        input: &DmaBuf,
+        output: &mut DmaBuf,
+    ) -> HsmResult<()>;
+
+    /// AES Key Wrap with Padding (RFC 5649) — unwrap key data.
+    ///
+    /// Verifies the AIV (constant prefix + Message Length
+    /// Indicator) and that all trailing pad bytes are zero.
+    ///
+    /// # Parameters
+    ///
+    /// - `io` — caller's I/O context (per-IO scope).
+    /// - `key` — Key Encryption Key (16 / 24 / 32 bytes).
+    /// - `input` — wrapped key data.  Must be ≥ 16 bytes, a
+    ///   multiple of 8, and at most 3080 bytes.
+    /// - `output` — destination; must be at least
+    ///   `input.len() - 8` bytes.
+    ///
+    /// # Returns
+    ///
+    /// - `Ok(mli)` — the recovered plaintext length (the MLI from
+    ///   the AIV); `output[..mli]` is valid plaintext.
+    /// - `Err(HsmError::InvalidArg)` — size constraints violated.
+    /// - `Err(HsmError::AesUnwrapFailed)` — AIV mismatch or
+    ///   non-zero pad bytes.
+    /// - `Err(HsmError)` — AES driver failure.
+    async fn aes_kwp_unwrap(
+        &self,
+        io: &impl HsmIo,
+        key: &DmaBuf,
+        input: &DmaBuf,
+        output: &mut DmaBuf,
+    ) -> HsmResult<usize>;
 
     // ── AES-XTS (IEEE 1619 / NIST SP 800-38E) ─────────────────────
 
-    /// Generate a random AES-256-XTS key pair (K1 || K2).
+    /// Generate a random AES-256-XTS key (`K1 || K2`).
     ///
-    /// Fills `key` with 64 random bytes and verifies K1 ≠ K2.
+    /// Fills `key` with 64 random bytes and ensures `K1 ≠ K2` (XTS
+    /// requires distinct halves; the standard prohibits a tweak
+    /// degenerate case).
     ///
     /// # Parameters
-    /// - `key` — Output buffer. Must be exactly 64 bytes.
     ///
-    /// # Errors
-    /// Returns [`HsmError::InvalidArg`] if `key.len() != 64`.
-    async fn aes_xts_gen_key(&self, key: &mut [u8]) -> HsmResult<()>;
+    /// - `io` — caller's I/O context (per-IO scope).
+    /// - `key` — output buffer; must be exactly 64 bytes.
+    ///
+    /// # Returns
+    ///
+    /// - `Ok(())` — `key` populated, `K1 ≠ K2`.
+    /// - `Err(HsmError::InvalidArg)` — `key.len() != 64`.
+    /// - `Err(HsmError)` — propagated from the CSPRNG.
+    async fn aes_xts_gen_key(&self, io: &impl HsmIo, key: &mut [u8]) -> HsmResult<()>;
 
-    /// AES-XTS encrypt with separate input/output buffers.
+    /// AES-XTS encrypt with separate input / output buffers
+    /// (IEEE 1619 / NIST SP 800-38E).
     ///
     /// # Parameters
-    /// - `key` — XTS key (64 bytes: K1\[32\] || K2\[32\]).
-    /// - `tweak` — 8-byte tweak (sector number, little-endian).
-    /// - `dul` — Data unit length mode.
-    /// - `input` — Plaintext. Must be ≥ 16 bytes, a multiple of 16,
-    ///   and a multiple of `dul` (when not [`XtsDataUnitLen::Full`]).
-    /// - `output` — Ciphertext buffer. Must be at least `input.len()`.
     ///
-    /// # Errors
-    /// Returns [`HsmError::InvalidArg`] on invalid key/tweak/input sizes.
+    /// - `io` — caller's I/O context (per-IO scope).
+    /// - `key` — XTS key, exactly 64 bytes (`K1[32] || K2[32]`).
+    /// - `tweak` — 8-byte tweak (typically a little-endian sector
+    ///   number).
+    /// - `dul` — data-unit length selector; controls how the
+    ///   tweak is incremented.
+    /// - `input` — plaintext.  Must be ≥ 16 bytes, a multiple of
+    ///   16, and a multiple of `dul.bytes()` when `dul` is not
+    ///   [`XtsDataUnitLen::Full`].
+    /// - `output` — destination; must be at least
+    ///   `input.len()` bytes.
+    ///
+    /// # Returns
+    ///
+    /// - `Ok(())` — `output[..input.len()]` populated.
+    /// - `Err(HsmError::InvalidArg)` — size or alignment
+    ///   violation, or `K1 == K2`.
+    /// - `Err(HsmError)` — AES driver failure.
     async fn aes_xts_encrypt(
         &self,
-        key: &[u8],
-        tweak: &[u8],
+        io: &impl HsmIo,
+        key: &DmaBuf,
+        tweak: &DmaBuf,
         dul: XtsDataUnitLen,
-        input: &[u8],
-        output: &mut [u8],
+        input: &DmaBuf,
+        output: &mut DmaBuf,
     ) -> HsmResult<()>;
 
-    /// AES-XTS decrypt with separate input/output buffers.
+    /// AES-XTS decrypt with separate input / output buffers.
     ///
-    /// Same parameters and constraints as
-    /// [`aes_xts_encrypt`](Self::aes_xts_encrypt).
+    /// Parameter and return semantics match
+    /// [`aes_xts_encrypt`](Self::aes_xts_encrypt) with the
+    /// direction reversed; `input` is ciphertext and `output`
+    /// receives plaintext.
     async fn aes_xts_decrypt(
         &self,
-        key: &[u8],
-        tweak: &[u8],
+        io: &impl HsmIo,
+        key: &DmaBuf,
+        tweak: &DmaBuf,
         dul: XtsDataUnitLen,
-        input: &[u8],
-        output: &mut [u8],
+        input: &DmaBuf,
+        output: &mut DmaBuf,
     ) -> HsmResult<()>;
 
     /// AES-XTS encrypt in-place.
     ///
     /// # Parameters
-    /// - `key` — XTS key (64 bytes: K1\[32\] || K2\[32\]).
-    /// - `tweak` — 8-byte tweak (sector number, little-endian).
-    /// - `dul` — Data unit length mode.
-    /// - `data` — Buffer holding plaintext; overwritten with ciphertext.
-    ///   Must be ≥ 16 bytes, a multiple of 16, and a multiple of `dul`.
+    ///
+    /// - `io` — caller's I/O context (per-IO scope).
+    /// - `key` — XTS key, exactly 64 bytes (`K1[32] || K2[32]`).
+    /// - `tweak` — 8-byte tweak.
+    /// - `dul` — data-unit length selector.
+    /// - `data` — plaintext on entry, ciphertext on return; must
+    ///   be ≥ 16 bytes, a multiple of 16, and a multiple of
+    ///   `dul.bytes()` when `dul` is not [`XtsDataUnitLen::Full`].
+    ///
+    /// # Returns
+    ///
+    /// - `Ok(())` — `data` overwritten with ciphertext.
+    /// - `Err(HsmError::InvalidArg)` — size or alignment
+    ///   violation, or `K1 == K2`.
+    /// - `Err(HsmError)` — AES driver failure.
     async fn aes_xts_encrypt_in_place(
         &self,
-        key: &[u8],
-        tweak: &[u8],
+        io: &impl HsmIo,
+        key: &DmaBuf,
+        tweak: &DmaBuf,
         dul: XtsDataUnitLen,
-        data: &mut [u8],
+        data: &mut DmaBuf,
     ) -> HsmResult<()>;
 
     /// AES-XTS decrypt in-place.
     ///
-    /// Same parameters and constraints as
-    /// [`aes_xts_encrypt_in_place`](Self::aes_xts_encrypt_in_place).
+    /// Parameter and return semantics match
+    /// [`aes_xts_encrypt_in_place`](Self::aes_xts_encrypt_in_place)
+    /// with the direction reversed; `data` holds ciphertext on
+    /// entry and plaintext on return.
     async fn aes_xts_decrypt_in_place(
         &self,
-        key: &[u8],
-        tweak: &[u8],
+        io: &impl HsmIo,
+        key: &DmaBuf,
+        tweak: &DmaBuf,
         dul: XtsDataUnitLen,
-        data: &mut [u8],
+        data: &mut DmaBuf,
     ) -> HsmResult<()>;
 }

--- a/fw/pal/traits/src/crypto/ecc.rs
+++ b/fw/pal/traits/src/crypto/ecc.rs
@@ -91,101 +91,147 @@ impl HsmEccCurve {
     }
 }
 
-/// ECC Pairwise Consistency Test (PCT) type used to indicate which
-/// operation should be exercised in a self-test: none, signing, or key
-/// agreement.
+/// ECC Pairwise Consistency Test (PCT) mode for key generation.
+///
+/// FIPS 140-3 requires a PCT after key generation to verify the key
+/// pair is functional.  The variant selects which operation is used
+/// for verification, or skips the test entirely.
 pub enum HsmEccPct {
+    /// No PCT — skip the consistency test.
     None,
+
+    /// Sign / verify round-trip with the freshly generated key pair.
     SignVerify,
+
+    /// ECDH key-agreement self-test against a known public-key
+    /// counterpart.
     KeyAgreement,
 }
 
-/// Asynchronous ECC operations trait.
+/// Asynchronous ECC operations.
 ///
-/// PAL implementations provide this to the core for ECC key generation,
-/// signing, and verification. The async signatures allow hardware-backed
-/// implementations to yield while the PKA engine processes operations.
+/// PAL implementations provide this to core for ECC key generation,
+/// signing, verification, and ECDH.  The `async` signatures let
+/// hardware-backed implementations yield while the PKA engine runs.
 ///
-/// All key parameters are plain `&[u8]` byte slices containing
-/// DER-encoded key material (PKCS#8 for private keys, SPKI for public
-/// keys). Each PAL implementation is responsible for parsing them into
-/// whatever internal representation it needs.
+/// Key parameters are byte slices in raw `priv || pub_x || pub_y`
+/// format — not DER — sized per [`HsmEccCurve::priv_key_len`] /
+/// [`HsmEccCurve::pub_key_len`].
 pub trait HsmEcc {
-    /// Generate an ECC key pair on the specified curve.
+    /// Generates an ECC key pair on the chosen curve and writes
+    /// `priv_key || pub_key` contiguously into `key_out`.
     ///
-    /// Writes PKCS#8 DER private key into `priv_key` (pass `None` to
-    /// query size).  Writes raw public key coordinates (x ∥ y) into
-    /// `pub_key` — fixed size per curve: [`HsmEccCurve::pub_key_len`].
+    /// # Parameters
+    ///
+    /// - `io` — caller's I/O context (per-IO scope).
+    /// - `curve` — NIST curve selector.
+    /// - `key_out` — output buffer; must be at least
+    ///   `curve.priv_key_len() + curve.pub_key_len()` bytes.  On
+    ///   success, `key_out[..nsk]` holds the private scalar and
+    ///   `key_out[nsk..nsk+npk]` holds the uncompressed public point
+    ///   (`x || y`).
+    /// - `pct` — pairwise consistency test selector.
     ///
     /// # Returns
-    /// The actual private key DER length written.
     ///
-    /// # Parameters
-    /// - `curve` — The NIST curve to use for key generation.
-    /// - `priv_key` — `None` to query size, `Some(buf)` for PKCS#8 DER output.
-    /// - `pub_key` — Output buffer for raw coordinates (x ∥ y).  Must be
-    ///   at least [`HsmEccCurve::pub_key_len`] bytes.
-    /// - `pct` — Pairwise Consistency Test mode.
-    async fn ecc_gen_keypair(
+    /// - `Ok((priv_key, pub_key))` — borrowed views into `key_out`.
+    /// - `Err(HsmError::InvalidArg)` — `key_out` too small.
+    /// - `Err(HsmError)` — PKA / RNG / PCT failure.
+    async fn ecc_gen_keypair<'a>(
         &self,
+        io: &impl HsmIo,
         curve: HsmEccCurve,
-        priv_key: Option<&mut [u8]>,
-        pub_key: &mut [u8],
+        key_out: &'a mut DmaBuf,
         pct: HsmEccPct,
-    ) -> HsmResult<usize>;
+    ) -> HsmResult<(&'a DmaBuf, &'a DmaBuf)>;
 
-    /// Raw EC sign over a pre-computed hash digest.
+    /// Raw EC sign over a pre-computed message digest.
+    ///
+    /// The caller is responsible for hashing the message; this method
+    /// performs no hashing itself.
     ///
     /// # Parameters
-    /// - `priv_key` — The signing key.
-    /// - `hash` — Pre-computed hash digest to sign.
-    /// - `signature` — Output buffer for the signature. Must be at least
-    ///   [`HsmEccCurve::sig_len`] bytes.
     ///
-    /// # Errors
-    /// Returns [`HsmError`] if signing fails or the buffer is too small.
+    /// - `io` — caller's I/O context (per-IO scope).
+    /// - `curve` — NIST curve the private key is on.
+    /// - `priv_key` — signing key; must be exactly
+    ///   `curve.priv_key_len()` bytes.
+    /// - `hash` — message digest to sign.  Truncated or zero-padded
+    ///   internally if shorter/longer than the curve's order.
+    /// - `signature` — output buffer; must be at least
+    ///   `curve.sig_len()` bytes (`r || s`).
+    ///
+    /// # Returns
+    ///
+    /// - `Ok(())` — `signature[..sig_len]` populated.
+    /// - `Err(HsmError::InvalidArg)` — buffer-size mismatch.
+    /// - `Err(HsmError)` — PKA / RNG failure.
     async fn ecc_sign(
         &self,
+        io: &impl HsmIo,
         curve: HsmEccCurve,
-        priv_key: &[u8],
-        hash: &[u8],
-        signature: &mut [u8],
+        priv_key: &DmaBuf,
+        hash: &DmaBuf,
+        signature: &mut DmaBuf,
     ) -> HsmResult<()>;
 
-    /// Raw EC verify a signature over a pre-computed hash digest.
+    /// Raw EC verify of `signature` against a pre-computed message
+    /// digest.
     ///
     /// # Parameters
-    /// - `pub_key` — The verification key.
-    /// - `curve` — The NIST curve that the key was generated on (P-256,
-    ///   P-384, or P-521). Used to determine the expected signature length.
-    /// - `hash` — Pre-computed hash digest that was signed.
-    /// - `signature` — The signature to verify.
+    ///
+    /// - `io` — caller's I/O context (per-IO scope).
+    /// - `curve` — NIST curve the public key is on; determines the
+    ///   expected signature length.
+    /// - `pub_key` — verification key; uncompressed `x || y`,
+    ///   `curve.pub_key_len()` bytes.
+    /// - `hash` — message digest that was signed.
+    /// - `signature` — signature to verify; must be exactly
+    ///   `curve.sig_len()` bytes.
     ///
     /// # Returns
-    /// `true` if the signature is valid, `false` otherwise.
+    ///
+    /// - `Ok(true)` — signature is valid.
+    /// - `Ok(false)` — signature is invalid (not an error).
+    /// - `Err(HsmError::InvalidArg)` — buffer-size mismatch or
+    ///   malformed public key.
+    /// - `Err(HsmError)` — propagated from the PKA driver.
     async fn ecc_verify(
         &self,
+        io: &impl HsmIo,
         curve: HsmEccCurve,
-        pub_key: &[u8],
-        hash: &[u8],
-        signature: &[u8],
+        pub_key: &DmaBuf,
+        hash: &DmaBuf,
+        signature: &DmaBuf,
     ) -> HsmResult<bool>;
 
-    /// Perform ECDH key agreement to derive a shared secret.
+    /// ECDH key agreement: derives a shared secret from a local
+    /// private key and a remote public key.
     ///
     /// # Parameters
-    /// - `priv_key` — The local private key.
-    /// - `pub_key` — The remote party's public key.
-    /// - `secret` — Output for the derived shared secret.
     ///
-    /// # Errors
-    /// Returns [`HsmError`] if the key agreement operation fails (e.g., PKA
-    /// engine error, invalid public key point).
+    /// - `io` — caller's I/O context (per-IO scope).
+    /// - `curve` — NIST curve both keys are on.
+    /// - `priv_key` — local private scalar; must be exactly
+    ///   `curve.priv_key_len()` bytes.
+    /// - `pub_key` — remote uncompressed point; must be exactly
+    ///   `curve.pub_key_len()` bytes.
+    /// - `secret` — output buffer; must be at least
+    ///   `curve.secret_len()` bytes.  On success, holds the
+    ///   x-coordinate of the shared point.
+    ///
+    /// # Returns
+    ///
+    /// - `Ok(())` — `secret[..secret_len]` populated.
+    /// - `Err(HsmError::InvalidArg)` — buffer mismatch or invalid
+    ///   public-key point.
+    /// - `Err(HsmError)` — PKA driver failure.
     async fn ecdh_derive(
         &self,
+        io: &impl HsmIo,
         curve: HsmEccCurve,
-        priv_key: &[u8],
-        pub_key: &[u8],
-        secret: &mut [u8],
+        priv_key: &DmaBuf,
+        pub_key: &DmaBuf,
+        secret: &mut DmaBuf,
     ) -> HsmResult<()>;
 }

--- a/fw/pal/traits/src/crypto/hash.rs
+++ b/fw/pal/traits/src/crypto/hash.rs
@@ -3,7 +3,7 @@
 
 //! Cryptographic hash (digest) trait for the HSM PAL.
 //!
-//! Defines [`HsmHashAlgo`], [`HsmHashState`], and the [`HsmHash`] trait that PAL
+//! Defines [`HsmHashAlgo`] and the [`HsmHash`] trait that PAL
 //! implementations use to expose hardware-accelerated or software-backed hash
 //! computation.
 //!
@@ -64,13 +64,14 @@ impl HsmHashAlgo {
         }
     }
 
-    /// Minimum buffer size for [`HsmHashState`]: state + block.
+    /// Minimum buffer size for a multi-step hash context: state +
+    /// block.
     pub const fn hash_state_len(&self) -> usize {
         self.state_len() + self.block_len()
     }
 
-    /// Buffer size for `HsmHashState` in HMAC multi-step:
-    /// state + block (pending) + block (opad key).
+    /// Buffer size for a multi-step HMAC context: state + block
+    /// (pending) + block (opad key).
     pub const fn hmac_state_len(&self) -> usize {
         self.state_len() + self.block_len() * 2
     }
@@ -90,100 +91,146 @@ impl HsmHashAlgo {
     }
 }
 
-/// Caller-owned hash state buffer tagged with its algorithm.
+/// Asynchronous SHA digest interface.
 ///
-/// The buffer layout is `[state | block]`, where the first
-/// [`HsmHashAlgo::state_len`] bytes hold the SHA working variables and the next
-/// [`HsmHashAlgo::block_len`] bytes hold a partial block buffer.
-#[derive(Debug)]
-pub struct HsmHashState<'a> {
-    buf: &'a mut [u8],
-    algo: HsmHashAlgo,
-}
-
-impl<'a> HsmHashState<'a> {
-    /// Creates a new hash state wrapper.
-    pub fn new(algo: HsmHashAlgo, buf: &'a mut [u8]) -> Self {
-        debug_assert!(buf.len() >= algo.hash_state_len());
-        Self { buf, algo }
-    }
-
-    /// Returns the final digest bytes.
-    pub fn digest(&self) -> &[u8] {
-        &self.buf[..self.algo.digest_len()]
-    }
-
-    /// Returns the working-variable state portion of the buffer.
-    pub fn state(&self) -> &[u8] {
-        &self.buf[..self.algo.state_len()]
-    }
-
-    /// Returns the wrapped algorithm.
-    pub fn algo(&self) -> HsmHashAlgo {
-        self.algo
-    }
-
-    /// Returns the underlying buffer length.
-    pub fn len(&self) -> usize {
-        self.buf.len()
-    }
-
-    /// Returns whether the underlying buffer is empty.
-    pub fn is_empty(&self) -> bool {
-        self.buf.is_empty()
-    }
-
-    /// Consumes the wrapper and returns the underlying mutable buffer.
-    pub fn into_buf(self) -> &'a mut [u8] {
-        self.buf
-    }
-}
-
-/// Asynchronous hash computation trait.
+/// Implementations expose two complementary APIs:
+///
+/// - **One-shot** ([`hash`](Self::hash)) — entire message available up
+///   front; submitted to the engine in a single descriptor.
+/// - **Multi-step** ([`hash_begin`](Self::hash_begin) →
+///   [`hash_continue`](Self::hash_continue) … →
+///   [`hash_finish`](Self::hash_finish)) — message arrives in
+///   fragments; intermediate state lives in a PAL-allocated context.
+///
+/// All output digests can be requested in either NIST big-endian or
+/// byte-swapped little-endian order via the `big_endian` flag, to
+/// match what the next consumer (DDI response framing, KDF input,
+/// etc.) expects.
 pub trait HsmHash {
     /// Platform-specific multi-step hash context.
+    ///
+    /// Created by [`hash_begin`](Self::hash_begin) and consumed by
+    /// [`hash_finish`](Self::hash_finish).  Holds the intermediate
+    /// SHA working state and a single block's worth of pending
+    /// bytes; the underlying buffer is allocated from the
+    /// [`HsmScopedAlloc`] passed to `hash_begin`, so the context's
+    /// lifetime is bounded by that scope.
     type HashCtx<'a>
     where
         Self: 'a;
 
-    /// Compute a one-shot hash.
+    /// Computes a SHA digest in a single call.
     ///
     /// # Parameters
-    /// - `algo` — Hash algorithm.
-    /// - `data` — Input message.
-    /// - `digest` — Output buffer (≥ `algo.digest_len()` bytes).
-    /// - `big_endian` — If true, big-endian (NIST standard). If false, little-endian.
+    ///
+    /// - `io` — caller's I/O context (per-IO scope).
+    /// - `algo` — hash algorithm; selects the digest length and
+    ///   hardware mode.
+    /// - `data` — input message; any length, including zero.
+    /// - `digest` — output buffer; must be at least
+    ///   [`HsmHashAlgo::digest_len`] bytes.  Only the leading
+    ///   `digest_len` bytes are written.
+    /// - `big_endian` — `true` for NIST big-endian output, `false`
+    ///   for byte-swapped little-endian.
+    ///
+    /// # Returns
+    ///
+    /// - `Ok(())` — `digest[..digest_len]` populated.
+    /// - `Err(HsmError::InvalidArg)` — `digest` shorter than
+    ///   `algo.digest_len()` or `data.len()` exceeds the engine's
+    ///   length limit.
+    /// - `Err(HsmError)` — propagated from the SHA driver.
     async fn hash(
         &self,
+        io: &impl HsmIo,
         algo: HsmHashAlgo,
-        data: &[u8],
-        digest: &mut [u8],
+        data: &DmaBuf,
+        digest: &mut DmaBuf,
         big_endian: bool,
     ) -> HsmResult<()>;
 
-    /// Begin a multi-step hash.
+    /// Begins a multi-step hash.
+    ///
+    /// Allocates the working state buffer from `alloc` and returns a
+    /// fresh context with no bytes processed and an empty pending
+    /// region.
     ///
     /// # Parameters
-    /// - `algo` — Hash algorithm.
-    /// - `state` — Working state buffer (≥ `algo.hash_state_len()` bytes).
-    async fn hash_begin<'a>(
+    ///
+    /// - `io` — caller's I/O context (per-IO scope).
+    /// - `algo` — hash algorithm.
+    /// - `alloc` — scoped allocator used to back the
+    ///   [`Self::HashCtx`] state buffer; the returned context
+    ///   borrows from this allocator's scope.
+    ///
+    /// # Returns
+    ///
+    /// - `Ok(ctx)` — fresh hash context ready for
+    ///   [`hash_continue`](Self::hash_continue).
+    /// - `Err(HsmError::NotEnoughSpace)` — `alloc` cannot satisfy
+    ///   the state-buffer allocation
+    ///   ([`HsmHashAlgo::hash_state_len`] bytes).
+    fn hash_begin<'a>(
         &self,
+        io: &impl HsmIo,
         algo: HsmHashAlgo,
-        state: HsmHashState<'a>,
+        alloc: &'a impl HsmScopedAlloc,
     ) -> HsmResult<Self::HashCtx<'a>>
     where
         Self: 'a;
 
-    /// Feed arbitrary-length data into a multi-step hash.
+    /// Feeds bytes into the running hash.
     ///
-    /// Data is buffered internally. Full blocks are submitted to
-    /// hardware as they accumulate.
-    async fn hash_continue(&self, ctx: &mut Self::HashCtx<'_>, data: &[u8]) -> HsmResult<()>;
-
-    /// Finalize the hash and return the state buffer containing the digest.
-    async fn hash_finish<'a>(
+    /// Implementations buffer a partial trailing block internally
+    /// and submit full blocks to the engine as soon as they are
+    /// available; callers can pass arbitrary-length fragments,
+    /// including zero-length.
+    ///
+    /// # Parameters
+    ///
+    /// - `io` — caller's I/O context (per-IO scope).
+    /// - `ctx` — context returned by
+    ///   [`hash_begin`](Self::hash_begin).
+    /// - `data` — bytes to append to the running hash.
+    ///
+    /// # Returns
+    ///
+    /// - `Ok(())` on success.
+    /// - `Err(HsmError::InvalidArg)` — cumulative byte count
+    ///   overflows the engine's length field.
+    /// - `Err(HsmError)` — propagated from the SHA driver.
+    async fn hash_continue(
         &self,
-        ctx: Self::HashCtx<'a>,
+        io: &impl HsmIo,
+        ctx: &mut Self::HashCtx<'_>,
+        data: &DmaBuf,
+    ) -> HsmResult<()>;
+
+    /// Finalises the hash and writes the digest into `digest`.
+    ///
+    /// Consumes `ctx`; any pending bytes are flushed with SHA
+    /// auto-padding before the final block is submitted.
+    ///
+    /// # Parameters
+    ///
+    /// - `io` — caller's I/O context (per-IO scope).
+    /// - `ctx` — context to finalise (consumed).
+    /// - `digest` — output buffer; must be at least
+    ///   [`HsmHashAlgo::digest_len`] bytes.
+    /// - `big_endian` — `true` for NIST big-endian output, `false`
+    ///   for byte-swapped little-endian.
+    ///
+    /// # Returns
+    ///
+    /// - `Ok(())` — `digest[..digest_len]` populated.
+    /// - `Err(HsmError::InvalidArg)` — `digest` is shorter than
+    ///   `digest_len`.
+    /// - `Err(HsmError)` — propagated from the SHA driver.
+    async fn hash_finish(
+        &self,
+        io: &impl HsmIo,
+        ctx: Self::HashCtx<'_>,
+        digest: &mut DmaBuf,
         big_endian: bool,
-    ) -> HsmResult<HsmHashState<'a>>;
+    ) -> HsmResult<()>;
 }

--- a/fw/pal/traits/src/crypto/hmac.rs
+++ b/fw/pal/traits/src/crypto/hmac.rs
@@ -28,11 +28,11 @@
 //! [`hmac_begin`](HsmHmac::hmac_begin) /
 //! [`hmac_continue`](HsmHmac::hmac_continue) /
 //! [`hmac_finish`](HsmHmac::hmac_finish) (or
-//! [`hmac_finish_verify`](HsmHmac::hmac_finish_verify)). The caller
-//! provides an [`HsmHashState`] buffer of at least
-//! [`HsmHashAlgo::hmac_state_len`] bytes which the PAL uses to persist
-//! intermediate state between calls.
+//! [`hmac_finish_verify`](HsmHmac::hmac_finish_verify)). The PAL allocates
+//! the intermediate HMAC state from an [`HsmScopedAlloc`], matching the
+//! scoped-allocation pattern used by the hash API.
 
+use super::HsmScopedAlloc;
 use super::*;
 
 /// Asynchronous HMAC operations trait.
@@ -62,151 +62,211 @@ pub trait HsmHmac {
     ///
     /// # Parameters
     ///
-    /// - `algo` — hash algorithm that determines the recommended key
-    ///   size, though the actual key length is controlled by `key.len()`.
-    /// - `key` — output buffer filled with random key material. The
-    ///   buffer length determines the key size (e.g., 32 bytes for
-    ///   HMAC-SHA256, 48 for HMAC-SHA384, 64 for HMAC-SHA512).
+    /// - `io` — caller's I/O context (per-IO scope).
+    /// - `algo` — underlying hash algorithm; informational, used by
+    ///   PAL implementations that record key metadata.  The actual
+    ///   key length is determined by `key.len()`.
+    /// - `key` — output buffer; entire length is filled with random
+    ///   bytes.  Typical sizes are `algo.digest_len()`
+    ///   (32 / 48 / 64 bytes for SHA-256 / 384 / 512).
     ///
-    /// # Errors
+    /// # Returns
     ///
-    /// Returns [`HsmError`] if RNG fails or the PCT verification fails.
-    async fn hmac_gen_key(&self, algo: HsmHashAlgo, key: &mut [u8]) -> HsmResult<()>;
+    /// - `Ok(())` — `key` populated with `key.len()` random bytes.
+    /// - `Err(HsmError)` — propagated from the CSPRNG.
+    async fn hmac_gen_key(
+        &self,
+        io: &impl HsmIo,
+        algo: HsmHashAlgo,
+        key: &mut [u8],
+    ) -> HsmResult<()>;
 
     /// Compute an HMAC tag (sign) in a single call.
     ///
     /// # Parameters
     ///
-    /// - `algo` — hash algorithm (e.g. SHA-256, SHA-512).
-    /// - `key` — the HMAC key to use.
-    /// - `data` — input message to authenticate.
-    /// - `tag` — output buffer for the MAC tag. Must be at least
-    ///   [`HsmHashAlgo::digest_len`] bytes for the chosen algorithm.
-    /// - `state` — caller-owned buffer of at least
-    ///   [`HsmHashAlgo::hmac_state_len`] bytes for intermediate state.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`HsmError`] if the HMAC computation fails or `tag` is
-    /// too short.
-    async fn hmac_sign<'a>(
-        &self,
-        algo: HsmHashAlgo,
-        key: &[u8],
-        data: &[u8],
-        tag: &mut [u8],
-        state: HsmHashState<'a>,
-    ) -> HsmResult<()>
-    where
-        Self: 'a;
-
-    /// Verify an HMAC tag in a single call.
-    ///
-    /// # Parameters
-    ///
-    /// - `algo` — hash algorithm (e.g. SHA-256, SHA-512).
-    /// - `key` — the HMAC key to use.
-    /// - `data` — the message that was authenticated.
-    /// - `tag` — the MAC tag to verify against.
-    /// - `state` — caller-owned buffer of at least
-    ///   [`HsmHashAlgo::hmac_state_len`] bytes for intermediate state.
+    /// - `io` — caller's I/O context (per-IO scope).
+    /// - `algo` — underlying hash algorithm.
+    /// - `key` — HMAC key bytes; longer than `algo.block_len()`
+    ///   triggers an internal pre-hash to `algo.digest_len()`.
+    /// - `data` — message to authenticate.  Any length, including
+    ///   zero.
+    /// - `tag` — output buffer; must be at least
+    ///   `algo.digest_len()` bytes.  Only the leading `digest_len`
+    ///   bytes are written.
     ///
     /// # Returns
     ///
-    /// `true` if the tag is valid, `false` if it does not match.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`HsmError`] if the HMAC computation itself fails (distinct
-    /// from a tag mismatch, which returns `Ok(false)`).
-    async fn hmac_verify<'a>(
+    /// - `Ok(())` — `tag[..digest_len]` populated.
+    /// - `Err(HsmError::InvalidArg)` — `tag` shorter than
+    ///   `algo.digest_len()`.
+    /// - `Err(HsmError::NotEnoughSpace)` — internal scoped allocation
+    ///   cannot fit the HMAC state buffer.
+    /// - `Err(HsmError)` — SHA driver failure.
+    async fn hmac_sign(
         &self,
+        io: &impl HsmIo,
         algo: HsmHashAlgo,
-        key: &[u8],
-        data: &[u8],
-        tag: &[u8],
-        state: HsmHashState<'a>,
-    ) -> HsmResult<bool>
-    where
-        Self: 'a;
+        key: &DmaBuf,
+        data: &DmaBuf,
+        tag: &mut DmaBuf,
+    ) -> HsmResult<()>;
+
+    /// Verify an HMAC tag in a single call using constant-time
+    /// comparison.
+    ///
+    /// # Parameters
+    ///
+    /// - `io` — caller's I/O context (per-IO scope).
+    /// - `algo` — underlying hash algorithm.
+    /// - `key` — HMAC key (same key that produced the tag).
+    /// - `data` — message that was authenticated.
+    /// - `tag` — MAC tag to verify against.
+    ///
+    /// # Returns
+    ///
+    /// - `Ok(true)` — tag is valid.
+    /// - `Ok(false)` — tag does not match (not an error).
+    /// - `Err(HsmError::NotEnoughSpace)` — internal scoped allocation
+    ///   cannot fit the HMAC state buffer.
+    /// - `Err(HsmError)` — SHA driver failure.
+    async fn hmac_verify(
+        &self,
+        io: &impl HsmIo,
+        algo: HsmHashAlgo,
+        key: &DmaBuf,
+        data: &DmaBuf,
+        tag: &DmaBuf,
+    ) -> HsmResult<bool>;
 
     /// Begin a multi-step HMAC computation.
     ///
     /// Derives the inner (ipad) and outer (opad) keys from `key` per
-    /// RFC 2104 and submits the ipad block as the first SHA input.
+    /// RFC 2104, submits the ipad block as the first SHA input, and
+    /// stores the opad-keyed prefix in the returned context for use
+    /// at finalisation.
     ///
     /// # Parameters
     ///
-    /// - `algo` — hash algorithm.
-    /// - `key` — the HMAC key. Keys longer than `algo.block_len()` are
-    ///   first hashed to `algo.digest_len()` bytes.
-    /// - `state` — caller-owned buffer that must wrap at least
-    ///   [`HsmHashAlgo::hmac_state_len`] bytes. Layout:
-    ///   `[digest(state_len) | pending_block(block_len) | opad(block_len)]`.
+    /// - `io` — caller's I/O context (per-IO scope).
+    /// - `algo` — underlying hash algorithm.
+    /// - `key` — HMAC key bytes; keys longer than
+    ///   `algo.block_len()` are first hashed.
+    /// - `alloc` — scoped allocator backing
+    ///   [`Self::HmacCtx`]; the context borrows from this scope.
     ///
-    /// # Errors
+    /// # Returns
     ///
-    /// Returns [`HsmError`] if `state` is too small.
+    /// - `Ok(ctx)` — fresh HMAC context.
+    /// - `Err(HsmError::NotEnoughSpace)` — `alloc` cannot satisfy
+    ///   `algo.hmac_state_len()` bytes.
+    /// - `Err(HsmError)` — SHA driver failure during the ipad
+    ///   prelude.
     async fn hmac_begin<'a>(
         &self,
+        io: &impl HsmIo,
         algo: HsmHashAlgo,
-        key: &[u8],
-        state: HsmHashState<'a>,
+        key: &DmaBuf,
+        alloc: &'a impl HsmScopedAlloc,
     ) -> HsmResult<Self::HmacCtx<'a>>
     where
         Self: 'a;
 
-    /// Feed arbitrary-length data into the running HMAC computation.
+    /// Feed arbitrary-length data into a running HMAC.
     ///
-    /// May be called zero or more times between [`hmac_begin`](Self::hmac_begin)
-    /// and [`hmac_finish`](Self::hmac_finish). Internally buffers a partial
-    /// block and submits full blocks to the SHA engine.
+    /// May be called any number of times (including zero) between
+    /// [`hmac_begin`](Self::hmac_begin) and the chosen finaliser.
+    /// Implementations buffer a partial trailing block and submit
+    /// full blocks to the SHA engine as soon as they accumulate.
     ///
     /// # Parameters
     ///
-    /// - `ctx` — the HMAC context returned by [`hmac_begin`](Self::hmac_begin).
+    /// - `io` — caller's I/O context (per-IO scope).
+    /// - `ctx` — context returned by
+    ///   [`hmac_begin`](Self::hmac_begin).
     /// - `data` — message bytes to append.
-    async fn hmac_continue(&self, ctx: &mut Self::HmacCtx<'_>, data: &[u8]) -> HsmResult<()>;
-
-    /// Finalize the inner hash and compute the outer hash to produce the
-    /// HMAC tag. Consumes the context.
     ///
     /// # Returns
     ///
-    /// An [`HsmHashState`] whose [`digest()`](HsmHashState::digest) slice
-    /// contains the final MAC tag.
-    async fn hmac_finish<'a>(&self, ctx: Self::HmacCtx<'a>) -> HsmResult<HsmHashState<'a>>;
+    /// - `Ok(())` on success.
+    /// - `Err(HsmError)` — SHA driver failure.
+    async fn hmac_continue(
+        &self,
+        io: &impl HsmIo,
+        ctx: &mut Self::HmacCtx<'_>,
+        data: &DmaBuf,
+    ) -> HsmResult<()>;
 
-    /// Finalize the HMAC and write the tag directly to `dest`.
-    ///
-    /// Like [`hmac_finish`](Self::hmac_finish), but the SHA hardware DMA
-    /// writes the outer hash digest straight into `dest` instead of the
-    /// context's state buffer. This avoids a `copy_from_slice` when the
-    /// caller needs the tag in a separate output buffer (e.g. KDF
-    /// iterations).
+    /// Finalise the inner hash, compute the outer hash, and write
+    /// the resulting tag into `tag`.  Consumes `ctx`.
     ///
     /// # Parameters
     ///
-    /// - `ctx` — the HMAC context to finalize (consumed).
-    /// - `dest` — output buffer of at least
-    ///   [`HsmHashAlgo::digest_len`] bytes.
-    async fn hmac_finish_into(&self, ctx: Self::HmacCtx<'_>, dest: &mut [u8]) -> HsmResult<()>;
-
-    /// Finalize and verify the MAC tag against `tag` using hardware
-    /// constant-time comparison. Consumes the context.
-    ///
-    /// # Parameters
-    ///
-    /// - `ctx` — the HMAC context to finalize.
-    /// - `tag` — the expected MAC tag to compare against.
+    /// - `io` — caller's I/O context (per-IO scope).
+    /// - `ctx` — context to finalise (consumed).
+    /// - `tag` — output buffer; must be at least
+    ///   `algo.digest_len()` bytes.  Only the leading `digest_len`
+    ///   bytes are written.
     ///
     /// # Returns
     ///
-    /// `true` if the computed tag matches, `false` otherwise.
+    /// - `Ok(())` — `tag[..digest_len]` populated.
+    /// - `Err(HsmError::InvalidArg)` — `tag` too short.
+    /// - `Err(HsmError)` — SHA driver failure.
+    async fn hmac_finish(
+        &self,
+        io: &impl HsmIo,
+        ctx: Self::HmacCtx<'_>,
+        tag: &mut DmaBuf,
+    ) -> HsmResult<()>;
+
+    /// Finalise the HMAC and write the tag directly to `dest`.
     ///
-    /// # Errors
+    /// Identical to [`hmac_finish`](Self::hmac_finish) except the
+    /// SHA hardware DMA writes the outer-hash digest straight into
+    /// `dest` rather than into the context's state buffer.  This
+    /// elides a `copy_from_slice` when the caller already has a
+    /// destination in mind (e.g. KDF iterations).
     ///
-    /// Returns [`HsmError`] if the HMAC computation itself fails (distinct
-    /// from a tag mismatch, which returns `Ok(false)`).
-    async fn hmac_finish_verify(&self, ctx: Self::HmacCtx<'_>, tag: &[u8]) -> HsmResult<bool>;
+    /// # Parameters
+    ///
+    /// - `io` — caller's I/O context (per-IO scope).
+    /// - `ctx` — context to finalise (consumed).
+    /// - `dest` — destination buffer; must be at least
+    ///   `algo.digest_len()` bytes.  Only the leading `digest_len`
+    ///   bytes are written.
+    ///
+    /// # Returns
+    ///
+    /// - `Ok(())` — `dest[..digest_len]` populated.
+    /// - `Err(HsmError::InvalidArg)` — `dest` too short.
+    /// - `Err(HsmError)` — SHA driver failure.
+    async fn hmac_finish_into(
+        &self,
+        io: &impl HsmIo,
+        ctx: Self::HmacCtx<'_>,
+        dest: &mut DmaBuf,
+    ) -> HsmResult<()>;
+
+    /// Finalise and verify the running HMAC against an expected
+    /// `tag` using hardware constant-time comparison.  Consumes
+    /// `ctx`.
+    ///
+    /// # Parameters
+    ///
+    /// - `io` — caller's I/O context (per-IO scope).
+    /// - `ctx` — context to finalise (consumed).
+    /// - `tag` — expected MAC tag.
+    ///
+    /// # Returns
+    ///
+    /// - `Ok(true)` — tag matches.
+    /// - `Ok(false)` — tag does not match (not an error).
+    /// - `Err(HsmError)` — SHA driver failure.
+    async fn hmac_finish_verify(
+        &self,
+        io: &impl HsmIo,
+        ctx: Self::HmacCtx<'_>,
+        tag: &DmaBuf,
+    ) -> HsmResult<bool>;
 }

--- a/fw/pal/traits/src/crypto/kdf.rs
+++ b/fw/pal/traits/src/crypto/kdf.rs
@@ -36,8 +36,9 @@
 //! | X9.63 KDF (SEC 1 §3.6.1) | `Z \|\| counter \|\| SharedInfo` |
 //! | SP 800-56A one-step | `counter \|\| Z \|\| OtherInfo` |
 //!
-//! All three accept a caller-owned state buffer sized by
-//! [`HsmHashAlgo::mgf1_state_len`] (or the corresponding KDF variant).
+//! All three allocate their internal working state from an
+//! [`HsmScopedAlloc`] sized by [`HsmHashAlgo::mgf1_state_len`] (or the
+//! corresponding KDF variant).
 //!
 //! ## HKDF (RFC 5869)
 //!
@@ -49,22 +50,20 @@
 //!   from a PRK + info context.
 //!
 //! This split supports protocols (e.g., TLS 1.3) that perform one extract
-//! followed by multiple expands with different info values. Both methods
-//! accept an [`HsmKdfState`] of at least [`HsmHashAlgo::hmac_state_len`]
-//! bytes as working space.
+//! followed by multiple expands with different info values. The HMAC-backed
+//! methods allocate their internal working state from an [`HsmScopedAlloc`].
 
 use super::*;
 
-/// Caller-owned working buffer for KDF operations.
+/// Buffer-backed working state for PAL-internal KDF helpers.
 ///
-/// A zero-cost newtype over `&mut [u8]` that provides type safety —
-/// prevents accidentally passing an unrelated buffer where a KDF
-/// state is expected. Unlike [`HsmHashState`], this carries no
-/// algorithm tag; the algorithm is passed separately to each KDF
-/// method.
+/// A zero-cost newtype over `&mut [u8]` that provides type safety when
+/// a PAL needs to manage concatenation-KDF scratch space explicitly.
+/// Public [`HsmKdf`] methods allocate their working state from an
+/// [`HsmScopedAlloc`], but this wrapper remains available for buffer-
+/// backed helper code.
 ///
 /// Size requirements depend on the KDF:
-/// - HKDF / SP 800-108: [`HsmHashAlgo::hmac_state_len`] bytes.
 /// - MGF1: [`HsmHashAlgo::mgf1_state_len`] bytes.
 /// - X9.63 / SP 800-56A: [`HsmHashAlgo::concat_kdf_state_len`] bytes.
 #[repr(transparent)]
@@ -72,7 +71,7 @@ use super::*;
 pub struct HsmKdfState<'a>(&'a mut [u8]);
 
 impl<'a> HsmKdfState<'a> {
-    /// Wrap a caller-owned byte slice as KDF working state.
+    /// Wrap a caller-owned byte slice as buffer-backed KDF state.
     pub fn new(buf: &'a mut [u8]) -> Self {
         Self(buf)
     }
@@ -100,40 +99,40 @@ impl<'a> HsmKdfState<'a> {
 /// KDF algorithms. The async signatures allow hardware-backed
 /// implementations to yield while the hash/HMAC engine processes data.
 pub trait HsmKdf {
-    /// HKDF-Extract (RFC 5869 §2.2) — condense IKM + salt into a PRK.
+    /// HKDF-Extract (RFC 5869 §2.2): condense `ikm` and `salt` into
+    /// a fixed-length pseudorandom key.
     ///
     /// `PRK = HMAC-Hash(salt, IKM)`
     ///
     /// # Parameters
     ///
-    /// - `algo` — the underlying hash algorithm (e.g. SHA-256).
-    /// - `salt` — optional salt value. Pass `&[]` to use the default
-    ///   salt (a string of zero bytes of hash length).
+    /// - `io` — caller's I/O context (per-IO scope).
+    /// - `algo` — underlying hash algorithm (e.g. SHA-256).
+    /// - `salt` — optional salt; `&[]` selects the RFC 5869 default
+    ///   (a string of zero bytes of `algo.digest_len()`).
     /// - `ikm` — input keying material.
-    /// - `prk` — output buffer for the pseudorandom key. Must be at
-    ///   least [`HsmHashAlgo::digest_len`] bytes.
-    /// - `state` — caller-owned working buffer. Must wrap at least
-    ///   [`HsmHashAlgo::hmac_state_len`] bytes.
+    /// - `prk` — output PRK; must be at least `algo.digest_len()`
+    ///   bytes.  Only the leading `digest_len` bytes are written.
     ///
     /// # Returns
     ///
-    /// The `state` buffer, returned for reuse in subsequent calls
-    /// (e.g. [`hkdf_expand`](Self::hkdf_expand)).
-    ///
-    /// # Errors
-    ///
-    /// Returns [`HsmError`] if `prk` is too short, `state` is too
-    /// small, or the HMAC operation fails.
-    async fn hkdf_extract<'a>(
+    /// - `Ok(())` — `prk[..digest_len]` populated.
+    /// - `Err(HsmError::InvalidArg)` — `prk` shorter than
+    ///   `algo.digest_len()`.
+    /// - `Err(HsmError::NotEnoughSpace)` — internal scoped allocation too
+    ///   small for the HMAC state.
+    /// - `Err(HsmError)` — SHA / HMAC driver failure.
+    async fn hkdf_extract(
         &self,
+        io: &impl HsmIo,
         algo: HsmHashAlgo,
-        salt: &[u8],
-        ikm: &[u8],
-        prk: &mut [u8],
-        state: HsmKdfState<'a>,
-    ) -> HsmResult<HsmKdfState<'a>>;
+        salt: &DmaBuf,
+        ikm: &DmaBuf,
+        prk: &mut DmaBuf,
+    ) -> HsmResult<()>;
 
-    /// HKDF-Expand (RFC 5869 §2.3) — derive OKM from a PRK.
+    /// HKDF-Expand (RFC 5869 §2.3): derive arbitrary-length output
+    /// key material from a PRK.
     ///
     /// ```text
     /// T(0) = empty
@@ -143,174 +142,172 @@ pub trait HsmKdf {
     ///
     /// # Parameters
     ///
-    /// - `algo` — the underlying hash algorithm.
-    /// - `prk` — pseudorandom key from [`hkdf_extract`](Self::hkdf_extract).
-    /// - `info` — context and application-specific info. Pass `&[]` if
-    ///   not needed.
-    /// - `output` — buffer for the derived output key material (OKM).
-    ///   Length must not exceed `255 * digest_len`.
-    /// - `state` — caller-owned working buffer. Must wrap at least
-    ///   [`HsmHashAlgo::hmac_state_len`] bytes.
+    /// - `io` — caller's I/O context (per-IO scope).
+    /// - `algo` — underlying hash algorithm.
+    /// - `prk` — PRK from
+    ///   [`hkdf_extract`](Self::hkdf_extract).
+    /// - `info` — context / application info; `&[]` to omit.
+    /// - `output` — OKM destination; `output.len()` must satisfy
+    ///   `output.len() <= 255 * algo.digest_len()`.
     ///
     /// # Returns
     ///
-    /// The `state` buffer, returned for reuse in subsequent expand calls.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`HsmError`] if `output` exceeds the RFC limit, `state`
-    /// is too small, or the HMAC operation fails.
-    async fn hkdf_expand<'a>(
+    /// - `Ok(())` — `output` filled with `output.len()` bytes of OKM.
+    /// - `Err(HsmError::InvalidArg)` — `output` exceeds the RFC 5869
+    ///   length cap.
+    /// - `Err(HsmError::NotEnoughSpace)` — internal scoped allocation too
+    ///   small.
+    /// - `Err(HsmError)` — SHA / HMAC driver failure.
+    async fn hkdf_expand(
         &self,
+        io: &impl HsmIo,
         algo: HsmHashAlgo,
-        prk: &[u8],
-        info: &[u8],
-        output: &mut [u8],
-        state: HsmKdfState<'a>,
-    ) -> HsmResult<HsmKdfState<'a>>;
+        prk: &DmaBuf,
+        info: &DmaBuf,
+        output: &mut DmaBuf,
+    ) -> HsmResult<()>;
 
-    /// Derive key material using SP 800-108 KDF in Counter Mode with HMAC.
+    /// SP 800-108 Counter Mode KDF with HMAC PRF.
     ///
-    /// Uses HMAC as the PRF with an incrementing counter. The derived
-    /// output is computed as:
     /// `K(i) = HMAC(key, i ‖ label ‖ 0x00 ‖ context ‖ L)` for each
-    /// block `i`, where `L` is the requested output length in bits.
+    /// block `i`, with `L` the requested output length in bits.
     ///
     /// # Parameters
     ///
-    /// - `algo` — the HMAC hash algorithm (e.g. SHA-384).
-    /// - `key` — the key-derivation key (KDK).
-    /// - `label` — a string identifying the purpose of the derived key.
-    ///   Pass `&[]` if not needed.
-    /// - `context` — context information binding the derived key to a
-    ///   specific use. Pass `&[]` if not needed.
-    /// - `output` — buffer for the derived key material. The buffer
-    ///   length determines how many bytes are derived.
-    /// - `state` — caller-owned working buffer. Must wrap at least
-    ///   [`HsmHashAlgo::hmac_state_len`] bytes.
+    /// - `io` — caller's I/O context (per-IO scope).
+    /// - `algo` — HMAC underlying hash (e.g. SHA-384).
+    /// - `key` — key-derivation key (KDK).
+    /// - `label` — purpose string; `&[]` to omit.
+    /// - `context` — binding context; `&[]` to omit.
+    /// - `output` — derived-key destination; `output.len()` bytes
+    ///   are produced.
     ///
     /// # Returns
     ///
-    /// The `state` buffer, returned for reuse.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`HsmError`] if the KDF operation fails (e.g.,
-    /// unsupported algorithm, HMAC computation error).
-    async fn sp800_108_kdf<'a>(
+    /// - `Ok(())` — `output` filled.
+    /// - `Err(HsmError::InvalidArg)` — `output` exceeds the
+    ///   `2^32 - 1` block-counter limit.
+    /// - `Err(HsmError::NotEnoughSpace)` — internal scoped allocation too small.
+    /// - `Err(HsmError)` — SHA / HMAC driver failure.
+    async fn sp800_108_kdf(
         &self,
+        io: &impl HsmIo,
         algo: HsmHashAlgo,
-        key: &[u8],
-        label: &[u8],
-        context: &[u8],
-        output: &mut [u8],
-        state: HsmKdfState<'a>,
-    ) -> HsmResult<HsmKdfState<'a>>;
+        key: &DmaBuf,
+        label: &DmaBuf,
+        context: &DmaBuf,
+        output: &mut DmaBuf,
+    ) -> HsmResult<()>;
 
-    /// Compute MGF1 per [RFC 8017 §B.2.1](https://www.rfc-editor.org/rfc/rfc8017#appendix-B.2.1).
+    /// MGF1 mask generation per
+    /// [RFC 8017 §B.2.1](https://www.rfc-editor.org/rfc/rfc8017#appendix-B.2.1).
     ///
-    /// Expands `seed` into `mask.len()` bytes of mask material using
-    /// the specified hash algorithm:
+    /// Expands `seed` into `mask.len()` mask bytes:
     /// `T(C) = Hash(seed || I2OSP(C, 4))` for `C = 0, 1, …`.
     ///
     /// # Parameters
     ///
-    /// - `algo` — hash algorithm (e.g. SHA-256).
-    /// - `seed` — the MGF1 seed input.
-    /// - `mask` — output buffer; filled with `mask.len()` bytes of mask
-    ///   material.
-    /// - `state` — caller-owned working buffer. Must be at least
-    ///   [`HsmHashAlgo::mgf1_state_len`]`(seed.len())` bytes.
-    ///   Layout: `[hash(digest_len) | input(seed_len + 4)]`.
+    /// - `io` — caller's I/O context (per-IO scope).
+    /// - `algo` — hash algorithm.
+    /// - `seed` — MGF1 seed.
+    /// - `mask` — mask destination; `mask.len()` bytes are written.
     ///
-    /// # Errors
+    /// # Returns
     ///
-    /// Returns [`HsmError`] if `state` is too small or the underlying
-    /// hash operation fails.
+    /// - `Ok(())` — `mask` overwritten with mask material.
+    /// - `Err(HsmError::NotEnoughSpace)` — internal scoped allocation too small.
+    /// - `Err(HsmError)` — SHA driver failure.
     async fn mgf1(
         &self,
+        io: &impl HsmIo,
         algo: HsmHashAlgo,
-        seed: &[u8],
-        mask: &mut [u8],
-        state: &mut [u8],
+        seed: &DmaBuf,
+        mask: &mut DmaBuf,
     ) -> HsmResult<()>;
 
-    /// MGF1 with in-place XOR (RFC 8017 §B.2.1).
+    /// MGF1 with in-place XOR.
     ///
-    /// Like [`mgf1`](Self::mgf1) but instead of overwriting `mask`, each
-    /// generated mask byte is **XOR'd** into the existing content of
-    /// `mask`. This is the primitive needed by OAEP and PSS padding.
+    /// Identical to [`mgf1`](Self::mgf1), but each generated mask
+    /// byte is XOR'd into the existing content of `mask` rather than
+    /// overwriting it.  This is the primitive used by OAEP unmasking
+    /// and PSS encoding/verification.
     ///
     /// # Parameters
     ///
+    /// - `io` — caller's I/O context (per-IO scope).
     /// - `algo` — hash algorithm.
-    /// - `seed` — the MGF1 seed input.
-    /// - `mask` — buffer to XOR the generated mask into (in-place).
-    /// - `state` — caller-owned working buffer. Must be at least
-    ///   [`HsmHashAlgo::mgf1_state_len`]`(seed.len())` bytes.
+    /// - `seed` — MGF1 seed.
+    /// - `mask` — in-place buffer; XOR'd with `mask.len()` bytes of
+    ///   mask material.
+    ///
+    /// # Returns
+    ///
+    /// - `Ok(())` on success.
+    /// - `Err(HsmError::NotEnoughSpace)` — internal scoped allocation too small.
+    /// - `Err(HsmError)` — SHA driver failure.
     async fn mgf1_xor(
         &self,
+        io: &impl HsmIo,
         algo: HsmHashAlgo,
-        seed: &[u8],
-        mask: &mut [u8],
-        state: &mut [u8],
+        seed: &DmaBuf,
+        mask: &mut DmaBuf,
     ) -> HsmResult<()>;
 
-    /// Derive key material using X9.63 KDF (SEC 1 §3.6.1).
+    /// X9.63 KDF (SEC 1 §3.6.1) — the KDF used by ECIES variants
+    /// and CMS ECDH key wrap.
     ///
-    /// Expands shared secret `z` into `key.len()` bytes of key material:
-    /// `T(C) = Hash(Z || I2OSP(C, 4) || SharedInfo)` for `C = 1, 2, …`.
+    /// `T(C) = Hash(Z || I2OSP(C, 4) || SharedInfo)` for `C = 1, 2,
+    /// …`.
     ///
     /// # Parameters
     ///
-    /// - `algo` — hash algorithm (e.g. SHA-256).
-    /// - `z` — the shared secret (e.g. ECDH output).
-    /// - `shared_info` — optional shared info. Pass `&[]` to omit.
-    /// - `key` — output buffer; filled with `key.len()` bytes of derived
-    ///   key material.
-    /// - `state` — caller-owned working buffer. Must be at least
-    ///   [`HsmHashAlgo::concat_kdf_state_len`]`(z.len(), shared_info.len())`
-    ///   bytes. Layout: `[hash(digest_len) | input(z_len + 4 + info_len)]`.
+    /// - `io` — caller's I/O context (per-IO scope).
+    /// - `algo` — hash algorithm.
+    /// - `z` — shared secret (typically an ECDH x-coordinate).
+    /// - `shared_info` — SharedInfo octet string; `&[]` to omit.
+    /// - `key` — derived-key destination; `key.len()` bytes are
+    ///   written.
     ///
-    /// # Errors
+    /// # Returns
     ///
-    /// Returns [`HsmError`] if `state` is too small or the underlying
-    /// hash operation fails.
+    /// - `Ok(())` — `key` filled.
+    /// - `Err(HsmError::NotEnoughSpace)` — internal scoped allocation too small.
+    /// - `Err(HsmError)` — SHA driver failure.
     async fn x963_kdf(
         &self,
+        io: &impl HsmIo,
         algo: HsmHashAlgo,
-        z: &[u8],
-        shared_info: &[u8],
-        key: &mut [u8],
-        state: &mut [u8],
+        z: &DmaBuf,
+        shared_info: &DmaBuf,
+        key: &mut DmaBuf,
     ) -> HsmResult<()>;
 
-    /// Derive key material using SP 800-56A one-step Concatenation KDF.
+    /// SP 800-56A r3 §5.8.2.1 one-step concatenation KDF.
     ///
-    /// Expands shared secret `z` into `key.len()` bytes of key material:
-    /// `T(C) = Hash(I2OSP(C, 4) || Z || OtherInfo)` for `C = 1, 2, …`.
+    /// `T(C) = Hash(I2OSP(C, 4) || Z || OtherInfo)` for `C = 1, 2,
+    /// …`.  Differs from X9.63 only in field ordering (counter
+    /// first).
     ///
     /// # Parameters
     ///
-    /// - `algo` — hash algorithm (e.g. SHA-256).
-    /// - `z` — the shared secret (e.g. ECDH output).
-    /// - `other_info` — context information. Pass `&[]` to omit.
-    /// - `key` — output buffer; filled with `key.len()` bytes of derived
-    ///   key material.
-    /// - `state` — caller-owned working buffer. Must be at least
-    ///   [`HsmHashAlgo::concat_kdf_state_len`]`(z.len(), other_info.len())`
-    ///   bytes. Layout: `[hash(digest_len) | input(4 + z_len + info_len)]`.
+    /// - `io` — caller's I/O context (per-IO scope).
+    /// - `algo` — hash algorithm.
+    /// - `z` — shared secret.
+    /// - `other_info` — OtherInfo octet string; `&[]` to omit.
+    /// - `key` — derived-key destination; `key.len()` bytes are
+    ///   written.
     ///
-    /// # Errors
+    /// # Returns
     ///
-    /// Returns [`HsmError`] if `state` is too small or the underlying
-    /// hash operation fails.
+    /// - `Ok(())` — `key` filled.
+    /// - `Err(HsmError::NotEnoughSpace)` — internal scoped allocation too small.
+    /// - `Err(HsmError)` — SHA driver failure.
     async fn sp800_56a_kdf(
         &self,
+        io: &impl HsmIo,
         algo: HsmHashAlgo,
-        z: &[u8],
-        other_info: &[u8],
-        key: &mut [u8],
-        state: &mut [u8],
+        z: &DmaBuf,
+        other_info: &DmaBuf,
+        key: &mut DmaBuf,
     ) -> HsmResult<()>;
 }

--- a/fw/pal/traits/src/crypto/mod.rs
+++ b/fw/pal/traits/src/crypto/mod.rs
@@ -3,17 +3,36 @@
 
 //! Cryptographic primitives for the HSM PAL.
 //!
-//! This module bundles all crypto-related traits under the [`HsmCrypto`]
-//! supertrait. A PAL implementation must implement all constituent traits
-//! to satisfy the [`HsmPal`](super::HsmPal) bound.
+//! Bundles every crypto sub-trait under a single [`HsmCrypto`]
+//! supertrait.  PAL implementations satisfy the
+//! [`HsmPal`](super::HsmPal) bound by implementing each sub-trait
+//! and then writing an empty `impl HsmCrypto for MyPal {}`.
+//!
+//! ## Sub-traits
 //!
 //! | Trait | Purpose |
 //! |---|---|
 //! | [`HsmRng`] | Cryptographically secure random bytes |
-//! | [`HsmHash`] | SHA-1/256/384/512 digest computation |
-//! | [`HsmEcc`] | Elliptic curve key generation, signing, verification, and ECDH |
-//! | [`HsmHmac`] | HMAC computation using SHA-1/256/384/512 |
-//! | [`HsmKdf`] | KDF / MGF: HKDF, KBKDF, MGF1, X9.63, SP 800-56A |
+//! | [`HsmHash`] | SHA-1 / SHA-256 / SHA-384 / SHA-512 digest |
+//! | [`HsmHmac`] | HMAC sign / verify with the same SHA family |
+//! | [`HsmAes`] | AES key gen + ECB / CBC / GCM / KW / KWP / XTS |
+//! | [`HsmEcc`] | ECC key gen, raw EC sign / verify, ECDH (NIST P-256/384/521) |
+//! | [`HsmRsa`] | RSA key gen + raw mod-exp + PKCS#1 v1.5 / OAEP / PSS |
+//! | [`HsmKdf`] | HKDF, KBKDF (SP 800-108), MGF1, X9.63, SP 800-56A |
+//!
+//! ## Conventions
+//!
+//! Every method takes an `&impl HsmIo` handle to scope per-IO state
+//! (allocator scope, partition).  Hardware-backed methods are
+//! `async`; the only synchronous trait is [`HsmRng`] (RNG fills are
+//! sub-tick and never benefit from yielding).
+//!
+//! Output buffers are caller-supplied `&mut [u8]` with size contracts
+//! documented per method (typically derived from the algorithm or
+//! key-size selector enum).  Methods whose scratch escapes the call
+//! (for example, multi-step contexts) take an `&'a impl HsmScopedAlloc`;
+//! one-shot helpers may allocate scoped scratch internally and free it
+//! before they return.
 
 mod aes;
 mod ecc;
@@ -33,8 +52,11 @@ pub use rsa::*;
 
 use super::*;
 
-/// Composite crypto trait — requires all crypto sub-traits.
+/// Aggregate crypto trait — supertrait of every other crypto trait
+/// in this module.
 ///
-/// Implementations are typically empty (`impl HsmCrypto for MyPal {}`)
-/// since this trait only bundles the sub-trait bounds.
+/// Implementations are typically empty (`impl HsmCrypto for MyPal
+/// {}`) since this trait only bundles the sub-trait bounds.  Adding
+/// a new crypto family means adding a sub-trait here and a method
+/// table to the standard PAL.
 pub trait HsmCrypto: HsmRng + HsmHash + HsmHmac + HsmAes + HsmEcc + HsmRsa + HsmKdf {}

--- a/fw/pal/traits/src/crypto/rng.rs
+++ b/fw/pal/traits/src/crypto/rng.rs
@@ -1,28 +1,39 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-//! Cryptographically secure random number generation trait for the HSM PAL.
+//! Cryptographically secure random number generation trait.
 //!
-//! Defines the [`HsmRng`] trait that PAL implementations use to expose
-//! hardware or software CSPRNG. On Cortex-M7 hardware this would be
-//! backed by a TRNG peripheral; on the standard PAL it uses OpenSSL's
-//! `RAND_bytes`.
+//! Defines the [`HsmRng`] trait used by every PAL sub-component that
+//! needs random bytes — IV/nonce generation, ephemeral keys, PSS salts,
+//! masking blobs, etc.
+//!
+//! Implementations are backed by a hardware TRNG on the Cortex-M7
+//! target and OpenSSL `RAND_bytes` on the standard PAL.
 
 use super::super::*;
 
-/// Synchronous random number generation interface.
+/// Synchronous random-byte source.
 ///
-/// Unlike [`HsmHash`] and [`HsmEcc`], this is a synchronous trait — RNG
-/// fill is fast enough that yielding to the executor is unnecessary.
+/// Unlike [`super::HsmHash`] / [`super::HsmEcc`], this trait is
+/// **synchronous**: an RNG fill is fast enough (well below the
+/// scheduler tick) that there is no benefit to yielding.  Callers can
+/// use it from `async` and non-`async` contexts alike.
 pub trait HsmRng {
-    /// Fill `buf` with cryptographically secure random bytes.
+    /// Fills `buf` with cryptographically secure random bytes.
+    ///
+    /// Every byte of `buf` is overwritten on success; on error the
+    /// contents of `buf` are unspecified and must not be used.
     ///
     /// # Parameters
-    /// - `buf` — Output buffer to fill. All `buf.len()` bytes will be
-    ///   overwritten with random data on success.
     ///
-    /// # Errors
-    /// Returns [`HsmError`] if the CSPRNG fails (e.g., insufficient
-    /// entropy, hardware TRNG error).
-    fn rng_fill_bytes(&self, buf: &mut [u8]) -> HsmResult<()>;
+    /// - `io` — caller's I/O context (per-IO scope).
+    /// - `buf` — output buffer; entire length is filled with random
+    ///   data.  Zero-length is a no-op success.
+    ///
+    /// # Returns
+    ///
+    /// - `Ok(())` — `buf` populated with `buf.len()` random bytes.
+    /// - `Err(HsmError)` — propagated from the CSPRNG (TRNG hardware
+    ///   error, entropy starvation, OpenSSL `RAND_bytes` failure).
+    fn rng_fill_bytes(&self, io: &impl HsmIo, buf: &mut [u8]) -> HsmResult<()>;
 }

--- a/fw/pal/traits/src/crypto/rsa.rs
+++ b/fw/pal/traits/src/crypto/rsa.rs
@@ -30,6 +30,7 @@
 //! responsible for providing buffers of the correct size (key size in
 //! bytes for RSA operations).
 
+use super::HsmScopedAlloc;
 use super::*;
 
 // ── RSA key size ───────────────────────────────────────────────────
@@ -141,7 +142,7 @@ impl HsmRsaKey {
     pub const fn pss_work_len(&self, algo: HsmHashAlgo) -> usize {
         let k = self.modulus_len();
         let h_len = algo.digest_len();
-        k + algo.hash_state_len() + algo.mgf1_state_len(h_len)
+        k + algo.mgf1_state_len(h_len)
     }
 }
 
@@ -172,254 +173,380 @@ pub trait HsmRsa {
     /// Generate an RSA key pair.
     ///
     /// # Parameters
-    /// - `key_size` — RSA modulus size in bits (2048, 3072, or 4096).
-    /// - `priv_key` — Output buffer for the serialized private key.
-    /// - `pub_key` — Output buffer for the serialized public key.
-    /// - `pct` — Pairwise Consistency Test mode. When not [`HsmRsaPct::None`],
-    ///   a sign/verify or encrypt/decrypt round-trip is performed to
-    ///   validate the generated key pair (FIPS 140-3 requirement).
     ///
-    /// # Errors
-    /// Returns [`HsmError`] if key generation fails, or if the PCT
-    /// verification fails.
+    /// - `io` — caller's I/O context (per-IO scope).
+    /// - `key_size` — modulus size selector (2048 / 3072 / 4096).
+    /// - `priv_key` — destination for the serialized private key;
+    ///   length depends on `key_size` and CRT vs non-CRT layout.
+    /// - `pub_key` — destination for the serialized public key;
+    ///   length is `key_size.modulus_len()` plus the encoded
+    ///   exponent.
+    /// - `pct` — Pairwise Consistency Test selector.  When not
+    ///   [`HsmRsaPct::None`], a sign / verify or encrypt / decrypt
+    ///   round-trip is performed (FIPS 140-3 requirement).
+    ///
+    /// # Returns
+    ///
+    /// - `Ok(())` — both buffers populated.
+    /// - `Err(HsmError::InvalidArg)` — buffer-size mismatch.
+    /// - `Err(HsmError)` — PKA / RNG failure or PCT failed (the key
+    ///   pair is rejected).
     async fn ras_gen_keypair(
         &self,
+        io: &impl HsmIo,
         key_size: HsmRsaKey,
-        priv_key: &mut [u8],
-        pub_key: &mut [u8],
+        priv_key: &mut DmaBuf,
+        pub_key: &mut DmaBuf,
         pct: HsmRsaPct,
     ) -> Result<(), HsmError>;
 
     /// Private-key modular exponentiation: `x = y^d mod n`.
     ///
-    /// Used for RSA decryption and signing.
+    /// Used by RSA decryption and signing primitives.
     ///
     /// # Parameters
-    /// - `key` — The RSA private key.
-    /// - `y` — Input data (ciphertext for decryption, message hash for
-    ///   signing). Must be exactly the key size in bytes.
-    /// - `x` — Output buffer for the result. Must be exactly the key
-    ///   size in bytes.
     ///
-    /// # Errors
-    /// Returns [`HsmError`] if the exponentiation fails (e.g., PKA
-    /// engine error, invalid key).
+    /// - `io` — caller's I/O context (per-IO scope).
+    /// - `key_size` — modulus size selector.
+    /// - `key` — RSA private key in PAL-defined serialization
+    ///   matching `key_size.is_crt()`.
+    /// - `y` — input integer; must be exactly
+    ///   `key_size.modulus_len()` bytes.
+    /// - `x` — output integer; must be exactly
+    ///   `key_size.modulus_len()` bytes.
+    ///
+    /// # Returns
+    ///
+    /// - `Ok(())` — `x` populated.
+    /// - `Err(HsmError::InvalidArg)` — buffer-size mismatch.
+    /// - `Err(HsmError)` — PKA driver failure.
     async fn mod_exp_priv(
         &self,
+        io: &impl HsmIo,
         key_size: HsmRsaKey,
-        key: &[u8],
-        y: &[u8],
-        x: &mut [u8],
+        key: &DmaBuf,
+        y: &DmaBuf,
+        x: &mut DmaBuf,
     ) -> Result<(), HsmError>;
 
     /// Public-key modular exponentiation: `y = x^e mod n`.
     ///
-    /// Used for RSA encryption and signature verification.
+    /// Used by RSA encryption and signature-verification primitives.
     ///
     /// # Parameters
-    /// - `key` — The RSA public key.
-    /// - `x` — Input data (plaintext for encryption, signature for
-    ///   verification). Must be exactly the key size in bytes.
-    /// - `y` — Output buffer for the result. Must be exactly the key
-    ///   size in bytes.
     ///
-    /// # Errors
-    /// Returns [`HsmError`] if the exponentiation fails (e.g., PKA
-    /// engine error, invalid key).
+    /// - `io` — caller's I/O context (per-IO scope).
+    /// - `key_size` — modulus size selector.
+    /// - `key` — RSA public key.
+    /// - `x` — input integer; must be exactly
+    ///   `key_size.modulus_len()` bytes.
+    /// - `y` — output integer; must be exactly
+    ///   `key_size.modulus_len()` bytes.
+    ///
+    /// # Returns
+    ///
+    /// - `Ok(())` — `y` populated.
+    /// - `Err(HsmError::InvalidArg)` — buffer-size mismatch.
+    /// - `Err(HsmError)` — PKA driver failure.
     async fn mod_exp_pub(
         &self,
+        io: &impl HsmIo,
         key_size: HsmRsaKey,
-        key: &[u8],
-        x: &[u8],
-        y: &mut [u8],
+        key: &DmaBuf,
+        x: &DmaBuf,
+        y: &mut DmaBuf,
     ) -> Result<(), HsmError>;
 
     /// PKCS#1 v1.5 encrypt (EME-PKCS1-v1_5).
     ///
-    /// Pads `message` with random non-zero bytes per RFC 8017 §7.2.1, then
-    /// encrypts with the public key.
+    /// Pads `message` with random non-zero bytes per RFC 8017 §7.2.1
+    /// and encrypts under `pub_key`.
     ///
     /// # Parameters
     ///
+    /// - `io` — caller's I/O context (per-IO scope).
+    /// - `key_size` — modulus size selector.
     /// - `pub_key` — RSA public key.
-    /// - `message` — plaintext. Must satisfy `message.len() <= k - 11`.
-    /// - `output` — ciphertext output buffer. Must be at least `rsa_pkcs1_work_len(k)` bytes.
-    /// - `work` — scratch buffer. Must be at least `rsa_pkcs1_work_len(k)` bytes.
-    async fn rsa_pkcs1_encrypt(
+    /// - `message` — plaintext; must satisfy
+    ///   `message.len() <= key_size.max_pkcs1_message()`.
+    /// - `output` — ciphertext destination; must be at least
+    ///   `key_size.pkcs1_work_len()` bytes.
+    /// - `alloc` — scoped allocator for RSA scratch.
+    ///
+    /// # Returns
+    ///
+    /// - `Ok(())` — `output[..modulus_len]` populated.
+    /// - `Err(HsmError::InvalidArg)` — message too long or buffer
+    ///   too small.
+    /// - `Err(HsmError::NotEnoughSpace)` — allocator scope too
+    ///   small.
+    /// - `Err(HsmError)` — RNG / PKA failure.
+    async fn rsa_pkcs1_encrypt<'a>(
         &self,
+        io: &impl HsmIo,
         key_size: HsmRsaKey,
-        pub_key: &[u8],
-        message: &[u8],
-        output: &mut [u8],
-        work: &mut [u8],
-    ) -> HsmResult<()>;
+        pub_key: &DmaBuf,
+        message: &DmaBuf,
+        output: &mut DmaBuf,
+        alloc: &'a impl HsmScopedAlloc,
+    ) -> HsmResult<()>
+    where
+        Self: 'a;
 
     /// PKCS#1 v1.5 decrypt (EME-PKCS1-v1_5).
     ///
-    /// Decrypts `ciphertext` with the private key and removes padding.
+    /// Decrypts `ciphertext` under `priv_key` and strips PKCS#1 v1.5
+    /// padding.
     ///
     /// # Parameters
     ///
+    /// - `io` — caller's I/O context (per-IO scope).
+    /// - `key_size` — modulus size selector.
     /// - `priv_key` — RSA private key.
-    /// - `ciphertext` — encrypted data. Must be exactly `k` bytes.
-    /// - `output` — plaintext output buffer. Must be at least `k - 11` bytes.
-    /// - `work` — scratch buffer. Must be at least `rsa_pkcs1_work_len(k)` bytes.
+    /// - `ciphertext` — must be exactly
+    ///   `key_size.modulus_len()` bytes.
+    /// - `output` — plaintext destination; must be at least
+    ///   `key_size.max_pkcs1_message()` bytes.
+    /// - `alloc` — scoped allocator for RSA scratch.
     ///
     /// # Returns
     ///
-    /// The length of the recovered plaintext.
-    async fn rsa_pkcs1_decrypt(
+    /// - `Ok(len)` — length of recovered plaintext;
+    ///   `output[..len]` is valid.
+    /// - `Err(HsmError::InvalidArg)` — buffer-size mismatch.
+    /// - `Err(HsmError::RsaPkcs1DecryptFailed)` — padding check
+    ///   failed (likely wrong key or tampered ciphertext).
+    /// - `Err(HsmError::NotEnoughSpace)` — allocator scope too small.
+    /// - `Err(HsmError)` — PKA failure.
+    async fn rsa_pkcs1_decrypt<'a>(
         &self,
+        io: &impl HsmIo,
         key_size: HsmRsaKey,
-        priv_key: &[u8],
-        ciphertext: &[u8],
-        output: &mut [u8],
-        work: &mut [u8],
-    ) -> HsmResult<usize>;
+        priv_key: &DmaBuf,
+        ciphertext: &DmaBuf,
+        output: &mut DmaBuf,
+        alloc: &'a impl HsmScopedAlloc,
+    ) -> HsmResult<usize>
+    where
+        Self: 'a;
 
     /// PKCS#1 v1.5 sign (EMSA-PKCS1-v1_5, pre-hashed).
     ///
-    /// Builds DigestInfo from `message_hash`, pads, and signs.
+    /// Builds DigestInfo from `message_hash`, applies EMSA padding,
+    /// and signs.
     ///
     /// # Parameters
     ///
-    /// - `algo` — hash algorithm for DigestInfo OID.
+    /// - `io` — caller's I/O context (per-IO scope).
+    /// - `key_size` — modulus size selector.
+    /// - `algo` — hash algorithm whose OID is embedded in
+    ///   DigestInfo.
     /// - `priv_key` — RSA private key.
-    /// - `message_hash` — pre-computed message digest (`algo.digest_len()`
-    ///   bytes).
-    /// - `signature` — output buffer. Must be at least `rsa_pkcs1_work_len(k)` bytes.
-    /// - `work` — scratch buffer. Must be at least
-    ///   `rsa_pkcs1_work_len(k)` bytes.
-    async fn rsa_pkcs1_sign(
-        &self,
-        key_size: HsmRsaKey,
-        algo: HsmHashAlgo,
-        priv_key: &[u8],
-        message_hash: &[u8],
-        signature: &mut [u8],
-        work: &mut [u8],
-    ) -> HsmResult<()>;
-
-    /// PKCS#1 v1.5 verify (EMSA-PKCS1-v1_5, pre-hashed).
-    ///
-    /// Verifies `signature` against `message_hash` using the public key.
-    ///
-    /// # Parameters
-    ///
-    /// - `algo` — hash algorithm for DigestInfo OID.
-    /// - `pub_key` — RSA public key.
-    /// - `message_hash` — pre-computed message digest.
-    /// - `signature` — signature to verify.
-    /// - `work` — scratch buffer. Must be at least
-    ///   `rsa_pkcs1_work_len(k)` bytes.
-    async fn rsa_pkcs1_verify(
-        &self,
-        key_size: HsmRsaKey,
-        algo: HsmHashAlgo,
-        pub_key: &[u8],
-        message_hash: &[u8],
-        signature: &[u8],
-        work: &mut [u8],
-    ) -> HsmResult<bool>;
-
-    /// OAEP encrypt (EME-OAEP).
-    ///
-    /// Pads `message` with OAEP per RFC 8017 §7.1.1 and encrypts.
-    ///
-    /// # Parameters
-    ///
-    /// - `algo` — hash algorithm for OAEP (label hash + MGF1).
-    /// - `pub_key` — RSA public key.
-    /// - `message` — plaintext. Must satisfy `message.len() <= k - 2*hLen - 2`.
-    /// - `label` — optional label (pass `&[]` for default empty label).
-    /// - `output` — ciphertext output buffer. Must be at least `rsa_pkcs1_work_len(k)` bytes.
-    /// - `work` — scratch buffer. Must be at least
-    ///   `k + mgf1_state_len(k - hLen - 1)` bytes.
-    async fn rsa_oaep_encrypt(
-        &self,
-        key_size: HsmRsaKey,
-        algo: HsmHashAlgo,
-        pub_key: &[u8],
-        message: &[u8],
-        label: &[u8],
-        output: &mut [u8],
-        work: &mut [u8],
-    ) -> HsmResult<()>;
-
-    /// OAEP decrypt (EME-OAEP).
-    ///
-    /// Decrypts `ciphertext` with OAEP unpadding per RFC 8017 §7.1.2.
-    ///
-    /// # Parameters
-    ///
-    /// - `algo` — hash algorithm for OAEP.
-    /// - `priv_key` — RSA private key.
-    /// - `ciphertext` — encrypted data. Must be exactly `k` bytes.
-    /// - `label` — optional label (must match encryption label).
-    /// - `output` — plaintext output buffer. Must be at least
-    ///   `k - 2*hLen - 2` bytes (max recoverable plaintext).
-    /// - `work` — scratch buffer. Must be at least
-    ///   `rsa_oaep_work_len(algo, k)` bytes.
+    /// - `message_hash` — pre-computed digest;
+    ///   `algo.digest_len()` bytes.
+    /// - `signature` — destination; must be at least
+    ///   `key_size.pkcs1_work_len()` bytes.
+    /// - `alloc` — scoped allocator for RSA scratch.
     ///
     /// # Returns
     ///
-    /// The length of the recovered plaintext.
-    async fn rsa_oaep_decrypt(
+    /// - `Ok(())` — `signature[..modulus_len]` populated.
+    /// - `Err(HsmError::InvalidArg)` — buffer-size mismatch.
+    /// - `Err(HsmError::NotEnoughSpace)` — allocator scope too small.
+    /// - `Err(HsmError)` — PKA failure.
+    async fn rsa_pkcs1_sign<'a>(
         &self,
+        io: &impl HsmIo,
         key_size: HsmRsaKey,
         algo: HsmHashAlgo,
-        priv_key: &[u8],
-        ciphertext: &[u8],
-        label: &[u8],
-        output: &mut [u8],
-        work: &mut [u8],
-    ) -> HsmResult<usize>;
+        priv_key: &DmaBuf,
+        message_hash: &DmaBuf,
+        signature: &mut DmaBuf,
+        alloc: &'a impl HsmScopedAlloc,
+    ) -> HsmResult<()>
+    where
+        Self: 'a;
 
-    /// PSS sign (EMSA-PSS, pre-hashed).
+    /// PKCS#1 v1.5 verify (EMSA-PKCS1-v1_5, pre-hashed).
     ///
-    /// Pads `message_hash` with PSS per RFC 8017 §9.1.1 and signs.
+    /// Verifies `signature` against `message_hash` under `pub_key`.
     ///
     /// # Parameters
     ///
-    /// - `algo` — hash algorithm for PSS (H and MGF1).
-    /// - `priv_key` — RSA private key.
-    /// - `message_hash` — pre-computed message digest (`hLen` bytes).
-    /// - `salt_len` — PSS salt length in bytes.
-    /// - `signature` — output buffer. Must be at least `rsa_pkcs1_work_len(k)` bytes.
-    /// - `work` — scratch buffer. Must be at least
-    ///   `k + hash_state_len + mgf1_state_len(hLen)` bytes.
-    async fn rsa_pss_sign(
-        &self,
-        key_size: HsmRsaKey,
-        algo: HsmHashAlgo,
-        priv_key: &[u8],
-        message_hash: &[u8],
-        salt_len: usize,
-        signature: &mut [u8],
-        work: &mut [u8],
-    ) -> HsmResult<()>;
-
-    /// PSS verify (EMSA-PSS, pre-hashed).
-    ///
-    /// Verifies `signature` against `message_hash` using PSS per RFC 8017 §9.1.2.
-    ///
-    /// # Parameters
-    ///
-    /// - `algo` — hash algorithm for PSS.
+    /// - `io` — caller's I/O context (per-IO scope).
+    /// - `key_size` — modulus size selector.
+    /// - `algo` — hash algorithm whose OID is expected in
+    ///   DigestInfo.
     /// - `pub_key` — RSA public key.
-    /// - `message_hash` — pre-computed message digest (`hLen` bytes).
-    /// - `salt_len` — PSS salt length in bytes.
-    /// - `signature` — signature to verify.
-    /// - `work` — scratch buffer. Must be at least
-    ///   `k + hash_state_len + mgf1_state_len(hLen)` bytes.
-    async fn rsa_pss_verify(
+    /// - `message_hash` — pre-computed digest.
+    /// - `signature` — signature to verify;
+    ///   `key_size.modulus_len()` bytes.
+    /// - `alloc` — scoped allocator for RSA scratch.
+    ///
+    /// # Returns
+    ///
+    /// - `Ok(true)` — signature valid.
+    /// - `Ok(false)` — signature does not verify.
+    /// - `Err(HsmError::InvalidArg)` — buffer-size mismatch.
+    /// - `Err(HsmError::NotEnoughSpace)` — allocator scope too small.
+    /// - `Err(HsmError)` — PKA failure.
+    async fn rsa_pkcs1_verify<'a>(
         &self,
+        io: &impl HsmIo,
         key_size: HsmRsaKey,
         algo: HsmHashAlgo,
-        pub_key: &[u8],
-        message_hash: &[u8],
+        pub_key: &DmaBuf,
+        message_hash: &DmaBuf,
+        signature: &DmaBuf,
+        alloc: &'a impl HsmScopedAlloc,
+    ) -> HsmResult<bool>
+    where
+        Self: 'a;
+
+    /// OAEP encrypt (EME-OAEP, RFC 8017 §7.1.1).
+    ///
+    /// # Parameters
+    ///
+    /// - `io` — caller's I/O context (per-IO scope).
+    /// - `key_size` — modulus size selector.
+    /// - `algo` — OAEP hash (label hash + MGF1).
+    /// - `pub_key` — RSA public key.
+    /// - `message` — plaintext; must satisfy `message.len() <=
+    ///   key_size.max_oaep_message(algo)`.
+    /// - `label` — OAEP label; `&[]` for the default empty label.
+    /// - `output` — ciphertext destination; must be at least
+    ///   `key_size.oaep_work_len(algo)` bytes.
+    /// - `alloc` — scoped allocator for RSA scratch.
+    ///
+    /// # Returns
+    ///
+    /// - `Ok(())` — `output[..modulus_len]` populated.
+    /// - `Err(HsmError::InvalidArg)` — message too long or buffer
+    ///   too small.
+    /// - `Err(HsmError::NotEnoughSpace)` — allocator scope too small.
+    /// - `Err(HsmError)` — RNG / SHA / PKA failure.
+    async fn rsa_oaep_encrypt<'a>(
+        &self,
+        io: &impl HsmIo,
+        key_size: HsmRsaKey,
+        algo: HsmHashAlgo,
+        pub_key: &DmaBuf,
+        message: &DmaBuf,
+        label: &DmaBuf,
+        output: &mut DmaBuf,
+        alloc: &'a impl HsmScopedAlloc,
+    ) -> HsmResult<()>
+    where
+        Self: 'a;
+
+    /// OAEP decrypt (EME-OAEP, RFC 8017 §7.1.2).
+    ///
+    /// # Parameters
+    ///
+    /// - `io` — caller's I/O context (per-IO scope).
+    /// - `key_size` — modulus size selector.
+    /// - `algo` — OAEP hash.
+    /// - `priv_key` — RSA private key.
+    /// - `ciphertext` — must be exactly
+    ///   `key_size.modulus_len()` bytes.
+    /// - `label` — OAEP label; must equal the encryption-time
+    ///   label.
+    /// - `output` — plaintext destination; must be at least
+    ///   `key_size.max_oaep_message(algo)` bytes.
+    /// - `alloc` — scoped allocator for RSA scratch.
+    ///
+    /// # Returns
+    ///
+    /// - `Ok(len)` — length of recovered plaintext;
+    ///   `output[..len]` is valid.
+    /// - `Err(HsmError::InvalidArg)` — buffer-size mismatch.
+    /// - `Err(HsmError::RsaOaepDecryptFailed)` — OAEP unmasking
+    ///   detected tampering or label mismatch.
+    /// - `Err(HsmError::NotEnoughSpace)` — allocator scope too small.
+    /// - `Err(HsmError)` — SHA / PKA failure.
+    async fn rsa_oaep_decrypt<'a>(
+        &self,
+        io: &impl HsmIo,
+        key_size: HsmRsaKey,
+        algo: HsmHashAlgo,
+        priv_key: &DmaBuf,
+        ciphertext: &DmaBuf,
+        label: &DmaBuf,
+        output: &mut DmaBuf,
+        alloc: &'a impl HsmScopedAlloc,
+    ) -> HsmResult<usize>
+    where
+        Self: 'a;
+
+    /// PSS sign (EMSA-PSS, RFC 8017 §9.1.1, pre-hashed).
+    ///
+    /// # Parameters
+    ///
+    /// - `io` — caller's I/O context (per-IO scope).
+    /// - `key_size` — modulus size selector.
+    /// - `algo` — PSS hash (H and MGF1).
+    /// - `priv_key` — RSA private key.
+    /// - `message_hash` — pre-computed digest;
+    ///   `algo.digest_len()` bytes.
+    /// - `salt_len` — PSS salt length in bytes.
+    /// - `signature` — destination; must be at least
+    ///   `key_size.pss_work_len(algo)` bytes.
+    /// - `alloc` — scoped allocator for RSA scratch.
+    ///
+    /// # Returns
+    ///
+    /// - `Ok(())` — `signature[..modulus_len]` populated.
+    /// - `Err(HsmError::InvalidArg)` — buffer-size mismatch or
+    ///   `salt_len` exceeds the EMSA-PSS limit.
+    /// - `Err(HsmError::NotEnoughSpace)` — allocator scope too small.
+    /// - `Err(HsmError)` — RNG / SHA / PKA failure.
+    async fn rsa_pss_sign<'a>(
+        &self,
+        io: &impl HsmIo,
+        key_size: HsmRsaKey,
+        algo: HsmHashAlgo,
+        priv_key: &DmaBuf,
+        message_hash: &DmaBuf,
         salt_len: usize,
-        signature: &[u8],
-        work: &mut [u8],
-    ) -> HsmResult<bool>;
+        signature: &mut DmaBuf,
+        alloc: &'a impl HsmScopedAlloc,
+    ) -> HsmResult<()>
+    where
+        Self: 'a;
+
+    /// PSS verify (EMSA-PSS, RFC 8017 §9.1.2, pre-hashed).
+    ///
+    /// # Parameters
+    ///
+    /// - `io` — caller's I/O context (per-IO scope).
+    /// - `key_size` — modulus size selector.
+    /// - `algo` — PSS hash.
+    /// - `pub_key` — RSA public key.
+    /// - `message_hash` — pre-computed digest;
+    ///   `algo.digest_len()` bytes.
+    /// - `salt_len` — expected PSS salt length in bytes.
+    /// - `signature` — signature to verify;
+    ///   `key_size.modulus_len()` bytes.
+    /// - `alloc` — scoped allocator for RSA scratch.
+    ///
+    /// # Returns
+    ///
+    /// - `Ok(true)` — signature valid.
+    /// - `Ok(false)` — signature does not verify.
+    /// - `Err(HsmError::InvalidArg)` — buffer-size mismatch.
+    /// - `Err(HsmError::NotEnoughSpace)` — allocator scope too small.
+    /// - `Err(HsmError)` — SHA / PKA failure.
+    async fn rsa_pss_verify<'a>(
+        &self,
+        io: &impl HsmIo,
+        key_size: HsmRsaKey,
+        algo: HsmHashAlgo,
+        pub_key: &DmaBuf,
+        message_hash: &DmaBuf,
+        salt_len: usize,
+        signature: &DmaBuf,
+        alloc: &'a impl HsmScopedAlloc,
+    ) -> HsmResult<bool>
+    where
+        Self: 'a;
 }

--- a/fw/pal/traits/src/gdma.rs
+++ b/fw/pal/traits/src/gdma.rs
@@ -1,9 +1,54 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+//! GDMA controller trait.
+//!
+//! Defines the [`HsmGdmaController`] trait used by the HSM core to
+//! move bulk data between three memory domains:
+//!
+//! - **Host** memory — addressed by 64-bit physical addresses
+//!   ([`HsmDmaAddr`]) supplied by the host in SQE PRP fields.
+//! - **HSM-local DMA-capable memory** — the SRAM region from which
+//!   the per-IO DMA bump allocator (see [`HsmAlloc`]) hands out
+//!   buffers.
+//! - **HSM-local non-DMA memory** — DTCM scratch space used for
+//!   crypto state.  The GDMA does *not* operate on DTCM; only the
+//!   on-device variant of [`copy_mem`](HsmGdmaController::copy_mem)
+//!   may target a non-DMA buffer (and only when both endpoints fit
+//!   that requirement; PAL implementations may fall back to a
+//!   memcpy in that case).
+//!
+//! ## When DMA buffers are required
+//!
+//! Both [`copy_mem_from_host`](HsmGdmaController::copy_mem_from_host)
+//! and [`copy_mem_to_host`](HsmGdmaController::copy_mem_to_host)
+//! require their HSM-local endpoints to live in DMA-capable memory.
+//! In practice this means the slice must come from
+//! [`HsmAlloc::alloc_buf`] with [`HsmHeap::Dma`] (or one of the
+//! `dma_*` convenience helpers).  Passing a DTCM-backed buffer is
+//! undefined behavior at the hardware level; PAL implementations
+//! are free to reject it with [`HsmError::InvalidArg`].
+//!
+//! ## PRP vs. flat addressing
+//!
+//! Host-side transfers take a `prp: bool` flag:
+//!
+//! - `prp = true` — `src`/`dst` is a *PRP1* host pointer; the GDMA
+//!   walks the PRP list to assemble a scatter/gather descriptor.
+//!   Used for the request/response DMAs that bracket every
+//!   [`OP_GENERIC`](crate) command.
+//! - `prp = false` — `src`/`dst` is a flat host physical address; a
+//!   single contiguous transfer is performed.  Used for inline
+//!   sub-blob copies (e.g. cert chain fragments) where PRP overhead
+//!   is unwanted.
+
 use super::*;
 
-/// A 64-bit DMA address split into high and low 32-bit halves.
+/// 64-bit DMA address split into high and low 32-bit halves.
+///
+/// Mirrors the host's PRP / flat-address representation: SQE fields
+/// store the address as two adjacent dwords, and PAL drivers consume
+/// the two halves directly without needing to reconstruct a `u64`.
 #[derive(Debug, Clone, Copy, Default)]
 pub struct HsmDmaAddr {
     /// Lower 32 bits of the address.
@@ -15,43 +60,129 @@ pub struct HsmDmaAddr {
 
 impl HsmDmaAddr {
     /// Returns `true` if both halves are zero (null address).
+    ///
+    /// Used by the core to detect optional / absent host buffers in
+    /// the SQE before attempting a DMA.
+    ///
+    /// # Returns
+    ///
+    /// - `true` — `lo == 0 && hi == 0`.
+    /// - `false` — at least one half is non-zero.
     #[inline]
     pub fn is_null(&self) -> bool {
         self.lo == 0 && self.hi == 0
     }
 }
 
-/// Trait for performing DMA memory copy operations via the GDMA controller.
+/// GDMA memory-copy interface.
+///
+/// All three methods are `async`: they queue a DMA descriptor with
+/// the GDMA hardware and yield until the engine signals completion.
+/// They are partition-scoped via the [`HsmIo`] handle (the GDMA
+/// driver uses `io.pid()` to apply per-partition policy and
+/// throttling) and consume no per-IO allocator scope.
+///
+/// PAL implementations may serialize concurrent calls through an
+/// internal async mutex; callers should treat the await as
+/// potentially long-running.
 pub trait HsmGdmaController {
-    /// Copies data from `src` to `dst` within HSM-local memory.
-    async fn copy_mem(&self, src: &[u8], dst: &mut [u8]) -> HsmResult<()>;
-
-    /// Copies data from the host at `src` into the HSM-local buffer `dst`.
+    /// Copies bytes between two HSM-local buffers.
     ///
-    /// * `part_id` — Identifier of the host controller interface.
-    /// * `src` — Host-side source DMA address.
-    /// * `dst` — HSM-local destination buffer.
-    /// * `prp` — If `true`, interpret `src` as a PRP address pair;
-    ///   if `false`, interpret it as an SGL descriptor pair.
+    /// Both endpoints live in HSM-local memory.  At least one — and
+    /// often both — must be DMA-capable; PAL implementations may
+    /// fall back to a memcpy when both happen to be non-DMA, but
+    /// callers should not rely on this.
+    ///
+    /// `dst.len()` must equal `src.len()`; partial copies are not
+    /// supported.
+    ///
+    /// # Parameters
+    ///
+    /// - `io` — caller's I/O context (partition scope; per-IO state
+    ///   is not consumed).
+    /// - `src` — source buffer.
+    /// - `dst` — destination buffer; must satisfy
+    ///   `dst.len() == src.len()`.
+    ///
+    /// # Returns
+    ///
+    /// - `Ok(())` — the copy completed successfully.
+    /// - `Err(HsmError::InvalidArg)` — length mismatch, or one of
+    ///   the buffers is not in a memory region the GDMA can
+    ///   address.
+    /// - `Err(HsmError::FailedToStartDmaTransaction)` — descriptor
+    ///   could not be queued (e.g. engine in error state).
+    /// - `Err(HsmError)` — propagated from the GDMA driver on
+    ///   completion errors.
+    async fn copy_mem(&self, io: &impl HsmIo, src: &DmaBuf, dst: &mut DmaBuf) -> HsmResult<()>;
+
+    /// Copies bytes from host memory into an HSM-local DMA buffer.
+    ///
+    /// `dst` **must** live in DMA-capable memory (see module-level
+    /// docs).  The transfer length is `dst.len()`; the host buffer
+    /// at `src` must be at least that long.
+    ///
+    /// # Parameters
+    ///
+    /// - `io` — caller's I/O context (partition scope).
+    /// - `src` — host-side address.  When `prp == true`, this is the
+    ///   PRP1 entry from the SQE; the GDMA walks the PRP list
+    ///   pointed to by it to handle scatter/gather.  When
+    ///   `prp == false`, this is a flat 64-bit physical host
+    ///   address.
+    /// - `dst` — HSM-local DMA-capable destination buffer.  Length
+    ///   determines the transfer size.
+    /// - `prp` — `true` to interpret `src` as a PRP entry, `false`
+    ///   for a flat address.
+    ///
+    /// # Returns
+    ///
+    /// - `Ok(())` — bytes copied successfully; `dst` is fully
+    ///   populated.
+    /// - `Err(HsmError::InvalidArg)` — `dst` is not in DMA memory,
+    ///   or `src` is null when a non-empty transfer was requested.
+    /// - `Err(HsmError::FailedToStartDmaTransaction)` — descriptor
+    ///   could not be queued.
+    /// - `Err(HsmError)` — propagated from the GDMA driver on
+    ///   completion errors (e.g. host bus fault).
     async fn copy_mem_from_host(
         &self,
-        part_id: HsmPartId,
+        io: &impl HsmIo,
         src: HsmDmaAddr,
-        dst: &mut [u8],
+        dst: &mut DmaBuf,
         prp: bool,
     ) -> HsmResult<()>;
 
-    /// Copies data from the HSM-local buffer `src` to the host at `dst`.
+    /// Copies bytes from an HSM-local DMA buffer to host memory.
     ///
-    /// * `part_id` — Partition identifier.
-    /// * `src` — HSM-local source buffer.
-    /// * `dst` — Host-side destination DMA address.
-    /// * `prp` — If `true`, interpret `dst` as a PRP address pair;
-    ///   if `false`, interpret it as an SGL descriptor pair.
+    /// `src` **must** live in DMA-capable memory (see module-level
+    /// docs).  The transfer length is `src.len()`; the host buffer
+    /// at `dst` must be at least that long.
+    ///
+    /// # Parameters
+    ///
+    /// - `io` — caller's I/O context (partition scope).
+    /// - `src` — HSM-local DMA-capable source buffer.  Length
+    ///   determines the transfer size.
+    /// - `dst` — host-side address.  Same `prp == true`/`false`
+    ///   semantics as
+    ///   [`copy_mem_from_host`](Self::copy_mem_from_host).
+    /// - `prp` — `true` to interpret `dst` as a PRP entry, `false`
+    ///   for a flat address.
+    ///
+    /// # Returns
+    ///
+    /// - `Ok(())` — bytes copied successfully.
+    /// - `Err(HsmError::InvalidArg)` — `src` is not in DMA memory,
+    ///   or `dst` is null when a non-empty transfer was requested.
+    /// - `Err(HsmError::FailedToStartDmaTransaction)` — descriptor
+    ///   could not be queued.
+    /// - `Err(HsmError)` — propagated from the GDMA driver on
+    ///   completion errors.
     async fn copy_mem_to_host(
         &self,
-        part_id: HsmPartId,
-        src: &[u8],
+        io: &impl HsmIo,
+        src: &DmaBuf,
         dst: HsmDmaAddr,
         prp: bool,
     ) -> HsmResult<()>;

--- a/fw/pal/traits/src/io.rs
+++ b/fw/pal/traits/src/io.rs
@@ -1,67 +1,218 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-//! I/O controller and IO traits for the HSM platform abstraction layer.
+//! I/O controller and per-IO traits for the HSM platform abstraction
+//! layer.
+//!
+//! Defines the two traits the core uses to receive and complete host
+//! commands:
+//!
+//! - [`HsmIoController`] — the platform's I/O fabric.  Drives the
+//!   submission/completion queue lifecycle and produces individual
+//!   [`HsmIo`] handles.
+//! - [`HsmIo`] — a single in-flight command: borrows of its SQE/CQE,
+//!   plus the partition / queue / slot identifiers used to scope
+//!   per-IO state (partition, allocator scope, vault, session).
+//!
+//! ## SQE / CQE layout
+//!
+//! Submission and completion queue entries are fixed-size dword
+//! arrays with platform-defined contents.  This crate exposes only
+//! the raw shape ([`HsmSqe`], [`HsmCqe`], [`SQE_DWORDS`],
+//! [`CQE_DWORDS`]); the semantic decode (opcode, PRP fields, session
+//! flags, status word, …) lives in the core (`azihsm_fw_hsm_core`).
+//!
+//! ## Pipeline
+//!
+//! ```text
+//! poll_io().await        — receive next request
+//!   ↓
+//! io.sqe() / io.cqe()    — decode SQE, populate CQE
+//! io.pid()               — resolve partition for downstream PAL calls
+//!   ↓
+//! complete_io(io).await  — emit CQE; or
+//! drop_io(io).await      — silently discard (e.g. disabled partition)
+//! ```
 
 use super::*;
 
 /// Number of dwords in a submission queue entry.
+///
+/// The total SQE size in bytes is `SQE_DWORDS * 4`.
 pub const SQE_DWORDS: usize = 16;
 
-// Number of dwords in a completion queue entry.
+/// Number of dwords in a completion queue entry.
+///
+/// The total CQE size in bytes is `CQE_DWORDS * 4`.
 pub const CQE_DWORDS: usize = 4;
 
 /// A submission queue entry as a raw dword array.
+///
+/// Layout is platform-defined and decoded by the core's `Sqe` wrapper.
 pub type HsmSqe = [u32; SQE_DWORDS];
 
 /// A completion queue entry as a raw dword array.
+///
+/// Layout is platform-defined and decoded by the core's `Cqe` wrapper.
 pub type HsmCqe = [u32; CQE_DWORDS];
 
-/// A single I/O received from a controller queue.
+/// Handle to a single in-flight I/O.
 ///
-/// Represents a submission/completion pair: the caller reads the submission
-/// queue entry ([`sqe`](Self::sqe)) to determine the requested operation and
-/// writes the result into the completion queue entry ([`cqe`](Self::cqe)).
+/// Represents a submission/completion pair: the caller reads the
+/// submission queue entry via [`sqe`](Self::sqe) to determine the
+/// requested operation and writes the result into the completion
+/// queue entry via [`cqe`](Self::cqe).  The handle also exposes the
+/// partition, queue, and slot identifiers used to scope per-IO state
+/// (allocator scope, vault, sessions, certificate store) across the
+/// rest of the PAL traits.
+///
+/// `HsmIo` is `Send` (via [`HsmIoController::Io`]) so an IO can be
+/// moved between Embassy executor tasks during processing.  It is
+/// **not** `Sync`: each IO is owned by exactly one task at a time.
+///
+/// The handle is consumed by exactly one of
+/// [`HsmIoController::complete_io`] or
+/// [`HsmIoController::drop_io`]; failing to do so leaks the
+/// underlying queue slot.
 pub trait HsmIo {
+    /// Returns the IO slot index used to address per-IO resources
+    /// (e.g. the per-IO bump-allocator scope).
+    ///
+    /// # Returns
+    ///
+    /// A `u16` in the range `0..N`, where `N` is the platform's IO
+    /// concurrency (e.g. number of preallocated SQE/CQE buffer
+    /// slots).  Stable across the lifetime of this `HsmIo`.
+    fn index(&self) -> u16;
+
     /// Returns the partition that owns this IO.
+    ///
+    /// All partition-scoped PAL calls (vault, session, partition
+    /// metadata, certificate store) resolve their target partition
+    /// by calling this method on the IO handle they're given.
+    ///
+    /// # Returns
+    ///
+    /// The [`HsmPartId`] of the partition whose submission queue
+    /// produced this IO.  Stable across the lifetime of this
+    /// `HsmIo`.
     fn pid(&self) -> HsmPartId;
 
-    /// Returns the queue within the controller that this IO belongs to.
+    /// Returns the controller queue this IO belongs to.
+    ///
+    /// A partition may be backed by multiple SQ/CQ pairs; this
+    /// identifies which one delivered the request and to which the
+    /// completion will be posted.
+    ///
+    /// # Returns
+    ///
+    /// The queue identifier as a `u16`.  Stable across the lifetime
+    /// of this `HsmIo`.
     fn queue_id(&self) -> u16;
 
-    /// Returns the index of this IO within its queue.
+    /// Returns the slot index of this IO within its controller queue.
+    ///
+    /// # Returns
+    ///
+    /// The intra-queue index as a `u16`.  Stable across the lifetime
+    /// of this `HsmIo`.
     fn queue_idx(&self) -> u16;
 
-    /// Convenience method to get SQE
+    /// Borrows the submission queue entry.
+    ///
+    /// The SQE is read-only from the firmware's perspective: the
+    /// host populated it before raising the doorbell that triggered
+    /// [`HsmIoController::poll_io`].
+    ///
+    /// # Returns
+    ///
+    /// An immutable reference to the [`HsmSqe`] dword array.  Borrow
+    /// lives for the duration of the `&self` borrow.
     fn sqe(&self) -> &HsmSqe;
 
-    /// Convenience method to get CQE
+    /// Borrows the completion queue entry for in-place population.
+    ///
+    /// The firmware writes the status word, response length, and any
+    /// session-control fields here before calling
+    /// [`HsmIoController::complete_io`].  Contents prior to that
+    /// call are unspecified; callers must overwrite, not read.
+    ///
+    /// # Returns
+    ///
+    /// A mutable reference to the [`HsmCqe`] dword array.  Borrow
+    /// lives for the duration of the `&mut self` borrow.
     fn cqe(&mut self) -> &mut HsmCqe;
-
-    /// Returns a mutable slice of the large IO buffer (8KB).
-    fn mem(&mut self) -> (&mut [u8], &mut [u8]);
 }
 
-/// An asynchronous I/O controller that produces and consumes IOs.
+/// Asynchronous I/O controller that produces and completes IOs.
 ///
-/// Implementors provide platform-specific queue access. The controller
-/// receives IOs from a submission queue and sends completed IOs back
-/// through a completion queue.
+/// Implementations own the platform's submission/completion queue
+/// pair (or pairs): IPC mailboxes on Ocelot, in-process channels for
+/// the std PAL emulator.  The controller is consumed by the core's
+/// main loop, which calls [`poll_io`](Self::poll_io) in an
+/// `async` fashion and dispatches each returned [`HsmIo`] to the
+/// command pipeline.
+///
+/// Lifecycle invariant: every IO returned by
+/// [`poll_io`](Self::poll_io) must eventually be passed to either
+/// [`complete_io`](Self::complete_io) or
+/// [`drop_io`](Self::drop_io) — dropping the IO without either call
+/// leaks the underlying queue slot.
 pub trait HsmIoController {
-    /// The platform-specific IO type.
+    /// Platform-specific IO type.
+    ///
+    /// Bound to be `Send` so that the core can move IOs across
+    /// Embassy executor tasks during async processing.
     type Io: HsmIo + Send;
 
-    /// Waits for the next IO from the submission queue.
+    /// Awaits the next IO from any submission queue.
+    ///
+    /// Yields until at least one queue has a pending entry, then
+    /// returns the corresponding [`Self::Io`] handle.
+    ///
+    /// # Returns
+    ///
+    /// - `Ok(io)` — a fresh in-flight IO ready for processing.
+    /// - `Err(HsmError)` — fatal queue error (controller is no
+    ///   longer usable; the main loop should treat this as
+    ///   unrecoverable).
     async fn poll_io(&self) -> HsmResult<Self::Io>;
 
-    /// Sends a completed IO back through the completion queue.
-    /// Consumes the IO, freeing the underlying slot.
+    /// Posts the completion entry for `io` and frees its queue slot.
+    ///
+    /// Consumes the [`Self::Io`] handle.  Callers must have written
+    /// the desired CQE contents via [`HsmIo::cqe`] before invoking
+    /// this method; the contents are flushed to the host as part of
+    /// completion.
+    ///
+    /// # Parameters
+    ///
+    /// - `io` — handle previously returned by
+    ///   [`poll_io`](Self::poll_io).
+    ///
+    /// # Returns
+    ///
+    /// - `Ok(())` — completion was successfully posted.
+    /// - `Err(HsmError)` — failed to enqueue the CQE; the slot is
+    ///   still freed, but the host will not see this completion.
     async fn complete_io(&self, io: Self::Io) -> HsmResult<()>;
 
-    /// Drops an IO without sending a completion.
+    /// Frees the queue slot **without** posting a CQE.
     ///
-    /// Frees the underlying buffer slot but does **not** send a CQE
-    /// through the completion queue. Used when the IO must be silently
-    /// discarded (e.g. the partition is not enabled).
+    /// Used when the IO must be silently discarded — for example
+    /// when it arrived for a non-[`PartState::Enabled`](crate::PartState::Enabled)
+    /// partition and core wants to drop it without surfacing
+    /// anything to the host.
+    ///
+    /// # Parameters
+    ///
+    /// - `io` — handle previously returned by
+    ///   [`poll_io`](Self::poll_io).
+    ///
+    /// # Returns
+    ///
+    /// - `Ok(())` — slot was freed.
+    /// - `Err(HsmError)` — slot release failed (logged by core; the
+    ///   IO is no longer accessible regardless).
     async fn drop_io(&self, io: Self::Io) -> HsmResult<()>;
 }

--- a/fw/pal/traits/src/lib.rs
+++ b/fw/pal/traits/src/lib.rs
@@ -6,9 +6,9 @@
 //!
 //! This crate is the **central contract** between the platform-agnostic
 //! HSM core (`azihsm_fw_hsm_core`) and platform-specific implementations
-//! (e.g., `azihsm_fw_hsm_pal_std` for host-native simulation,
+//! (e.g. `azihsm_fw_hsm_pal_std` for host-native simulation,
 //! `azihsm_fw_hsm_pal_ocelot` for hardware).  It is `#![no_std]` and
-//! has zero external dependencies beyond `open_enum`, so it compiles on
+//! has no external dependencies beyond `open_enum`, so it compiles on
 //! bare-metal targets.
 //!
 //! # Trait hierarchy
@@ -18,40 +18,87 @@
 //!
 //! ```text
 //! HsmPal
-//!  ├── HsmIoController      — I/O submission and completion
-//!  ├── HsmGdmaController    — host↔device memory copies
-//!  ├── HsmPartitionManager  — partition lifecycle
-//!  ├── HsmPartitionLock     — per-partition async mutex
-//!  ├── HsmCertStore         — per-partition certificate chains
-//!  ├── HsmSessionManager    — session allocation and state
-//!  ├── HsmVault             — key storage and metadata
-//!  └── HsmCrypto            — cryptographic operations
-//!       ├── HsmRng          — random number generation
-//!       ├── HsmHash         — SHA digest
-//!       ├── HsmHmac         — HMAC sign/verify
-//!       ├── HsmAes          — AES encrypt/decrypt
-//!       ├── HsmEcc          — ECC keygen/sign/verify/ECDH
-//!       ├── HsmRsa          — RSA keygen/mod_exp
-//!       └── HsmKdf          — HKDF and KBKDF key derivation
+//!  ├── HsmAlloc            — per-IO bump-allocator scopes (DTCM and DMA SRAM)
+//!  ├── HsmIoController     — I/O submission and completion
+//!  ├── HsmGdmaController   — host↔device memory copies
+//!  ├── HsmPartitionManager — partition lifecycle
+//!  ├── HsmPartitionLock    — per-partition async mutex
+//!  ├── HsmCertStore        — per-partition certificate chains
+//!  ├── HsmSessionManager   — session allocation and state
+//!  ├── HsmVault            — key storage and metadata
+//!  └── HsmCrypto           — cryptographic operations
+//!       ├── HsmRng         — random number generation
+//!       ├── HsmHash        — SHA digest
+//!       ├── HsmHmac        — HMAC sign/verify
+//!       ├── HsmAes         — AES encrypt/decrypt
+//!       ├── HsmEcc         — ECC keygen/sign/verify/ECDH
+//!       ├── HsmRsa         — RSA keygen/mod_exp
+//!       └── HsmKdf         — HKDF and KBKDF key derivation
 //! ```
 //!
 //! # Identifier newtypes
 //!
 //! Three lightweight newtypes — [`HsmPartId`], [`HsmKeyId`], and
 //! [`HsmSessId`] — prevent accidental mixing of partition, key, and
-//! session indices.  Each wraps a small integer and provides
-//! zero-cost [`From`] / [`Into`] conversions.
+//! session indices.  Each wraps a small integer, is
+//! `#[repr(transparent)]`, and provides zero-cost [`From`] / [`Into`]
+//! conversions to/from its underlying primitive.
 //!
 //! # Error model
 //!
-//! All fallible operations return [`HsmResult<T>`], which is
-//! `Result<T, HsmError>`.  [`HsmError`] is an [`open_enum`] over `u32`
-//! with ~200 named variants covering DDI-level, PAL-level, and
-//! cryptographic error codes.
+//! All fallible operations return [`HsmResult<T>`], which is a type
+//! alias for `Result<T, HsmError>`.  [`HsmError`] is an
+//! [`open_enum`] over `u32` with ~200 named variants covering
+//! DDI-level, PAL-level, and cryptographic error codes; the numeric
+//! values are wire-stable and reused as DDI status codes on the host
+//! protocol.
+//!
+//! # Conventions
+//!
+//! The following conventions are used uniformly across all PAL
+//! sub-traits in this crate:
+//!
+//! ## `&self` + interior mutability
+//!
+//! Every method takes `&self`.  PAL implementations are expected to
+//! use plain `Cell`/`RefCell` (or static `UnsafeCell`-backed slots)
+//! for shared state — the firmware is single-core and cooperatively
+//! scheduled, so there are no atomics and no `&mut self` requirement.
+//!
+//! ## Implicit partition scoping via `HsmIo`
+//!
+//! Methods that operate on partition-scoped state (sessions, vault
+//! keys, certificate chains, partition metadata) take an
+//! `&impl HsmIo` handle rather than an explicit [`HsmPartId`].  The
+//! partition is resolved internally via [`HsmIo::pid`].  This makes
+//! cross-partition access impossible by construction and keeps the
+//! call sites uniform.
+//!
+//! ## Query/copy pattern for variable-length output
+//!
+//! Methods that return raw bytes into a caller buffer accept
+//! `out: Option<&mut [u8]>`:
+//!
+//! - `out = None` — query mode: returns the required size without
+//!   copying.
+//! - `out = Some(buf)` — copy mode: writes the data into `buf[..size]`
+//!   and returns the same `size`.  `buf.len()` must be ≥ `size` or
+//!   the call returns [`HsmError::InvalidArg`].
+//!
+//! ## RAII guards for fallible-creation operations
+//!
+//! [`HsmVault::vault_key_create`] and
+//! [`HsmSessionManager::session_create`] return guards
+//! ([`VaultKeyGuard`], [`SessionGuard`]) that auto-rollback on drop
+//! and require an explicit `dismiss()` call to commit.  This makes it
+//! safe for callers to perform additional fallible work between
+//! creation and commit (e.g. encoding the response buffer) without
+//! leaking partial state on the error path.
 
 #![no_std]
 #![allow(async_fn_in_trait)]
 
+mod alloc;
 mod cert;
 mod crypto;
 mod error;
@@ -62,6 +109,8 @@ mod pal;
 mod part;
 mod session;
 mod vault;
+
+pub use alloc::*;
 
 pub use cert::*;
 pub use crypto::*;
@@ -74,12 +123,17 @@ pub use part::*;
 pub use session::*;
 pub use vault::*;
 
-/// Partition identifier — an opaque `u8` index into the HSM's partition
-/// table.
+/// Partition identifier — an opaque `u8` index into the HSM's
+/// partition table.
 ///
-/// Each HSM supports a fixed number of partitions (typically 65).  A
-/// `HsmPartId` uniquely selects one partition for session, vault, and
-/// certificate operations.
+/// Each HSM build supports a fixed number of partitions (typically up
+/// to 65).  A `HsmPartId` uniquely selects one partition for session,
+/// vault, and certificate operations.  Within the firmware, partition
+/// IDs are usually obtained indirectly through [`HsmIo::pid`] rather
+/// than being constructed directly.
+///
+/// `#[repr(transparent)]` over `u8` so a slice of `HsmPartId` is
+/// layout-compatible with `&[u8]`.
 ///
 /// # Conversions
 ///
@@ -93,7 +147,18 @@ pub use vault::*;
 pub struct HsmPartId(u8);
 
 impl From<u8> for HsmPartId {
-    /// Create a partition identifier from a raw `u8` index.
+    /// Wraps a raw `u8` index into a [`HsmPartId`].
+    ///
+    /// # Parameters
+    ///
+    /// - `v` — partition index in `0..HSM_NUM_PARTITIONS`.  Out-of-range
+    ///   values are accepted here and rejected later by the trait
+    ///   method that consumes them (typically with
+    ///   [`HsmError::InvalidArg`]).
+    ///
+    /// # Returns
+    ///
+    /// A [`HsmPartId`] wrapping `v`.
     #[inline]
     fn from(v: u8) -> Self {
         Self(v)
@@ -101,7 +166,15 @@ impl From<u8> for HsmPartId {
 }
 
 impl From<HsmPartId> for u8 {
-    /// Extract the raw `u8` index from a partition identifier.
+    /// Unwraps a [`HsmPartId`] to its raw `u8` index.
+    ///
+    /// # Parameters
+    ///
+    /// - `id` — partition identifier.
+    ///
+    /// # Returns
+    ///
+    /// The underlying `u8` slot index.
     #[inline]
     fn from(id: HsmPartId) -> Self {
         id.0
@@ -110,9 +183,13 @@ impl From<HsmPartId> for u8 {
 
 /// Key identifier — an opaque `u16` index into the vault's key table.
 ///
-/// Returned by [`HsmVault::vault_key_create`] and passed to all
-/// subsequent key operations (load, delete, attribute queries).  The
-/// value is only meaningful within the vault that created it.
+/// Returned by [`HsmVault::vault_key_create`] (via the
+/// [`VaultKeyGuard`] handle) and passed to all subsequent key
+/// operations (lookup, delete, attribute queries).  The value is only
+/// meaningful within the vault that created it; do not reuse a key
+/// ID across partitions.
+///
+/// `#[repr(transparent)]` over `u16`.
 ///
 /// # Conversions
 ///
@@ -126,7 +203,15 @@ impl From<HsmPartId> for u8 {
 pub struct HsmKeyId(u16);
 
 impl From<u16> for HsmKeyId {
-    /// Create a key identifier from a raw `u16` index.
+    /// Wraps a raw `u16` index into a [`HsmKeyId`].
+    ///
+    /// # Parameters
+    ///
+    /// - `v` — vault key-table index.
+    ///
+    /// # Returns
+    ///
+    /// A [`HsmKeyId`] wrapping `v`.
     #[inline]
     fn from(v: u16) -> Self {
         Self(v)
@@ -134,22 +219,33 @@ impl From<u16> for HsmKeyId {
 }
 
 impl From<HsmKeyId> for u16 {
-    /// Extract the raw `u16` index from a key identifier.
+    /// Unwraps a [`HsmKeyId`] to its raw `u16` index.
+    ///
+    /// # Parameters
+    ///
+    /// - `id` — key identifier.
+    ///
+    /// # Returns
+    ///
+    /// The underlying `u16` table index.
     #[inline]
     fn from(id: HsmKeyId) -> Self {
         id.0
     }
 }
 
-/// Session identifier — an opaque `u16` slot index into the per-partition
-/// session table.
+/// Session identifier — an opaque `u16` slot index into the
+/// per-partition session table.
 ///
-/// Returned by [`HsmSessionManager::session_create`] and used by all
-/// subsequent session operations (state query, deletion).  A session ID
-/// is only valid within the partition that allocated it.
+/// Returned by [`HsmSessionManager::session_create`] (via the
+/// [`SessionGuard`] handle) and used by all subsequent session
+/// operations (state query, deletion).  A session ID is only valid
+/// within the partition that allocated it.
 ///
-/// In the standard PAL, slot indices range from 0 to 7 (8 sessions per
-/// partition).
+/// In the standard PAL, slot indices range from 0 to 7 (8 sessions
+/// per partition).  Hardware builds may use a different cap.
+///
+/// `#[repr(transparent)]` over `u16`.
 ///
 /// # Conversions
 ///
@@ -163,7 +259,15 @@ impl From<HsmKeyId> for u16 {
 pub struct HsmSessId(u16);
 
 impl From<u16> for HsmSessId {
-    /// Create a session identifier from a raw `u16` slot index.
+    /// Wraps a raw `u16` slot index into a [`HsmSessId`].
+    ///
+    /// # Parameters
+    ///
+    /// - `v` — session-table slot index.
+    ///
+    /// # Returns
+    ///
+    /// A [`HsmSessId`] wrapping `v`.
     #[inline]
     fn from(v: u16) -> Self {
         Self(v)
@@ -171,7 +275,15 @@ impl From<u16> for HsmSessId {
 }
 
 impl From<HsmSessId> for u16 {
-    /// Extract the raw `u16` slot index from a session identifier.
+    /// Unwraps a [`HsmSessId`] to its raw `u16` slot index.
+    ///
+    /// # Parameters
+    ///
+    /// - `id` — session identifier.
+    ///
+    /// # Returns
+    ///
+    /// The underlying `u16` slot index.
     #[inline]
     fn from(id: HsmSessId) -> Self {
         id.0

--- a/fw/pal/traits/src/lock.rs
+++ b/fw/pal/traits/src/lock.rs
@@ -34,10 +34,10 @@ use super::*;
 /// # Usage
 ///
 /// ```text
-/// async fn handle_ddi<P: HsmPal>(pal: &P, pid: HsmPartId) {
-///     let _lock = pal.partition_lock(pid).await;
+/// async fn handle_ddi<P: HsmPal>(pal: &P, io: &impl HsmIo) {
+///     let _lock = pal.partition_lock(io).await;
 ///     // Exclusive access to this partition until _lock drops.
-///     let sess = pal.session_create(pid, api_rev, mk, None)?;
+///     let sess = pal.session_create(io, api_rev, mk, None)?;
 ///     sess.dismiss();
 /// }
 /// ```
@@ -58,6 +58,9 @@ pub trait HsmPartitionLock {
     ///
     /// # Errors
     ///
-    /// Returns [`HsmError::InvalidArg`] if `pid` is out of range.
-    async fn partition_lock(&self, pid: HsmPartId) -> HsmResult<Self::PartitionGuard<'_>>;
+    /// Returns [`HsmError::InvalidArg`] if `io.pid()` is out of range.
+    async fn partition_lock(
+        &self,
+        io: &impl HsmIo,
+    ) -> HsmResult<Self::PartitionGuard<'_>>;
 }

--- a/fw/pal/traits/src/pal.rs
+++ b/fw/pal/traits/src/pal.rs
@@ -2,29 +2,63 @@
 // Licensed under the MIT License.
 
 //! HSM platform abstraction layer trait.
+//!
+//! Defines the [`HsmPal`] aggregate trait — the single bound that the
+//! HSM core uses to talk to a platform implementation.  Concrete
+//! platforms (`OcelotHsmPal` for STM32, `StdHsmPal` for the host-side
+//! emulator) implement [`HsmPal`] by composing all of the smaller PAL
+//! sub-traits in this crate.
+//!
+//! ## Lifecycle
+//!
+//! ```text
+//! HsmPal::default()        — construct (zero-init)
+//!   ↓
+//! HsmPal::init(&self)      — one-time hardware bring-up (sync)
+//!   ↓
+//! HsmPal::run(&self).await — main event loop, returns on fatal error
+//!   ↓
+//! HsmPal::deinit(&self)    — release resources (sync)
+//! ```
+//!
+//! The trait is `&self` throughout: PAL implementations rely on
+//! interior mutability (no atomics; the firmware is single-core and
+//! cooperatively scheduled).
 
 use super::*;
 
-/// The core trait that all HSM platform implementations must implement.
+/// Aggregate platform trait implemented by every HSM PAL.
 ///
-/// Bundles all PAL sub-traits into a single bound.  A platform
-/// implementation provides hardware-specific behavior behind this
-/// common interface.
+/// `HsmPal` is the single entry point the HSM core depends on.  All
+/// hardware- and platform-specific behavior is reached through one of
+/// the supertraits listed below; this trait itself only adds the
+/// platform-wide lifecycle hooks ([`init`](Self::init),
+/// [`run`](Self::run), [`deinit`](Self::deinit)) and the [`Default`]
+/// constructibility constraint.
 ///
 /// ## Supertraits
 ///
 /// | Trait | Purpose |
 /// |-------|---------|
+/// | [`HsmAlloc`] | Per-IO bump-allocator scopes (DTCM and DMA SRAM) |
 /// | [`HsmIoController`] | I/O submission and completion |
-/// | [`HsmGdmaController`] | Host↔device memory copies |
-/// | [`HsmPartitionManager`] | Partition lifecycle queries |
+/// | [`HsmGdmaController`] | Host↔device memory copies (GDMA) |
+/// | [`HsmPartitionManager`] | Partition lifecycle and identity queries |
 /// | [`HsmPartitionLock`] | Per-partition async mutex for DDI handlers |
-/// | [`HsmCertStore`] | Per-partition certificate chains |
+/// | [`HsmCertStore`] | Per-partition certificate chain storage |
 /// | [`HsmSessionManager`] | Session allocation (vault-backed) |
 /// | [`HsmVault`] | Key storage with firmware capacity emulation |
-/// | [`HsmCrypto`] | Cryptographic operations (7 sub-traits) |
+/// | [`HsmCrypto`] | Cryptographic operations (hash, hmac, kdf, …) |
+///
+/// ## Construction
+///
+/// `HsmPal: Default` lets the core build the platform from a constant
+/// context.  Implementations should make `default()` cheap (no
+/// hardware access, no allocations, no panics); real bring-up belongs
+/// in [`init`](Self::init).
 pub trait HsmPal:
-    HsmIoController
+    HsmAlloc
+    + HsmIoController
     + HsmGdmaController
     + HsmPartitionManager
     + HsmPartitionLock
@@ -34,22 +68,60 @@ pub trait HsmPal:
     + HsmCrypto
     + Default
 {
-    /// Initializes the platform.
+    /// One-time platform bring-up.
     ///
-    /// Must be called before [`run`](Self::run). Performs any one-time hardware
-    /// or driver setup required by the platform.
+    /// Called exactly once after construction and before
+    /// [`run`](Self::run).  Owns synchronous hardware and driver
+    /// initialisation that must complete before any IO can be
+    /// processed: clock/PLL setup, peripheral enable, RNG/SHA/PKA
+    /// driver init, vault zeroing, etc.
+    ///
+    /// Implementations may panic on unrecoverable bring-up failure;
+    /// otherwise this method is infallible by contract.
+    ///
+    /// # Parameters
+    ///
+    /// - `&self` — fully constructed platform (interior-mutable).
+    ///
+    /// # Returns
+    ///
+    /// Nothing.  Successful return implies the platform is ready for
+    /// [`run`](Self::run).
     fn init(&self);
 
-    /// Runs the main platform event loop.
+    /// Drives the platform's main event loop.
     ///
-    /// This is an async entry point that drives the platform's ongoing
-    /// operation. It returns when the platform has completed or encountered
-    /// a fatal error.
+    /// This future runs for the lifetime of the firmware: it polls
+    /// the IO controller for incoming SQEs, dispatches them through
+    /// the core's IO pipeline, and yields back to the executor while
+    /// hardware operations are in flight.  It returns only on a
+    /// fatal, unrecoverable error.
+    ///
+    /// # Parameters
+    ///
+    /// - `&self` — initialised platform.  Must have had
+    ///   [`init`](Self::init) called previously.
+    ///
+    /// # Returns
+    ///
+    /// `()` once the loop has terminated.  Errors are surfaced
+    /// internally (logged, mapped to CQE statuses, etc.) and do not
+    /// propagate from this method.
     async fn run(&self);
 
-    /// Deinitializes the platform.
+    /// Releases platform resources.
     ///
-    /// Called after [`run`](Self::run) returns. Releases resources and
-    /// performs any cleanup required by the platform.
+    /// Called after [`run`](Self::run) returns.  Powers down
+    /// peripherals, flushes any pending logs, and clears
+    /// vault/session state.  Idempotent — safe to call from drop or
+    /// panic paths.
+    ///
+    /// # Parameters
+    ///
+    /// - `&self` — platform instance to tear down.
+    ///
+    /// # Returns
+    ///
+    /// Nothing.
     fn deinit(&self);
 }

--- a/fw/pal/traits/src/part.rs
+++ b/fw/pal/traits/src/part.rs
@@ -3,148 +3,391 @@
 
 //! Partition management types and traits.
 //!
-//! Defines the [`PartitionManager`] trait for querying and managing HSM
-//! partitions. Each partition represents a distinct host controller interface
-//! identified by [`HsmPartId`].
+//! Defines the [`HsmPartitionManager`] trait used by core to query
+//! and mutate per-partition state.  Each partition is a host-facing
+//! controller interface identified by [`HsmPartId`]; the firmware
+//! supports up to `HSM_NUM_PARTITIONS` of them, addressed implicitly
+//! through the [`HsmIo`] handle (`io.pid()`).
+//!
+//! ## Per-partition state
+//!
+//! Each partition slot owns:
+//!
+//! - A [`PartState`] lifecycle field.
+//! - A resource count (number of host-allocated SQ/CQ pairs).
+//! - An opaque identity blob ([`PartId`]) and an ECC-P384 identity
+//!   key pair.
+//! - A pair of crypto material slots used during credential
+//!   establishment and session setup:
+//!   - **establish-cred** — one-time RSA-OAEP keypair used to receive
+//!     the host's bootstrap credential. Cleared after use.
+//!   - **session-enc** — long-lived ECDH key used to derive
+//!     per-session encryption keys.
+//! - A 32-byte randomness nonce, refreshed per credential / session
+//!   event.
+//! - An optional sealed BK3 blob (set once, ≤ 1024 bytes).
+//!
+//! ## Lifecycle
+//!
+//! ```text
+//! Unallocated ── allocate resources + identity ──▶ Allocated
+//!                                                      │
+//!                          generate internal keys + nonce
+//!                                                      ▼
+//!                                                  Enabled ──▶ Disabled
+//!                                                                │
+//!                                              re-enable internal keys
+//!                                                                │
+//!                                                                ▼
+//!                                                            Enabled
+//! ```
+//!
+//! ## Implicit partition addressing
+//!
+//! All trait methods take an [`HsmIo`] handle rather than an explicit
+//! [`HsmPartId`].  The partition is resolved via [`HsmIo::pid`].  This
+//! prevents accidental cross-partition queries and keeps the trait
+//! shape uniform with the rest of the PAL.
 
 use super::*;
 
 /// Opaque identity blob for a partition.
+///
+/// Returned by [`HsmPartitionManager::part_id`].  The slice borrows
+/// directly from partition state and is valid for the duration of the
+/// `&self` borrow on the [`HsmPartitionManager`] implementation.  The
+/// content is treated as opaque by core; only the host knows how to
+/// interpret it.
 pub type PartId<'a> = &'a [u8];
 
-/// Represents the current state of a partition.
+/// Lifecycle state of a partition slot.
+///
+/// State transitions are driven by host management commands; this
+/// enum is the canonical observation point for downstream code (DDI
+/// dispatch, IO gating, vault/session scoping).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PartState {
-    /// Partition slot is not allocated. No resources assigned.
+    /// The partition slot is free.  No resources, no identity, no
+    /// keys.  IO arriving for this partition is dropped.
     Unallocated,
 
-    /// Partition is allocated with resources and identity key pair, but
-    /// internal crypto keys (establish-cred, session-enc) and nonce
-    /// have not been created yet.
+    /// Resources and the ECC-P384 identity key pair are present, but
+    /// the establish-cred and session-enc keys plus the nonce have
+    /// not been generated yet.  The host must complete provisioning
+    /// before DDI traffic is accepted.
     Allocated,
 
-    /// Partition is fully operational. Internal keys and nonce are
-    /// present. DDI operations can proceed.
+    /// The partition is fully provisioned and ready for DDI
+    /// operations.  All internal crypto material (identity,
+    /// establish-cred, session-enc, nonce) is present.
     Enabled,
 
-    /// Partition has been disabled. Internal keys, nonce, vault keys,
-    /// and sessions are cleared, but resources and identity remain.
-    /// Can be re-enabled via `part_enable`.
+    /// The partition was previously [`Enabled`](Self::Enabled) and has
+    /// been disabled by the host.  Internal crypto material, vault
+    /// keys, and sessions are cleared, but the resource allocation
+    /// and identity key pair are retained so the partition can be
+    /// re-enabled without a full re-provision.
     Disabled,
 }
 
 /// Partition manager interface.
 ///
-/// Provides methods for querying partition status, resource allocation, and
-/// identity credentials. Each partition is addressed by [`HsmPartId`].
+/// All methods take an [`HsmIo`] handle and operate on the partition
+/// resolved from `io.pid()`.  The trait is `&self`; PAL
+/// implementations are expected to use interior mutability.
+///
+/// Methods returning `usize` follow a uniform query/copy pattern: pass
+/// `out = None` to obtain the required buffer size, then call again
+/// with `out = Some(&mut buf[..size])` to perform the copy.  Both
+/// calls return the same canonical size.
 pub trait HsmPartitionManager {
-    /// Returns whether the partition identified by `pid` is enabled.
+    /// Returns the lifecycle state of the calling partition.
+    ///
+    /// Cheap probe used by IO dispatch to drop traffic for
+    /// non-[`Enabled`](PartState::Enabled) partitions.
     ///
     /// # Parameters
-    /// - `pid` — Partition identifier.
+    ///
+    /// - `io` — caller's I/O context (partition selected via
+    ///   [`HsmIo::pid`]).
     ///
     /// # Returns
-    /// The current [`PartState`] of the partition identified by `pid`.
     ///
-    /// # Errors
-    /// Returns [`HsmError`] if the partition index is invalid.
-    fn part_state(&self, pid: HsmPartId) -> HsmResult<PartState>;
+    /// - `Ok(state)` — the current [`PartState`].
+    /// - `Err(HsmError::InvalidArg)` — `io.pid()` is out of range
+    ///   for this build.
+    fn part_state(&self, io: &impl HsmIo) -> HsmResult<PartState>;
 
-    /// Returns the resource count allocated to the given partition.
+    /// Returns the number of host-allocated resources (SQ/CQ pairs)
+    /// bound to this partition.
     ///
     /// # Parameters
-    /// - `pid` — Partition identifier.
+    ///
+    /// - `io` — caller's I/O context.
     ///
     /// # Returns
-    /// The number of resources allocated to the partition.
     ///
-    /// # Errors
-    /// Returns [`HsmError`] if the partition index is invalid.
-    fn part_res_count(&self, pid: HsmPartId) -> HsmResult<u8>;
+    /// - `Ok(count)` — number of resources, in the range `0..=u8::MAX`.
+    ///   `0` is valid for [`PartState::Unallocated`].
+    /// - `Err(HsmError::InvalidArg)` — `io.pid()` is out of range.
+    fn part_res_count(&self, io: &impl HsmIo) -> HsmResult<u8>;
 
-    /// Returns the opaque identity blob for the given partition.
+    /// Borrows the opaque identity blob for the calling partition.
+    ///
+    /// The returned slice points into partition storage and is valid
+    /// for the duration of the `&self` borrow.  Content is opaque to
+    /// core.
     ///
     /// # Parameters
-    /// - `pid` — Partition identifier.
+    ///
+    /// - `io` — caller's I/O context.
     ///
     /// # Returns
-    /// A borrowed byte slice ([`PartId`]) containing the partition's identity.
     ///
-    /// # Errors
-    /// Returns [`HsmError`] if the partition index is invalid.
-    fn part_id(&self, pid: HsmPartId) -> HsmResult<PartId<'_>>;
+    /// - `Ok(id)` — borrowed [`PartId`] slice.
+    /// - `Err(HsmError::InvalidArg)` — `io.pid()` is out of range.
+    /// - `Err(HsmError::PartitionNotProvisioned)` — partition is
+    ///   [`Unallocated`](PartState::Unallocated).
+    fn part_id(&self, io: &impl HsmIo) -> HsmResult<PartId<'_>>;
 
-    /// Returns the vault key ID for the partition's identity ECC-384 key.
+    /// Returns the vault key ID for the partition's ECC-P384
+    /// identity key pair.
     ///
-    /// The private key is stored in the vault as `Ecc384Private` with
-    /// `sign + local + internal` attributes.
-    fn part_id_key_id(&self, pid: HsmPartId) -> HsmResult<HsmKeyId>;
+    /// The private key is stored in the vault as
+    /// [`HsmVaultKeyKind::Ecc384Private`] with `sign + local +
+    /// internal` attributes set.  The corresponding public key is
+    /// served by [`part_id_pub_key`](Self::part_id_pub_key).
+    ///
+    /// # Parameters
+    ///
+    /// - `io` — caller's I/O context.
+    ///
+    /// # Returns
+    ///
+    /// - `Ok(key_id)` — vault [`HsmKeyId`] for the identity private
+    ///   key.
+    /// - `Err(HsmError::InvalidArg)` — `io.pid()` is out of range.
+    /// - `Err(HsmError::PartitionNotProvisioned)` — partition is
+    ///   [`Unallocated`](PartState::Unallocated) (no identity key yet).
+    fn part_id_key_id(&self, io: &impl HsmIo) -> HsmResult<HsmKeyId>;
 
-    /// Returns the DER-encoded public key for the partition's identity key.
+    /// Returns the DER-encoded SubjectPublicKeyInfo for the
+    /// partition's identity key, optionally copying it into a
+    /// caller-supplied buffer.
     ///
-    /// Pass `None` to query the size; pass `Some(buf)` to copy into `buf`.
-    fn part_id_pub_key(&self, pid: HsmPartId, out: Option<&mut [u8]>) -> HsmResult<usize>;
+    /// # Parameters
+    ///
+    /// - `io` — caller's I/O context.
+    /// - `out` —
+    ///   - `None` — query mode; no copy is performed, just return the
+    ///     required size.
+    ///   - `Some(buf)` — copy mode; the encoded key is written to
+    ///     `buf[..size]`.  `buf.len()` must be ≥ size.
+    ///
+    /// # Returns
+    ///
+    /// - `Ok(size)` — number of bytes that were (or would be) written.
+    /// - `Err(HsmError::InvalidArg)` — `io.pid()` is out of range, or
+    ///   `out` is `Some(buf)` and `buf.len() < size`.
+    /// - `Err(HsmError::PartitionNotProvisioned)` — no identity key.
+    fn part_id_pub_key(&self, io: &impl HsmIo, out: Option<&mut [u8]>) -> HsmResult<usize>;
 
-    /// Returns the establish-credential encryption key ID.
+    /// Returns the vault key ID of the establish-credential
+    /// encryption key, if present.
     ///
-    /// Returns `None` if the key has been cleared (one-time use pattern)
-    /// or if the partition is not in [`Enabled`](PartState::Enabled) state.
-    fn part_establish_cred_key_id(&self, pid: HsmPartId) -> HsmResult<Option<HsmKeyId>>;
+    /// The establish-cred key is a one-time-use RSA-OAEP keypair
+    /// generated when the partition transitions to
+    /// [`Enabled`](PartState::Enabled).  Core calls
+    /// [`part_clear_establish_cred_key`](Self::part_clear_establish_cred_key)
+    /// once the bootstrap credential has been received, after which
+    /// this method returns `Ok(None)`.
+    ///
+    /// # Parameters
+    ///
+    /// - `io` — caller's I/O context.
+    ///
+    /// # Returns
+    ///
+    /// - `Ok(Some(key_id))` — key is present in the vault.
+    /// - `Ok(None)` — key has been cleared (one-time-use complete).
+    /// - `Err(HsmError::InvalidArg)` — `io.pid()` is out of range.
+    /// - `Err(HsmError::PartitionNotEnabled)` — partition is not
+    ///   currently [`Enabled`](PartState::Enabled).
+    fn part_establish_cred_key_id(&self, io: &impl HsmIo) -> HsmResult<Option<HsmKeyId>>;
 
-    /// Returns the DER-encoded public key for establish-credential encryption.
+    /// Returns the DER-encoded SubjectPublicKeyInfo for the
+    /// establish-credential encryption key, optionally copying it.
     ///
-    /// Pass `None` to query the size; pass `Some(buf)` to copy into `buf`.
-    /// Returns 0 if the key has been cleared.
+    /// Follows the same query/copy pattern as
+    /// [`part_id_pub_key`](Self::part_id_pub_key).  After the key has
+    /// been cleared, returns `Ok(0)` (no data, no error) so callers
+    /// can treat absence as a `len == 0` reply.
+    ///
+    /// # Parameters
+    ///
+    /// - `io` — caller's I/O context.
+    /// - `out` — `None` for size query, `Some(buf)` to copy.
+    ///
+    /// # Returns
+    ///
+    /// - `Ok(size)` — bytes that were (or would be) written; `0` if
+    ///   the key has been cleared.
+    /// - `Err(HsmError::InvalidArg)` — `io.pid()` is out of range, or
+    ///   `out = Some(buf)` and `buf.len() < size`.
+    /// - `Err(HsmError::PartitionNotEnabled)` — partition is not
+    ///   currently [`Enabled`](PartState::Enabled).
     fn part_establish_cred_pub_key(
         &self,
-        pid: HsmPartId,
+        io: &impl HsmIo,
         out: Option<&mut [u8]>,
     ) -> HsmResult<usize>;
 
-    /// Clear the establish-credential encryption key from the vault.
+    /// Removes the establish-credential encryption key from the
+    /// vault.
     ///
-    /// After clearing, [`part_establish_cred_key_id`](Self::part_establish_cred_key_id)
-    /// returns `None`.  This implements the one-time-use pattern: the
-    /// core calls this after credential establishment completes.
+    /// Implements the one-time-use pattern: core calls this after
+    /// the bootstrap credential has been received.  Idempotent —
+    /// calling on an already-cleared key returns `Ok(())`.  After
+    /// this call,
+    /// [`part_establish_cred_key_id`](Self::part_establish_cred_key_id)
+    /// returns `Ok(None)` and
+    /// [`part_establish_cred_pub_key`](Self::part_establish_cred_pub_key)
+    /// returns `Ok(0)`.
     ///
-    /// Idempotent — calling on an already-cleared key succeeds silently.
-    fn part_clear_establish_cred_key(&self, pid: HsmPartId) -> HsmResult<()>;
+    /// # Parameters
+    ///
+    /// - `io` — caller's I/O context.
+    ///
+    /// # Returns
+    ///
+    /// - `Ok(())` on success or if already cleared.
+    /// - `Err(HsmError::InvalidArg)` — `io.pid()` is out of range.
+    /// - `Err(HsmError::PartitionNotEnabled)` — partition is not
+    ///   currently [`Enabled`](PartState::Enabled).
+    fn part_clear_establish_cred_key(&self, io: &impl HsmIo) -> HsmResult<()>;
 
-    /// Returns the session encryption key ID.
+    /// Returns the vault key ID of the session encryption key.
     ///
-    /// # Errors
-    /// Returns [`HsmError`] if the partition is not [`Enabled`](PartState::Enabled).
-    fn part_session_enc_key_id(&self, pid: HsmPartId) -> HsmResult<HsmKeyId>;
+    /// Unlike the establish-cred key, this key is long-lived and is
+    /// reused for every session opened against this partition.  It
+    /// is regenerated only on disable→enable transitions.
+    ///
+    /// # Parameters
+    ///
+    /// - `io` — caller's I/O context.
+    ///
+    /// # Returns
+    ///
+    /// - `Ok(key_id)` — vault [`HsmKeyId`] for the session-enc
+    ///   private key.
+    /// - `Err(HsmError::InvalidArg)` — `io.pid()` is out of range.
+    /// - `Err(HsmError::PartitionNotEnabled)` — partition is not
+    ///   currently [`Enabled`](PartState::Enabled).
+    fn part_session_enc_key_id(&self, io: &impl HsmIo) -> HsmResult<HsmKeyId>;
 
-    /// Returns the DER-encoded public key for session encryption.
+    /// Returns the DER-encoded SubjectPublicKeyInfo for the session
+    /// encryption key, optionally copying it.
     ///
-    /// Pass `None` to query the size; pass `Some(buf)` to copy into `buf`.
-    fn part_session_enc_pub_key(&self, pid: HsmPartId, out: Option<&mut [u8]>) -> HsmResult<usize>;
+    /// Follows the same query/copy pattern as
+    /// [`part_id_pub_key`](Self::part_id_pub_key).
+    ///
+    /// # Parameters
+    ///
+    /// - `io` — caller's I/O context.
+    /// - `out` — `None` for size query, `Some(buf)` to copy.
+    ///
+    /// # Returns
+    ///
+    /// - `Ok(size)` — bytes that were (or would be) written.
+    /// - `Err(HsmError::InvalidArg)` — `io.pid()` is out of range, or
+    ///   `out = Some(buf)` and `buf.len() < size`.
+    /// - `Err(HsmError::PartitionNotEnabled)` — partition is not
+    ///   currently [`Enabled`](PartState::Enabled).
+    fn part_session_enc_pub_key(&self, io: &impl HsmIo, out: Option<&mut [u8]>)
+    -> HsmResult<usize>;
 
-    /// Returns the 32-byte random nonce for the partition.
+    /// Returns the partition's 32-byte random nonce, optionally
+    /// copying it.
     ///
-    /// Pass `None` to query the size; pass `Some(buf)` to copy into `buf`.
+    /// The nonce is freshened by
+    /// [`part_nonce_refresh`](Self::part_nonce_refresh) on credential
+    /// and session events; the size is therefore always 32.
     ///
-    /// # Errors
-    /// Returns [`HsmError`] if the partition is not [`Enabled`](PartState::Enabled).
-    fn part_nonce(&self, pid: HsmPartId, out: Option<&mut [u8]>) -> HsmResult<usize>;
+    /// # Parameters
+    ///
+    /// - `io` — caller's I/O context.
+    /// - `out` — `None` for size query, `Some(buf)` to copy.
+    ///
+    /// # Returns
+    ///
+    /// - `Ok(32)` always (on success), with `buf[..32]` populated when
+    ///   `out = Some(buf)`.
+    /// - `Err(HsmError::InvalidArg)` — `io.pid()` is out of range, or
+    ///   `out = Some(buf)` and `buf.len() < 32`.
+    /// - `Err(HsmError::PartitionNotEnabled)` — partition is not
+    ///   currently [`Enabled`](PartState::Enabled).
+    fn part_nonce(&self, io: &impl HsmIo, out: Option<&mut [u8]>) -> HsmResult<usize>;
 
-    /// Refresh (regenerate) the partition nonce from the RNG.
+    /// Regenerates the partition nonce from the hardware RNG.
     ///
-    /// Called after credential establishment or session open to ensure
-    /// nonce freshness.
-    fn part_nonce_refresh(&self, pid: HsmPartId) -> HsmResult<()>;
+    /// Called by core after credential establishment and session open
+    /// to ensure the nonce read by the host has not been observed in
+    /// a previous transaction.
+    ///
+    /// # Parameters
+    ///
+    /// - `io` — caller's I/O context.
+    ///
+    /// # Returns
+    ///
+    /// - `Ok(())` on success.
+    /// - `Err(HsmError::InvalidArg)` — `io.pid()` is out of range.
+    /// - `Err(HsmError::PartitionNotEnabled)` — partition is not
+    ///   currently [`Enabled`](PartState::Enabled).
+    /// - `Err(HsmError)` — propagated from the RNG driver.
+    fn part_nonce_refresh(&self, io: &impl HsmIo) -> HsmResult<()>;
 
-    /// Returns the sealed BK3 blob for the partition.
+    /// Returns the sealed BK3 blob for the partition, optionally
+    /// copying it.
     ///
-    /// Pass `None` to query the size; pass `Some(buf)` to copy into `buf`.
-    /// Returns 0 if no sealed BK3 has been stored yet.
-    fn part_sealed_bk3(&self, pid: HsmPartId, out: Option<&mut [u8]>) -> HsmResult<usize>;
+    /// The sealed BK3 is set once via
+    /// [`part_set_sealed_bk3`](Self::part_set_sealed_bk3); subsequent
+    /// reads return the same blob.  Before any write, returns
+    /// `Ok(0)`.
+    ///
+    /// # Parameters
+    ///
+    /// - `io` — caller's I/O context.
+    /// - `out` — `None` for size query, `Some(buf)` to copy.
+    ///
+    /// # Returns
+    ///
+    /// - `Ok(size)` — bytes that were (or would be) written; `0` if
+    ///   no sealed BK3 has been stored.
+    /// - `Err(HsmError::InvalidArg)` — `io.pid()` is out of range, or
+    ///   `out = Some(buf)` and `buf.len() < size`.
+    /// - `Err(HsmError::PartitionNotEnabled)` — partition is not
+    ///   currently [`Enabled`](PartState::Enabled).
+    fn part_sealed_bk3(&self, io: &impl HsmIo, out: Option<&mut [u8]>) -> HsmResult<usize>;
 
-    /// Store the sealed BK3 blob for the partition.
+    /// Stores the sealed BK3 blob for the partition.
     ///
-    /// # Errors
-    /// - [`HsmError::SealedBk3AlreadySet`] if already stored.
-    /// - [`HsmError::SealedBk3TooLarge`] if `data` exceeds 1024 bytes.
-    fn part_set_sealed_bk3(&self, pid: HsmPartId, data: &[u8]) -> HsmResult<()>;
+    /// Write-once: a second call returns
+    /// [`HsmError::SealedBk3AlreadySet`].
+    ///
+    /// # Parameters
+    ///
+    /// - `io` — caller's I/O context.
+    /// - `data` — sealed BK3 bytes; must be ≤ 1024 bytes.
+    ///
+    /// # Returns
+    ///
+    /// - `Ok(())` on success.
+    /// - `Err(HsmError::InvalidArg)` — `io.pid()` is out of range.
+    /// - `Err(HsmError::PartitionNotEnabled)` — partition is not
+    ///   currently [`Enabled`](PartState::Enabled).
+    /// - `Err(HsmError::SealedBk3AlreadySet)` — a sealed BK3 has
+    ///   already been stored.
+    /// - `Err(HsmError::SealedBk3TooLarge)` — `data.len() > 1024`.
+    fn part_set_sealed_bk3(&self, io: &impl HsmIo, data: &[u8]) -> HsmResult<()>;
 }

--- a/fw/pal/traits/src/session.rs
+++ b/fw/pal/traits/src/session.rs
@@ -18,13 +18,13 @@
 //! ## Session lifecycle
 //!
 //! ```text
-//! session_create(pid, api_rev, masking_key, None) → logical HsmSessId
+//! session_create(io, api_rev, masking_key, None) → logical HsmSessId
 //!   ↓
-//! session_state(pid, id)   — verify session is active
+//! session_state(io, id)   — verify session is active
 //!   ↓
-//! session_create(pid, api_rev, masking_key, Some(id)) — re-key after migration
+//! session_create(io, api_rev, masking_key, Some(id)) — re-key after migration
 //!   ↓
-//! session_delete(pid, id)  — close: delete scoped keys + session key + free slot
+//! session_destroy(io, id) — close: delete scoped keys + session key + free slot
 //! ```
 //!
 //! ## Session–key binding
@@ -36,126 +36,186 @@
 use super::*;
 
 /// Lifecycle state of a session.
+///
+/// Returned by [`HsmSessionManager::session_state`].  The state is
+/// derived from the underlying vault entry plus session-table
+/// metadata; there is no separate persistent state field.
 pub enum HsmSessionState {
-    /// The session exists and is active.
+    /// The session slot is allocated and the masking key is valid for
+    /// the current API revision.  The session may be used.
     Active,
 
-    /// The session exists but requires re-negotiation (e.g., after VM migration).
+    /// The session slot is allocated, but the API revision recorded in
+    /// the masking blob does not match the live one (e.g. after a VM
+    /// migration).  The host must call
+    /// [`HsmSessionManager::session_create`] with `id =
+    /// Some(existing)` to re-key before any further operations.
     NeedsRenegotiation,
 
-    /// The session has been deleted or is otherwise invalid.
+    /// The slot is free, the partition does not own such a session, or
+    /// the session was destroyed.  Any operation referencing this ID
+    /// must fail.
     Invalid,
 }
 
 /// RAII guard for a newly created session.
 ///
-/// Returned by [`HsmSessionManager::session_create`].  If dropped without
-/// calling [`dismiss`](Self::dismiss), the session is automatically deleted
-/// (cascading: session-scoped vault keys, session vault key, logical slot).
+/// Returned by [`HsmSessionManager::session_create`].  The guard
+/// implements an explicit commit/rollback discipline: the session is
+/// *provisional* until [`dismiss`](Self::dismiss) is called.  If the
+/// guard is dropped without dismissing — for example because a
+/// downstream encode step or DDI handler returned an error — the
+/// destructor tears the session down (frees the slot, deletes the
+/// session vault key, removes any session-scoped keys), leaving no
+/// half-created session behind.
 ///
-/// # Usage
+/// Typical usage:
 ///
-/// ```text
-/// let guard = pal.session_create(pid, api_rev, masking_key, None)?;
-/// // ... derive keys, validate credential ...
-/// let sess_id = guard.dismiss();  // committed — session persists
+/// ```ignore
+/// let guard = pal.session_create(io, api_rev, masking_key, None)?;
+/// // ... fallible work that uses `guard.sess_id()` ...
+/// let id = guard.dismiss(); // commit; session now permanent
 /// ```
-pub struct SessionGuard<'a, P: HsmSessionManager + ?Sized> {
-    pal: &'a P,
-    pid: HsmPartId,
-    sess_id: Option<HsmSessId>,
-}
+pub trait SessionGuard {
+    /// Returns the session ID assigned to the provisional session.
+    ///
+    /// Safe to call multiple times; does **not** commit the session.
+    ///
+    /// # Returns
+    ///
+    /// The [`HsmSessId`] under which the session is currently
+    /// registered in the partition's session table.
+    fn sess_id(&self) -> HsmSessId;
 
-impl<'a, P: HsmSessionManager + ?Sized> SessionGuard<'a, P> {
-    /// Create a guard wrapping a newly created session.
-    pub fn new(pal: &'a P, pid: HsmPartId, sess_id: HsmSessId) -> Self {
-        Self {
-            pal,
-            pid,
-            sess_id: Some(sess_id),
-        }
-    }
-
-    /// Peek at the session ID before committing.
-    pub fn sess_id(&self) -> HsmSessId {
-        self.sess_id.unwrap()
-    }
-
-    /// Commit — session persists permanently.  Returns the session ID.
-    pub fn dismiss(mut self) -> HsmSessId {
-        self.sess_id.take().unwrap()
-    }
-}
-
-impl<P: HsmSessionManager + ?Sized> Drop for SessionGuard<'_, P> {
-    fn drop(&mut self) {
-        if let Some(sid) = self.sess_id.take() {
-            let _ = self.pal.session_delete(self.pid, sid);
-        }
-    }
+    /// Commits the session.  The session table entry persists past
+    /// the guard's lifetime and the destructor becomes a no-op.
+    ///
+    /// # Returns
+    ///
+    /// The committed [`HsmSessId`].
+    fn dismiss(self) -> HsmSessId;
 }
 
 /// Session management interface.
 ///
-/// Sessions are stored as vault keys.  `session_create` builds the
-/// session blob, stores it in the vault, and allocates a logical slot.
-/// `session_delete` cascades: removes session-scoped keys, deletes the
-/// session vault key, and frees the slot.
-///
-/// All methods are synchronous — session operations are fast table
-/// lookups or vault operations, not hardware-offloaded crypto.
+/// All methods take an [`HsmIo`] handle, which scopes the operation to
+/// the calling partition: a session created by partition A is
+/// invisible to partition B.  The trait is `&self`; PAL
+/// implementations are expected to use interior mutability for the
+/// session table (the firmware is single-core, cooperatively
+/// scheduled, so a plain `Cell`/`RefCell` suffices).
 pub trait HsmSessionManager {
-    /// Check whether the partition has at least one free session slot.
-    fn session_limit_reached(&self, pid: HsmPartId) -> bool;
+    /// RAII guard returned by
+    /// [`session_create`](Self::session_create).
+    ///
+    /// The lifetime parameter ties the guard to the session manager
+    /// so an uncommitted session cannot outlive the manager that
+    /// owns it.
+    type Guard<'a>: SessionGuard
+    where
+        Self: 'a;
 
-    /// Create (or re-key) a session.
+    /// Returns `true` if the calling partition has no free session
+    /// slots.
     ///
-    /// Builds an 88-byte session blob from `api_rev` (8 bytes) and
-    /// `masking_key` (80 bytes), stores it in the vault as
-    /// [`HsmVaultKeyKind::Session`], and allocates a logical session
-    /// slot pointing to that vault key.
-    ///
-    /// Returns a [`SessionGuard`] that auto-deletes the session on drop
-    /// unless [`dismiss`](SessionGuard::dismiss) is called to persist it.
+    /// Used by DDI handlers to short-circuit `OpenSession` requests
+    /// with [`HsmError::VaultSessionLimitReached`] before allocating
+    /// any crypto state.
     ///
     /// # Parameters
-    /// - `pid` — Partition to create the session in.
-    /// - `api_rev` — 8-byte API revision negotiated during OpenSession.
-    /// - `masking_key` — 80-byte session masking key (AES-256 + HMAC-384).
-    /// - `id` — If `Some`, re-keys an existing session (must be in
-    ///   `NeedsRenegotiation` state). If `None`, creates a new session.
+    ///
+    /// - `io` — caller's I/O context (partition scope).
     ///
     /// # Returns
-    /// A [`SessionGuard`] wrapping the logical [`HsmSessId`] (0–7).
     ///
-    /// # Errors
-    /// - [`HsmError::VaultSessionLimitReached`] — no free slots.
-    /// - [`HsmError::NotEnoughSpace`] — vault cannot store session key.
-    /// - [`HsmError::InvalidArg`] — re-key requested but session is not
-    ///   in `NeedsRenegotiation` state.
+    /// - `true` — every session slot for this partition is in use.
+    /// - `false` — at least one slot is free; a subsequent
+    ///   [`session_create`](Self::session_create) with `id == None`
+    ///   may succeed.
+    fn session_limit_reached(&self, io: &impl HsmIo) -> bool;
+
+    /// Creates a new session, or re-keys an existing one in place.
+    ///
+    /// On success, returns a [`Self::Guard`] that holds the session
+    /// in a *provisional* state.  The caller must invoke
+    /// [`SessionGuard::dismiss`] to commit; dropping the guard
+    /// otherwise rolls the session back.
+    ///
+    /// # Parameters
+    ///
+    /// - `io` — caller's I/O context (partition scope).
+    /// - `api_rev` — 8-byte API-revision tag stored alongside the
+    ///   masking key; later compared by
+    ///   [`session_state`](Self::session_state) to detect post-
+    ///   migration drift.
+    /// - `masking_key` — 80-byte masking-key blob to seal into the
+    ///   session vault entry.
+    /// - `id` — `None` to allocate a new slot; `Some(existing)` to
+    ///   re-key an already-open session in place (post-migration
+    ///   renegotiation).  The existing session must currently be in
+    ///   either [`HsmSessionState::Active`] or
+    ///   [`HsmSessionState::NeedsRenegotiation`].
+    ///
+    /// # Returns
+    ///
+    /// - `Ok(guard)` — provisional session; commit with
+    ///   [`SessionGuard::dismiss`].
+    /// - `Err(HsmError::VaultSessionLimitReached)` — `id == None` and
+    ///   no slots are free (see
+    ///   [`session_limit_reached`](Self::session_limit_reached)).
+    /// - `Err(HsmError::InvalidArg)` — `id == Some(_)` and the slot
+    ///   is free, or `api_rev`/`masking_key` is the wrong length.
+    /// - `Err(HsmError::NotEnoughSpace)` — vault is full and cannot
+    ///   store the masking blob.
     fn session_create(
         &self,
-        pid: HsmPartId,
+        io: &impl HsmIo,
         api_rev: &[u8],
         masking_key: &[u8],
         id: Option<HsmSessId>,
-    ) -> HsmResult<SessionGuard<'_, Self>>;
+    ) -> HsmResult<Self::Guard<'_>>;
 
-    /// Delete (close) a session.
+    /// Closes a session.
     ///
-    /// 1. Deletes all session-scoped vault keys bound to this session's
-    ///    physical key ID.
-    /// 2. Deletes the session vault key itself.
-    /// 3. Frees the logical session slot.
+    /// Tears down the session in this order:
     ///
-    /// # Errors
-    /// - [`HsmError::SessionNotFound`] — session ID is invalid.
-    fn session_delete(&self, pid: HsmPartId, id: HsmSessId) -> HsmResult<()>;
+    /// 1. Removes every vault key bound to the session's physical
+    ///    vault key ID (see module-level docs for the
+    ///    session→physical-ID binding).
+    /// 2. Deletes the session vault entry itself.
+    /// 3. Frees the session table slot.
+    ///
+    /// Idempotent only in the sense that a freed slot is safe to
+    /// reuse; calling `session_destroy` on an already-free slot is
+    /// reported as [`HsmError::InvalidArg`].
+    ///
+    /// # Parameters
+    ///
+    /// - `io` — caller's I/O context (partition scope).
+    /// - `id` — session to close.
+    ///
+    /// # Returns
+    ///
+    /// - `Ok(())` on success.
+    /// - `Err(HsmError::InvalidArg)` — `id` does not refer to a live
+    ///   session in the caller's partition.
+    fn session_destroy(&self, io: &impl HsmIo, id: HsmSessId) -> HsmResult<()>;
 
-    /// Query the current state of a session.
+    /// Queries the lifecycle state of a session slot.
     ///
-    /// Returns one of the [`HsmSessionState`] variants indicating whether
-    /// the session is active, requires re-negotiation, or has been
-    /// deleted/invalidated.
-    fn session_state(&self, pid: HsmPartId, id: HsmSessId) -> HsmSessionState;
+    /// This is an infallible probe: an unknown or freed slot is
+    /// reported as [`HsmSessionState::Invalid`] rather than an
+    /// `HsmError`.
+    ///
+    /// # Parameters
+    ///
+    /// - `io` — caller's I/O context (partition scope).
+    /// - `id` — session slot to probe.
+    ///
+    /// # Returns
+    ///
+    /// One of [`HsmSessionState::Active`],
+    /// [`HsmSessionState::NeedsRenegotiation`], or
+    /// [`HsmSessionState::Invalid`].
+    fn session_state(&self, io: &impl HsmIo, id: HsmSessId) -> HsmSessionState;
 }

--- a/fw/pal/traits/src/vault.rs
+++ b/fw/pal/traits/src/vault.rs
@@ -25,9 +25,9 @@
 //!
 //! ## Key identifiers
 //!
-//! Each key is assigned a [`HsmVaultKeyId`] (`u16`) on creation. This
-//! ID is used in all subsequent DDI operations (sign, encrypt, delete,
-//! etc.) to reference the key without exposing key material.
+//! Each key is assigned a [`HsmKeyId`] (`u16` newtype) on creation.
+//! This ID is used in all subsequent DDI operations (sign, encrypt,
+//! delete, etc.) to reference the key without exposing key material.
 //!
 //! ## Key attributes
 //!
@@ -222,156 +222,230 @@ pub struct HsmVaultKeyAttrs {
 
 /// RAII guard for a newly created vault key.
 ///
-/// Returned by [`HsmVault::vault_key_create`].  If dropped without
-/// calling [`dismiss`](Self::dismiss), the key is automatically deleted
-/// from the vault — providing rollback safety for multi-step DDI
-/// operations (e.g., GenerateKeyPair creates private + public keys;
-/// if the second create fails, the first is automatically rolled back).
+/// Returned by [`HsmVault::vault_key_create`]. The guard implements an
+/// explicit commit/rollback discipline: the key is *provisional* until
+/// [`dismiss`](Self::dismiss) is called.  If the guard is dropped
+/// without dismissing — for example because a downstream encode step
+/// or DDI handler returned an error — the destructor deletes the key
+/// from the vault, leaving no half-created entry behind.
 ///
-/// # Usage
+/// Typical usage:
 ///
-/// ```text
-/// let guard = pal.vault_key_create(pid, key, kind, ...)?;
-/// // ... more fallible work ...
-/// let key_id = guard.dismiss();  // committed — key persists
+/// ```ignore
+/// let guard = pal.vault_key_create(io, &key, kind, sess, attrs, meta)?;
+/// // ... fallible work that uses `guard.key_id()` ...
+/// let id = guard.dismiss(); // commit; key now permanent
 /// ```
-pub struct VaultKeyGuard<'a, P: HsmVault + ?Sized> {
-    pal: &'a P,
-    pid: HsmPartId,
-    key_id: Option<HsmKeyId>,
-}
-
-impl<'a, P: HsmVault + ?Sized> VaultKeyGuard<'a, P> {
-    /// Create a guard wrapping a newly created key.
-    pub fn new(pal: &'a P, pid: HsmPartId, key_id: HsmKeyId) -> Self {
-        Self {
-            pal,
-            pid,
-            key_id: Some(key_id),
-        }
-    }
-
-    /// Peek at the key ID (e.g., to read key material before committing).
-    pub fn key_id(&self) -> HsmKeyId {
-        self.key_id.unwrap()
-    }
-
-    /// Commit — key persists permanently.  Returns the key ID.
-    pub fn dismiss(mut self) -> HsmKeyId {
-        self.key_id.take().unwrap()
-    }
-}
-
-impl<P: HsmVault + ?Sized> Drop for VaultKeyGuard<'_, P> {
-    fn drop(&mut self) {
-        if let Some(kid) = self.key_id.take() {
-            let _ = self.pal.vault_key_delete(self.pid, kid);
-        }
-    }
-}
-
-/// Trait defining the HSM key vault interface.
-///
-/// Provides creation, deletion, and querying of cryptographic keys stored
-/// in protected memory. Implementations are platform-specific:
-/// - **Cortex-M7**: keys stored in on-chip SRAM with hardware protection.
-/// - **Standard PAL**: keys stored on the heap for simulation/testing.
-///
-/// All methods are synchronous — vault operations are fast table lookups
-/// or memory copies, not hardware-offloaded crypto.
-pub trait HsmVault {
-    /// Store a new key in the vault.
+pub trait VaultKeyGuard {
+    /// Returns the key ID assigned to the provisional key.
     ///
-    /// Returns a [`VaultKeyGuard`] that auto-deletes the key on drop
-    /// unless [`dismiss`](VaultKeyGuard::dismiss) is called to persist it.
-    ///
-    /// # Parameters
-    /// - `key` — The key material to store.
-    /// - `kind` — The type/algorithm of the key (e.g., `Aes256`, `Ecc384Private`).
-    /// - `session_id` — If `Some(id)`, the key is session-scoped and will be
-    ///   deleted when the session closes. `None` for application-scoped keys.
-    /// - `attrs` — Key attribute bitfield (encrypt, sign, extractable, etc.).
-    /// - `meta` — Arbitrary per-key metadata blob (e.g., key label, DDI
-    ///   target key metadata).
+    /// Safe to call multiple times; does **not** commit the key.
     ///
     /// # Returns
-    /// A [`VaultKeyGuard`] wrapping the new key ID.
     ///
-    /// # Errors
-    /// Returns [`HsmError`] if the vault is full or the key kind is invalid.
+    /// The [`HsmKeyId`] under which the key is currently registered in
+    /// the vault.
+    fn key_id(&self) -> HsmKeyId;
+
+    /// Commits the key. The vault entry persists past the guard's
+    /// lifetime and the destructor becomes a no-op.
+    ///
+    /// # Returns
+    ///
+    /// The committed [`HsmKeyId`].
+    fn dismiss(self) -> HsmKeyId;
+}
+
+/// HSM key vault interface.
+///
+/// All accessor methods take an [`HsmIo`] handle, used to scope the
+/// query to the calling partition — a key created under one partition
+/// is invisible to other partitions.  Methods returning `&[u8]`
+/// borrow directly from vault storage; the borrow lives no longer
+/// than the `&self` borrow on the vault.
+pub trait HsmVault {
+    /// RAII guard returned by [`vault_key_create`](Self::vault_key_create).
+    ///
+    /// The lifetime parameter ties the guard to the vault so an
+    /// uncommitted key cannot outlive the vault that owns it.
+    type KeyGuard<'a>: VaultKeyGuard
+    where
+        Self: 'a;
+
+    /// Stores a new key in the vault under a freshly assigned
+    /// [`HsmKeyId`].
+    ///
+    /// The returned [`Self::KeyGuard`] holds the key in a *provisional*
+    /// state.  The caller must invoke [`VaultKeyGuard::dismiss`] to
+    /// commit the entry; dropping the guard otherwise rolls the key
+    /// back.
+    ///
+    /// # Parameters
+    ///
+    /// - `io` — caller's I/O context, used to bind the key to the
+    ///   active partition.
+    /// - `key` — raw key material. Length must match `kind`'s expected
+    ///   size (see [`vault_key_len`](Self::vault_key_len)).
+    /// - `kind` — algorithm/size tag for the key (see
+    ///   [`HsmVaultKeyKind`]).
+    /// - `session_id` — `Some(id)` to scope the key to a session
+    ///   (auto-deleted on session close), `None` for a partition-wide
+    ///   key.
+    /// - `attrs` — PKCS#11-style permission bitfield (see
+    ///   [`HsmVaultKeyAttrs`]).
+    /// - `meta` — opaque per-key metadata (e.g. label, ECC point
+    ///   encoding); stored verbatim and returned by
+    ///   [`vault_key_meta`](Self::vault_key_meta).
+    ///
+    /// # Returns
+    ///
+    /// - `Ok(guard)` — provisional vault entry; commit with
+    ///   [`VaultKeyGuard::dismiss`].
+    /// - `Err(HsmError::NotEnoughSpace)` — vault is full.
+    /// - `Err(HsmError::InvalidArg)` — `key.len()` does not match
+    ///   `kind`, or `attrs` are inconsistent.
     fn vault_key_create(
         &self,
-        pid: HsmPartId,
+        io: &impl HsmIo,
         key: &[u8],
         kind: HsmVaultKeyKind,
         session_id: Option<HsmSessId>,
         attrs: HsmVaultKeyAttrs,
         meta: &[u8],
-    ) -> HsmResult<VaultKeyGuard<'_, Self>>;
+    ) -> HsmResult<Self::KeyGuard<'_>>;
 
-    /// Delete a key from the vault by ID.
+    /// Deletes a single key by ID.
     ///
-    /// Zeroizes the key material and frees the slot.
+    /// Idempotent in the sense that a deleted slot becomes available
+    /// for the next [`vault_key_create`](Self::vault_key_create), but
+    /// the deletion of an already-deleted ID is reported as
+    /// [`HsmError::InvalidArg`].
     ///
-    /// # Errors
-    /// Returns [`HsmError`] if the key ID is invalid or the key is
-    /// non-destroyable (internal key).
-    fn vault_key_delete(&self, pid: HsmPartId, key_id: HsmKeyId) -> HsmResult<()>;
-
-    /// Delete all keys associated with the given session.
+    /// # Parameters
     ///
-    /// Called during session close to clean up session-scoped keys.
-    ///
-    /// # Errors
-    /// Returns [`HsmError`] if the session ID is invalid.
-    fn vault_key_delete_by_session(&self, pid: HsmPartId, session_id: HsmSessId) -> HsmResult<()>;
-
-    /// Delete all keys from the vault.
-    ///
-    /// Zeroizes all key material and resets the vault to its initial
-    /// empty state. Used during partition deallocation.
-    ///
-    /// # Errors
-    /// Returns [`HsmError`] if the clear operation fails.
-    fn vault_clear(&self, pid: HsmPartId) -> HsmResult<()>;
-
-    /// Retrieve the key material for a given key ID.
+    /// - `io` — caller's I/O context (partition scope).
+    /// - `key_id` — ID returned by a previous successful
+    ///   [`vault_key_create`](Self::vault_key_create).
     ///
     /// # Returns
-    /// A borrowed reference to the key material. The lifetime is tied
-    /// to the vault's internal storage.
     ///
-    /// # Errors
-    /// Returns [`HsmError`] if the key ID is invalid or the slot is free.
-    fn vault_key(&self, pid: HsmPartId, key_id: HsmKeyId) -> HsmResult<&[u8]>;
+    /// - `Ok(())` on success.
+    /// - `Err(HsmError::InvalidArg)` if `key_id` does not refer to a
+    ///   live key in the caller's partition.
+    /// - `Err(HsmError::NotPermitted)` if the key's `destroyable` bit
+    ///   is unset (e.g. internal device keys).
+    fn vault_key_delete(&self, io: &impl HsmIo, key_id: HsmKeyId) -> HsmResult<()>;
 
-    /// Return the key material length in bytes for a given key kind.
+    /// Deletes every key whose `session_id` matches `session_id`.
     ///
-    /// This is a static property of the key type (e.g., 32 for AES-256,
-    /// 48 for ECC-384 private key) and does not require a key ID.
+    /// Used during session teardown to reap session-scoped keys in
+    /// bulk.  Keys with no associated session are unaffected.
     ///
-    /// # Errors
-    /// Returns [`HsmError`] if the key kind is unknown.
-    fn vault_key_len(&self, pid: HsmPartId, kind: HsmVaultKeyKind) -> HsmResult<u16>;
-
-    /// Query the key kind for a stored key.
+    /// # Parameters
     ///
-    /// # Errors
-    /// Returns [`HsmError`] if the key ID is invalid.
-    fn vault_key_kind(&self, pid: HsmPartId, key_id: HsmKeyId) -> HsmResult<HsmVaultKeyKind>;
-
-    /// Query the attribute bitfield for a stored key.
-    ///
-    /// # Errors
-    /// Returns [`HsmError`] if the key ID is invalid.
-    fn vault_key_attrs(&self, pid: HsmPartId, key_id: HsmKeyId) -> HsmResult<HsmVaultKeyAttrs>;
-
-    /// Query the metadata blob for a stored key.
+    /// - `io` — caller's I/O context (partition scope).
+    /// - `session_id` — session whose keys must be removed.
     ///
     /// # Returns
-    /// A borrowed reference to the per-key metadata set at creation time.
     ///
-    /// # Errors
-    /// Returns [`HsmError`] if the key ID is invalid.
-    fn vault_key_meta(&self, pid: HsmPartId, key_id: HsmKeyId) -> HsmResult<&[u8]>;
+    /// - `Ok(())` always; deleting zero keys is not an error.
+    fn vault_key_delete_by_session(&self, io: &impl HsmIo, session_id: HsmSessId) -> HsmResult<()>;
+
+    /// Deletes every key owned by the caller's partition, regardless
+    /// of session or attribute flags.
+    ///
+    /// # Parameters
+    ///
+    /// - `io` — caller's I/O context (partition scope).
+    ///
+    /// # Returns
+    ///
+    /// - `Ok(())` always; an already-empty vault is not an error.
+    fn vault_clear(&self, io: &impl HsmIo) -> HsmResult<()>;
+
+    /// Borrows the raw key material for `key_id`.
+    ///
+    /// The returned slice points into vault storage and is valid for
+    /// the duration of the `&self` borrow.
+    ///
+    /// # Parameters
+    ///
+    /// - `io` — caller's I/O context (partition scope).
+    /// - `key_id` — key to look up.
+    ///
+    /// # Returns
+    ///
+    /// - `Ok(&[u8])` — raw key bytes; length matches
+    ///   [`vault_key_len`](Self::vault_key_len) for the key's `kind`.
+    /// - `Err(HsmError::InvalidArg)` — `key_id` does not refer to a
+    ///   live key in the caller's partition.
+    fn vault_key(&self, io: &impl HsmIo, key_id: HsmKeyId) -> HsmResult<&DmaBuf>;
+
+    /// Returns the canonical byte length of a key of the given kind.
+    ///
+    /// For variable-length kinds (e.g. `VarLenHmacSha256`) this
+    /// returns the maximum supported length.
+    ///
+    /// # Parameters
+    ///
+    /// - `io` — caller's I/O context (used only for partition policy
+    ///   checks; no key lookup is performed).
+    /// - `kind` — key kind tag.
+    ///
+    /// # Returns
+    ///
+    /// - `Ok(len)` — expected `key.len()` for
+    ///   [`vault_key_create`](Self::vault_key_create) calls of this
+    ///   `kind`.
+    /// - `Err(HsmError::InvalidArg)` — `kind` is `Free` or otherwise
+    ///   not a real key type.
+    fn vault_key_len(&self, io: &impl HsmIo, kind: HsmVaultKeyKind) -> HsmResult<u16>;
+
+    /// Returns the [`HsmVaultKeyKind`] tag stored alongside the key.
+    ///
+    /// # Parameters
+    ///
+    /// - `io` — caller's I/O context (partition scope).
+    /// - `key_id` — key to look up.
+    ///
+    /// # Returns
+    ///
+    /// - `Ok(kind)` — algorithm/size tag.
+    /// - `Err(HsmError::InvalidArg)` — `key_id` does not refer to a
+    ///   live key in the caller's partition.
+    fn vault_key_kind(&self, io: &impl HsmIo, key_id: HsmKeyId) -> HsmResult<HsmVaultKeyKind>;
+
+    /// Returns the attribute bitfield stored alongside the key.
+    ///
+    /// # Parameters
+    ///
+    /// - `io` — caller's I/O context (partition scope).
+    /// - `key_id` — key to look up.
+    ///
+    /// # Returns
+    ///
+    /// - `Ok(attrs)` — the [`HsmVaultKeyAttrs`] supplied at creation.
+    /// - `Err(HsmError::InvalidArg)` — `key_id` does not refer to a
+    ///   live key in the caller's partition.
+    fn vault_key_attrs(&self, io: &impl HsmIo, key_id: HsmKeyId) -> HsmResult<HsmVaultKeyAttrs>;
+
+    /// Borrows the per-key metadata blob.
+    ///
+    /// The returned slice points into vault storage and is valid for
+    /// the duration of the `&self` borrow.  Content is whatever was
+    /// passed to
+    /// [`vault_key_create`](Self::vault_key_create)'s `meta`
+    /// parameter.
+    ///
+    /// # Parameters
+    ///
+    /// - `io` — caller's I/O context (partition scope).
+    /// - `key_id` — key to look up.
+    ///
+    /// # Returns
+    ///
+    /// - `Ok(&[u8])` — metadata bytes (may be empty).
+    /// - `Err(HsmError::InvalidArg)` — `key_id` does not refer to a
+    ///   live key in the caller's partition.
+    fn vault_key_meta(&self, io: &impl HsmIo, key_id: HsmKeyId) -> HsmResult<&[u8]>;
 }

--- a/fw/plat/std/pal/src/aes.rs
+++ b/fw/plat/std/pal/src/aes.rs
@@ -8,73 +8,135 @@
 //! the driver. Newly added AES-KW/AES-XTS trait entry points are stubbed
 //! with `todo!()` for now.
 
+use core::convert::TryInto;
+
 use super::*;
 
+fn aes_op_is_encrypt(op: AesOp) -> bool {
+    matches!(op, AesOp::Encrypt)
+}
+
+fn gcm_iv(iv: &DmaBuf) -> HsmResult<&[u8; 12]> {
+    let iv: &[u8] = iv;
+    iv.try_into().map_err(|_| HsmError::AesGcmInvalidBufferSize)
+}
+
+fn gcm_tag(tag: &DmaBuf) -> HsmResult<&[u8; 16]> {
+    let tag: &[u8] = tag;
+    tag.try_into()
+        .map_err(|_| HsmError::AesGcmInvalidBufferSize)
+}
+
+fn gcm_tag_mut(tag: &mut DmaBuf) -> HsmResult<&mut [u8; 16]> {
+    let tag: &mut [u8] = tag;
+    tag.try_into()
+        .map_err(|_| HsmError::AesGcmInvalidBufferSize)
+}
+
 impl HsmAes for StdHsmPal {
-    async fn aes_gen_key(&self, key: &mut [u8]) -> HsmResult<()> {
+    async fn aes_gen_key(&self, _io: &impl HsmIo, key: &mut [u8]) -> HsmResult<()> {
         self.aes.gen_key(key).await
     }
 
     async fn aes_cbc_enc_dec(
         &self,
-        key: &[u8],
-        encrypt: bool,
-        iv: &mut [u8],
-        input: &[u8],
-        output: &mut [u8],
+        _io: &impl HsmIo,
+        op: AesOp,
+        key: &DmaBuf,
+        input: &DmaBuf,
+        iv_in: &DmaBuf,
+        output: &mut DmaBuf,
+        iv_out: Option<&mut DmaBuf>,
     ) -> HsmResult<()> {
-        self.aes.cbc_enc_dec(key, encrypt, iv, input, output).await
+        let mut iv = iv_in.to_vec();
+        self.aes
+            .cbc_enc_dec(
+                &key[..],
+                aes_op_is_encrypt(op),
+                &mut iv,
+                &input[..],
+                &mut output[..],
+            )
+            .await?;
+        if let Some(iv_out) = iv_out {
+            iv_out[..iv.len()].copy_from_slice(&iv);
+        }
+        Ok(())
     }
 
     async fn aes_cbc_enc_dec_in_place(
         &self,
-        key: &[u8],
-        encrypt: bool,
-        iv: &mut [u8],
-        data: &mut [u8],
+        _io: &impl HsmIo,
+        op: AesOp,
+        key: &DmaBuf,
+        data: &mut DmaBuf,
+        iv_in: &DmaBuf,
+        iv_out: Option<&mut DmaBuf>,
     ) -> HsmResult<()> {
+        let mut iv = iv_in.to_vec();
         let input = data.to_vec();
-        self.aes.cbc_enc_dec(key, encrypt, iv, &input, data).await
+        self.aes
+            .cbc_enc_dec(
+                &key[..],
+                aes_op_is_encrypt(op),
+                &mut iv,
+                &input,
+                &mut data[..],
+            )
+            .await?;
+        if let Some(iv_out) = iv_out {
+            iv_out[..iv.len()].copy_from_slice(&iv);
+        }
+        Ok(())
     }
 
     async fn aes_ecb_enc_dec(
         &self,
-        key: &[u8],
-        encrypt: bool,
-        input: &[u8],
-        output: &mut [u8],
+        _io: &impl HsmIo,
+        op: AesOp,
+        key: &DmaBuf,
+        input: &DmaBuf,
+        output: &mut DmaBuf,
     ) -> HsmResult<()> {
-        self.aes.ecb_enc_dec(key, encrypt, input, output).await
+        self.aes
+            .ecb_enc_dec(&key[..], aes_op_is_encrypt(op), &input[..], &mut output[..])
+            .await
     }
 
     async fn aes_ecb_enc_dec_in_place(
         &self,
-        key: &[u8],
-        encrypt: bool,
-        data: &mut [u8],
+        _io: &impl HsmIo,
+        op: AesOp,
+        key: &DmaBuf,
+        data: &mut DmaBuf,
     ) -> HsmResult<()> {
         let input = data.to_vec();
-        self.aes.ecb_enc_dec(key, encrypt, &input, data).await
+        self.aes
+            .ecb_enc_dec(&key[..], aes_op_is_encrypt(op), &input, &mut data[..])
+            .await
     }
 
     async fn gcm_encrypt(
         &self,
-        key: &[u8],
-        iv: &[u8; 12],
+        _io: &impl HsmIo,
+        key: &DmaBuf,
+        iv: &DmaBuf,
         aad_len: usize,
-        plaintext: &[u8],
-        ciphertext: &mut [u8],
-        tag: &mut [u8; 16],
+        plaintext: &DmaBuf,
+        ciphertext: &mut DmaBuf,
+        tag: &mut DmaBuf,
     ) -> HsmResult<()> {
+        let iv = gcm_iv(iv)?;
+        let tag = gcm_tag_mut(tag)?;
         if aad_len > plaintext.len() || aad_len > ciphertext.len() {
             return Err(HsmError::AesGcmInvalidBufferSize);
         }
-        let aad = if aad_len > 0 {
+        let aad: Option<&[u8]> = if aad_len > 0 {
             Some(&plaintext[..aad_len])
         } else {
             None
         };
-        let data = &plaintext[aad_len..];
+        let data: &[u8] = &plaintext[aad_len..];
         if let Some(aad) = aad {
             ciphertext[..aad_len].copy_from_slice(aad);
         }
@@ -85,12 +147,15 @@ impl HsmAes for StdHsmPal {
 
     async fn gcm_encrypt_in_place(
         &self,
-        key: &[u8],
-        iv: &[u8; 12],
+        _io: &impl HsmIo,
+        key: &DmaBuf,
+        iv: &DmaBuf,
         aad_len: usize,
-        data: &mut [u8],
-        tag: &mut [u8; 16],
+        data: &mut DmaBuf,
+        tag: &mut DmaBuf,
     ) -> HsmResult<()> {
+        let iv = gcm_iv(iv)?;
+        let tag = gcm_tag_mut(tag)?;
         if aad_len > data.len() {
             return Err(HsmError::AesGcmInvalidBufferSize);
         }
@@ -108,23 +173,26 @@ impl HsmAes for StdHsmPal {
 
     async fn gcm_decrypt(
         &self,
-        key: &[u8],
-        iv: &[u8; 12],
+        _io: &impl HsmIo,
+        key: &DmaBuf,
+        iv: &DmaBuf,
         aad_len: usize,
-        tag: &[u8; 16],
-        ciphertext: &[u8],
-        plaintext: &mut [u8],
+        tag: &DmaBuf,
+        ciphertext: &DmaBuf,
+        plaintext: &mut DmaBuf,
     ) -> HsmResult<()> {
+        let iv = gcm_iv(iv)?;
+        let tag = gcm_tag(tag)?;
         if aad_len > ciphertext.len() || aad_len > plaintext.len() {
             return Err(HsmError::AesGcmInvalidBufferSize);
         }
-        let aad = if aad_len > 0 {
+        let aad: Option<&[u8]> = if aad_len > 0 {
             plaintext[..aad_len].copy_from_slice(&ciphertext[..aad_len]);
             Some(&ciphertext[..aad_len])
         } else {
             None
         };
-        let data = &ciphertext[aad_len..];
+        let data: &[u8] = &ciphertext[aad_len..];
         self.aes
             .gcm_decrypt(key, iv, aad, tag, data, &mut plaintext[aad_len..])
             .await
@@ -132,12 +200,15 @@ impl HsmAes for StdHsmPal {
 
     async fn gcm_decrypt_in_place(
         &self,
-        key: &[u8],
-        iv: &[u8; 12],
+        _io: &impl HsmIo,
+        key: &DmaBuf,
+        iv: &DmaBuf,
         aad_len: usize,
-        tag: &[u8; 16],
-        data: &mut [u8],
+        tag: &DmaBuf,
+        data: &mut DmaBuf,
     ) -> HsmResult<()> {
+        let iv = gcm_iv(iv)?;
+        let tag = gcm_tag(tag)?;
         if aad_len > data.len() {
             return Err(HsmError::AesGcmInvalidBufferSize);
         }
@@ -153,69 +224,92 @@ impl HsmAes for StdHsmPal {
             .await
     }
 
-    async fn aes_kw_wrap(&self, _key: &[u8], _input: &[u8], _output: &mut [u8]) -> HsmResult<()> {
+    async fn aes_kw_wrap(
+        &self,
+        _io: &impl HsmIo,
+        _key: &DmaBuf,
+        _input: &DmaBuf,
+        _output: &mut DmaBuf,
+    ) -> HsmResult<()> {
         todo!()
     }
 
-    async fn aes_kw_unwrap(&self, _key: &[u8], _input: &[u8], _output: &mut [u8]) -> HsmResult<()> {
+    async fn aes_kw_unwrap(
+        &self,
+        _io: &impl HsmIo,
+        _key: &DmaBuf,
+        _input: &DmaBuf,
+        _output: &mut DmaBuf,
+    ) -> HsmResult<()> {
         todo!()
     }
 
-    async fn aes_kwp_wrap(&self, _key: &[u8], _input: &[u8], _output: &mut [u8]) -> HsmResult<()> {
+    async fn aes_kwp_wrap(
+        &self,
+        _io: &impl HsmIo,
+        _key: &DmaBuf,
+        _input: &DmaBuf,
+        _output: &mut DmaBuf,
+    ) -> HsmResult<()> {
         todo!()
     }
 
     async fn aes_kwp_unwrap(
         &self,
-        _key: &[u8],
-        _input: &[u8],
-        _output: &mut [u8],
+        _io: &impl HsmIo,
+        _key: &DmaBuf,
+        _input: &DmaBuf,
+        _output: &mut DmaBuf,
     ) -> HsmResult<usize> {
         todo!()
     }
 
-    async fn aes_xts_gen_key(&self, _key: &mut [u8]) -> HsmResult<()> {
+    async fn aes_xts_gen_key(&self, _io: &impl HsmIo, _key: &mut [u8]) -> HsmResult<()> {
         todo!()
     }
 
     async fn aes_xts_encrypt(
         &self,
-        _key: &[u8],
-        _tweak: &[u8],
+        _io: &impl HsmIo,
+        _key: &DmaBuf,
+        _tweak: &DmaBuf,
         _dul: XtsDataUnitLen,
-        _input: &[u8],
-        _output: &mut [u8],
+        _input: &DmaBuf,
+        _output: &mut DmaBuf,
     ) -> HsmResult<()> {
         todo!()
     }
 
     async fn aes_xts_decrypt(
         &self,
-        _key: &[u8],
-        _tweak: &[u8],
+        _io: &impl HsmIo,
+        _key: &DmaBuf,
+        _tweak: &DmaBuf,
         _dul: XtsDataUnitLen,
-        _input: &[u8],
-        _output: &mut [u8],
+        _input: &DmaBuf,
+        _output: &mut DmaBuf,
     ) -> HsmResult<()> {
         todo!()
     }
 
     async fn aes_xts_encrypt_in_place(
         &self,
-        _key: &[u8],
-        _tweak: &[u8],
+        _io: &impl HsmIo,
+        _key: &DmaBuf,
+        _tweak: &DmaBuf,
         _dul: XtsDataUnitLen,
-        _data: &mut [u8],
+        _data: &mut DmaBuf,
     ) -> HsmResult<()> {
         todo!()
     }
 
     async fn aes_xts_decrypt_in_place(
         &self,
-        _key: &[u8],
-        _tweak: &[u8],
+        _io: &impl HsmIo,
+        _key: &DmaBuf,
+        _tweak: &DmaBuf,
         _dul: XtsDataUnitLen,
-        _data: &mut [u8],
+        _data: &mut DmaBuf,
     ) -> HsmResult<()> {
         todo!()
     }

--- a/fw/plat/std/pal/src/alloc.rs
+++ b/fw/plat/std/pal/src/alloc.rs
@@ -1,0 +1,318 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! [`HsmAlloc`] implementation for the standard PAL.
+//!
+//! Per-IO bump allocator over the [`BufferPool`]'s pre-allocated
+//! NonDma (`NONDMA_BUF_SIZE`) and Dma (`DMA_BUF_SIZE`) buffers.  One
+//! watermark per (slot, heap) pair lives in the pool itself; the
+//! allocator only advances them.
+//!
+//! ## Aliasing
+//!
+//! [`BufferPool`] exposes raw pointers + capacity (no whole-slab
+//! `&mut` views).  Each bump allocation constructs a `&mut [u8]`
+//! covering only the freshly allocated, disjoint range, so successive
+//! allocations from the same `&self` never alias.
+//!
+//! ## Lifetime gotcha
+//!
+//! Allocations made *directly* on the PAL inside an
+//! [`HsmAlloc::alloc_scoped`] / [`HsmAlloc::alloc_scoped_async`]
+//! closure will be silently freed when the scope's watermark is
+//! restored on drop.  Direct PAL allocations should be made before the
+//! scope opens or after it closes.
+//!
+//! No atomics — single-threaded Embassy executor with cooperative
+//! scheduling.
+
+use core::cell::Cell;
+use core::mem;
+use core::ops::AsyncFnOnce;
+
+use azihsm_fw_hsm_pal_traits::*;
+
+use crate::buf_pool::BufferPool;
+use crate::buf_pool::DMA_BUF_SIZE;
+use crate::buf_pool::NONDMA_BUF_SIZE;
+use crate::StdHsmPal;
+
+// ── Heap identifiers (PAL-internal) ───────────────────────────────
+
+#[derive(Copy, Clone)]
+enum Heap {
+    NonDma,
+    Dma,
+}
+
+impl Heap {
+    #[inline(always)]
+    fn capacity(self) -> usize {
+        match self {
+            Heap::NonDma => NONDMA_BUF_SIZE,
+            Heap::Dma => DMA_BUF_SIZE,
+        }
+    }
+}
+
+// ── Helpers ───────────────────────────────────────────────────────
+
+#[inline(always)]
+fn ptr_for(pool: &BufferPool, slot: u16, heap: Heap) -> *mut u8 {
+    match heap {
+        Heap::NonDma => pool.nondma_ptr(slot),
+        Heap::Dma => pool.dma_ptr(slot),
+    }
+}
+
+#[inline(always)]
+fn mark_for(pool: &BufferPool, slot: u16, heap: Heap) -> &Cell<usize> {
+    match heap {
+        Heap::NonDma => pool.nondma_mark(slot),
+        Heap::Dma => pool.dma_mark(slot),
+    }
+}
+
+/// Bump-allocate `size` bytes with the given alignment from `(slot,
+/// heap)`. Returns the new `&mut [u8]` view over the freshly
+/// allocated region (disjoint from any prior allocation).
+fn bump<'a>(
+    pool: &'a BufferPool,
+    slot: u16,
+    heap: Heap,
+    size: usize,
+    align: usize,
+) -> HsmResult<&'a mut [u8]> {
+    let cap = heap.capacity();
+    let mark_cell = mark_for(pool, slot, heap);
+    let mark = mark_cell.get().min(cap);
+
+    let base = ptr_for(pool, slot, heap) as usize;
+    let aligned = (base + mark + align - 1) & !(align - 1);
+    let start = aligned - base;
+    let end = start.checked_add(size).ok_or(HsmError::NotEnoughSpace)?;
+
+    if end > cap {
+        return Err(HsmError::NotEnoughSpace);
+    }
+
+    mark_cell.set(end);
+
+    // SAFETY: the BufferPool gives the caller exclusive access to its slot's
+    // raw pointer for the lifetime of the allocated IO. The bump watermark
+    // ensures every returned slice covers a disjoint range, and the pool only
+    // reuses the slot after the IO completes (which freezes any prior
+    // borrows). The returned `&mut [u8]` therefore aliases nothing.
+    let ptr = unsafe { ptr_for(pool, slot, heap).add(start) };
+    Ok(unsafe { core::slice::from_raw_parts_mut(ptr, size) })
+}
+
+// ── Scoped allocator handle ───────────────────────────────────────
+
+/// Scoped allocator handle for the standard PAL.
+///
+/// Snapshots both per-slot watermarks on construction and restores
+/// them on drop, freeing every allocation made through the handle in
+/// LIFO order.
+pub struct StdScopedAlloc<'a> {
+    pool: &'a BufferPool,
+    slot: u16,
+    nondma_mark: usize,
+    dma_mark: usize,
+}
+
+impl HsmScopedAlloc for StdScopedAlloc<'_> {
+    #[inline(always)]
+    fn alloc(&self, size: usize) -> HsmResult<&mut [u8]> {
+        bump(self.pool, self.slot, Heap::NonDma, size, 4)
+    }
+
+    #[inline(always)]
+    fn alloc_zeroed(&self, size: usize) -> HsmResult<&mut [u8]> {
+        let s = self.alloc(size)?;
+        s.fill(0);
+        Ok(s)
+    }
+
+    #[inline(always)]
+    fn alloc_val<T: Sized>(&self, value: T) -> HsmResult<&mut T> {
+        let s = bump(
+            self.pool,
+            self.slot,
+            Heap::NonDma,
+            mem::size_of::<T>(),
+            mem::align_of::<T>().max(1),
+        )?;
+        let ptr = s.as_mut_ptr().cast::<T>();
+        // SAFETY: bump() reserved exactly size_of::<T>() bytes with
+        // align_of::<T>() alignment. The pointer is non-null and writable.
+        unsafe {
+            ptr.write(value);
+            Ok(&mut *ptr)
+        }
+    }
+
+    #[inline(always)]
+    fn dma_alloc(&self, size: usize) -> HsmResult<&mut DmaBuf> {
+        let s = bump(self.pool, self.slot, Heap::Dma, size, 4)?;
+        // SAFETY: the Dma heap is DMA-accessible by construction.
+        Ok(unsafe { DmaBuf::from_raw_mut(s) })
+    }
+
+    #[inline(always)]
+    fn dma_alloc_zeroed(&self, size: usize) -> HsmResult<&mut DmaBuf> {
+        let s = self.dma_alloc(size)?;
+        s.fill(0);
+        Ok(s)
+    }
+}
+
+impl Drop for StdScopedAlloc<'_> {
+    fn drop(&mut self) {
+        self.pool.nondma_mark(self.slot).set(self.nondma_mark);
+        self.pool.dma_mark(self.slot).set(self.dma_mark);
+    }
+}
+
+// ── HsmAlloc impl ─────────────────────────────────────────────────
+
+impl HsmAlloc for StdHsmPal {
+    type Scoped<'a> = StdScopedAlloc<'a>;
+
+    #[inline(always)]
+    fn alloc(&self, io: &impl HsmIo, size: usize) -> HsmResult<&mut [u8]> {
+        bump(self.iic.pool(), io.index(), Heap::NonDma, size, 4)
+    }
+
+    #[inline(always)]
+    fn alloc_zeroed(&self, io: &impl HsmIo, size: usize) -> HsmResult<&mut [u8]> {
+        let s = self.alloc(io, size)?;
+        s.fill(0);
+        Ok(s)
+    }
+
+    #[inline(always)]
+    fn alloc_val<T: Sized>(&self, io: &impl HsmIo, value: T) -> HsmResult<&mut T> {
+        let s = bump(
+            self.iic.pool(),
+            io.index(),
+            Heap::NonDma,
+            mem::size_of::<T>(),
+            mem::align_of::<T>().max(1),
+        )?;
+        let ptr = s.as_mut_ptr().cast::<T>();
+        // SAFETY: see StdScopedAlloc::alloc_val.
+        unsafe {
+            ptr.write(value);
+            Ok(&mut *ptr)
+        }
+    }
+
+    #[inline(always)]
+    fn dma_alloc(&self, io: &impl HsmIo, size: usize) -> HsmResult<&mut DmaBuf> {
+        let s = bump(self.iic.pool(), io.index(), Heap::Dma, size, 4)?;
+        // SAFETY: the Dma heap is DMA-accessible by construction.
+        Ok(unsafe { DmaBuf::from_raw_mut(s) })
+    }
+
+    #[inline(always)]
+    fn dma_alloc_zeroed(&self, io: &impl HsmIo, size: usize) -> HsmResult<&mut DmaBuf> {
+        let s = self.dma_alloc(io, size)?;
+        s.fill(0);
+        Ok(s)
+    }
+
+    fn dma_alloc_var<F>(&self, io: &impl HsmIo, f: F) -> HsmResult<&mut DmaBuf>
+    where
+        F: FnOnce(&mut [u8]) -> HsmResult<usize>,
+    {
+        let pool = self.iic.pool();
+        let slot = io.index();
+        let cap = Heap::Dma.capacity();
+        let mark_cell = pool.dma_mark(slot);
+        let saved_mark = mark_cell.get().min(cap);
+        let aligned = (saved_mark + 3) & !3;
+        if aligned >= cap {
+            return Err(HsmError::NotEnoughSpace);
+        }
+        let buf = bump(pool, slot, Heap::Dma, cap - aligned, 4)?;
+        match f(buf) {
+            Ok(len) => {
+                if len > buf.len() {
+                    // Closure overran the buffer it was handed; refuse to
+                    // expose a longer slice than we actually own.
+                    mark_cell.set(saved_mark);
+                    return Err(HsmError::InvalidArg);
+                }
+                let final_end = aligned + len;
+                mark_cell.set(final_end);
+                // SAFETY: the Dma heap is DMA-accessible by construction.
+                Ok(unsafe { DmaBuf::from_raw_mut(&mut buf[..len]) })
+            }
+            Err(e) => {
+                mark_cell.set(saved_mark);
+                Err(e)
+            }
+        }
+    }
+
+    fn dma_alloc_var_with<F, T>(&self, io: &impl HsmIo, f: F) -> HsmResult<(&mut DmaBuf, T)>
+    where
+        F: FnOnce(&mut [u8]) -> HsmResult<(usize, T)>,
+    {
+        let pool = self.iic.pool();
+        let slot = io.index();
+        let cap = Heap::Dma.capacity();
+        let mark_cell = pool.dma_mark(slot);
+        let saved_mark = mark_cell.get().min(cap);
+        let aligned = (saved_mark + 3) & !3;
+        if aligned >= cap {
+            return Err(HsmError::NotEnoughSpace);
+        }
+        let buf = bump(pool, slot, Heap::Dma, cap - aligned, 4)?;
+        match f(buf) {
+            Ok((len, extra)) => {
+                if len > buf.len() {
+                    mark_cell.set(saved_mark);
+                    return Err(HsmError::InvalidArg);
+                }
+                let final_end = aligned + len;
+                mark_cell.set(final_end);
+                // SAFETY: the Dma heap is DMA-accessible by construction.
+                Ok((unsafe { DmaBuf::from_raw_mut(&mut buf[..len]) }, extra))
+            }
+            Err(e) => {
+                mark_cell.set(saved_mark);
+                Err(e)
+            }
+        }
+    }
+
+    #[inline]
+    fn alloc_scoped<R>(&self, io: &impl HsmIo, f: impl FnOnce(&Self::Scoped<'_>) -> R) -> R {
+        let pool = self.iic.pool();
+        let slot = io.index();
+        let scope = StdScopedAlloc {
+            pool,
+            slot,
+            nondma_mark: pool.nondma_mark(slot).get(),
+            dma_mark: pool.dma_mark(slot).get(),
+        };
+        f(&scope)
+    }
+
+    async fn alloc_scoped_async<R, F>(&self, io: &impl HsmIo, f: F) -> R
+    where
+        F: for<'a> AsyncFnOnce(&'a Self::Scoped<'a>) -> R,
+    {
+        let pool = self.iic.pool();
+        let slot = io.index();
+        let scope = StdScopedAlloc {
+            pool,
+            slot,
+            nondma_mark: pool.nondma_mark(slot).get(),
+            dma_mark: pool.dma_mark(slot).get(),
+        };
+        f(&scope).await
+    }
+}

--- a/fw/plat/std/pal/src/buf_pool.rs
+++ b/fw/plat/std/pal/src/buf_pool.rs
@@ -4,14 +4,33 @@
 //! Pre-allocated IO buffer pool with async bitmap allocation.
 //!
 //! The buffer pool owns [`MAX_IO_SLOTS`] pairs of buffers:
-//! - **Fast buffers** (2KB each) — small per-IO scratch space
-//! - **Large buffers** (8KB each) — larger per-IO data buffers
+//! - **NonDma (fast) buffers** ([`NONDMA_BUF_SIZE`] bytes each) — small per-IO
+//!   scratch space (analogue of DTCM on hardware).
+//! - **Dma (large) buffers** ([`DMA_BUF_SIZE`] bytes each) — larger per-IO
+//!   data buffers (analogue of SRAM on hardware).
 //!
 //! Slot allocation is O(1) via `trailing_zeros` on a `u64` free bitmap.
 //! When all slots are in use, [`alloc`](BufferPool::alloc) suspends and
 //! is woken by [`free`](BufferPool::free) via `WakerRegistration`.
 //!
-//! # Thread safety
+//! ## Bump-allocator backing
+//!
+//! Each slot also owns two `Cell<usize>` watermarks (one per heap)
+//! that serve the [`HsmAlloc`](azihsm_fw_hsm_pal_traits::HsmAlloc)
+//! trait implementation in [`crate::alloc`].  `alloc()` resets both
+//! watermarks to zero when handing out a fresh slot, and the
+//! allocator advances them as it bumps out new sub-slices.
+//!
+//! ## Aliasing model
+//!
+//! Buffer storage is exposed as *raw pointers + capacity*
+//! ([`nondma_ptr`](Self::nondma_ptr) / [`dma_ptr`](Self::dma_ptr)).
+//! The bump allocator is the only consumer; it constructs
+//! `&mut [u8]` views over the freshly bumped (disjoint) range, so no
+//! two outstanding borrows ever overlap.  Callers must NOT obtain a
+//! `&mut [u8]` over the whole slab while bump allocations are live.
+//!
+//! ## Thread safety
 //!
 //! The pool is only accessed from the single-threaded Embassy executor.
 //! Interior mutability uses `Cell`/`RefCell` — no locks needed.
@@ -27,11 +46,11 @@ use embassy_sync::waitqueue::WakerRegistration;
 /// Maximum concurrent IO slots.
 pub const MAX_IO_SLOTS: usize = 32;
 
-/// Size of each fast buffer in bytes.
-const FAST_BUF_SIZE: usize = 2048;
+/// Size of each NonDma (fast / DTCM-equivalent) buffer in bytes.
+pub const NONDMA_BUF_SIZE: usize = 2048;
 
-/// Size of each large buffer in bytes.
-const LARGE_BUF_SIZE: usize = 8192;
+/// Size of each Dma (large / SRAM-equivalent) buffer in bytes.
+pub const DMA_BUF_SIZE: usize = 8192;
 
 /// Pre-allocated buffer pool with async bitmap allocation.
 ///
@@ -39,11 +58,21 @@ const LARGE_BUF_SIZE: usize = 8192;
 /// are handed out via [`alloc`](Self::alloc) and returned via
 /// [`free`](Self::free).
 pub struct BufferPool {
-    /// 2KB fast buffers, one per slot.
-    fast_bufs: Box<[UnsafeCell<[u8; FAST_BUF_SIZE]>; MAX_IO_SLOTS]>,
+    /// NonDma (fast / DTCM) buffers, one per slot.
+    nondma_bufs: Box<[UnsafeCell<[u8; NONDMA_BUF_SIZE]>; MAX_IO_SLOTS]>,
 
-    /// 8KB large buffers, one per slot.
-    large_bufs: Box<[UnsafeCell<[u8; LARGE_BUF_SIZE]>; MAX_IO_SLOTS]>,
+    /// Dma (large / SRAM) buffers, one per slot.
+    dma_bufs: Box<[UnsafeCell<[u8; DMA_BUF_SIZE]>; MAX_IO_SLOTS]>,
+
+    /// Per-slot bump-allocator watermark for the NonDma heap.
+    ///
+    /// Reset to zero by [`alloc`](Self::alloc) before the slot is
+    /// returned, advanced by the bump allocator, and snapshotted /
+    /// restored by `StdScopedAlloc`.
+    nondma_marks: Box<[Cell<usize>; MAX_IO_SLOTS]>,
+
+    /// Per-slot bump-allocator watermark for the Dma heap.
+    dma_marks: Box<[Cell<usize>; MAX_IO_SLOTS]>,
 
     /// Bitmap of free slots. Bit set = slot available.
     free_mask: Cell<u64>,
@@ -55,22 +84,27 @@ pub struct BufferPool {
 impl BufferPool {
     /// Create a new buffer pool with all slots free.
     ///
-    /// Allocates `MAX_IO_SLOTS × (2KB + 8KB)` = 320KB on the heap.
+    /// Allocates `MAX_IO_SLOTS × (NONDMA_BUF_SIZE + DMA_BUF_SIZE)` on
+    /// the heap.  All bump watermarks start at zero.
     pub fn new() -> Self {
-        let fast_bufs = Box::new(core::array::from_fn::<_, MAX_IO_SLOTS, _>(|_| {
-            UnsafeCell::new([0u8; FAST_BUF_SIZE])
+        let nondma_bufs = Box::new(core::array::from_fn::<_, MAX_IO_SLOTS, _>(|_| {
+            UnsafeCell::new([0u8; NONDMA_BUF_SIZE])
         }));
-        let large_bufs = Box::new(core::array::from_fn::<_, MAX_IO_SLOTS, _>(|_| {
-            UnsafeCell::new([0u8; LARGE_BUF_SIZE])
+        let dma_bufs = Box::new(core::array::from_fn::<_, MAX_IO_SLOTS, _>(|_| {
+            UnsafeCell::new([0u8; DMA_BUF_SIZE])
         }));
+        let nondma_marks = Box::new(core::array::from_fn::<_, MAX_IO_SLOTS, _>(|_| Cell::new(0)));
+        let dma_marks = Box::new(core::array::from_fn::<_, MAX_IO_SLOTS, _>(|_| Cell::new(0)));
         let free_mask = if MAX_IO_SLOTS >= 64 {
             u64::MAX
         } else {
             (1u64 << MAX_IO_SLOTS) - 1
         };
         Self {
-            fast_bufs,
-            large_bufs,
+            nondma_bufs,
+            dma_bufs,
+            nondma_marks,
+            dma_marks,
             free_mask: Cell::new(free_mask),
             waker: RefCell::new(WakerRegistration::new()),
         }
@@ -78,50 +112,76 @@ impl BufferPool {
 
     /// Allocate a buffer slot. O(1) via `trailing_zeros`.
     ///
+    /// Resets both bump watermarks for the slot to zero before
+    /// returning, so the bump allocator starts from a clean slate on
+    /// every IO.
+    ///
     /// If all slots are in use, suspends the caller until
     /// [`free`](Self::free) returns a slot and wakes this future.
     pub async fn alloc(&self) -> u16 {
-        poll_fn(|cx| {
+        let idx = poll_fn(|cx| {
             let mask = self.free_mask.get();
             if mask == 0 {
                 self.waker.borrow_mut().register(cx.waker());
                 return Poll::Pending;
             }
-            let idx = mask.trailing_zeros() as u16;
-            self.free_mask.set(mask & !(1u64 << idx));
-            Poll::Ready(idx)
+            let i = mask.trailing_zeros() as u16;
+            self.free_mask.set(mask & !(1u64 << i));
+            Poll::Ready(i)
         })
-        .await
+        .await;
+        self.reset_marks(idx);
+        idx
     }
 
     /// Free a buffer slot back to the pool.
     ///
     /// Sets the slot's bit in the free bitmap and wakes any task
-    /// suspended in [`alloc`](Self::alloc).
+    /// suspended in [`alloc`](Self::alloc).  Watermarks for the slot
+    /// are *not* reset here; they will be reset on the next
+    /// [`alloc`](Self::alloc).
     pub fn free(&self, idx: u16) {
         self.free_mask.set(self.free_mask.get() | (1u64 << idx));
         self.waker.borrow_mut().wake();
     }
 
-    /// Get a mutable reference to the fast buffer (2KB) at `idx`.
+    /// Reset both bump watermarks for the given slot to zero.
+    pub fn reset_marks(&self, idx: u16) {
+        self.nondma_marks[idx as usize].set(0);
+        self.dma_marks[idx as usize].set(0);
+    }
+
+    /// Returns a raw pointer to the start of the NonDma buffer for
+    /// `idx`.
     ///
     /// # Safety
     ///
     /// Caller must ensure exclusive access — only one IO holds a
-    /// given index at a time (enforced by the alloc/free protocol).
-    #[allow(clippy::mut_from_ref)]
-    pub fn fast_buf(&self, idx: u16) -> &mut [u8] {
-        unsafe { &mut *self.fast_bufs[idx as usize].get() }
+    /// given slot at a time (enforced by the alloc/free protocol),
+    /// and only the bump allocator may construct `&mut [u8]` views
+    /// over disjoint sub-ranges of this region.
+    pub fn nondma_ptr(&self, idx: u16) -> *mut u8 {
+        self.nondma_bufs[idx as usize].get() as *mut u8
     }
 
-    /// Get a mutable reference to the large buffer (8KB) at `idx`.
+    /// Returns a raw pointer to the start of the Dma buffer for `idx`.
     ///
     /// # Safety
     ///
-    /// Same exclusivity requirement as [`fast_buf`](Self::fast_buf).
-    #[allow(clippy::mut_from_ref)]
-    pub fn large_buf(&self, idx: u16) -> &mut [u8] {
-        unsafe { &mut *self.large_bufs[idx as usize].get() }
+    /// Same exclusivity requirement as
+    /// [`nondma_ptr`](Self::nondma_ptr).
+    pub fn dma_ptr(&self, idx: u16) -> *mut u8 {
+        self.dma_bufs[idx as usize].get() as *mut u8
+    }
+
+    /// Returns the watermark cell for the NonDma heap of slot `idx`.
+    pub fn nondma_mark(&self, idx: u16) -> &Cell<usize> {
+        &self.nondma_marks[idx as usize]
+    }
+
+    /// Returns the watermark cell for the Dma heap of slot `idx`.
+    pub fn dma_mark(&self, idx: u16) -> &Cell<usize> {
+        &self.dma_marks[idx as usize]
     }
 }
 

--- a/fw/plat/std/pal/src/cert.rs
+++ b/fw/plat/std/pal/src/cert.rs
@@ -16,10 +16,19 @@
 //! [`StdHsmPal::init_cert_store`].  The leaf cert is generated lazily
 //! on first access per partition.
 //!
-//! All cryptographic operations (key generation, hashing, signing) flow
-//! through PAL traits ([`HsmEcc`], [`HsmHash`]) — no direct dependency
-//! on `azihsm_crypto`.
+//! Sideband paths (init / leaf-cert generation / chain hashing) call the
+//! underlying [`StdHash`](crate::drivers::hash::StdHash) and
+//! [`StdEcc`](crate::drivers::ecc::StdEcc) drivers directly — they have
+//! no `HsmIo` context to satisfy the new PAL crypto trait surface, so
+//! they bypass it entirely. The trait impl ([`HsmCertStore`]) at the
+//! bottom of this file is the only path the core uses.
 
+use azihsm_crypto::EccCurve;
+use azihsm_crypto::EccKeyOp;
+use azihsm_crypto::EccPrivateKey;
+use azihsm_crypto::ExportableKey;
+use azihsm_crypto::HashAlgo;
+use azihsm_crypto::ImportableKey;
 use azihsm_fw_hsm_std_x509::cert_builder;
 use azihsm_fw_hsm_std_x509::cert_builder::*;
 
@@ -287,13 +296,9 @@ impl StdHsmPal {
         rd_concat[..root_cert_len].copy_from_slice(&root_cert[..root_cert_len]);
         rd_concat[root_cert_len..].copy_from_slice(&deviceid_cert[..deviceid_cert_len]);
         let mut root_deviceid_hash = [0u8; 32];
-        self.hash(
-            HsmHashAlgo::Sha256,
-            &rd_concat,
-            &mut root_deviceid_hash,
-            true,
-        )
-        .await?;
+        self.hash
+            .hash(HashAlgo::sha256(), &rd_concat, &mut root_deviceid_hash)
+            .await?;
 
         // Commit to store.
         let store = &mut *self.cert_store_mut();
@@ -311,23 +316,30 @@ impl StdHsmPal {
     }
 
     /// Generate a P-384 key pair and compute SKI for cert construction.
+    ///
+    /// Bypasses the [`HsmEcc`] trait (which requires an `HsmIo`) and
+    /// drives the [`StdEcc`] driver directly, mirroring what the trait
+    /// impl in `crate::ecc` would do.
     async fn gen_cert_keypair(&self) -> HsmResult<CertKeyPair> {
-        let priv_max = HsmEccCurve::P384.priv_key_der_max();
-        let mut priv_der = vec![0u8; priv_max];
+        let (pk, pubk) = self.ecc.gen_keypair(EccCurve::P384).await?;
+
+        // Export private key as PKCS#8 DER.
+        let priv_len = pk.to_bytes(None).map_err(|_| HsmError::EccToDerError)?;
+        let mut priv_der = vec![0u8; priv_len];
+        pk.to_bytes(Some(&mut priv_der[..priv_len]))
+            .map_err(|_| HsmError::EccToDerError)?;
+
+        // Export raw P-384 public key (x ∥ y).
         let mut pub_raw = [0u8; P384_PUB_KEY_LEN];
-        let priv_len = self
-            .ecc_gen_keypair(
-                HsmEccCurve::P384,
-                Some(&mut priv_der),
-                &mut pub_raw,
-                HsmEccPct::SignVerify,
-            )
-            .await?;
-        priv_der.truncate(priv_len);
+        let half = P384_PUB_KEY_LEN / 2;
+        let (x_buf, y_buf) = pub_raw.split_at_mut(half);
+        pubk.coord(Some((x_buf, y_buf)))
+            .map_err(|_| HsmError::EccToDerError)?;
 
         let uncompressed = to_uncompressed(&pub_raw);
         let mut ski = [0u8; 20];
-        self.hash(HsmHashAlgo::Sha1, &uncompressed, &mut ski, true)
+        self.hash
+            .hash(HashAlgo::sha1(), &uncompressed, &mut ski)
             .await?;
 
         Ok(CertKeyPair {
@@ -338,23 +350,29 @@ impl StdHsmPal {
     }
 
     /// Hash TBS with SHA-384, then sign with ECC P-384. Returns (r, s).
+    ///
+    /// Sideband helper that bypasses the PAL crypto trait surface
+    /// (no `HsmIo` available during cert init / leaf-cert generation).
     async fn hash_and_sign(
         &self,
         priv_der: &[u8],
         tbs: &[u8],
     ) -> HsmResult<([u8; P384_SIG_COMPONENT], [u8; P384_SIG_COMPONENT])> {
         let mut tbs_hash = [0u8; 48];
-        self.hash(HsmHashAlgo::Sha384, tbs, &mut tbs_hash, true)
+        self.hash
+            .hash(HashAlgo::sha384(), tbs, &mut tbs_hash)
             .await?;
 
-        let mut sig = [0u8; 96];
-        self.ecc_sign(HsmEccCurve::P384, priv_der, &tbs_hash, &mut sig)
-            .await?;
+        let key = EccPrivateKey::from_bytes(priv_der).map_err(|_| HsmError::InvalidArg)?;
+        let sig = self.ecc.ecc_sign(&key, &tbs_hash).await?;
+        if sig.len() < 2 * P384_SIG_COMPONENT {
+            return Err(HsmError::EccSignFailed);
+        }
 
         let mut r = [0u8; P384_SIG_COMPONENT];
         let mut s = [0u8; P384_SIG_COMPONENT];
-        r.copy_from_slice(&sig[..48]);
-        s.copy_from_slice(&sig[48..96]);
+        r.copy_from_slice(&sig[..P384_SIG_COMPONENT]);
+        s.copy_from_slice(&sig[P384_SIG_COMPONENT..2 * P384_SIG_COMPONENT]);
         Ok((r, s))
     }
 
@@ -380,7 +398,8 @@ impl StdHsmPal {
 
         // SKI = SHA-1(uncompressed pubkey).
         let mut ski = [0u8; 20];
-        self.hash(HsmHashAlgo::Sha1, &uncompressed, &mut ski, true)
+        self.hash
+            .hash(HashAlgo::sha1(), &uncompressed, &mut ski)
             .await?;
 
         // Prepare TBS.
@@ -438,6 +457,7 @@ impl StdHsmPal {
 impl HsmCertStore for StdHsmPal {
     async fn get_cert_chain_info(
         &self,
+        _io: &impl HsmIo,
         part_id: HsmPartId,
         slot_id: u8,
     ) -> HsmResult<CertChainInfo> {
@@ -453,22 +473,22 @@ impl HsmCertStore for StdHsmPal {
 
         // Thumbprint = SHA-256(SHA-256(root||devid) || SHA-256(alias) || SHA-256(leaf))
         let mut alias_hash = [0u8; 32];
-        self.hash(
-            HsmHashAlgo::Sha256,
-            self.cert_store().shared_cert(2).unwrap(),
-            &mut alias_hash,
-            true,
-        )
-        .await?;
+        self.hash
+            .hash(
+                HashAlgo::sha256(),
+                self.cert_store().shared_cert(2).unwrap(),
+                &mut alias_hash,
+            )
+            .await?;
 
         let mut leaf_hash = [0u8; 32];
-        self.hash(
-            HsmHashAlgo::Sha256,
-            &entry.leaf_cert[..entry.leaf_cert_len],
-            &mut leaf_hash,
-            true,
-        )
-        .await?;
+        self.hash
+            .hash(
+                HashAlgo::sha256(),
+                &entry.leaf_cert[..entry.leaf_cert_len],
+                &mut leaf_hash,
+            )
+            .await?;
 
         let mut combined = [0u8; 96];
         combined[..32].copy_from_slice(&self.cert_store().root_deviceid_hash);
@@ -476,7 +496,8 @@ impl HsmCertStore for StdHsmPal {
         combined[64..96].copy_from_slice(&leaf_hash);
 
         let mut thumbprint = [0u8; 32];
-        self.hash(HsmHashAlgo::Sha256, &combined, &mut thumbprint, true)
+        self.hash
+            .hash(HashAlgo::sha256(), &combined, &mut thumbprint)
             .await?;
 
         Ok(CertChainInfo {
@@ -487,6 +508,7 @@ impl HsmCertStore for StdHsmPal {
 
     async fn get_cert(
         &self,
+        _io: &impl HsmIo,
         part_id: HsmPartId,
         slot_id: u8,
         idx: u8,
@@ -505,7 +527,7 @@ impl HsmCertStore for StdHsmPal {
                 .ok_or(HsmError::InvalidArg)?;
             if let Some(buf) = cert {
                 if buf.len() < src.len() {
-                    return Err(HsmError::NotEnoughSpace);
+                    return Err(HsmError::InvalidArg);
                 }
                 buf[..src.len()].copy_from_slice(src);
             }
@@ -524,7 +546,7 @@ impl HsmCertStore for StdHsmPal {
         let len = entry.leaf_cert_len;
         if let Some(buf) = cert {
             if buf.len() < len {
-                return Err(HsmError::NotEnoughSpace);
+                return Err(HsmError::InvalidArg);
             }
             buf[..len].copy_from_slice(&entry.leaf_cert[..len]);
         }

--- a/fw/plat/std/pal/src/drivers/iic.rs
+++ b/fw/plat/std/pal/src/drivers/iic.rs
@@ -24,7 +24,7 @@ pub struct StdIic {
     /// Channel receiver for incoming IO requests.
     submit_rx: Receiver<HsmIoRequest>,
 
-    /// Shared buffer pool for fast and large buffers.
+    /// Shared buffer pool for NonDma and Dma buffers.
     buf_pool: Arc<BufferPool>,
 }
 
@@ -41,6 +41,8 @@ impl StdIic {
     ///
     /// Returns the request and its allocated slot index. Suspends if
     /// no requests are available or if the buffer pool is exhausted.
+    /// The pool resets the slot's bump-allocator watermarks before
+    /// returning, so the new IO starts with empty NonDma/Dma heaps.
     pub async fn recv(&self) -> HsmResult<(HsmIoRequest, u16)> {
         let req = self.submit_rx.recv().await.map_err(|_| {
             error!("iic", HsmError::InternalError, "submit channel closed");
@@ -62,8 +64,12 @@ impl StdIic {
         self.buf_pool.free(slot);
     }
 
-    /// Returns a cloned `Arc` reference to the buffer pool.
-    pub fn pool(&self) -> Arc<BufferPool> {
-        Arc::clone(&self.buf_pool)
+    /// Borrows the buffer pool used by this IIC driver.
+    ///
+    /// Used by the [`HsmAlloc`](azihsm_fw_hsm_pal_traits::HsmAlloc)
+    /// implementation on [`crate::StdHsmPal`] to bump-allocate from
+    /// the per-slot NonDma / Dma heaps.
+    pub fn pool(&self) -> &BufferPool {
+        &self.buf_pool
     }
 }

--- a/fw/plat/std/pal/src/ecc.rs
+++ b/fw/plat/std/pal/src/ecc.rs
@@ -55,74 +55,48 @@ impl HsmEcc for StdHsmPal {
     ///
     /// Delegates to [`StdEcc::gen_keypair`] which returns OpenSSL handles,
     /// then exports the private key as PKCS#8 DER and the public key as
-    /// SPKI DER into the caller-provided buffers.
-    ///
-    /// # Parameters
-    /// - `curve` — NIST curve (P-256, P-384, or P-521).
-    /// - `priv_key` — Output buffer for PKCS#8 DER private key.
-    /// - `pub_key` — Output buffer for SPKI DER public key.
-    /// - `_pct` — Pairwise consistency test mode (currently ignored).
-    ///
-    /// # Errors
-    /// - [`HsmError::EccGenerateError`] — key generation failed.
-    /// - [`HsmError::EccToDerError`] — DER export failed.
-    /// - [`HsmError::EccInvalidKeyLength`] — output buffer too small.
-    async fn ecc_gen_keypair(
+    /// raw coordinates into the caller-provided buffer.
+    async fn ecc_gen_keypair<'a>(
         &self,
+        _io: &impl HsmIo,
         curve: HsmEccCurve,
-        priv_key: Option<&mut [u8]>,
-        pub_key: &mut [u8],
+        key_out: &'a mut DmaBuf,
         _pct: HsmEccPct,
-    ) -> HsmResult<usize> {
+    ) -> HsmResult<(&'a DmaBuf, &'a DmaBuf)> {
         let (pk, pubk) = self.ecc.gen_keypair(to_ecc_curve(curve)).await?;
 
         // Export private key as PKCS#8 DER.
         let priv_len = pk.to_bytes(None).map_err(|_| HsmError::EccToDerError)?;
-        if let Some(buf) = priv_key {
-            if buf.len() < priv_len {
-                return Err(HsmError::EccInvalidKeyLength);
-            }
-            pk.to_bytes(Some(&mut buf[..priv_len]))
-                .map_err(|_| HsmError::EccToDerError)?;
-        }
-
-        // Export public key as raw coordinates (x ∥ y).
         let coord_len = curve.pub_key_len();
-        if pub_key.len() < coord_len {
+        if key_out.len() < priv_len + coord_len {
             return Err(HsmError::EccInvalidKeyLength);
         }
-        let half = coord_len / 2;
-        let (x_buf, y_buf) = pub_key[..coord_len].split_at_mut(half);
-        pubk.coord(Some((x_buf, y_buf)))
+
+        let (priv_key, rest) = key_out.split_at_mut(priv_len);
+        pk.to_bytes(Some(&mut priv_key[..priv_len]))
             .map_err(|_| HsmError::EccToDerError)?;
 
-        Ok(priv_len)
+        // Export public key as raw coordinates (x ∥ y).
+        let pub_key = &mut rest[..coord_len];
+        let half = coord_len / 2;
+        let (x_buf, y_buf) = pub_key.split_at_mut(half);
+        pubk.coord(Some((&mut x_buf[..], &mut y_buf[..])))
+            .map_err(|_| HsmError::EccToDerError)?;
+
+        Ok((&*priv_key, &*pub_key))
     }
 
     /// Raw EC sign over a pre-computed hash digest.
-    ///
-    /// Imports the private key from PKCS#8 DER, delegates signing to
-    /// the driver, and copies the raw `r ∥ s` signature into the
-    /// caller's buffer.
-    ///
-    /// # Parameters
-    /// - `_curve` — Curve hint (unused; curve is encoded in the DER key).
-    /// - `priv_key` — PKCS#8 DER private key bytes.
-    /// - `hash` — Pre-computed hash digest to sign.
-    /// - `signature` — Output buffer (must be ≥ [`HsmEccCurve::sig_len`]).
-    ///
-    /// # Errors
-    /// - [`HsmError::InvalidArg`] — DER import failed.
-    /// - [`HsmError::EccSignFailed`] — signing failed or buffer too small.
     async fn ecc_sign(
         &self,
+        _io: &impl HsmIo,
         _curve: HsmEccCurve,
-        priv_key: &[u8],
-        hash: &[u8],
-        signature: &mut [u8],
+        priv_key: &DmaBuf,
+        hash: &DmaBuf,
+        signature: &mut DmaBuf,
     ) -> HsmResult<()> {
-        let key = EccPrivateKey::from_bytes(priv_key).map_err(|_| HsmError::InvalidArg)?;
-        let sig = self.ecc.ecc_sign(&key, hash).await?;
+        let key = EccPrivateKey::from_bytes(&priv_key[..]).map_err(|_| HsmError::InvalidArg)?;
+        let sig = self.ecc.ecc_sign(&key, &hash[..]).await?;
         if signature.len() < sig.len() {
             return Err(HsmError::EccSignFailed);
         }
@@ -131,57 +105,29 @@ impl HsmEcc for StdHsmPal {
     }
 
     /// Raw EC verify a signature over a pre-computed hash digest.
-    ///
-    /// Imports the public key from SPKI DER, delegates verification
-    /// to the driver.
-    ///
-    /// # Parameters
-    /// - `_curve` — Curve hint (unused; curve is encoded in the DER key).
-    /// - `pub_key` — SPKI DER public key bytes.
-    /// - `hash` — Pre-computed hash digest that was signed.
-    /// - `signature` — The raw `r ∥ s` signature to verify.
-    ///
-    /// # Returns
-    /// `true` if valid, `false` otherwise.
-    ///
-    /// # Errors
-    /// - [`HsmError::InvalidArg`] — DER import failed.
-    /// - [`HsmError::EccVerifyFailed`] — OpenSSL verification error.
     async fn ecc_verify(
         &self,
+        _io: &impl HsmIo,
         _curve: HsmEccCurve,
-        pub_key: &[u8],
-        hash: &[u8],
-        signature: &[u8],
+        pub_key: &DmaBuf,
+        hash: &DmaBuf,
+        signature: &DmaBuf,
     ) -> HsmResult<bool> {
-        let key = EccPublicKey::from_bytes(pub_key).map_err(|_| HsmError::InvalidArg)?;
-        self.ecc.ecc_verify(&key, hash, signature).await
+        let key = EccPublicKey::from_bytes(&pub_key[..]).map_err(|_| HsmError::InvalidArg)?;
+        self.ecc.ecc_verify(&key, &hash[..], &signature[..]).await
     }
 
     /// ECDH key agreement — derives a shared secret.
-    ///
-    /// Imports both keys from DER, delegates ECDH to the driver, and
-    /// writes the raw shared secret (x-coordinate) into `secret`.
-    ///
-    /// # Parameters
-    /// - `_curve` — Curve hint (unused; curve is encoded in the DER keys).
-    /// - `priv_key` — PKCS#8 DER local private key bytes.
-    /// - `pub_key` — SPKI DER remote public key bytes.
-    /// - `secret` — Output buffer (must be ≥ [`HsmEccCurve::secret_len`]).
-    ///
-    /// # Errors
-    /// - [`HsmError::InvalidArg`] — DER import failed.
-    /// - [`HsmError::EccDeriveError`] — ECDH computation failed or
-    ///   output buffer too small.
     async fn ecdh_derive(
         &self,
+        _io: &impl HsmIo,
         _curve: HsmEccCurve,
-        priv_key: &[u8],
-        pub_key: &[u8],
-        secret: &mut [u8],
+        priv_key: &DmaBuf,
+        pub_key: &DmaBuf,
+        secret: &mut DmaBuf,
     ) -> HsmResult<()> {
-        let pk = EccPrivateKey::from_bytes(priv_key).map_err(|_| HsmError::InvalidArg)?;
-        let pubk = EccPublicKey::from_bytes(pub_key).map_err(|_| HsmError::InvalidArg)?;
-        self.ecc.ecdh_derive(&pk, &pubk, secret).await
+        let pk = EccPrivateKey::from_bytes(&priv_key[..]).map_err(|_| HsmError::InvalidArg)?;
+        let pubk = EccPublicKey::from_bytes(&pub_key[..]).map_err(|_| HsmError::InvalidArg)?;
+        self.ecc.ecdh_derive(&pk, &pubk, &mut secret[..]).await
     }
 }

--- a/fw/plat/std/pal/src/gdma.rs
+++ b/fw/plat/std/pal/src/gdma.rs
@@ -12,8 +12,8 @@ use crate::StdHsmPal;
 
 impl HsmGdmaController for StdHsmPal {
     /// Copy data between HSM-local buffers.
-    async fn copy_mem(&self, src: &[u8], dst: &mut [u8]) -> HsmResult<()> {
-        self.gdma.copy_mem(src, dst);
+    async fn copy_mem(&self, _io: &impl HsmIo, src: &DmaBuf, dst: &mut DmaBuf) -> HsmResult<()> {
+        self.gdma.copy_mem(&src[..], &mut dst[..]);
         Ok(())
     }
 
@@ -22,16 +22,16 @@ impl HsmGdmaController for StdHsmPal {
     /// Interprets the PRP address as a raw host pointer.
     async fn copy_mem_from_host(
         &self,
-        _part_id: HsmPartId,
+        _io: &impl HsmIo,
         src: HsmDmaAddr,
-        dst: &mut [u8],
+        dst: &mut DmaBuf,
         _prp: bool,
     ) -> HsmResult<()> {
         // SAFETY: In the std platform, PRP addresses are raw host-process
         // pointers set up by the caller (test harness or integration test).
         // The caller is responsible for ensuring the address is valid and
         // the buffer remains alive for the duration of the copy.
-        unsafe { self.gdma.copy_mem_from_host(src, dst) };
+        unsafe { self.gdma.copy_mem_from_host(src, &mut dst[..]) };
         Ok(())
     }
 
@@ -40,8 +40,8 @@ impl HsmGdmaController for StdHsmPal {
     /// Interprets the PRP address as a raw host pointer.
     async fn copy_mem_to_host(
         &self,
-        _part_id: HsmPartId,
-        src: &[u8],
+        _io: &impl HsmIo,
+        src: &DmaBuf,
         dst: HsmDmaAddr,
         _prp: bool,
     ) -> HsmResult<()> {
@@ -49,7 +49,7 @@ impl HsmGdmaController for StdHsmPal {
         // pointers set up by the caller (test harness or integration test).
         // The caller is responsible for ensuring the address is valid and
         // the buffer remains alive for the duration of the copy.
-        unsafe { self.gdma.copy_mem_to_host(src, dst) };
+        unsafe { self.gdma.copy_mem_to_host(&src[..], dst) };
         Ok(())
     }
 }

--- a/fw/plat/std/pal/src/hash.rs
+++ b/fw/plat/std/pal/src/hash.rs
@@ -23,26 +23,36 @@ fn to_hash_algo(algo: HsmHashAlgo) -> HashAlgo {
     }
 }
 
+#[allow(dead_code)]
+pub struct StdHashCtx<'a> {
+    algo: HsmHashAlgo,
+    state: &'a mut [u8],
+}
+
 impl HsmHash for StdHsmPal {
     type HashCtx<'a>
-        = HsmHashState<'a>
+        = StdHashCtx<'a>
     where
         Self: 'a;
 
     async fn hash(
         &self,
+        _io: &impl HsmIo,
         algo: HsmHashAlgo,
-        data: &[u8],
-        digest: &mut [u8],
+        data: &DmaBuf,
+        digest: &mut DmaBuf,
         _big_endian: bool,
     ) -> HsmResult<()> {
-        self.hash.hash(to_hash_algo(algo), data, digest).await
+        self.hash
+            .hash(to_hash_algo(algo), &data[..], &mut digest[..])
+            .await
     }
 
-    async fn hash_begin<'a>(
+    fn hash_begin<'a>(
         &self,
+        _io: &impl HsmIo,
         _algo: HsmHashAlgo,
-        _state: HsmHashState<'a>,
+        _alloc: &'a impl HsmScopedAlloc,
     ) -> HsmResult<Self::HashCtx<'a>>
     where
         Self: 'a,
@@ -50,15 +60,22 @@ impl HsmHash for StdHsmPal {
         todo!()
     }
 
-    async fn hash_continue(&self, _ctx: &mut Self::HashCtx<'_>, _data: &[u8]) -> HsmResult<()> {
+    async fn hash_continue(
+        &self,
+        _io: &impl HsmIo,
+        _ctx: &mut Self::HashCtx<'_>,
+        _data: &DmaBuf,
+    ) -> HsmResult<()> {
         todo!()
     }
 
-    async fn hash_finish<'a>(
+    async fn hash_finish(
         &self,
-        _ctx: Self::HashCtx<'a>,
+        _io: &impl HsmIo,
+        _ctx: Self::HashCtx<'_>,
+        _digest: &mut DmaBuf,
         _big_endian: bool,
-    ) -> HsmResult<HsmHashState<'a>> {
+    ) -> HsmResult<()> {
         todo!()
     }
 }

--- a/fw/plat/std/pal/src/hmac.rs
+++ b/fw/plat/std/pal/src/hmac.rs
@@ -20,49 +20,59 @@ fn to_hash_algo(algo: HsmHashAlgo) -> HashAlgo {
     }
 }
 
+#[allow(dead_code)]
+pub struct StdHmacCtx<'a> {
+    algo: HsmHashAlgo,
+    state: &'a mut [u8],
+}
+
 impl HsmHmac for StdHsmPal {
     type HmacCtx<'a>
-        = HsmHashState<'a>
+        = StdHmacCtx<'a>
     where
         Self: 'a;
 
-    async fn hmac_gen_key(&self, _algo: HsmHashAlgo, key: &mut [u8]) -> HsmResult<()> {
+    async fn hmac_gen_key(
+        &self,
+        _io: &impl HsmIo,
+        _algo: HsmHashAlgo,
+        key: &mut [u8],
+    ) -> HsmResult<()> {
         self.hmac.gen_key(key).await
     }
 
-    async fn hmac_sign<'a>(
+    async fn hmac_sign(
         &self,
+        _io: &impl HsmIo,
         algo: HsmHashAlgo,
-        key: &[u8],
-        data: &[u8],
-        tag: &mut [u8],
-        _state: HsmHashState<'a>,
-    ) -> HsmResult<()>
-    where
-        Self: 'a,
-    {
-        self.hmac.sign(to_hash_algo(algo), key, data, tag).await
+        key: &DmaBuf,
+        data: &DmaBuf,
+        tag: &mut DmaBuf,
+    ) -> HsmResult<()> {
+        self.hmac
+            .sign(to_hash_algo(algo), &key[..], &data[..], &mut tag[..])
+            .await
     }
 
-    async fn hmac_verify<'a>(
+    async fn hmac_verify(
         &self,
+        _io: &impl HsmIo,
         algo: HsmHashAlgo,
-        key: &[u8],
-        data: &[u8],
-        tag: &[u8],
-        _state: HsmHashState<'a>,
-    ) -> HsmResult<bool>
-    where
-        Self: 'a,
-    {
-        self.hmac.verify(to_hash_algo(algo), key, data, tag).await
+        key: &DmaBuf,
+        data: &DmaBuf,
+        tag: &DmaBuf,
+    ) -> HsmResult<bool> {
+        self.hmac
+            .verify(to_hash_algo(algo), &key[..], &data[..], &tag[..])
+            .await
     }
 
     async fn hmac_begin<'a>(
         &self,
+        _io: &impl HsmIo,
         _algo: HsmHashAlgo,
-        _key: &[u8],
-        _state: HsmHashState<'a>,
+        _key: &DmaBuf,
+        _alloc: &'a impl HsmScopedAlloc,
     ) -> HsmResult<Self::HmacCtx<'a>>
     where
         Self: 'a,
@@ -70,19 +80,39 @@ impl HsmHmac for StdHsmPal {
         todo!()
     }
 
-    async fn hmac_continue(&self, _ctx: &mut Self::HmacCtx<'_>, _data: &[u8]) -> HsmResult<()> {
+    async fn hmac_continue(
+        &self,
+        _io: &impl HsmIo,
+        _ctx: &mut Self::HmacCtx<'_>,
+        _data: &DmaBuf,
+    ) -> HsmResult<()> {
         todo!()
     }
 
-    async fn hmac_finish<'a>(&self, _ctx: Self::HmacCtx<'a>) -> HsmResult<HsmHashState<'a>> {
+    async fn hmac_finish(
+        &self,
+        _io: &impl HsmIo,
+        _ctx: Self::HmacCtx<'_>,
+        _tag: &mut DmaBuf,
+    ) -> HsmResult<()> {
         todo!()
     }
 
-    async fn hmac_finish_into(&self, _ctx: Self::HmacCtx<'_>, _dest: &mut [u8]) -> HsmResult<()> {
+    async fn hmac_finish_into(
+        &self,
+        _io: &impl HsmIo,
+        _ctx: Self::HmacCtx<'_>,
+        _dest: &mut DmaBuf,
+    ) -> HsmResult<()> {
         todo!()
     }
 
-    async fn hmac_finish_verify(&self, _ctx: Self::HmacCtx<'_>, _tag: &[u8]) -> HsmResult<bool> {
+    async fn hmac_finish_verify(
+        &self,
+        _io: &impl HsmIo,
+        _ctx: Self::HmacCtx<'_>,
+        _tag: &DmaBuf,
+    ) -> HsmResult<bool> {
         todo!()
     }
 }

--- a/fw/plat/std/pal/src/io.rs
+++ b/fw/plat/std/pal/src/io.rs
@@ -8,12 +8,9 @@
 //! to [`StdIic`](crate::drivers::iic::StdIic) for receiving and
 //! [`StdOic`](crate::drivers::oic::StdOic) for completing IOs.
 
-use std::sync::Arc;
-
 use azihsm_fw_hsm_pal_traits::*;
 use tokio::sync::oneshot::Sender as ReplySender;
 
-use crate::buf_pool::BufferPool;
 use crate::StdHsmPal;
 
 /// An IO submit request sent from the user thread to the Embassy thread.
@@ -47,12 +44,11 @@ pub struct HsmIoRequest {
 ///
 /// # Buffers
 ///
-/// Each `StdHsmIo` holds an `Arc<BufferPool>` reference, providing safe
-/// access to its slot's buffers without raw pointers:
-/// - [`fast_mem()`](Self::fast_mem) — 2KB fast buffer
-/// - [`mem()`](Self::mem) — 8KB large buffer
-///
-/// Buffers are pre-allocated in the [`BufferPool`] and reused across IOs.
+/// `StdHsmIo` holds the index of its slot in the
+/// [`BufferPool`](crate::buf_pool::BufferPool); the
+/// [`HsmAlloc`](azihsm_fw_hsm_pal_traits::HsmAlloc) implementation on
+/// [`StdHsmPal`] uses [`HsmIo::index`] to address per-slot bump
+/// allocators backed by the pool's pre-allocated NonDma + Dma buffers.
 pub struct StdHsmIo {
     /// Source partition identifier.
     pub(crate) pid: HsmPartId,
@@ -63,7 +59,9 @@ pub struct StdHsmIo {
     /// Index within the source queue.
     pub(crate) qidx: u16,
 
-    /// Index into the buffer pool (used to free the slot on completion).
+    /// Index into the buffer pool (also the [`HsmIo::index`] value
+    /// used by [`HsmAlloc`](azihsm_fw_hsm_pal_traits::HsmAlloc) to
+    /// address per-IO bump heaps).
     pub(crate) slot: u16,
 
     /// Oneshot channel for the CQE reply.
@@ -74,26 +72,20 @@ pub struct StdHsmIo {
 
     /// The 16-byte completion queue entry to be populated by the core.
     pub(crate) cqe: HsmCqe,
-
-    /// Shared reference to the buffer pool.
-    pool: Arc<BufferPool>,
 }
 
 // SAFETY: StdHsmIo is only used on the single-threaded Embassy executor.
-// Arc<BufferPool> is Send+Sync; the UnsafeCell buffers inside are
-// protected by the alloc/free protocol (one owner per slot at a time).
 unsafe impl Send for StdHsmIo {}
 
 impl StdHsmIo {
-    /// Construct a new IO work item from a request, allocated slot, and pool.
-    fn new(req: HsmIoRequest, slot: u16, pool: Arc<BufferPool>) -> Self {
+    /// Construct a new IO work item from a request and an allocated slot.
+    fn new(req: HsmIoRequest, slot: u16) -> Self {
         Self {
             pid: req.pid,
             qid: req.qid,
             qidx: req.qidx,
             sqe: req.sqe,
             slot,
-            pool,
             tx: req.tx,
             cqe: [0; CQE_DWORDS],
         }
@@ -111,6 +103,10 @@ impl core::fmt::Debug for StdHsmIo {
 }
 
 impl HsmIo for StdHsmIo {
+    fn index(&self) -> u16 {
+        self.slot
+    }
+
     fn pid(&self) -> HsmPartId {
         self.pid
     }
@@ -130,13 +126,6 @@ impl HsmIo for StdHsmIo {
     fn cqe(&mut self) -> &mut HsmCqe {
         &mut self.cqe
     }
-
-    fn mem(&mut self) -> (&mut [u8], &mut [u8]) {
-        (
-            self.pool.fast_buf(self.slot),
-            self.pool.large_buf(self.slot),
-        )
-    }
 }
 
 impl HsmIoController for StdHsmPal {
@@ -146,11 +135,14 @@ impl HsmIoController for StdHsmPal {
     ///
     /// Delegates to [`StdIic::recv`](crate::drivers::iic::StdIic::recv)
     /// which receives from the submit channel and allocates a pool slot.
+    /// The pool resets the slot's bump-allocator watermarks before
+    /// returning, so the new IO starts with empty NonDma/Dma heaps.
+    ///
     /// Suspends if no requests are available or if the buffer pool is
     /// exhausted.
     async fn poll_io(&self) -> HsmResult<StdHsmIo> {
         let (req, slot) = self.iic.recv().await?;
-        Ok(StdHsmIo::new(req, slot, self.iic.pool()))
+        Ok(StdHsmIo::new(req, slot))
     }
 
     /// Complete an IO: send response via OIC driver, then free the buffer.

--- a/fw/plat/std/pal/src/kdf.rs
+++ b/fw/plat/std/pal/src/kdf.rs
@@ -25,101 +25,104 @@ fn to_hash_algo(algo: HsmHashAlgo) -> HashAlgo {
 }
 
 impl HsmKdf for StdHsmPal {
-    async fn hkdf_extract<'a>(
+    async fn hkdf_extract(
         &self,
+        _io: &impl HsmIo,
         algo: HsmHashAlgo,
-        salt: &[u8],
-        ikm: &[u8],
-        prk: &mut [u8],
-        state: HsmKdfState<'a>,
-    ) -> HsmResult<HsmKdfState<'a>> {
+        salt: &DmaBuf,
+        ikm: &DmaBuf,
+        prk: &mut DmaBuf,
+    ) -> HsmResult<()> {
         self.kdf
             .hkdf(
-                ikm,
+                &ikm[..],
                 to_hash_algo(algo),
                 azihsm_crypto::HkdfMode::Extract,
-                salt,
+                &salt[..],
                 &[],
-                prk,
+                &mut prk[..],
             )
-            .await?;
-        Ok(state)
+            .await
     }
 
-    async fn hkdf_expand<'a>(
+    async fn hkdf_expand(
         &self,
+        _io: &impl HsmIo,
         algo: HsmHashAlgo,
-        prk: &[u8],
-        info: &[u8],
-        output: &mut [u8],
-        state: HsmKdfState<'a>,
-    ) -> HsmResult<HsmKdfState<'a>> {
+        prk: &DmaBuf,
+        info: &DmaBuf,
+        output: &mut DmaBuf,
+    ) -> HsmResult<()> {
         self.kdf
             .hkdf(
-                prk,
+                &prk[..],
                 to_hash_algo(algo),
                 azihsm_crypto::HkdfMode::Expand,
                 &[],
-                info,
-                output,
+                &info[..],
+                &mut output[..],
             )
-            .await?;
-        Ok(state)
+            .await
     }
 
-    async fn sp800_108_kdf<'a>(
+    async fn sp800_108_kdf(
         &self,
+        _io: &impl HsmIo,
         algo: HsmHashAlgo,
-        key: &[u8],
-        label: &[u8],
-        context: &[u8],
-        output: &mut [u8],
-        state: HsmKdfState<'a>,
-    ) -> HsmResult<HsmKdfState<'a>> {
+        key: &DmaBuf,
+        label: &DmaBuf,
+        context: &DmaBuf,
+        output: &mut DmaBuf,
+    ) -> HsmResult<()> {
         self.kdf
-            .kbkdf(key, to_hash_algo(algo), label, context, output)
-            .await?;
-        Ok(state)
+            .kbkdf(
+                &key[..],
+                to_hash_algo(algo),
+                &label[..],
+                &context[..],
+                &mut output[..],
+            )
+            .await
     }
 
     async fn mgf1(
         &self,
+        _io: &impl HsmIo,
         _algo: HsmHashAlgo,
-        _seed: &[u8],
-        _mask: &mut [u8],
-        _state: &mut [u8],
+        _seed: &DmaBuf,
+        _mask: &mut DmaBuf,
     ) -> HsmResult<()> {
         todo!()
     }
 
     async fn mgf1_xor(
         &self,
+        _io: &impl HsmIo,
         _algo: HsmHashAlgo,
-        _seed: &[u8],
-        _mask: &mut [u8],
-        _state: &mut [u8],
+        _seed: &DmaBuf,
+        _mask: &mut DmaBuf,
     ) -> HsmResult<()> {
         todo!()
     }
 
     async fn x963_kdf(
         &self,
+        _io: &impl HsmIo,
         _algo: HsmHashAlgo,
-        _z: &[u8],
-        _shared_info: &[u8],
-        _key: &mut [u8],
-        _state: &mut [u8],
+        _z: &DmaBuf,
+        _shared_info: &DmaBuf,
+        _key: &mut DmaBuf,
     ) -> HsmResult<()> {
         todo!()
     }
 
     async fn sp800_56a_kdf(
         &self,
+        _io: &impl HsmIo,
         _algo: HsmHashAlgo,
-        _z: &[u8],
-        _other_info: &[u8],
-        _key: &mut [u8],
-        _state: &mut [u8],
+        _z: &DmaBuf,
+        _other_info: &DmaBuf,
+        _key: &mut DmaBuf,
     ) -> HsmResult<()> {
         todo!()
     }

--- a/fw/plat/std/pal/src/lib.rs
+++ b/fw/plat/std/pal/src/lib.rs
@@ -49,6 +49,7 @@
 //! [`HsmIo`]: azihsm_fw_hsm_pal_traits::HsmIo
 
 mod aes;
+mod alloc;
 mod buf_pool;
 mod cert;
 mod drivers;
@@ -67,6 +68,8 @@ mod session;
 mod tracing;
 mod vault;
 mod worker;
+
+pub use alloc::StdScopedAlloc;
 
 use azihsm_fw_hsm_pal_traits::*;
 pub use io::HsmIoRequest;

--- a/fw/plat/std/pal/src/part.rs
+++ b/fw/plat/std/pal/src/part.rs
@@ -85,12 +85,22 @@ pub(crate) const P384_PUB_KEY_LEN: usize = P384_COORD_SIZE * 2;
 /// | Field | Size | Description |
 /// |-------|------|-------------|
 /// | `state` | 1 B | Lifecycle state (`Disabled` / `Uninitialized`) |
+/// | `gen` | 4 B | Incarnation counter (bumped on alloc / free) |
 /// | `res_mask` | 16 B | Resource bitmask (each bit = one vault table) |
 /// | `id` | 16 B | Random identity blob |
 /// | `pub_key` | 96 B | Raw P-384 public key (x ∥ y) |
 /// | `priv_key_der` | 256 B | PKCS#8 DER-encoded P-384 private key |
 /// | `leaf_cert` | 2 KB | Cached DER-encoded partition leaf certificate |
 /// | `session_table` | 2 B | Bitmask session allocator |
+///
+/// ## Generation counter
+///
+/// `gen` increments on every `part_alloc_internal` and
+/// `part_free_internal` call.  RAII guards (`StdVaultKeyGuard`,
+/// `StdSessionGuard`) capture the value at create time and refuse to
+/// roll back if the partition has since been freed and reallocated —
+/// otherwise a stale guard could delete unrelated state from a
+/// re-incarnated partition.
 ///
 /// ## Zeroization
 ///
@@ -103,6 +113,9 @@ pub(crate) const P384_PUB_KEY_LEN: usize = P384_COORD_SIZE * 2;
 pub(crate) struct PartitionEntry {
     /// Current lifecycle state.
     pub(crate) state: PartState,
+
+    /// Partition incarnation counter.  Bumped on every alloc and free.
+    pub(crate) gen: u32,
 
     /// Resource bitmask — each set bit corresponds to one vault table
     /// assigned to this partition.  `count_ones()` gives the table count.
@@ -158,6 +171,7 @@ impl Default for PartitionEntry {
     fn default() -> Self {
         Self {
             state: PartState::Unallocated,
+            gen: 0,
             res_mask: 0,
             id: [0u8; PART_ID_LEN],
             id_key_id: None,
@@ -260,22 +274,22 @@ pub enum PartCommand {
 // ---------------------------------------------------------------------------
 
 impl HsmPartitionManager for StdHsmPal {
-    /// Returns the current state of the partition at index `pid`.
-    fn part_state(&self, pid: HsmPartId) -> HsmResult<PartState> {
+    /// Returns the current state of the calling partition (`io.pid()`).
+    fn part_state(&self, io: &impl HsmIo) -> HsmResult<PartState> {
         // SAFETY: Embassy is single-threaded. This synchronous method
         // completes without yielding, so no concurrent mutation occurs.
         let table = unsafe { &*self.part_table.get() };
-        let idx = u8::from(pid) as usize;
+        let idx = u8::from(io.pid()) as usize;
         if idx >= NUM_PARTITIONS {
             return Err(HsmError::InvalidArg);
         }
         Ok(table.entries[idx].state)
     }
 
-    /// Returns the resource count allocated to the partition at `pid`.
-    fn part_res_count(&self, pid: HsmPartId) -> HsmResult<u8> {
+    /// Returns the resource count allocated to the calling partition.
+    fn part_res_count(&self, io: &impl HsmIo) -> HsmResult<u8> {
         let table = unsafe { &*self.part_table.get() };
-        let idx = u8::from(pid) as usize;
+        let idx = u8::from(io.pid()) as usize;
         if idx >= NUM_PARTITIONS {
             return Err(HsmError::InvalidArg);
         }
@@ -286,10 +300,10 @@ impl HsmPartitionManager for StdHsmPal {
         Ok(entry.res_mask.count_ones() as u8)
     }
 
-    /// Returns the 16-byte identity blob for the partition at `pid`.
-    fn part_id(&self, pid: HsmPartId) -> HsmResult<PartId<'_>> {
+    /// Returns the 16-byte identity blob for the calling partition.
+    fn part_id(&self, io: &impl HsmIo) -> HsmResult<PartId<'_>> {
         let table = unsafe { &*self.part_table.get() };
-        let idx = u8::from(pid) as usize;
+        let idx = u8::from(io.pid()) as usize;
         if idx >= NUM_PARTITIONS {
             return Err(HsmError::InvalidArg);
         }
@@ -300,43 +314,52 @@ impl HsmPartitionManager for StdHsmPal {
         Ok(&entry.id)
     }
 
-    fn part_id_key_id(&self, pid: HsmPartId) -> HsmResult<HsmKeyId> {
-        self.active_part(pid)?
+    fn part_id_key_id(&self, io: &impl HsmIo) -> HsmResult<HsmKeyId> {
+        self.active_part(io.pid())?
             .id_key_id
             .ok_or(HsmError::InternalError)
     }
 
-    fn part_id_pub_key(&self, pid: HsmPartId, out: Option<&mut [u8]>) -> HsmResult<usize> {
-        copy_out(&self.active_part(pid)?.id_pub_key, out)
+    fn part_id_pub_key(&self, io: &impl HsmIo, out: Option<&mut [u8]>) -> HsmResult<usize> {
+        copy_out(&self.active_part(io.pid())?.id_pub_key, out)
     }
 
-    fn part_establish_cred_key_id(&self, pid: HsmPartId) -> HsmResult<Option<HsmKeyId>> {
-        Ok(self.enabled_part(u8::from(pid))?.establish_cred_key_id)
+    fn part_establish_cred_key_id(&self, io: &impl HsmIo) -> HsmResult<Option<HsmKeyId>> {
+        Ok(self.enabled_part(u8::from(io.pid()))?.establish_cred_key_id)
     }
 
     fn part_establish_cred_pub_key(
         &self,
-        pid: HsmPartId,
+        io: &impl HsmIo,
         out: Option<&mut [u8]>,
     ) -> HsmResult<usize> {
         copy_out(
-            &self.enabled_part(u8::from(pid))?.establish_cred_pub_key,
+            &self
+                .enabled_part(u8::from(io.pid()))?
+                .establish_cred_pub_key,
             out,
         )
     }
 
-    fn part_session_enc_key_id(&self, pid: HsmPartId) -> HsmResult<HsmKeyId> {
-        self.enabled_part(u8::from(pid))?
+    fn part_session_enc_key_id(&self, io: &impl HsmIo) -> HsmResult<HsmKeyId> {
+        self.enabled_part(u8::from(io.pid()))?
             .session_enc_key_id
             .ok_or(HsmError::InternalError)
     }
 
-    fn part_session_enc_pub_key(&self, pid: HsmPartId, out: Option<&mut [u8]>) -> HsmResult<usize> {
-        copy_out(&self.enabled_part(u8::from(pid))?.session_enc_pub_key, out)
+    fn part_session_enc_pub_key(
+        &self,
+        io: &impl HsmIo,
+        out: Option<&mut [u8]>,
+    ) -> HsmResult<usize> {
+        copy_out(
+            &self.enabled_part(u8::from(io.pid()))?.session_enc_pub_key,
+            out,
+        )
     }
 
-    fn part_clear_establish_cred_key(&self, pid: HsmPartId) -> HsmResult<()> {
-        let entry = self.enabled_part_mut(u8::from(pid))?;
+    fn part_clear_establish_cred_key(&self, io: &impl HsmIo) -> HsmResult<()> {
+        let entry = self.enabled_part_mut(u8::from(io.pid()))?;
         if let Some(kid) = entry.establish_cred_key_id.take() {
             let _ = entry.vault.delete(kid);
         }
@@ -344,23 +367,23 @@ impl HsmPartitionManager for StdHsmPal {
         Ok(())
     }
 
-    fn part_nonce(&self, pid: HsmPartId, out: Option<&mut [u8]>) -> HsmResult<usize> {
-        copy_out(&self.enabled_part(u8::from(pid))?.nonce, out)
+    fn part_nonce(&self, io: &impl HsmIo, out: Option<&mut [u8]>) -> HsmResult<usize> {
+        copy_out(&self.enabled_part(u8::from(io.pid()))?.nonce, out)
     }
 
-    fn part_nonce_refresh(&self, pid: HsmPartId) -> HsmResult<()> {
-        let entry = self.enabled_part_mut(u8::from(pid))?;
+    fn part_nonce_refresh(&self, io: &impl HsmIo) -> HsmResult<()> {
+        let entry = self.enabled_part_mut(u8::from(io.pid()))?;
         Rng::rand_bytes(&mut entry.nonce).map_err(|_| HsmError::InternalError)
     }
 
-    fn part_sealed_bk3(&self, pid: HsmPartId, out: Option<&mut [u8]>) -> HsmResult<usize> {
-        let entry = self.active_part(pid)?;
+    fn part_sealed_bk3(&self, io: &impl HsmIo, out: Option<&mut [u8]>) -> HsmResult<usize> {
+        let entry = self.active_part(io.pid())?;
         let len = entry.sealed_bk3_len as usize;
         copy_out(&entry.sealed_bk3[..len], out)
     }
 
-    fn part_set_sealed_bk3(&self, pid: HsmPartId, data: &[u8]) -> HsmResult<()> {
-        let entry = self.active_part_mut(pid)?;
+    fn part_set_sealed_bk3(&self, io: &impl HsmIo, data: &[u8]) -> HsmResult<()> {
+        let entry = self.active_part_mut(io.pid())?;
         if entry.sealed_bk3_len != 0 {
             return Err(HsmError::SealedBk3AlreadySet);
         }
@@ -378,6 +401,21 @@ impl HsmPartitionManager for StdHsmPal {
 // ---------------------------------------------------------------------------
 
 impl StdHsmPal {
+    /// Returns the partition incarnation counter.
+    ///
+    /// Captured by RAII guards (`StdVaultKeyGuard`, `StdSessionGuard`)
+    /// at create time; if the value differs at drop time, the guard
+    /// has outlived its partition incarnation and skips rollback to
+    /// avoid corrupting a re-allocated partition.
+    pub(crate) fn partition_gen(&self, pid: HsmPartId) -> u32 {
+        let table = unsafe { &*self.part_table.get() };
+        let idx = u8::from(pid) as usize;
+        if idx >= NUM_PARTITIONS {
+            return 0;
+        }
+        table.entries[idx].gen
+    }
+
     /// Borrow a partition entry that is not Unallocated.
     pub(crate) fn active_part(&self, pid: HsmPartId) -> HsmResult<&PartitionEntry> {
         let table = unsafe { &*self.part_table.get() };
@@ -434,10 +472,13 @@ impl StdHsmPal {
 }
 
 /// Copy `data` into `out` if provided, return length.
+///
+/// Returns [`HsmError::InvalidArg`] (per the new partition trait
+/// docs) when the caller-supplied buffer is too small.
 fn copy_out(data: &[u8], out: Option<&mut [u8]>) -> HsmResult<usize> {
     if let Some(buf) = out {
         if buf.len() < data.len() {
-            return Err(HsmError::NotEnoughSpace);
+            return Err(HsmError::InvalidArg);
         }
         buf[..data.len()].copy_from_slice(data);
     }
@@ -477,6 +518,9 @@ impl StdHsmPal {
 
         // Reserve resources + create vault so keygen has somewhere to store.
         let entry = &mut table.entries[idx];
+        // Bump the partition incarnation counter so RAII guards captured
+        // against the prior incarnation refuse to roll back.
+        entry.gen = entry.gen.wrapping_add(1);
         entry.res_mask = res_mask;
         entry.vault = KeyVault::new(res_mask.count_ones() as usize);
         table.global_res_mask |= res_mask;
@@ -627,6 +671,10 @@ impl StdHsmPal {
 
         let entry = &mut table.entries[idx];
 
+        // Bump the partition incarnation counter so RAII guards captured
+        // before this free refuse to roll back into the next incarnation.
+        entry.gen = entry.gen.wrapping_add(1);
+
         // If enabled, clear internal keys/nonce/vault/sessions first.
         if entry.state == PartState::Enabled {
             Self::clear_enabled_state(entry);
@@ -654,9 +702,14 @@ impl StdHsmPal {
     // Helpers
     // -----------------------------------------------------------------------
 
-    /// Generate an ECC P-384 key pair via [`HsmEcc::ecc_gen_keypair`],
-    /// store the private key DER in the vault, and write raw public key
-    /// coordinates (x ∥ y) into `pub_key_out`.
+    /// Generate an ECC P-384 key pair, store the PKCS#8 DER private
+    /// key in the vault, and write raw public key coordinates (x ∥ y)
+    /// into `pub_key_out`.
+    ///
+    /// Bypasses [`HsmEcc::ecc_gen_keypair`] (which now requires an
+    /// `HsmIo`) and drives the [`StdEcc`](crate::drivers::ecc::StdEcc)
+    /// driver directly — this helper runs from the partition lifecycle
+    /// task where no IO context exists.
     ///
     /// Returns the vault key ID.
     async fn create_internal_ecc384_key(
@@ -664,15 +717,22 @@ impl StdHsmPal {
         pid: u8,
         kind: HsmVaultKeyKind,
         attrs: HsmVaultKeyAttrs,
-        pct: HsmEccPct,
+        _pct: HsmEccPct,
         pub_key_out: &mut [u8; P384_PUB_KEY_LEN],
     ) -> HsmResult<HsmKeyId> {
-        let priv_max = HsmEccCurve::P384.priv_key_der_max();
-        let mut priv_buf = vec![0u8; priv_max];
+        let (pk, pubk) = self.ecc.gen_keypair(EccCurve::P384).await?;
 
-        let priv_len = self
-            .ecc_gen_keypair(HsmEccCurve::P384, Some(&mut priv_buf), pub_key_out, pct)
-            .await?;
+        // Export private key as PKCS#8 DER.
+        let priv_len = pk.to_bytes(None).map_err(|_| HsmError::EccToDerError)?;
+        let mut priv_buf = vec![0u8; priv_len];
+        pk.to_bytes(Some(&mut priv_buf[..priv_len]))
+            .map_err(|_| HsmError::EccToDerError)?;
+
+        // Export raw P-384 public key coordinates (x ∥ y).
+        let half = P384_PUB_KEY_LEN / 2;
+        let (x_buf, y_buf) = pub_key_out.split_at_mut(half);
+        pubk.coord(Some((x_buf, y_buf)))
+            .map_err(|_| HsmError::EccToDerError)?;
 
         // Store private key DER in vault.
         let table = unsafe { &mut *self.part_table.get() };

--- a/fw/plat/std/pal/src/part_lock.rs
+++ b/fw/plat/std/pal/src/part_lock.rs
@@ -17,8 +17,8 @@ use crate::part::NUM_PARTITIONS;
 impl HsmPartitionLock for StdHsmPal {
     type PartitionGuard<'a> = MutexGuard<'a, NoopRawMutex, ()>;
 
-    async fn partition_lock(&self, pid: HsmPartId) -> HsmResult<Self::PartitionGuard<'_>> {
-        let idx = u8::from(pid) as usize;
+    async fn partition_lock(&self, io: &impl HsmIo) -> HsmResult<Self::PartitionGuard<'_>> {
+        let idx = u8::from(io.pid()) as usize;
         if idx >= NUM_PARTITIONS {
             return Err(HsmError::InvalidArg);
         }

--- a/fw/plat/std/pal/src/rng.rs
+++ b/fw/plat/std/pal/src/rng.rs
@@ -19,7 +19,7 @@ impl HsmRng for StdHsmPal {
     /// Delegates to [`azihsm_crypto::Rng::rand_bytes`], which calls
     /// OpenSSL's `RAND_bytes`. Returns [`HsmError::InternalError`] if
     /// the underlying CSPRNG fails (e.g., insufficient entropy).
-    fn rng_fill_bytes(&self, buf: &mut [u8]) -> HsmResult<()> {
+    fn rng_fill_bytes(&self, _io: &impl HsmIo, buf: &mut [u8]) -> HsmResult<()> {
         azihsm_crypto::Rng::rand_bytes(buf).map_err(|_| HsmError::InternalError)
     }
 }

--- a/fw/plat/std/pal/src/rsa.rs
+++ b/fw/plat/std/pal/src/rsa.rs
@@ -25,9 +25,10 @@ fn key_size_bits(key_size: HsmRsaKey) -> usize {
 impl HsmRsa for StdHsmPal {
     async fn ras_gen_keypair(
         &self,
+        _io: &impl HsmIo,
         key_size: HsmRsaKey,
-        priv_key: &mut [u8],
-        pub_key: &mut [u8],
+        priv_key: &mut DmaBuf,
+        pub_key: &mut DmaBuf,
         _pct: HsmRsaPct,
     ) -> Result<(), HsmError> {
         let (pk, pubk) = self.rsa.gen_keypair(key_size_bits(key_size)).await?;
@@ -51,121 +52,155 @@ impl HsmRsa for StdHsmPal {
 
     async fn mod_exp_priv(
         &self,
+        _io: &impl HsmIo,
         _key_size: HsmRsaKey,
-        key: &[u8],
-        y: &[u8],
-        x: &mut [u8],
+        key: &DmaBuf,
+        y: &DmaBuf,
+        x: &mut DmaBuf,
     ) -> Result<(), HsmError> {
-        let priv_key = RsaPrivateKey::from_bytes(key).map_err(|_| HsmError::InvalidArg)?;
-        self.rsa.mod_exp_priv(&priv_key, y, x).await
+        let priv_key = RsaPrivateKey::from_bytes(&key[..]).map_err(|_| HsmError::InvalidArg)?;
+        self.rsa.mod_exp_priv(&priv_key, &y[..], &mut x[..]).await
     }
 
     async fn mod_exp_pub(
         &self,
+        _io: &impl HsmIo,
         _key_size: HsmRsaKey,
-        key: &[u8],
-        x: &[u8],
-        y: &mut [u8],
+        key: &DmaBuf,
+        x: &DmaBuf,
+        y: &mut DmaBuf,
     ) -> Result<(), HsmError> {
-        let pub_key = RsaPublicKey::from_bytes(key).map_err(|_| HsmError::InvalidArg)?;
-        self.rsa.mod_exp_pub(&pub_key, x, y).await
+        let pub_key = RsaPublicKey::from_bytes(&key[..]).map_err(|_| HsmError::InvalidArg)?;
+        self.rsa.mod_exp_pub(&pub_key, &x[..], &mut y[..]).await
     }
 
-    async fn rsa_pkcs1_encrypt(
+    async fn rsa_pkcs1_encrypt<'a>(
         &self,
+        _io: &impl HsmIo,
         _key_size: HsmRsaKey,
-        _pub_key: &[u8],
-        _message: &[u8],
-        _output: &mut [u8],
-        _work: &mut [u8],
-    ) -> HsmResult<()> {
+        _pub_key: &DmaBuf,
+        _message: &DmaBuf,
+        _output: &mut DmaBuf,
+        _alloc: &'a impl HsmScopedAlloc,
+    ) -> HsmResult<()>
+    where
+        Self: 'a,
+    {
         todo!()
     }
 
-    async fn rsa_pkcs1_decrypt(
+    async fn rsa_pkcs1_decrypt<'a>(
         &self,
+        _io: &impl HsmIo,
         _key_size: HsmRsaKey,
-        _priv_key: &[u8],
-        _ciphertext: &[u8],
-        _output: &mut [u8],
-        _work: &mut [u8],
-    ) -> HsmResult<usize> {
+        _priv_key: &DmaBuf,
+        _ciphertext: &DmaBuf,
+        _output: &mut DmaBuf,
+        _alloc: &'a impl HsmScopedAlloc,
+    ) -> HsmResult<usize>
+    where
+        Self: 'a,
+    {
         todo!()
     }
 
-    async fn rsa_pkcs1_sign(
+    async fn rsa_pkcs1_sign<'a>(
         &self,
+        _io: &impl HsmIo,
         _key_size: HsmRsaKey,
         _algo: HsmHashAlgo,
-        _priv_key: &[u8],
-        _message_hash: &[u8],
-        _signature: &mut [u8],
-        _work: &mut [u8],
-    ) -> HsmResult<()> {
+        _priv_key: &DmaBuf,
+        _message_hash: &DmaBuf,
+        _signature: &mut DmaBuf,
+        _alloc: &'a impl HsmScopedAlloc,
+    ) -> HsmResult<()>
+    where
+        Self: 'a,
+    {
         todo!()
     }
 
-    async fn rsa_pkcs1_verify(
+    async fn rsa_pkcs1_verify<'a>(
         &self,
+        _io: &impl HsmIo,
         _key_size: HsmRsaKey,
         _algo: HsmHashAlgo,
-        _pub_key: &[u8],
-        _message_hash: &[u8],
-        _signature: &[u8],
-        _work: &mut [u8],
-    ) -> HsmResult<bool> {
+        _pub_key: &DmaBuf,
+        _message_hash: &DmaBuf,
+        _signature: &DmaBuf,
+        _alloc: &'a impl HsmScopedAlloc,
+    ) -> HsmResult<bool>
+    where
+        Self: 'a,
+    {
         todo!()
     }
 
-    async fn rsa_oaep_encrypt(
+    async fn rsa_oaep_encrypt<'a>(
         &self,
+        _io: &impl HsmIo,
         _key_size: HsmRsaKey,
         _algo: HsmHashAlgo,
-        _pub_key: &[u8],
-        _message: &[u8],
-        _label: &[u8],
-        _output: &mut [u8],
-        _work: &mut [u8],
-    ) -> HsmResult<()> {
+        _pub_key: &DmaBuf,
+        _message: &DmaBuf,
+        _label: &DmaBuf,
+        _output: &mut DmaBuf,
+        _alloc: &'a impl HsmScopedAlloc,
+    ) -> HsmResult<()>
+    where
+        Self: 'a,
+    {
         todo!()
     }
 
-    async fn rsa_oaep_decrypt(
+    async fn rsa_oaep_decrypt<'a>(
         &self,
+        _io: &impl HsmIo,
         _key_size: HsmRsaKey,
         _algo: HsmHashAlgo,
-        _priv_key: &[u8],
-        _ciphertext: &[u8],
-        _label: &[u8],
-        _output: &mut [u8],
-        _work: &mut [u8],
-    ) -> HsmResult<usize> {
+        _priv_key: &DmaBuf,
+        _ciphertext: &DmaBuf,
+        _label: &DmaBuf,
+        _output: &mut DmaBuf,
+        _alloc: &'a impl HsmScopedAlloc,
+    ) -> HsmResult<usize>
+    where
+        Self: 'a,
+    {
         todo!()
     }
 
-    async fn rsa_pss_sign(
+    async fn rsa_pss_sign<'a>(
         &self,
+        _io: &impl HsmIo,
         _key_size: HsmRsaKey,
         _algo: HsmHashAlgo,
-        _priv_key: &[u8],
-        _message_hash: &[u8],
+        _priv_key: &DmaBuf,
+        _message_hash: &DmaBuf,
         _salt_len: usize,
-        _signature: &mut [u8],
-        _work: &mut [u8],
-    ) -> HsmResult<()> {
+        _signature: &mut DmaBuf,
+        _alloc: &'a impl HsmScopedAlloc,
+    ) -> HsmResult<()>
+    where
+        Self: 'a,
+    {
         todo!()
     }
 
-    async fn rsa_pss_verify(
+    async fn rsa_pss_verify<'a>(
         &self,
+        _io: &impl HsmIo,
         _key_size: HsmRsaKey,
         _algo: HsmHashAlgo,
-        _pub_key: &[u8],
-        _message_hash: &[u8],
+        _pub_key: &DmaBuf,
+        _message_hash: &DmaBuf,
         _salt_len: usize,
-        _signature: &[u8],
-        _work: &mut [u8],
-    ) -> HsmResult<bool> {
+        _signature: &DmaBuf,
+        _alloc: &'a impl HsmScopedAlloc,
+    ) -> HsmResult<bool>
+    where
+        Self: 'a,
+    {
         todo!()
     }
 }

--- a/fw/plat/std/pal/src/session.rs
+++ b/fw/plat/std/pal/src/session.rs
@@ -9,9 +9,19 @@
 //! allocates a logical session slot in the [`SessionTable`] that maps
 //! to the vault key's physical [`HsmKeyId`].
 //!
-//! `session_delete` cascades cleanup: removes session-scoped vault
+//! `session_destroy` cascades cleanup: removes session-scoped vault
 //! keys, deletes the session vault key itself, and frees the logical
 //! slot.
+//!
+//! ## RAII guards
+//!
+//! [`session_create`] returns a [`StdSessionGuard`] in a *provisional*
+//! state — on drop the session is torn down (vault key + scoped keys
+//! removed, slot freed) unless the caller calls
+//! [`StdSessionGuard::dismiss`] to commit.  Each guard captures the
+//! partition's incarnation counter (`gen`) at create time; if the
+//! partition has since been freed and reallocated, rollback is
+//! skipped.
 //!
 //! [`KeyVault`]: crate::drivers::vault::KeyVault
 //! [`SessionTable`]: crate::drivers::session::SessionTable
@@ -28,10 +38,57 @@ const SESSION_MASKING_KEY_SIZE: usize = 80;
 /// Total session blob size stored in the vault.
 const SESSION_BLOB_SIZE: usize = SESSION_API_REV_SIZE + SESSION_MASKING_KEY_SIZE;
 
+/// RAII guard returned by [`HsmSessionManager::session_create`].
+///
+/// On drop, tears down the provisional session unless
+/// [`dismiss`](Self::dismiss) was called first.  Skips rollback if
+/// the partition's incarnation counter has changed since the guard
+/// was created.
+pub struct StdSessionGuard<'a> {
+    pal: &'a StdHsmPal,
+    pid: HsmPartId,
+    /// Captured partition incarnation counter; rollback is a no-op
+    /// if the live counter no longer matches.
+    gen: u32,
+    sess_id: HsmSessId,
+    committed: bool,
+}
+
+impl SessionGuard for StdSessionGuard<'_> {
+    fn sess_id(&self) -> HsmSessId {
+        self.sess_id
+    }
+
+    fn dismiss(mut self) -> HsmSessId {
+        self.committed = true;
+        self.sess_id
+    }
+}
+
+impl Drop for StdSessionGuard<'_> {
+    fn drop(&mut self) {
+        if self.committed {
+            return;
+        }
+        if self.pal.partition_gen(self.pid) != self.gen {
+            return;
+        }
+        if let Ok(entry) = self.pal.active_part_mut(self.pid) {
+            if let Ok(physical_id) = entry.session_table.physical_id(self.sess_id) {
+                let _ = entry.vault.delete_by_session_key(physical_id);
+                let _ = entry.vault.delete(physical_id);
+            }
+            let _ = entry.session_table.delete(self.sess_id);
+        }
+    }
+}
+
 impl HsmSessionManager for StdHsmPal {
+    type Guard<'a> = StdSessionGuard<'a>;
+
     /// Check whether the partition's session table is full.
-    fn session_limit_reached(&self, pid: HsmPartId) -> bool {
-        let Ok(entry) = self.active_part(pid) else {
+    fn session_limit_reached(&self, io: &impl HsmIo) -> bool {
+        let Ok(entry) = self.active_part(io.pid()) else {
             return true;
         };
         entry.session_table.limit_reached()
@@ -44,15 +101,16 @@ impl HsmSessionManager for StdHsmPal {
     /// 3. Allocates (or re-maps) a logical session slot.
     fn session_create(
         &self,
-        pid: HsmPartId,
+        io: &impl HsmIo,
         api_rev: &[u8],
         masking_key: &[u8],
         id: Option<HsmSessId>,
-    ) -> HsmResult<SessionGuard<'_, Self>> {
+    ) -> HsmResult<Self::Guard<'_>> {
         if api_rev.len() != SESSION_API_REV_SIZE || masking_key.len() != SESSION_MASKING_KEY_SIZE {
             return Err(HsmError::InvalidArg);
         }
 
+        let pid = io.pid();
         let entry = self.active_part_mut(pid)?;
 
         // On re-key: clean up old session-scoped keys and old session key
@@ -82,7 +140,13 @@ impl HsmSessionManager for StdHsmPal {
 
         // Rollback: if session table allocation fails, remove the vault key.
         match result {
-            Ok(sess_id) => Ok(SessionGuard::new(self, pid, sess_id)),
+            Ok(sess_id) => Ok(StdSessionGuard {
+                pal: self,
+                pid,
+                gen: self.partition_gen(pid),
+                sess_id,
+                committed: false,
+            }),
             Err(e) => {
                 let _ = entry.vault.delete(physical_id);
                 Err(e)
@@ -90,14 +154,14 @@ impl HsmSessionManager for StdHsmPal {
         }
     }
 
-    /// Delete (close) a session with cascading vault cleanup.
+    /// Destroy (close) a session with cascading vault cleanup.
     ///
     /// 1. Looks up physical vault key ID from logical session ID.
     /// 2. Deletes all session-scoped vault keys bound to that physical ID.
     /// 3. Deletes the session vault key itself.
     /// 4. Frees the logical session slot.
-    fn session_delete(&self, pid: HsmPartId, id: HsmSessId) -> HsmResult<()> {
-        let entry = self.active_part_mut(pid)?;
+    fn session_destroy(&self, io: &impl HsmIo, id: HsmSessId) -> HsmResult<()> {
+        let entry = self.active_part_mut(io.pid())?;
 
         // Look up physical session key ID.
         let physical_id = entry.session_table.physical_id(id)?;
@@ -114,8 +178,8 @@ impl HsmSessionManager for StdHsmPal {
     }
 
     /// Query the lifecycle state of a session.
-    fn session_state(&self, pid: HsmPartId, id: HsmSessId) -> HsmSessionState {
-        let Ok(entry) = self.active_part(pid) else {
+    fn session_state(&self, io: &impl HsmIo, id: HsmSessId) -> HsmSessionState {
+        let Ok(entry) = self.active_part(io.pid()) else {
             return HsmSessionState::Invalid;
         };
         entry.session_table.state(id)

--- a/fw/plat/std/pal/src/vault.rs
+++ b/fw/plat/std/pal/src/vault.rs
@@ -9,40 +9,103 @@
 //! access.  All methods are synchronous on the single-threaded Embassy
 //! executor.
 //!
+//! ## RAII guards
+//!
+//! [`vault_key_create`] returns a [`StdVaultKeyGuard`] in a
+//! *provisional* state — the key is removed from the vault on drop
+//! unless the caller calls [`StdVaultKeyGuard::dismiss`] to commit.
+//! Each guard captures the partition's incarnation counter (`gen`) at
+//! create time; if the partition has since been freed and reallocated,
+//! the rollback is skipped to avoid corrupting an unrelated incarnation.
+//!
 //! [`KeyVault`]: crate::drivers::vault::KeyVault
 //! [`PartitionEntry`]: crate::part::PartitionEntry
 
 use super::*;
 use crate::drivers::vault::KeyVault;
 
+/// RAII guard returned by [`HsmVault::vault_key_create`].
+///
+/// On drop, deletes the provisional vault entry unless
+/// [`dismiss`](Self::dismiss) was called first.  Skips rollback if the
+/// partition's incarnation counter has changed since the guard was
+/// created (i.e., the partition was freed and reallocated).
+pub struct StdVaultKeyGuard<'a> {
+    pal: &'a StdHsmPal,
+    pid: HsmPartId,
+    /// Captured partition incarnation counter; rollback is a no-op
+    /// if the live counter no longer matches.
+    gen: u32,
+    key_id: HsmKeyId,
+    committed: bool,
+}
+
+impl VaultKeyGuard for StdVaultKeyGuard<'_> {
+    fn key_id(&self) -> HsmKeyId {
+        self.key_id
+    }
+
+    fn dismiss(mut self) -> HsmKeyId {
+        self.committed = true;
+        self.key_id
+    }
+}
+
+impl Drop for StdVaultKeyGuard<'_> {
+    fn drop(&mut self) {
+        if self.committed {
+            return;
+        }
+        if self.pal.partition_gen(self.pid) != self.gen {
+            // Partition was freed/reallocated since this guard was
+            // created.  The original key no longer exists; another
+            // incarnation now owns the slot.
+            return;
+        }
+        if let Ok(entry) = self.pal.active_part_mut(self.pid) {
+            let _ = entry.vault.delete(self.key_id);
+        }
+    }
+}
+
 impl HsmVault for StdHsmPal {
+    type KeyGuard<'a> = StdVaultKeyGuard<'a>;
+
     /// Store a new key in the partition's vault.
     ///
     /// If `session_id` is `Some`, maps the logical session ID to the
     /// physical vault key ID via the session table before storing.
     ///
-    /// Returns a [`VaultKeyGuard`] — the key is auto-deleted on drop
-    /// unless the caller calls [`dismiss`](VaultKeyGuard::dismiss).
+    /// Returns a [`StdVaultKeyGuard`] — the key is auto-deleted on
+    /// drop unless the caller calls
+    /// [`VaultKeyGuard::dismiss`].
     fn vault_key_create(
         &self,
-        pid: HsmPartId,
+        io: &impl HsmIo,
         key: &[u8],
         kind: HsmVaultKeyKind,
         session_id: Option<HsmSessId>,
         attrs: HsmVaultKeyAttrs,
         meta: &[u8],
-    ) -> HsmResult<VaultKeyGuard<'_, Self>> {
+    ) -> HsmResult<Self::KeyGuard<'_>> {
+        let pid = io.pid();
         let entry = self.active_part_mut(pid)?;
         let session_key_id = session_id
             .map(|sid| entry.session_table.physical_id(sid))
             .transpose()?;
         let key_id = entry.vault.create(key, kind, session_key_id, attrs, meta)?;
-        Ok(VaultKeyGuard::new(self, pid, key_id))
+        Ok(StdVaultKeyGuard {
+            pal: self,
+            pid,
+            gen: self.partition_gen(pid),
+            key_id,
+            committed: false,
+        })
     }
 
     /// Delete a key from the partition's vault.
-    fn vault_key_delete(&self, pid: HsmPartId, key_id: HsmKeyId) -> HsmResult<()> {
-        let entry = self.active_part_mut(pid)?;
+    fn vault_key_delete(&self, io: &impl HsmIo, key_id: HsmKeyId) -> HsmResult<()> {
+        let entry = self.active_part_mut(io.pid())?;
         entry.vault.delete(key_id)
     }
 
@@ -50,45 +113,50 @@ impl HsmVault for StdHsmPal {
     ///
     /// Maps the logical session ID to the physical vault key ID, then
     /// removes all vault entries bound to that physical ID.
-    fn vault_key_delete_by_session(&self, pid: HsmPartId, session_id: HsmSessId) -> HsmResult<()> {
-        let entry = self.active_part_mut(pid)?;
+    fn vault_key_delete_by_session(&self, io: &impl HsmIo, session_id: HsmSessId) -> HsmResult<()> {
+        let entry = self.active_part_mut(io.pid())?;
         let physical_id = entry.session_table.physical_id(session_id)?;
         entry.vault.delete_by_session_key(physical_id)
     }
 
     /// Clear all keys from the partition's vault.
-    fn vault_clear(&self, pid: HsmPartId) -> HsmResult<()> {
-        let entry = self.active_part_mut(pid)?;
+    fn vault_clear(&self, io: &impl HsmIo) -> HsmResult<()> {
+        let entry = self.active_part_mut(io.pid())?;
         entry.vault.clear();
         Ok(())
     }
 
     /// Retrieve key material by ID.
-    fn vault_key(&self, pid: HsmPartId, key_id: HsmKeyId) -> HsmResult<&[u8]> {
-        let entry = self.active_part(pid)?;
-        entry.vault.key(key_id)
+    fn vault_key(&self, io: &impl HsmIo, key_id: HsmKeyId) -> HsmResult<&DmaBuf> {
+        let entry = self.active_part(io.pid())?;
+        let bytes = entry.vault.key(key_id)?;
+        // SAFETY: on the host, "DMA" is a fiction — every heap-allocated
+        // byte is reachable by every code path. Branding the slice as
+        // `DmaBuf` only satisfies the type system; no DMA hardware is
+        // involved.
+        Ok(unsafe { DmaBuf::from_raw(bytes) })
     }
 
     /// Return the firmware raw key size for a given kind.
-    fn vault_key_len(&self, _pid: HsmPartId, kind: HsmVaultKeyKind) -> HsmResult<u16> {
+    fn vault_key_len(&self, _io: &impl HsmIo, kind: HsmVaultKeyKind) -> HsmResult<u16> {
         KeyVault::key_len(kind)
     }
 
     /// Query key kind.
-    fn vault_key_kind(&self, pid: HsmPartId, key_id: HsmKeyId) -> HsmResult<HsmVaultKeyKind> {
-        let entry = self.active_part(pid)?;
+    fn vault_key_kind(&self, io: &impl HsmIo, key_id: HsmKeyId) -> HsmResult<HsmVaultKeyKind> {
+        let entry = self.active_part(io.pid())?;
         entry.vault.key_kind(key_id)
     }
 
     /// Query key attributes.
-    fn vault_key_attrs(&self, pid: HsmPartId, key_id: HsmKeyId) -> HsmResult<HsmVaultKeyAttrs> {
-        let entry = self.active_part(pid)?;
+    fn vault_key_attrs(&self, io: &impl HsmIo, key_id: HsmKeyId) -> HsmResult<HsmVaultKeyAttrs> {
+        let entry = self.active_part(io.pid())?;
         entry.vault.key_attrs(key_id)
     }
 
     /// Query key metadata.
-    fn vault_key_meta(&self, pid: HsmPartId, key_id: HsmKeyId) -> HsmResult<&[u8]> {
-        let entry = self.active_part(pid)?;
+    fn vault_key_meta(&self, io: &impl HsmIo, key_id: HsmKeyId) -> HsmResult<&[u8]> {
+        let entry = self.active_part(io.pid())?;
         entry.vault.key_meta(key_id)
     }
 }


### PR DESCRIPTION
 ## Summary

 Brings the firmware crates back in sync with upstream and updates the
 host-side StdPal so the workspace builds cleanly against the redesigned
 PAL trait surface.

 ## Vendor sync

 Pulls upstream changes for the firmware vendored crates under `fw/`
 (HsmAlloc scoped allocator, PAL trait API redesign, RDL sync).

 - **New crates** under `fw/core/crypto/`:
   - `aes-cbc-pad` — AES-CBC with PKCS#7 padding wrapper
   - `gcm-buf` — GCM buffer-layout helper
   - `hpke` — HPKE (RFC 9180) implementation
 - **New file** `fw/pal/traits/src/alloc.rs` — `HsmAlloc` /
   `HsmScopedAlloc` per-IO scoped allocator trait.
 - **35 updated files** under `fw/core/ddi/{mbor,tbor/derive}`,
   `fw/core/lib`, and the full `fw/pal/traits` surface (`cert`,
   `crypto/*`, `gdma`, `io`, `lib`, `lock`, `pal`, `part`, `session`,
   `vault`).
 - **Workspace registration** for the 3 new crypto crates (members +
   `azihsm_fw_core_crypto_*` workspace deps).

 ## StdPal trait-surface alignment

 Updates `fw/plat/std/pal` (the host-native simulator PAL) to satisfy
 the redesigned trait bounds.

 ### Foundations
 - `buf_pool`: switch `BufferPool` to raw-pointer + capacity accessors
   and per-slot per-heap (NonDma/Dma) bump watermarks; reset watermarks
   on slot allocation; drop the whole-slab `&mut` helpers
   (`fast_buf`/`large_buf`) to prevent aliasing UB.
 - `alloc.rs` (new): implement `HsmAlloc` on `StdHsmPal` as a per-IO
   bump allocator over the buffer pool. Includes `StdScopedAlloc<'a>`
   with watermark snapshot/restore on drop, `dma_alloc_var*` with
   closure-length validation, and `align_of::<T>()` for `alloc_val<T>`.
 - `io.rs`: add `HsmIo::index()`; drop the now-unused `mem()`
   (consumers obtain buffers via `HsmAlloc`).
 - `part_lock.rs`: `partition_lock` now takes `&impl HsmIo`.

 ### Sideband refactor (no IO context available)
 - `cert.rs::{init_cert_store, gen_cert_keypair, hash_and_sign}` and
   `part.rs::create_internal_ecc384_key` now call the `StdHash` /
   `StdEcc` drivers directly instead of going through PAL trait
   methods (which now require `&impl HsmIo`).

 ### RAII guards + partition incarnation counter
 - Add `gen: u32` to `PartitionEntry`, bumped on
   `part_alloc_internal` and `part_free_internal`.
 - `StdVaultKeyGuard` / `StdSessionGuard` capture `gen` at create
   time and skip rollback if the partition has since been freed and
   reallocated.
 - Use a `committed: bool` flag (not `mem::forget`) so `dismiss()`
   runs `Drop` with a no-op rollback.
 - Rename `HsmSessionManager::session_delete` → `session_destroy`.

 ### Crypto / cert / gdma trait surface
 - All `HsmRng`/`HsmHash`/`HsmHmac`/`HsmKdf`/`HsmAes`/`HsmEcc`/`HsmRsa`
   methods now take `&impl HsmIo`; DMA endpoints become `&DmaBuf` /
   `&mut DmaBuf`.
 - Define minimal `HashCtx`/`HmacCtx`/`KdfCtx` GAT types backed by
   `HsmScopedAlloc`; one-shot variants delegate to existing drivers,
   multi-step variants are `todo!()` stubs (not yet exercised on the
   host PAL).
 - `HsmAes` adopts the new `AesOp` enum (replacing `encrypt: bool`).
 - `HsmCertStore::get_cert` and `HsmGdmaController::copy_mem*` take
   the new typed signatures.

 ### Partition manager
 - Every getter takes `&impl HsmIo` and resolves the partition
   implicitly via `io.pid()`.
 - `copy_out` returns `HsmError::InvalidArg` (not `NotEnoughSpace`)
   when the caller buffer is too small, matching the redesigned
   trait docs.

 ## Validation

 - `cargo check --workspace`: clean (only the upstream-inherited
   unused-variable warning in `fw/core/ddi/tbor/derive` remains).
 - `cargo xtask nextest -p azihsm_fw_hsm_pal_std`: **101/101 pass**.
 - `cargo xtask nextest -p azihsm_fw_hsm_std`: **38/38 pass**.
 - `cargo nextest run -p azihsm_ddi --features emu --test azihsm_ddi_tests`:
   **563 tests run, 28 passed, 535 failed, 0 skipped** — no regression vs
   the prior baseline reported in `6073bc7`.
 - `cargo nextest run -p azihsm_ddi --features emu --test azihsm_ddi_tests smoke`:
   **6/6 pass** (`get_api_rev_smoke` × 3, `sealed_bk3_smoke` × 3).

 ## Out of scope

 - Behavior changes — only the trait surface is being aligned.
 - Bringing the multi-step `HashCtx` / `HmacCtx` / `KdfCtx` paths to
   parity with one-shot variants on the host PAL (currently `todo!()`
   stubs).
 - Aligning `part_alloc_internal` / `part_free_internal` with the
   partition lock — the per-partition generation counter is the
   immediate mitigation for guard-rollback safety.