### PR TITLE
[crypto] Fixed openssl rsa verify returns false for invalid signature

### DIFF
--- a/api/tests/src/algo/rsa/sign_tests.rs
+++ b/api/tests/src/algo/rsa/sign_tests.rs
@@ -783,19 +783,17 @@ fn test_rsa_verify_all_zero_and_all_ff_signature_fails(session: HsmSession) {
     let all_zero_sig = vec![0u8; sig_len];
     let all_ff_sig = vec![0xFFu8; sig_len];
 
-    let result_zero = HsmVerifier::verify(&mut algo, &pub_key, &hash, &all_zero_sig);
-    let result_ff = HsmVerifier::verify(&mut algo, &pub_key, &hash, &all_ff_sig);
+    let valid_zero = HsmVerifier::verify(&mut algo, &pub_key, &hash, &all_zero_sig)
+        .expect("Verification call failed");
+    let valid_ff = HsmVerifier::verify(&mut algo, &pub_key, &hash, &all_ff_sig)
+        .expect("Verification call failed");
 
-    // Accept both Ok(false) (Windows) and Err (Linux)
     assert!(
-        matches!(result_zero, Ok(false)) || result_zero.is_err(),
-        "Expected failure for all-zero signature, got {:?}",
-        result_zero
+        !valid_zero,
+        "Verification should report invalid signature for all-zero signature"
     );
-
     assert!(
-        matches!(result_ff, Ok(false)) || result_ff.is_err(),
-        "Expected failure for all-0xFF signature, got {:?}",
-        result_ff
+        !valid_ff,
+        "Verification should report invalid signature for all-0xFF signature"
     );
 }

--- a/api/tests/src/algo/rsa/sign_tests.rs
+++ b/api/tests/src/algo/rsa/sign_tests.rs
@@ -235,12 +235,10 @@ fn test_rsa_verify_wrong_public_key_fails(session: HsmSession) {
     let mut algo = HsmRsaSignAlgo::with_pkcs1_padding(hash_algo);
     let sig = HsmSigner::sign_vec(&mut algo, &priv1, &hash).expect("Failed to sign message");
 
-    let result = HsmVerifier::verify(&mut algo, &pub2, &hash, &sig);
-
-    assert!(
-        !matches!(result, Ok(true)),
-        "Verification should not succeed"
-    );
+    let result =
+        HsmVerifier::verify(&mut algo, &pub2, &hash, &sig).expect("Failed to verify signature");
+    // Expect failure here, but if it succeeds, it should not validate the signature
+    assert!(!result, "Verification should not succeed");
 }
 
 /// Ensure verification fails when signature is corrupted
@@ -262,12 +260,10 @@ fn test_rsa_verify_modified_signature_fails(session: HsmSession) {
 
     sig[0] ^= 0xFF; // corrupt signature
 
-    let result = HsmVerifier::verify(&mut algo, &pub_key, &hash, &sig);
+    let valid =
+        HsmVerifier::verify(&mut algo, &pub_key, &hash, &sig).expect("Verification call failed");
 
-    assert!(
-        !matches!(result, Ok(true)),
-        "Verification should not succeed"
-    );
+    assert!(!valid, "Verification should report invalid signature");
 }
 
 /// Ensure verification fails when hash differs
@@ -290,12 +286,10 @@ fn test_rsa_verify_wrong_hash_fails(session: HsmSession) {
     let mut algo = HsmRsaSignAlgo::with_pkcs1_padding(hash_algo);
     let sig = HsmSigner::sign_vec(&mut algo, &priv_key, &hash1).expect("Failed to sign message");
 
-    let result = HsmVerifier::verify(&mut algo, &pub_key, &hash2, &sig);
+    let valid =
+        HsmVerifier::verify(&mut algo, &pub_key, &hash2, &sig).expect("Verification call failed");
 
-    assert!(
-        !matches!(result, Ok(true)),
-        "Verification should not succeed"
-    );
+    assert!(!valid, "Verification should report invalid signature");
 }
 
 /// Ensure verification fails when using different hash algorithm
