### PR TITLE
Per-job permissions for create_new_cache and rust workflows

### DIFF
--- a/.github/workflows/create_new_cache.yml
+++ b/.github/workflows/create_new_cache.yml
@@ -11,6 +11,9 @@ env:
 
 jobs:
   create_new_cache_ubuntu:
+    permissions:
+      contents: read
+      actions: write
 
     runs-on: ubuntu-24.04
 
@@ -33,6 +36,9 @@ jobs:
         key: ${{ runner.os }}-cargo-${{ github.sha }}
 
   create_new_cache_windows:
+    permissions:
+      contents: read
+      actions: write
 
     runs-on: windows-latest
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -17,6 +17,9 @@ env:
 
 jobs:
   build_ubuntu:
+    permissions:
+      contents: read
+      actions: write
 
     runs-on: ubuntu-24.04
 
@@ -104,6 +107,9 @@ jobs:
         exit 1
   
   provider_integration:
+    permissions:
+      contents: read
+      actions: write
 
     runs-on: ubuntu-24.04
 
@@ -221,6 +227,9 @@ jobs:
           --profile ci-provider-integration
 
   build_windows:
+    permissions:
+      contents: read
+      actions: write
 
     runs-on: windows-latest
 


### PR DESCRIPTION
Two remaining workflows in this repo run without an explicit `permissions:` block, so the `GITHUB_TOKEN` falls back to the repo/org default scope (typically broader than necessary). The hardened siblings (`codeql.yml`, `copilot-setup-steps.yml`) already use per-job permissions blocks, so this PR matches that style.

### create_new_cache.yml
Two jobs (`ubuntu`, `windows`). Both checkout the repo and call `actions/cache/save@v5` to populate the Cargo cache. Granted:

```yaml
permissions:
  contents: read
  actions: write   # required by actions/cache/save
```

### rust.yml
Three jobs (`build_ubuntu`, `provider_integration`, `build_windows`). They run cargo lint/test, upload artifacts, and use `actions/cache@v5` (which saves on cache miss) plus `actions/cache/restore@v5` (read-only). Same minimal scope as above is sufficient because the workflow only reads source and writes to the cache.

YAML validated locally with `python3 -c "import yaml; yaml.safe_load(...)"` for both files. No behavioral change.