### PR TITLE
refactor(fw): make MBOR decoder and request types DMA-aware

### DIFF
--- a/fw/core/crypto/aes-cbc-pad/Cargo.toml
+++ b/fw/core/crypto/aes-cbc-pad/Cargo.toml
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 [package]
 edition = "2021"
 name = "azihsm_fw_core_crypto_aes_cbc_pad"

--- a/fw/core/crypto/aes-cbc-pad/src/lib.rs
+++ b/fw/core/crypto/aes-cbc-pad/src/lib.rs
@@ -1,4 +1,5 @@
 // Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 #![no_std]
 

--- a/fw/core/crypto/gcm-buf/Cargo.toml
+++ b/fw/core/crypto/gcm-buf/Cargo.toml
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 [package]
 edition = "2021"
 name = "azihsm_fw_core_crypto_gcm_buf"

--- a/fw/core/crypto/gcm-buf/src/lib.rs
+++ b/fw/core/crypto/gcm-buf/src/lib.rs
@@ -1,4 +1,5 @@
 // Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 #![no_std]
 

--- a/fw/core/crypto/hpke/Cargo.toml
+++ b/fw/core/crypto/hpke/Cargo.toml
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 [package]
 edition = "2021"
 name = "azihsm_fw_core_crypto_hpke"

--- a/fw/core/crypto/hpke/src/aead.rs
+++ b/fw/core/crypto/hpke/src/aead.rs
@@ -1,4 +1,5 @@
 // Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 //! HPKE AEAD seal / open — dispatches to AES-256-GCM or
 //! AES-256-CBC + HMAC depending on the chosen [`HpkeSuite`].

--- a/fw/core/crypto/hpke/src/error.rs
+++ b/fw/core/crypto/hpke/src/error.rs
@@ -1,4 +1,5 @@
 // Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 //! HPKE error types.
 //!

--- a/fw/core/crypto/hpke/src/helpers.rs
+++ b/fw/core/crypto/hpke/src/helpers.rs
@@ -1,4 +1,5 @@
 // Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 //! Internal helpers shared across HPKE submodules.
 

--- a/fw/core/crypto/hpke/src/kdf.rs
+++ b/fw/core/crypto/hpke/src/kdf.rs
@@ -1,4 +1,5 @@
 // Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 //! HPKE LabeledExtract and LabeledExpand (RFC 9180 §4).
 //!

--- a/fw/core/crypto/hpke/src/kem.rs
+++ b/fw/core/crypto/hpke/src/kem.rs
@@ -1,4 +1,5 @@
 // Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 //! DHKEM (RFC 9180 §4.1) — Encap / Decap and their Auth variants.
 //!

--- a/fw/core/crypto/hpke/src/lib.rs
+++ b/fw/core/crypto/hpke/src/lib.rs
@@ -1,4 +1,5 @@
 // Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 #![no_std]
 #![allow(clippy::too_many_arguments)]

--- a/fw/core/crypto/hpke/src/ops.rs
+++ b/fw/core/crypto/hpke/src/ops.rs
@@ -1,4 +1,5 @@
 // Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 //! HPKE single-shot seal / open / export operations (RFC 9180 §6).
 //!

--- a/fw/core/crypto/hpke/src/schedule.rs
+++ b/fw/core/crypto/hpke/src/schedule.rs
@@ -1,4 +1,5 @@
 // Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 //! HPKE key schedule (RFC 9180 §5.1).
 //!

--- a/fw/core/crypto/hpke/src/suite.rs
+++ b/fw/core/crypto/hpke/src/suite.rs
@@ -1,4 +1,5 @@
 // Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 //! HPKE ciphersuite definitions and per-suite size constants.
 //!