@@ -320,12 +314,10 @@ fn test_rsa_verify_mismatched_hash_algo_fails(session: HsmSession) {
 
     let mut verify_algo = HsmRsaSignAlgo::with_pkcs1_padding(hash_algo2);
 
-    let result = HsmVerifier::verify(&mut verify_algo, &pub_key, &hash, &sig);
+    let valid = HsmVerifier::verify(&mut verify_algo, &pub_key, &hash, &sig)
+        .expect("Verification call failed");
 
-    assert!(
-        !matches!(result, Ok(true)),
-        "Verification should not succeed"
-    );
+    assert!(!valid, "Verification should report invalid signature");
 }
 
 /// Ensure PSS verification fails with different salt length
@@ -348,12 +340,10 @@ fn test_rsa_pss_salt_len_mismatch_fails(session: HsmSession) {
 
     let mut verify_algo = HsmRsaSignAlgo::with_pss_padding(hash_algo, 20);
 
-    let result = HsmVerifier::verify(&mut verify_algo, &pub_key, &hash, &sig);
+    let valid = HsmVerifier::verify(&mut verify_algo, &pub_key, &hash, &sig)
+        .expect("Verification call failed");
 
-    assert!(
-        !matches!(result, Ok(true)),
-        "Verification should not succeed"
-    );
+    assert!(!valid, "Verification should report invalid signature");
 }
 
 /// Ensure unwrap fails when private key lacks sign capability
@@ -413,12 +403,10 @@ fn test_rsa_verify_pkcs1_vs_pss_mismatch_fails(session: HsmSession) {
     // Verify with PSS
     let mut verify_algo = HsmRsaSignAlgo::with_pss_padding(hash_algo, 32);
 
-    let result = HsmVerifier::verify(&mut verify_algo, &pub_key, &hash, &sig);
+    let valid = HsmVerifier::verify(&mut verify_algo, &pub_key, &hash, &sig)
+        .expect("Verification call failed");
 
-    assert!(
-        !matches!(result, Ok(true)),
-        "Verification should not succeed"
-    );
+    assert!(!valid, "Verification should report invalid signature");
 }
 
 /// Ensure PKCS1 signatures are deterministic
@@ -463,12 +451,10 @@ fn test_rsa_pss_vs_pkcs1_mismatch_fails(session: HsmSession) {
 
     let mut verify_algo = HsmRsaSignAlgo::with_pkcs1_padding(hash_algo);
 
-    let result = HsmVerifier::verify(&mut verify_algo, &pub_key, &hash, &sig);
+    let valid = HsmVerifier::verify(&mut verify_algo, &pub_key, &hash, &sig)
+        .expect("Verification call failed");
 
-    assert!(
-        !matches!(result, Ok(true)),
-        "Verification should not succeed"
-    );
+    assert!(!valid, "Verification should report invalid signature");
 }
 
 /// Ensure verification fails when signature is truncated
@@ -490,12 +476,10 @@ fn test_rsa_verify_truncated_signature_fails(session: HsmSession) {
 
     sig.truncate(sig.len() / 2);
 
-    let result = HsmVerifier::verify(&mut algo, &pub_key, &hash, &sig);
+    let valid =
+        HsmVerifier::verify(&mut algo, &pub_key, &hash, &sig).expect("Verification call failed");
 
-    assert!(
-        !matches!(result, Ok(true)),
-        "Verification should not succeed"
-    );
+    assert!(!valid, "Verification should report invalid signature");
 }
 
 /// Ensure verification fails when signature is too large
@@ -517,12 +501,10 @@ fn test_rsa_verify_oversized_signature_fails(session: HsmSession) {
 
     sig.extend_from_slice(&[0u8; 10]); // make too large
 
-    let result = HsmVerifier::verify(&mut algo, &pub_key, &hash, &sig);
+    let valid =
+        HsmVerifier::verify(&mut algo, &pub_key, &hash, &sig).expect("Verification call failed");
 
-    assert!(
-        !matches!(result, Ok(true)),
-        "Verification should not succeed"
-    );
+    assert!(!valid, "Verification should report invalid signature");
 }
 
 /// Ensure verification fails when key size differs
