### PR TITLE
skip caller mobk test for tpm path

### DIFF
--- a/api/tests/src/partition_tests.rs
+++ b/api/tests/src/partition_tests.rs
@@ -766,8 +766,8 @@ fn test_init_with_resiliency_tpm_obk_with_callback_fails() {
 
 #[api_test]
 fn test_init_with_resiliency_caller_obk_without_callback_fails() {
-    // This test verifies that when using Caller OBK, validation fails if mobk_callback is not provided,
-    // should be skipped for TPM since Caller OBK is not applicable and mobk_callback is allowed to be None in that case.
+    // Caller-source only: when running with `AZIHSM_USE_TPM` (TPM init path),
+    // Caller OBK is not applicable and `mobk_callback = None` is valid.
     if use_tpm() {
         return;
     }

--- a/api/tests/src/partition_tests.rs
+++ b/api/tests/src/partition_tests.rs
@@ -766,6 +766,12 @@ fn test_init_with_resiliency_tpm_obk_with_callback_fails() {
 
 #[api_test]
 fn test_init_with_resiliency_caller_obk_without_callback_fails() {
+    // This test verifies that when using Caller OBK, validation fails if mobk_callback is not provided,
+    // should be skipped for TPM since Caller OBK is not applicable and mobk_callback is allowed to be None in that case.
+    if use_tpm() {
+        return;
+    }
+
     let part_mgr = HsmPartitionManager::partition_info_list();
     assert!(!part_mgr.is_empty(), "No partitions found.");
     for part_info in part_mgr.iter() {


### PR DESCRIPTION
This pull request makes a targeted change to the `test_init_with_resiliency_caller_obk_without_callback_fails` test, ensuring it is skipped when running in a TPM environment, since Caller OBK is not applicable in that case and the `mobk_callback` can be `None`.

Test logic update:

* Updated `test_init_with_resiliency_caller_obk_without_callback_fails` in `partition_tests.rs` to skip the test when TPM is used, preventing irrelevant validation failures in that scenario.