--- a/fw/core/ddi/mbor/api/src/decoder.rs
+++ b/fw/core/ddi/mbor/api/src/decoder.rs
@@ -12,7 +12,7 @@ pub struct DdiDecoder<'b> {
 }
 
 impl<'b> DdiDecoder<'b> {
-    pub fn new(buf: &'b [u8]) -> Self {
+    pub fn new(buf: &'b DmaBuf) -> Self {
         Self {
             in_len: buf.len(),
             decoder: MborDecoder::new(buf),

--- a/fw/core/ddi/mbor/codec/src/decode.rs
+++ b/fw/core/ddi/mbor/codec/src/decode.rs
@@ -252,6 +252,8 @@ impl<'a> MborDecoder<'a> {
 mod tests {
     extern crate std;
 
+    use core::ops::Deref;
+
     use super::*;
 
     /// In tests, local arrays aren't DMA memory, but we need `&DmaBuf`
@@ -321,7 +323,7 @@ mod tests {
         let mut dec = MborDecoder::new(dma(&buf));
         let (pad, slice) = dec.decode_byte_slice().unwrap();
         assert_eq!(pad, 0);
-        assert_eq!(slice, &[1, 2, 3, 4]);
+        assert_eq!(slice.deref(), &[1, 2, 3, 4]);
         assert_eq!(slice.as_ptr(), buf[3..].as_ptr());
     }
 
@@ -332,7 +334,7 @@ mod tests {
         let mut dec = MborDecoder::new(dma(&buf));
         let (pad, slice) = dec.decode_byte_slice().unwrap();
         assert_eq!(pad, 1);
-        assert_eq!(slice, &[0xAA, 0xBB, 0xCC]);
+        assert_eq!(slice.deref(), &[0xAA, 0xBB, 0xCC]);
     }
 
     #[test]
@@ -367,7 +369,7 @@ mod tests {
         let buf = [BYTES_MARKER, 0, 4, 1, 2, 3, 4];
         let mut dec = MborDecoder::new(dma(&buf));
         let slice = dec.decode_byte_slice_exact(4).unwrap();
-        assert_eq!(slice, &[1, 2, 3, 4]);
+        assert_eq!(slice.deref(), &[1, 2, 3, 4]);
         assert_eq!(slice.as_ptr(), buf[3..].as_ptr());
     }
 
@@ -399,7 +401,7 @@ mod tests {
 
         let mut dec = MborDecoder::new(dma(&buf[..pos]));
         let slice = dec.decode_byte_slice_exact(4).unwrap();
-        assert_eq!(slice, &data);
+        assert_eq!(slice.deref(), &data);
     }
 
     #[test]
@@ -415,7 +417,7 @@ mod tests {
         let mut dec = MborDecoder::new(dma(&buf[..pos]));
         let (pad, slice) = dec.decode_byte_slice().unwrap();
         assert_eq!(pad, 1);
-        assert_eq!(slice, &data);
+        assert_eq!(slice.deref(), &data);
     }
 
     #[test]
@@ -443,6 +445,6 @@ mod tests {
         let mut dec = MborDecoder::new(dma(&buf[..pos]));
         let (pad, slice) = dec.decode_byte_slice().unwrap();
         assert_eq!(pad, 0);
-        assert_eq!(slice, &data);
+        assert_eq!(slice.deref(), &data);
     }
 }

--- a/fw/core/ddi/mbor/codec/src/decode.rs
+++ b/fw/core/ddi/mbor/codec/src/decode.rs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+use azihsm_fw_hsm_pal_traits::DmaBuf;
+
 use crate::*;
 
 /// Error type for MBOR decoding.
@@ -57,7 +59,7 @@ impl MborDecode<'_> for u8 {
 
 impl MborDecode<'_> for u16 {
     fn mbor_decode(decoder: &mut MborDecoder<'_>) -> Result<Self, MborDecodeError> {
-        let bytes = decoder.bytes(3)?;
+        let bytes: &[u8] = &decoder.bytes(3)?;
         // Skipping the first byte check (marker) for performance reasons.
         Ok(u16::from_be_bytes(
             bytes[1..].try_into().or(Err(MborDecodeError::DecodeU16))?,
@@ -67,7 +69,7 @@ impl MborDecode<'_> for u16 {
 
 impl MborDecode<'_> for u32 {
     fn mbor_decode(decoder: &mut MborDecoder<'_>) -> Result<Self, MborDecodeError> {
-        let bytes = decoder.bytes(5)?;
+        let bytes: &[u8] = &decoder.bytes(5)?;
         // Skipping the first byte check (marker) for performance reasons.
         Ok(u32::from_be_bytes(
             bytes[1..].try_into().or(Err(MborDecodeError::DecodeU32))?,
@@ -77,7 +79,7 @@ impl MborDecode<'_> for u32 {
 
 impl MborDecode<'_> for u64 {
     fn mbor_decode(decoder: &mut MborDecoder<'_>) -> Result<Self, MborDecodeError> {
-        let bytes = decoder.bytes(9)?;
+        let bytes: &[u8] = &decoder.bytes(9)?;
         // Skipping the first byte check (marker) for performance reasons.
         Ok(u64::from_be_bytes(
             bytes[1..].try_into().or(Err(MborDecodeError::DecodeU64))?,
@@ -108,18 +110,14 @@ impl<const N: usize> MborDecode<'_> for [u8; N] {
             return Err(MborDecodeError::InvalidPadding);
         }
 
-        let len = u16::from_be_bytes(
-            decoder
-                .bytes(core::mem::size_of::<u16>())?
-                .try_into()
-                .or(Err(MborDecodeError::DecodeU16))?,
-        );
+        let len_bytes: &[u8] = &decoder.bytes(core::mem::size_of::<u16>())?;
+        let len = u16::from_be_bytes(len_bytes.try_into().or(Err(MborDecodeError::DecodeU16))?);
 
         if len != N as u16 {
             return Err(MborDecodeError::InvalidLen);
         }
 
-        let data = decoder.bytes(len as usize)?;
+        let data: &[u8] = &decoder.bytes(len as usize)?;
 
         data.try_into().or(Err(MborDecodeError::DecodeU8N))
     }
@@ -130,13 +128,13 @@ impl<const N: usize> MborDecode<'_> for [u8; N] {
 /// Borrows the input buffer and returns sub-slices on decode, enabling
 /// zero-copy access to byte array fields.
 pub struct MborDecoder<'a> {
-    buffer: &'a [u8],
+    buffer: &'a DmaBuf,
     pos: usize,
 }
 
 impl<'a> MborDecoder<'a> {
     /// Create a new decoder over `buf`.
-    pub fn new(buf: &'a [u8]) -> Self {
+    pub fn new(buf: &'a DmaBuf) -> Self {
         Self {
             buffer: buf,
             pos: 0,
@@ -175,7 +173,7 @@ impl<'a> MborDecoder<'a> {
     /// of the input buffer (zero-copy). Accepts and skips padding.
     ///
     /// Returns `(padding, data_slice)`.
-    pub fn decode_byte_slice(&mut self) -> Result<(u8, &'a [u8]), MborDecodeError> {
+    pub fn decode_byte_slice(&mut self) -> Result<(u8, &'a DmaBuf), MborDecodeError> {
         let marker = self.byte()?;
         if marker & BYTES_MARKER != BYTES_MARKER {
             return Err(MborDecodeError::ExpectedU8);
@@ -183,11 +181,8 @@ impl<'a> MborDecoder<'a> {
 
         let pad = marker & BYTES_PAD_MASK;
 
-        let len = u16::from_be_bytes(
-            self.bytes(core::mem::size_of::<u16>())?
-                .try_into()
-                .or(Err(MborDecodeError::DecodeU16))?,
-        );
+        let len_bytes: &[u8] = &self.bytes(core::mem::size_of::<u16>())?;
+        let len = u16::from_be_bytes(len_bytes.try_into().or(Err(MborDecodeError::DecodeU16))?);
 
         // Skip padding bytes
         self.skip(pad as usize)?;
@@ -205,7 +200,7 @@ impl<'a> MborDecoder<'a> {
     pub fn decode_byte_slice_exact(
         &mut self,
         expected_len: usize,
-    ) -> Result<&'a [u8], MborDecodeError> {
+    ) -> Result<&'a DmaBuf, MborDecodeError> {
         let marker = self.byte()?;
         if marker & BYTES_MARKER != BYTES_MARKER {
             return Err(MborDecodeError::ExpectedU8);
@@ -216,11 +211,8 @@ impl<'a> MborDecoder<'a> {
             return Err(MborDecodeError::InvalidPadding);
         }
 
-        let len = u16::from_be_bytes(
-            self.bytes(core::mem::size_of::<u16>())?
-                .try_into()
-                .or(Err(MborDecodeError::DecodeU16))?,
-        );
+        let len_bytes: &[u8] = &self.bytes(core::mem::size_of::<u16>())?;
+        let len = u16::from_be_bytes(len_bytes.try_into().or(Err(MborDecodeError::DecodeU16))?);
 
         if len as usize != expected_len {
             return Err(MborDecodeError::InvalidLen);
@@ -237,7 +229,7 @@ impl<'a> MborDecoder<'a> {
     }
 
     #[inline(always)]
-    pub(crate) fn bytes(&mut self, len: usize) -> Result<&'a [u8], MborDecodeError> {
+    pub(crate) fn bytes(&mut self, len: usize) -> Result<&'a DmaBuf, MborDecodeError> {
         if len + self.pos > self.buffer.len() {
             return Err(MborDecodeError::BufferUnderFlow);
         }
@@ -256,55 +248,61 @@ impl<'a> MborDecoder<'a> {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used)]
+#[allow(clippy::unwrap_used, unsafe_code)]
 mod tests {
     extern crate std;
 
     use super::*;
 
+    /// In tests, local arrays aren't DMA memory, but we need `&DmaBuf`
+    /// to construct a decoder. This is safe in tests — no real DMA hw.
+    fn dma(buf: &[u8]) -> &DmaBuf {
+        unsafe { DmaBuf::from_raw(buf) }
+    }
+
     #[test]
     fn decode_bool() {
         let buf = [0x15]; // true
-        let mut dec = MborDecoder::new(&buf);
+        let mut dec = MborDecoder::new(dma(&buf));
         assert!(bool::mbor_decode(&mut dec).unwrap());
 
         let buf = [0x14]; // false
-        let mut dec = MborDecoder::new(&buf);
+        let mut dec = MborDecoder::new(dma(&buf));
         assert!(!bool::mbor_decode(&mut dec).unwrap());
     }
 
     #[test]
     fn decode_u8() {
         let buf = [U8_MARKER, 42];
-        let mut dec = MborDecoder::new(&buf);
+        let mut dec = MborDecoder::new(dma(&buf));
         assert_eq!(u8::mbor_decode(&mut dec).unwrap(), 42);
     }
 
     #[test]
     fn decode_u16() {
         let buf = [U16_MARKER, 0x12, 0x34];
-        let mut dec = MborDecoder::new(&buf);
+        let mut dec = MborDecoder::new(dma(&buf));
         assert_eq!(u16::mbor_decode(&mut dec).unwrap(), 0x1234);
     }
 
     #[test]
     fn decode_u32() {
         let buf = [U32_MARKER, 0xDE, 0xAD, 0xBE, 0xEF];
-        let mut dec = MborDecoder::new(&buf);
+        let mut dec = MborDecoder::new(dma(&buf));
         assert_eq!(u32::mbor_decode(&mut dec).unwrap(), 0xDEADBEEF);
     }
 
     #[test]
     fn decode_u64() {
         let buf = [U64_MARKER, 0, 0, 0, 0, 0, 0, 0, 1];
-        let mut dec = MborDecoder::new(&buf);
+        let mut dec = MborDecoder::new(dma(&buf));
         assert_eq!(u64::mbor_decode(&mut dec).unwrap(), 1);
     }
 
     #[test]
     fn decode_map() {
         let buf = [MAP_MARKER | 5];
-        let mut dec = MborDecoder::new(&buf);
+        let mut dec = MborDecoder::new(dma(&buf));
         let m = MborMap::mbor_decode(&mut dec).unwrap();
         assert_eq!(m.0, 5);
     }
@@ -312,7 +310,7 @@ mod tests {
     #[test]
     fn decode_fixed_array() {
         let buf = [BYTES_MARKER, 0, 3, 0xAA, 0xBB, 0xCC];
-        let mut dec = MborDecoder::new(&buf);
+        let mut dec = MborDecoder::new(dma(&buf));
         let arr: [u8; 3] = MborDecode::mbor_decode(&mut dec).unwrap();
         assert_eq!(arr, [0xAA, 0xBB, 0xCC]);
     }
@@ -320,11 +318,10 @@ mod tests {
     #[test]
     fn decode_byte_slice_zero_copy() {
         let buf = [BYTES_MARKER, 0, 4, 1, 2, 3, 4];
-        let mut dec = MborDecoder::new(&buf);
+        let mut dec = MborDecoder::new(dma(&buf));
         let (pad, slice) = dec.decode_byte_slice().unwrap();
         assert_eq!(pad, 0);
         assert_eq!(slice, &[1, 2, 3, 4]);
-        // Verify it's a true sub-slice of the input buffer
         assert_eq!(slice.as_ptr(), buf[3..].as_ptr());
     }
 
@@ -332,7 +329,7 @@ mod tests {
     fn decode_byte_slice_with_padding() {
         // marker=0x81 (pad=1), len=3, pad_byte=0, data=[0xAA, 0xBB, 0xCC]
         let buf = [BYTES_MARKER | 1, 0, 3, 0, 0xAA, 0xBB, 0xCC];
-        let mut dec = MborDecoder::new(&buf);
+        let mut dec = MborDecoder::new(dma(&buf));
         let (pad, slice) = dec.decode_byte_slice().unwrap();
         assert_eq!(pad, 1);
         assert_eq!(slice, &[0xAA, 0xBB, 0xCC]);
@@ -341,14 +338,14 @@ mod tests {
     #[test]
     fn decode_buffer_underflow() {
         let buf = [U32_MARKER, 0xDE]; // too short for u32
-        let mut dec = MborDecoder::new(&buf);
+        let mut dec = MborDecoder::new(dma(&buf));
         assert!(u32::mbor_decode(&mut dec).is_err());
     }
 
     #[test]
     fn peek_u8_does_not_consume() {
         let buf = [U8_MARKER, 99];
-        let mut dec = MborDecoder::new(&buf);
+        let mut dec = MborDecoder::new(dma(&buf));
         assert_eq!(dec.peek_u8(), Some(99));
         assert_eq!(dec.position(), 0);
         assert_eq!(u8::mbor_decode(&mut dec).unwrap(), 99);
@@ -357,7 +354,7 @@ mod tests {
     #[test]
     fn peek_byte_does_not_consume() {
         let buf = [MAP_MARKER | 2];
-        let mut dec = MborDecoder::new(&buf);
+        let mut dec = MborDecoder::new(dma(&buf));
         assert_eq!(dec.peek_byte(), Some(MAP_MARKER | 2));
         assert_eq!(dec.position(), 0);
     }
@@ -368,10 +365,9 @@ mod tests {
     fn decode_byte_slice_exact_ok() {
         // No padding, len=4, data=[1,2,3,4]
         let buf = [BYTES_MARKER, 0, 4, 1, 2, 3, 4];
-        let mut dec = MborDecoder::new(&buf);
+        let mut dec = MborDecoder::new(dma(&buf));
         let slice = dec.decode_byte_slice_exact(4).unwrap();
         assert_eq!(slice, &[1, 2, 3, 4]);
-        // Zero-copy: points into input buffer
         assert_eq!(slice.as_ptr(), buf[3..].as_ptr());
     }
 
@@ -379,7 +375,7 @@ mod tests {
     fn decode_byte_slice_exact_wrong_len() {
         // Data is 4 bytes but we expect 3
         let buf = [BYTES_MARKER, 0, 4, 1, 2, 3, 4];
-        let mut dec = MborDecoder::new(&buf);
+        let mut dec = MborDecoder::new(dma(&buf));
         assert!(dec.decode_byte_slice_exact(3).is_err());
     }
 
@@ -387,7 +383,7 @@ mod tests {
     fn decode_byte_slice_exact_rejects_padding() {
         // marker=0x81 (pad=1) — exact decode rejects padding
         let buf = [BYTES_MARKER | 1, 0, 3, 0, 0xAA, 0xBB, 0xCC];
-        let mut dec = MborDecoder::new(&buf);
+        let mut dec = MborDecoder::new(dma(&buf));
         assert!(dec.decode_byte_slice_exact(3).is_err());
     }
 
@@ -395,21 +391,19 @@ mod tests {
 
     #[test]
     fn roundtrip_byte_slice_no_padding() {
-        // Encode with MborByteSlice (no padding) → decode with exact
         let data = [0xDE, 0xAD, 0xBE, 0xEF];
         let mut buf = [0u8; 16];
         let mut enc = crate::MborEncoder::new(&mut buf);
         crate::MborByteSlice(&data).mbor_encode(&mut enc).unwrap();
         let pos = enc.position();
 
-        let mut dec = MborDecoder::new(&buf[..pos]);
+        let mut dec = MborDecoder::new(dma(&buf[..pos]));
         let slice = dec.decode_byte_slice_exact(4).unwrap();
         assert_eq!(slice, &data);
     }
 
     #[test]
     fn roundtrip_byte_slice_with_padding() {
-        // Encode with MborPaddedByteSlice (pad=1) → decode with decode_byte_slice
         let data = [0xAA; 10];
         let mut buf = [0u8; 32];
         let mut enc = crate::MborEncoder::new(&mut buf);
@@ -418,7 +412,7 @@ mod tests {
             .unwrap();
         let pos = enc.position();
 
-        let mut dec = MborDecoder::new(&buf[..pos]);
+        let mut dec = MborDecoder::new(dma(&buf[..pos]));
         let (pad, slice) = dec.decode_byte_slice().unwrap();
         assert_eq!(pad, 1);
         assert_eq!(slice, &data);
@@ -426,7 +420,6 @@ mod tests {
 
     #[test]
     fn padded_encode_rejected_by_exact_decode() {
-        // Encode with padding → exact decode must reject
         let data = [0xBB; 8];
         let mut buf = [0u8; 32];
         let mut enc = crate::MborEncoder::new(&mut buf);
@@ -435,20 +428,19 @@ mod tests {
             .unwrap();
         let pos = enc.position();
 
-        let mut dec = MborDecoder::new(&buf[..pos]);
+        let mut dec = MborDecoder::new(dma(&buf[..pos]));
         assert!(dec.decode_byte_slice_exact(8).is_err());
     }
 
     #[test]
     fn unpadded_encode_accepted_by_variable_decode() {
-        // Encode without padding → variable decode accepts (pad=0)
         let data = [0xCC; 6];
         let mut buf = [0u8; 16];
         let mut enc = crate::MborEncoder::new(&mut buf);
         crate::MborByteSlice(&data).mbor_encode(&mut enc).unwrap();
         let pos = enc.position();
 
-        let mut dec = MborDecoder::new(&buf[..pos]);
+        let mut dec = MborDecoder::new(dma(&buf[..pos]));
         let (pad, slice) = dec.decode_byte_slice().unwrap();
         assert_eq!(pad, 0);
         assert_eq!(slice, &data);

--- a/fw/core/ddi/mbor/codec/src/lib.rs
+++ b/fw/core/ddi/mbor/codec/src/lib.rs
@@ -107,10 +107,7 @@ pub trait MborFrameable {
     /// ensure no other live `&mut` references alias any byte covered by
     /// `layout`'s recorded ranges for the lifetime `'a`.
     #[allow(unsafe_code)]
-    unsafe fn mbor_from_layout<'a>(
-        buf_ptr: *mut u8,
-        layout: &Self::Layout,
-    ) -> Self::Frame<'a>;
+    unsafe fn mbor_from_layout<'a>(buf_ptr: *mut u8, layout: &Self::Layout) -> Self::Frame<'a>;
 }
 
 // ── Wire-format constants (identical to `ddi/serde/mbor`) ──────────────

--- a/fw/core/ddi/mbor/codec/tests/cross_compat.rs
+++ b/fw/core/ddi/mbor/codec/tests/cross_compat.rs
@@ -7,6 +7,7 @@
 
 #![allow(clippy::unwrap_used, unsafe_code)]
 
+use core::ops::Deref;
 use std::vec;
 
 // Old crate (dev-dependency)
@@ -148,7 +149,7 @@ fn old_byte_slice_new_decode_exact() {
     // New exact decode (no padding expected)
     let mut dec = new::MborDecoder::new(&dma(&buf)[..pos]);
     let slice = dec.decode_byte_slice_exact(4).unwrap();
-    assert_eq!(slice, &data);
+    assert_eq!(slice.deref(), &data);
 }
 
 #[test]
@@ -163,7 +164,7 @@ fn old_byte_slice_new_decode_variable() {
     let mut dec = new::MborDecoder::new(&dma(&buf)[..pos]);
     let (pad, slice) = dec.decode_byte_slice().unwrap();
     assert_eq!(pad, 0);
-    assert_eq!(slice, &data);
+    assert_eq!(slice.deref(), &data);
 }
 
 // ── Byte arrays: old encode (MborPaddedByteArray, with padding) → new decode ──
@@ -186,7 +187,7 @@ fn old_padded_array_new_decode_variable() {
     let mut dec = new::MborDecoder::new(&dma(&buf)[..pos]);
     let (pad, slice) = dec.decode_byte_slice().unwrap();
     assert_eq!(pad, 1);
-    assert_eq!(slice, &[0x55; 10]);
+    assert_eq!(slice.deref(), &[0x55; 10]);
 }
 
 #[test]

--- a/fw/core/ddi/mbor/codec/tests/cross_compat.rs
+++ b/fw/core/ddi/mbor/codec/tests/cross_compat.rs
@@ -5,7 +5,7 @@
 //! and the new `azihsm_fw_ddi_mbor` encoder/decoder. Validates that the wire
 //! format is identical.
 
-#![allow(clippy::unwrap_used)]
+#![allow(clippy::unwrap_used, unsafe_code)]
 
 use std::vec;
 
@@ -13,6 +13,12 @@ use std::vec;
 use azihsm_ddi_mbor as old;
 // New crate (this crate)
 use azihsm_fw_ddi_mbor as new;
+use azihsm_fw_hsm_pal_traits::DmaBuf;
+
+/// Test helper: brand a `&[u8]` as `&DmaBuf`. Safe in tests — no real DMA hw.
+fn dma(buf: &[u8]) -> &DmaBuf {
+    unsafe { DmaBuf::from_raw(buf) }
+}
 
 /// Helper to create an old MborEncoder, supplying the extra `pre_encode` flag
 /// that was added to the old crate's API.
@@ -40,7 +46,7 @@ fn old_encode_bool_new_decode() {
     let mut enc = old_encoder(&mut buf);
     old::MborEncode::mbor_encode(&true, &mut enc).unwrap();
 
-    let mut dec = new::MborDecoder::new(&buf);
+    let mut dec = new::MborDecoder::new(dma(&buf));
     assert!(<bool as new::MborDecode>::mbor_decode(&mut dec).unwrap());
 }
 
@@ -50,7 +56,7 @@ fn old_encode_u8_new_decode() {
     let mut enc = old_encoder(&mut buf);
     old::MborEncode::mbor_encode(&42u8, &mut enc).unwrap();
 
-    let mut dec = new::MborDecoder::new(&buf);
+    let mut dec = new::MborDecoder::new(dma(&buf));
     assert_eq!(<u8 as new::MborDecode>::mbor_decode(&mut dec).unwrap(), 42);
 }
 
@@ -60,7 +66,7 @@ fn old_encode_u16_new_decode() {
     let mut enc = old_encoder(&mut buf);
     old::MborEncode::mbor_encode(&0x1234u16, &mut enc).unwrap();
 
-    let mut dec = new::MborDecoder::new(&buf);
+    let mut dec = new::MborDecoder::new(dma(&buf));
     assert_eq!(
         <u16 as new::MborDecode>::mbor_decode(&mut dec).unwrap(),
         0x1234
@@ -73,7 +79,7 @@ fn old_encode_u32_new_decode() {
     let mut enc = old_encoder(&mut buf);
     old::MborEncode::mbor_encode(&0xDEADBEEFu32, &mut enc).unwrap();
 
-    let mut dec = new::MborDecoder::new(&buf);
+    let mut dec = new::MborDecoder::new(dma(&buf));
     assert_eq!(
         <u32 as new::MborDecode>::mbor_decode(&mut dec).unwrap(),
         0xDEADBEEF
@@ -86,7 +92,7 @@ fn old_encode_u64_new_decode() {
     let mut enc = old_encoder(&mut buf);
     old::MborEncode::mbor_encode(&0x0102030405060708u64, &mut enc).unwrap();
 
-    let mut dec = new::MborDecoder::new(&buf);
+    let mut dec = new::MborDecoder::new(dma(&buf));
     assert_eq!(
         <u64 as new::MborDecode>::mbor_decode(&mut dec).unwrap(),
         0x0102030405060708
@@ -99,7 +105,7 @@ fn old_encode_map_new_decode() {
     let mut enc = old_encoder(&mut buf);
     old::MborEncode::mbor_encode(&old::MborMap(7), &mut enc).unwrap();
 
-    let mut dec = new::MborDecoder::new(&buf);
+    let mut dec = new::MborDecoder::new(dma(&buf));
     let m = <new::MborMap as new::MborDecode>::mbor_decode(&mut dec).unwrap();
     assert_eq!(m.0, 7);
 }
@@ -140,7 +146,7 @@ fn old_byte_slice_new_decode_exact() {
     let pos = enc.position();
 
     // New exact decode (no padding expected)
-    let mut dec = new::MborDecoder::new(&buf[..pos]);
+    let mut dec = new::MborDecoder::new(&dma(&buf)[..pos]);
     let slice = dec.decode_byte_slice_exact(4).unwrap();
     assert_eq!(slice, &data);
 }
@@ -154,7 +160,7 @@ fn old_byte_slice_new_decode_variable() {
     let pos = enc.position();
 
     // New variable decode also works (pad=0)
-    let mut dec = new::MborDecoder::new(&buf[..pos]);
+    let mut dec = new::MborDecoder::new(&dma(&buf)[..pos]);
     let (pad, slice) = dec.decode_byte_slice().unwrap();
     assert_eq!(pad, 0);
     assert_eq!(slice, &data);
@@ -177,7 +183,7 @@ fn old_padded_array_new_decode_variable() {
     let pos = enc.position();
 
     // New variable decode handles padding
-    let mut dec = new::MborDecoder::new(&buf[..pos]);
+    let mut dec = new::MborDecoder::new(&dma(&buf)[..pos]);
     let (pad, slice) = dec.decode_byte_slice().unwrap();
     assert_eq!(pad, 1);
     assert_eq!(slice, &[0x55; 10]);
@@ -198,7 +204,7 @@ fn old_padded_array_new_exact_decode_rejects() {
     let pos = enc.position();
 
     // Exact decode rejects padding — correct behavior
-    let mut dec = new::MborDecoder::new(&buf[..pos]);
+    let mut dec = new::MborDecoder::new(&dma(&buf)[..pos]);
     assert!(dec.decode_byte_slice_exact(8).is_err());
 }
 
@@ -247,7 +253,7 @@ fn old_encode_struct_new_decode() {
     let pos = enc.position();
 
     // Decode with new
-    let mut dec = new::MborDecoder::new(&buf[..pos]);
+    let mut dec = new::MborDecoder::new(&dma(&buf)[..pos]);
     let m = <new::MborMap as new::MborDecode>::mbor_decode(&mut dec).unwrap();
     assert_eq!(m.0, 2);
     assert_eq!(<u8 as new::MborDecode>::mbor_decode(&mut dec).unwrap(), 0);

--- a/fw/core/ddi/mbor/types/src/aes_encrypt_decrypt.rs
+++ b/fw/core/ddi/mbor/types/src/aes_encrypt_decrypt.rs
@@ -13,9 +13,9 @@ pub struct DdiAesEncryptDecryptReq<'a> {
     #[ddi(id = 2)]
     pub op: DdiAesOp,
     #[ddi(id = 3, max_len = 1024)]
-    pub msg: &'a [u8],
+    pub msg: &'a DmaBuf,
     #[ddi(id = 4, max_len = 16)]
-    pub iv: &'a [u8],
+    pub iv: &'a DmaBuf,
 }
 
 impl DdiAesEncryptDecryptReq<'_> {

--- a/fw/core/ddi/mbor/types/src/attest_key.rs
+++ b/fw/core/ddi/mbor/types/src/attest_key.rs
@@ -11,7 +11,7 @@ pub struct DdiAttestKeyReq<'a> {
     #[ddi(id = 1)]
     pub key_id: u16,
     #[ddi(id = 2, max_len = 128)]
-    pub report_data: &'a [u8],
+    pub report_data: &'a DmaBuf,
 }
 
 impl DdiAttestKeyReq<'_> {

--- a/fw/core/ddi/mbor/types/src/change_pin.rs
+++ b/fw/core/ddi/mbor/types/src/change_pin.rs
@@ -8,14 +8,14 @@ use crate::*;
 #[derive(Debug, Ddi)]
 #[ddi(map)]
 pub struct DdiEncryptedPin<'a> {
-    #[ddi(id = 2, max_len = 16)]
-    pub encrypted_pin: &'a [u8],
-    #[ddi(id = 3, max_len = 16)]
-    pub iv: &'a [u8],
+    #[ddi(id = 2, len = 16)]
+    pub encrypted_pin: &'a DmaBuf,
+    #[ddi(id = 3, len = 16)]
+    pub iv: &'a DmaBuf,
     #[ddi(id = 4, len = 32)]
-    pub nonce: &'a [u8],
+    pub nonce: &'a DmaBuf,
     #[ddi(id = 5, len = 48)]
-    pub tag: &'a [u8],
+    pub tag: &'a DmaBuf,
 }
 
 #[derive(Debug, Ddi)]

--- a/fw/core/ddi/mbor/types/src/derive_hkdf.rs
+++ b/fw/core/ddi/mbor/types/src/derive_hkdf.rs
@@ -13,9 +13,9 @@ pub struct DdiHkdfDeriveReq<'a> {
     #[ddi(id = 2)]
     pub hash_algorithm: DdiHashAlgorithm,
     #[ddi(id = 3, max_len = 256)]
-    pub salt: Option<&'a [u8]>,
+    pub salt: Option<&'a DmaBuf>,
     #[ddi(id = 4, max_len = 256)]
-    pub info: Option<&'a [u8]>,
+    pub info: Option<&'a DmaBuf>,
     #[ddi(id = 5)]
     pub key_type: DdiKeyType,
     #[ddi(id = 6)]

--- a/fw/core/ddi/mbor/types/src/derive_kbkdf.rs
+++ b/fw/core/ddi/mbor/types/src/derive_kbkdf.rs
@@ -13,9 +13,9 @@ pub struct DdiKbkdfCounterHmacDeriveReq<'a> {
     #[ddi(id = 2)]
     pub hash_algorithm: DdiHashAlgorithm,
     #[ddi(id = 3, max_len = 256)]
-    pub label: Option<&'a [u8]>,
+    pub label: Option<&'a DmaBuf>,
     #[ddi(id = 4, max_len = 256)]
-    pub context: Option<&'a [u8]>,
+    pub context: Option<&'a DmaBuf>,
     #[ddi(id = 5)]
     pub key_type: DdiKeyType,
     #[ddi(id = 6)]

--- a/fw/core/ddi/mbor/types/src/ecc_sign.rs
+++ b/fw/core/ddi/mbor/types/src/ecc_sign.rs
@@ -11,7 +11,7 @@ pub struct DdiEccSignReq<'a> {
     #[ddi(id = 1)]
     pub key_id: u16,
     #[ddi(id = 2, max_len = 96)]
-    pub digest: &'a [u8],
+    pub digest: &'a DmaBuf,
     #[ddi(id = 3)]
     pub digest_algo: DdiHashAlgorithm,
 }

--- a/fw/core/ddi/mbor/types/src/ecdh_key_exchange.rs
+++ b/fw/core/ddi/mbor/types/src/ecdh_key_exchange.rs
@@ -11,7 +11,7 @@ pub struct DdiEcdhKeyExchangeReq<'a> {
     #[ddi(id = 1)]
     pub priv_key_id: u16,
     #[ddi(id = 2, max_len = 192)]
-    pub pub_key_der: &'a [u8],
+    pub pub_key_der: &'a DmaBuf,
     #[ddi(id = 3)]
     pub key_type: DdiKeyType,
     #[ddi(id = 4)]

--- a/fw/core/ddi/mbor/types/src/establish_credential.rs
+++ b/fw/core/ddi/mbor/types/src/establish_credential.rs
@@ -14,13 +14,13 @@ pub struct DdiEstablishCredentialReq<'a> {
     #[ddi(id = 2)]
     pub pub_key: DdiPublicKey<'a>,
     #[ddi(id = 3, max_len = 1024)]
-    pub masked_bk3: &'a [u8],
+    pub masked_bk3: &'a DmaBuf,
     #[ddi(id = 4, max_len = 1024)]
-    pub bmk: &'a [u8],
+    pub bmk: &'a DmaBuf,
     #[ddi(id = 5, max_len = 1024)]
-    pub masked_unwrapping_key: &'a [u8],
+    pub masked_unwrapping_key: &'a DmaBuf,
     #[ddi(id = 6, max_len = 1024)]
-    pub pota_sig: &'a [u8],
+    pub pota_sig: &'a DmaBuf,
     #[ddi(id = 7)]
     pub pota_pub_key: DdiPublicKey<'a>,
 }

--- a/fw/core/ddi/mbor/types/src/hmac.rs
+++ b/fw/core/ddi/mbor/types/src/hmac.rs
@@ -11,7 +11,7 @@ pub struct DdiHmacReq<'a> {
     #[ddi(id = 1)]
     pub key_id: u16,
     #[ddi(id = 2, max_len = 1024)]
-    pub msg: &'a [u8],
+    pub msg: &'a DmaBuf,
 }
 
 #[derive(Debug, Ddi)]

--- a/fw/core/ddi/mbor/types/src/init_bk3.rs
+++ b/fw/core/ddi/mbor/types/src/init_bk3.rs
@@ -8,8 +8,8 @@ use crate::*;
 #[derive(Debug, Ddi)]
 #[ddi(map)]
 pub struct DdiInitBk3Req<'a> {
-    #[ddi(id = 1, max_len = 48)]
-    pub bk3: &'a [u8],
+    #[ddi(id = 1, len = 48)]
+    pub bk3: &'a DmaBuf,
 }
 
 #[derive(Debug, Ddi)]

--- a/fw/core/ddi/mbor/types/src/lib.rs
+++ b/fw/core/ddi/mbor/types/src/lib.rs
@@ -4,6 +4,7 @@
 #![no_std]
 
 use azihsm_fw_ddi_mbor_derive::Ddi;
+use azihsm_fw_hsm_pal_traits::DmaBuf;
 use open_enum::open_enum;
 use pastey::paste;
 
@@ -329,7 +330,7 @@ pub struct DdiRespExt {}
 #[ddi(map)]
 pub struct DdiPublicKey<'a> {
     #[ddi(id = 1, max_len = 768)]
-    pub raw: &'a [u8],
+    pub raw: &'a DmaBuf,
     #[ddi(id = 2)]
     pub key_kind: DdiKeyType,
 }
@@ -343,7 +344,7 @@ pub struct DdiKeyProperties<'a> {
     #[ddi(id = 2)]
     pub key_availability: DdiKeyAvailability,
     #[ddi(id = 3, max_len = 128)]
-    pub key_label: &'a [u8],
+    pub key_label: &'a DmaBuf,
 }
 
 /// Target key metadata (16-byte bitflag blob).
@@ -361,7 +362,7 @@ pub struct DdiTargetKeyProperties<'a> {
     #[ddi(id = 1)]
     pub key_metadata: DdiTargetKeyMetadata,
     #[ddi(id = 2, max_len = 128)]
-    pub key_label: &'a [u8],
+    pub key_label: &'a DmaBuf,
 }
 
 // ── ddi_op_req_resp! macro ─────────────────────────────────────────────

--- a/fw/core/ddi/mbor/types/src/open_session.rs
+++ b/fw/core/ddi/mbor/types/src/open_session.rs
@@ -8,33 +8,33 @@ use crate::*;
 #[derive(Debug, Ddi)]
 #[ddi(map)]
 pub struct DdiEncryptedEstablishCredential<'a> {
-    #[ddi(id = 1, max_len = 16)]
-    pub encrypted_id: &'a [u8],
-    #[ddi(id = 2, max_len = 16)]
-    pub encrypted_pin: &'a [u8],
-    #[ddi(id = 3, max_len = 16)]
-    pub iv: &'a [u8],
+    #[ddi(id = 1, len = 16)]
+    pub encrypted_id: &'a DmaBuf,
+    #[ddi(id = 2, len = 16)]
+    pub encrypted_pin: &'a DmaBuf,
+    #[ddi(id = 3, len = 16)]
+    pub iv: &'a DmaBuf,
     #[ddi(id = 4, len = 32)]
-    pub nonce: &'a [u8],
+    pub nonce: &'a DmaBuf,
     #[ddi(id = 5, len = 48)]
-    pub tag: &'a [u8],
+    pub tag: &'a DmaBuf,
 }
 
 #[derive(Debug, Ddi)]
 #[ddi(map)]
 pub struct DdiEncryptedSessionCredential<'a> {
-    #[ddi(id = 1, max_len = 16)]
-    pub encrypted_id: &'a [u8],
-    #[ddi(id = 2, max_len = 16)]
-    pub encrypted_pin: &'a [u8],
-    #[ddi(id = 3, max_len = 48)]
-    pub encrypted_seed: &'a [u8],
-    #[ddi(id = 4, max_len = 16)]
-    pub iv: &'a [u8],
+    #[ddi(id = 1, len = 16)]
+    pub encrypted_id: &'a DmaBuf,
+    #[ddi(id = 2, len = 16)]
+    pub encrypted_pin: &'a DmaBuf,
+    #[ddi(id = 3, len = 48)]
+    pub encrypted_seed: &'a DmaBuf,
+    #[ddi(id = 4, len = 16)]
+    pub iv: &'a DmaBuf,
     #[ddi(id = 5, len = 32)]
-    pub nonce: &'a [u8],
+    pub nonce: &'a DmaBuf,
     #[ddi(id = 6, len = 48)]
-    pub tag: &'a [u8],
+    pub tag: &'a DmaBuf,
 }
 
 #[derive(Debug, Ddi)]

--- a/fw/core/ddi/mbor/types/src/reopen_session.rs
+++ b/fw/core/ddi/mbor/types/src/reopen_session.rs
@@ -14,7 +14,7 @@ pub struct DdiReopenSessionReq<'a> {
     #[ddi(id = 2)]
     pub pub_key: DdiPublicKey<'a>,
     #[ddi(id = 3, max_len = 1024)]
-    pub bmk_session: &'a [u8],
+    pub bmk_session: &'a DmaBuf,
 }
 
 #[derive(Debug, Ddi)]

--- a/fw/core/ddi/mbor/types/src/rsa_mod_exp.rs
+++ b/fw/core/ddi/mbor/types/src/rsa_mod_exp.rs
@@ -11,7 +11,7 @@ pub struct DdiRsaModExpReq<'a> {
     #[ddi(id = 1)]
     pub key_id: u16,
     #[ddi(id = 2, max_len = 512)]
-    pub y: &'a [u8],
+    pub y: &'a DmaBuf,
     #[ddi(id = 3)]
     pub op_type: DdiRsaOpType,
 }

--- a/fw/core/ddi/mbor/types/src/rsa_unwrap.rs
+++ b/fw/core/ddi/mbor/types/src/rsa_unwrap.rs
@@ -11,7 +11,7 @@ pub struct DdiRsaUnwrapReq<'a> {
     #[ddi(id = 1)]
     pub key_id: u16,
     #[ddi(id = 2, max_len = 3072)]
-    pub wrapped_blob: &'a [u8],
+    pub wrapped_blob: &'a DmaBuf,
     #[ddi(id = 3)]
     pub wrapped_blob_key_class: DdiKeyClass,
     #[ddi(id = 4)]

--- a/fw/core/ddi/mbor/types/src/set_sealed_bk3.rs
+++ b/fw/core/ddi/mbor/types/src/set_sealed_bk3.rs
@@ -9,7 +9,7 @@ use crate::*;
 #[ddi(map)]
 pub struct DdiSetSealedBk3Req<'a> {
     #[ddi(id = 1, max_len = 1024)]
-    pub sealed_bk3: &'a [u8],
+    pub sealed_bk3: &'a DmaBuf,
 }
 
 #[derive(Debug, Ddi)]

--- a/fw/core/ddi/mbor/types/src/sha_digest.rs
+++ b/fw/core/ddi/mbor/types/src/sha_digest.rs
@@ -11,7 +11,7 @@ pub struct DdiShaDigestReq<'a> {
     #[ddi(id = 1)]
     pub sha_mode: DdiHashAlgorithm,
     #[ddi(id = 2, max_len = 1024)]
-    pub msg: &'a [u8],
+    pub msg: &'a DmaBuf,
 }
 
 #[derive(Debug, Ddi)]

--- a/fw/core/ddi/mbor/types/src/unmask_key.rs
+++ b/fw/core/ddi/mbor/types/src/unmask_key.rs
@@ -9,7 +9,7 @@ use crate::*;
 #[ddi(map)]
 pub struct DdiUnmaskKeyReq<'a> {
     #[ddi(id = 1, max_len = 3072)]
-    pub masked_key: &'a [u8],
+    pub masked_key: &'a DmaBuf,
 }
 
 #[derive(Debug, Ddi)]

--- a/fw/core/ddi/tbor/derive/src/codegen_enc.rs
+++ b/fw/core/ddi/tbor/derive/src/codegen_enc.rs
@@ -97,9 +97,7 @@ fn build_toc_count_expr(layout: &TocLayout, fields: &[SchemaField]) -> TokenStre
 
 /// Generate the `#[doc(hidden)]` marker enums used as typestate tags
 /// (`FooS0`, `FooS1`, …, `FooSN`).
-fn gen_state_markers(
-    schema: &Schema,
-) -> (Vec<TokenStream>, Vec<syn::Ident>) {
+fn gen_state_markers(schema: &Schema) -> (Vec<TokenStream>, Vec<syn::Ident>) {
     let vis = &schema.vis;
     let n_fields = schema.fields.len();
     let state_markers: Vec<_> = (0..=n_fields)

--- a/fw/core/ddi/tbor/derive/src/codegen_view.rs
+++ b/fw/core/ddi/tbor/derive/src/codegen_view.rs
@@ -326,10 +326,7 @@ fn gen_padding_checks(layout: &TocLayout) -> Vec<TokenStream> {
 
 /// Generate length-constraint checks for buffer/sealed_key fields that
 /// have `fixed_len`, `min_len`, or `max_len` constraints.
-fn gen_len_checks(
-    schema: &Schema,
-    layout: &TocLayout,
-) -> Vec<TokenStream> {
+fn gen_len_checks(schema: &Schema, layout: &TocLayout) -> Vec<TokenStream> {
     let header_len_val = match schema.kind {
         MessageKind::Request { .. } => quote! { azihsm_fw_ddi_tbor::REQ_HEADER_LEN },
         MessageKind::Response => quote! { azihsm_fw_ddi_tbor::RESP_HEADER_LEN },

--- a/fw/core/lib/src/ddi/get_certificate.rs
+++ b/fw/core/lib/src/ddi/get_certificate.rs
@@ -42,8 +42,14 @@ pub(crate) async fn get_certificate<'p, P: HsmPal>(
 
     let frame = DdiGetCertificateResp::from_layout(resp, &layout);
 
-    pal.get_cert(io, io.pid(), body.slot_id, body.cert_id, Some(frame.certificate))
-        .await?;
+    pal.get_cert(
+        io,
+        io.pid(),
+        body.slot_id,
+        body.cert_id,
+        Some(frame.certificate),
+    )
+    .await?;
 
     Ok(resp)
 }

--- a/fw/core/lib/src/ddi/sha_digest.rs
+++ b/fw/core/lib/src/ddi/sha_digest.rs
@@ -47,8 +47,6 @@ pub(crate) async fn sha_digest<'p, P: HsmPal>(
         Ok((encoder.position(), layout))
     })?;
     let frame = DdiShaDigestResp::from_layout(resp, &layout);
-    let msg_dma = pal.dma_alloc(io, body.msg.len())?;
-    msg_dma.copy_from_slice(body.msg);
-    pal.hash(io, algo, msg_dma, frame.digest, true).await?;
+    pal.hash(io, algo, body.msg, frame.digest, true).await?;
     Ok(resp)
 }

--- a/fw/core/lib/src/io.rs
+++ b/fw/core/lib/src/io.rs
@@ -85,7 +85,8 @@ impl<P: HsmPal> Hsm<P> {
     /// Returns `true` if the partition for this IO is enabled.
     #[inline]
     fn partition_enabled(&self, io: &P::Io) -> bool {
-        self.pal().part_state(io)
+        self.pal()
+            .part_state(io)
             .is_ok_and(|s| s == PartState::Enabled)
     }
 
@@ -133,17 +134,12 @@ impl<P: HsmPal> Hsm<P> {
         let split = params.src_len.next_multiple_of(4);
         let req_buf = self
             .pal()
-            .dma_alloc(&*io, split)
+            .dma_alloc(io, split)
             .op_status(HostStatus::ALLOC_ERR)?;
 
         // ── Phase 1: inbound DMA (yield 1) ─────────────────────────
         self.pal()
-            .copy_mem_from_host(
-                &*io,
-                params.src_addr,
-                &mut req_buf[..params.src_len],
-                true,
-            )
+            .copy_mem_from_host(io, params.src_addr, &mut req_buf[..params.src_len], true)
             .await
             .op_err(
                 "core",
@@ -169,13 +165,13 @@ impl<P: HsmPal> Hsm<P> {
                 params.session_flags,
                 params.sqe_session_id,
             ) {
-                Ok(()) => ddi::dispatch(self.pal(), &*io, &mut decoder, &hdr).await,
+                Ok(()) => ddi::dispatch(self.pal(), io, &mut decoder, &hdr).await,
                 Err(e) => Err(e),
             };
 
             let resp: &DmaBuf = dispatch_result.or_else(|status| {
                 self.pal()
-                    .dma_alloc_var(&*io, |buf| ddi::encode_ddi_err(hdr.op, status, buf))
+                    .dma_alloc_var(io, |buf| ddi::encode_ddi_err(hdr.op, status, buf))
                     .op_status(HostStatus::INTERNAL_ERROR)
                     .map(|b| &*b)
             })?;
@@ -187,7 +183,7 @@ impl<P: HsmPal> Hsm<P> {
 
         // ── Outbound DMA (yield 2) ─────────────────────────────────
         self.pal()
-            .copy_mem_to_host(&*io, resp, params.dst_addr, true)
+            .copy_mem_to_host(io, resp, params.dst_addr, true)
             .await
             .op_err(
                 "core",

--- a/fw/pal/traits/src/alloc.rs
+++ b/fw/pal/traits/src/alloc.rs
@@ -167,26 +167,6 @@ impl core::fmt::Debug for DmaBuf {
     }
 }
 
-impl PartialEq for DmaBuf {
-    fn eq(&self, other: &Self) -> bool {
-        self.inner == other.inner
-    }
-}
-
-impl PartialEq<[u8]> for DmaBuf {
-    fn eq(&self, other: &[u8]) -> bool {
-        &self.inner == other
-    }
-}
-
-impl<const N: usize> PartialEq<[u8; N]> for DmaBuf {
-    fn eq(&self, other: &[u8; N]) -> bool {
-        &self.inner == other
-    }
-}
-
-impl Eq for DmaBuf {}
-
 impl core::ops::Index<usize> for DmaBuf {
     type Output = u8;
     #[inline(always)]

--- a/fw/pal/traits/src/alloc.rs
+++ b/fw/pal/traits/src/alloc.rs
@@ -167,6 +167,26 @@ impl core::fmt::Debug for DmaBuf {
     }
 }
 
+impl PartialEq for DmaBuf {
+    fn eq(&self, other: &Self) -> bool {
+        self.inner == other.inner
+    }
+}
+
+impl PartialEq<[u8]> for DmaBuf {
+    fn eq(&self, other: &[u8]) -> bool {
+        &self.inner == other
+    }
+}
+
+impl<const N: usize> PartialEq<[u8; N]> for DmaBuf {
+    fn eq(&self, other: &[u8; N]) -> bool {
+        &self.inner == other
+    }
+}
+
+impl Eq for DmaBuf {}
+
 impl core::ops::Index<usize> for DmaBuf {
     type Output = u8;
     #[inline(always)]

--- a/fw/pal/traits/src/lock.rs
+++ b/fw/pal/traits/src/lock.rs
@@ -59,8 +59,5 @@ pub trait HsmPartitionLock {
     /// # Errors
     ///
     /// Returns [`HsmError::InvalidArg`] if `io.pid()` is out of range.
-    async fn partition_lock(
-        &self,
-        io: &impl HsmIo,
-    ) -> HsmResult<Self::PartitionGuard<'_>>;
+    async fn partition_lock(&self, io: &impl HsmIo) -> HsmResult<Self::PartitionGuard<'_>>;
 }


### PR DESCRIPTION
The MborDecoder.buffer field and decoded byte-slice fields in MBOR request types now use &DmaBuf instead of &[u8]. Since the firmware DDI request buffer is always DMA memory, this propagates the DMA type all the way to PAL crypto calls, eliminating staging copies in handlers that previously had to copy borrowed wire data into DMA buffers before invoking crypto primitives.

Changes:
- fw/pal/traits: add PartialEq / Eq / PartialEq<[u8]> / PartialEq<[u8;N]>
  impls on DmaBuf so test assertions and equality checks work directly
  on &DmaBuf without explicit dereference.
- fw/core/ddi/mbor/codec: MborDecoder now stores &'a DmaBuf and returns &DmaBuf from bytes(), decode_byte_slice(), and decode_byte_slice_exact(). try_into() coercions go through an explicit &[u8] binding so the array conversion still resolves.
- fw/core/ddi/mbor/api: DdiDecoder::new takes &DmaBuf.
- fw/core/ddi/mbor/types: all Req struct byte-slice fields and shared types (DdiPublicKey.raw, DdiKeyProperties.key_label, DdiTargetKeyProperties.key_label) now use &'a DmaBuf. Resp fields stay &[u8] since they are constructed from mixed sources (stack arrays, byte literals, DMA frame slots).
- fw/core/ddi/mbor/types/{change_pin, open_session}: fix max_len -> len on fixed-size AES-encrypted fields (encrypted_id, encrypted_pin, iv, encrypted_seed) that were incorrectly marked variable-length.
- fw/core/lib/src/ddi/sha_digest.rs: drop the staging copy and pass body.msg directly to pal.hash().
- Update unit and cross-compat tests to use a dma() helper that wraps DmaBuf::from_raw for test slices.

Host-side MBOR (azihsm_ddi_mbor) is unchanged; this only affects the firmware-side codec.

Tests:
- fw mbor + types + api + core + pal_traits unit tests: 61/61 pass.
- emu smoke (azihsm_ddi --features emu, smoke filter): 10/10 pass.