### PR TITLE
removed test vectors dependency from release build

### DIFF
--- a/api/tests/Cargo.toml
+++ b/api/tests/Cargo.toml
@@ -7,7 +7,6 @@ name = "azihsm_api_tests"
 version = "0.0.0"
 
 [dependencies]
-azihsm_crypto = { features = ["testvectors"], workspace = true }
 azihsm_res_test_dev = { optional = true, workspace = true }
 
 [build-dependencies]
@@ -16,7 +15,7 @@ cmake.workspace = true
 [dev-dependencies]
 azihsm_api.workspace = true
 azihsm_api_tests_macro.workspace = true
-azihsm_crypto.workspace = true
+azihsm_crypto = { features = ["testvectors"], workspace = true }
 azihsm_resiliency_test_helpers.workspace = true
 hex.workspace = true
 libtest-mimic.workspace = true


### PR DESCRIPTION
This pull request updates the dependency configuration for the `azihsm_crypto` crate in the `api/tests/Cargo.toml` file. The main change is to ensure that the `testvectors` feature is enabled for `azihsm_crypto` in both dependencies and dev-dependencies.

Dependency configuration updates:

* Updated the `azihsm_crypto` dependency in `[dev-dependencies]` to enable the `testvectors` feature, ensuring consistency with the main dependencies section.
* Removed the `azihsm_crypto` dependency from the main `[dependencies]` section, as it is now fully specified in `[dev-dependencies]`.