@@ -549,12 +531,10 @@ fn test_rsa_verify_mismatched_key_size_fails(session: HsmSession) {
     let mut algo = HsmRsaSignAlgo::with_pkcs1_padding(hash_algo);
     let sig = HsmSigner::sign_vec(&mut algo, &priv1, &hash).expect("Failed to sign message");
 
-    let result = HsmVerifier::verify(&mut algo, &pub2, &hash, &sig);
+    let valid =
+        HsmVerifier::verify(&mut algo, &pub2, &hash, &sig).expect("Verification call failed");
 
-    assert!(
-        !matches!(result, Ok(true)),
-        "Verification should not succeed"
-    );
+    assert!(!valid, "Verification should report invalid signature");
 }
 
 /// Ensure PSS signatures are non-deterministic
@@ -610,12 +590,10 @@ fn test_rsa_verify_empty_signature_fails(session: HsmSession) {
 
     let mut algo = HsmRsaSignAlgo::with_pkcs1_padding(hash_algo);
 
-    let result = HsmVerifier::verify(&mut algo, &pub_key, &hash, &[]);
+    let valid =
+        HsmVerifier::verify(&mut algo, &pub_key, &hash, &[]).expect("Verification call failed");
 
-    assert!(
-        !matches!(result, Ok(true)),
-        "Verification should not succeed"
-    );
+    assert!(!valid, "Verification should report invalid signature");
 }
 
 /// Ensure verification fails when provided hash is empty
@@ -633,12 +611,10 @@ fn test_rsa_verify_empty_hash_fails(session: HsmSession) {
     // invalid hash
     let empty_hash = vec![];
 
-    let result = HsmVerifier::verify(&mut algo, &pub_key, &empty_hash, &sig);
+    let valid = HsmVerifier::verify(&mut algo, &pub_key, &empty_hash, &sig)
+        .expect("Verification call failed");
 
-    assert!(
-        !matches!(result, Ok(true)),
-        "Verification should not succeed"
-    );
+    assert!(!valid, "Verification should report invalid signature");
 }
 
 /// Ensure PSS works with zero salt length
@@ -707,12 +683,10 @@ fn test_rsa_verify_invalid_hash_length_fails(session: HsmSession) {
 
     let bad_hash = vec![0xAA; 10]; // invalid length
 
-    let result = HsmVerifier::verify(&mut algo, &pub_key, &bad_hash, &sig);
+    let valid = HsmVerifier::verify(&mut algo, &pub_key, &bad_hash, &sig)
+        .expect("Verification call failed");
 
-    assert!(
-        !matches!(result, Ok(true)),
-        "Verification should not succeed"
-    );
+    assert!(!valid, "Verification should report invalid signature");
 }
 
 /// Ensure repeated verification with same inputs consistently succeeds

--- a/api/tests/src/algo/rsa/sign_tests.rs
+++ b/api/tests/src/algo/rsa/sign_tests.rs
@@ -237,8 +237,8 @@ fn test_rsa_verify_wrong_public_key_fails(session: HsmSession) {
 
     let result =
         HsmVerifier::verify(&mut algo, &pub2, &hash, &sig).expect("Failed to verify signature");
-    // Expect failure here, but if it succeeds, it should not validate the signature
-    assert!(!result, "Verification should not succeed");
+    // Verification should return false when using the wrong public key.
+    assert!(!result, "Verification should return false with the wrong public key");
 }
 
 /// Ensure verification fails when signature is corrupted

--- a/api/tests/src/algo/rsa/sign_tests.rs
+++ b/api/tests/src/algo/rsa/sign_tests.rs
@@ -238,7 +238,10 @@ fn test_rsa_verify_wrong_public_key_fails(session: HsmSession) {
     let result =
         HsmVerifier::verify(&mut algo, &pub2, &hash, &sig).expect("Failed to verify signature");
     // Verification should return false when using the wrong public key.
-    assert!(!result, "Verification should return false with the wrong public key");
+    assert!(
+        !result,
+        "Verification should return false with the wrong public key"
+    );
 }
 
 /// Ensure verification fails when signature is corrupted

--- a/crates/crypto/src/rsa/rsa_sign_ossl.rs
+++ b/crates/crypto/src/rsa/rsa_sign_ossl.rs
@@ -139,11 +139,11 @@ impl VerifyOp for OsslRsaSignAlgo {
             .verify_init()
             .map_err(|_| CryptoError::RsaVerifyError)?;
         self.configure_pkey_ctx(&mut pkey_ctx)?;
-        // After successful setup, OpenSSL signals an invalid RSA signature by
-        // pushing an error onto its stack rather than returning Ok(false).
-        // All operational failure modes (allocation, init, configuration) have
-        // already been handled above, so treat any error from the final verify
-        // step as an invalid signature (fail-closed).
+        // After successful setup, OpenSSL may report an invalid RSA signature
+        // either as Ok(false) or, in some cases/platforms, by pushing an error
+        // onto its stack. All operational failure modes (allocation, init,
+        // configuration) have already been handled above, so treat any error
+        // from the final verify step as an invalid signature (fail-closed).
         match pkey_ctx.verify(data, signature) {
             Ok(valid) => Ok(valid),
             Err(_) => Ok(false),

--- a/crates/crypto/src/rsa/rsa_sign_ossl.rs
+++ b/crates/crypto/src/rsa/rsa_sign_ossl.rs
@@ -135,9 +135,15 @@ impl VerifyOp for OsslRsaSignAlgo {
             .verify_init()
             .map_err(|_| CryptoError::RsaVerifyError)?;
         self.configure_pkey_ctx(&mut pkey_ctx)?;
-        pkey_ctx
-            .verify(data, signature)
-            .map_err(|_| CryptoError::RsaVerifyError)
+        // After successful setup, OpenSSL signals an invalid RSA signature by
+        // pushing an error onto its stack rather than returning Ok(false).
+        // All operational failure modes (allocation, init, configuration) have
+        // already been handled above, so treat any error from the final verify
+        // step as an invalid signature (fail-closed).
+        match pkey_ctx.verify(data, signature) {
+            Ok(valid) => Ok(valid),
+            Err(_) => Ok(false),
+        }
     }
 }
 

--- a/crates/crypto/src/rsa/rsa_sign_ossl.rs
+++ b/crates/crypto/src/rsa/rsa_sign_ossl.rs
@@ -122,8 +122,12 @@ impl VerifyOp for OsslRsaSignAlgo {
     ///
     /// # Errors
     ///
-    /// Returns an error if internal OpenSSL operations fail.
-    /// Note: Invalid signatures return `Ok(false)`, not an error.
+    /// Returns an error only for setup/configuration failures before the final
+    /// OpenSSL verify step (for example context creation, `verify_init`, or
+    /// padding/hash configuration).
+    ///
+    /// Any error from the final OpenSSL `verify` call is treated as an invalid
+    /// signature and returns `Ok(false)` (fail-closed).
     fn verify(
         &mut self,
         key: &Self::Key,


### PR DESCRIPTION
This pull request refactors the RSA signature verification tests and the OpenSSL-based verification implementation to improve clarity and error handling. The main change is to treat any error during the final OpenSSL verification step as an invalid signature, and to simplify the test assertions accordingly. This ensures that tests consistently expect a boolean result and that operational errors are handled in a fail-closed manner.

**Test improvements and consistency:**

* Updated all RSA verification failure tests in `sign_tests.rs` to expect the verification call to succeed (i.e., not error), and to assert that the returned value is `false` when the signature is invalid. This replaces the previous pattern of matching on `Ok(true)` and makes the intent of each test clearer.

**Verification implementation changes:**

* Modified `OsslRsaSignAlgo`'s `verify` implementation to treat any error returned by OpenSSL's `verify` call as an invalid signature, returning `Ok(false)` instead of propagating the error. This ensures that only operational setup errors result in `Err`, and all signature mismatches (including OpenSSL errors) are treated as verification failures.