### PR TITLE
feat(fw): implement DDI EstablishCredential handler

### DIFF
--- a/ddi/mbor/types/src/lib.rs
+++ b/ddi/mbor/types/src/lib.rs
@@ -813,6 +813,10 @@ pub enum DdiStatus {
 
     /// Partition ID Key Generation PCT failed
     PartitionIdKeyGenerationPctFailed = 141557976,
+
+    /// AES Key Wrap unwrap operation failed (IV/AIV mismatch or
+    /// underlying AES failure)
+    AesUnwrapFailed = 141557977,
 }
 
 /// DDI Key Class

--- a/ddi/mbor/types/tests/azihsm_ddi_tests.rs
+++ b/ddi/mbor/types/tests/azihsm_ddi_tests.rs
@@ -24,6 +24,7 @@ mod integration {
     pub mod ecdh_384_key_exchange;
     pub mod ecdh_521_key_exchange;
     pub mod establish_credential;
+    pub mod establish_credential_smoke;
     pub mod extension_support;
     pub mod flush_session;
     pub mod get_api_rev;

--- a/ddi/mbor/types/tests/integration/establish_credential_smoke.rs
+++ b/ddi/mbor/types/tests/integration/establish_credential_smoke.rs
@@ -1,0 +1,118 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! EstablishCredential smoke tests for the emu backend.
+//!
+//! Exercises the EstablishCredential firmware command from the host
+//! side end-to-end:
+//!
+//! - Happy path: ECDH + HKDF + HMAC verify + AES-CBC decrypt succeed,
+//!   the user credential is persisted, BK3 is unmasked, the partition
+//!   masking key is generated, and the response includes a non-empty
+//!   `bmk` blob (the freshly generated masking key wrapped under the
+//!   partition BK).
+//! - Null user ID is rejected with `InvalidAppCredentials` after the
+//!   crypto succeeds (matches the reference firmware's credential
+//!   manager invariant).
+//! - Null user PIN is symmetrically rejected with
+//!   `InvalidAppCredentials`.
+
+#![cfg(test)]
+
+use azihsm_ddi::*;
+use azihsm_ddi_mbor_codec::MborByteArray;
+use azihsm_ddi_mbor_types::*;
+use test_with_tracing::test;
+
+use super::common::*;
+
+pub fn setup(dev: &mut <DdiTest as Ddi>::Dev, ddi: &DdiTest, path: &str) -> u16 {
+    common_cleanup(dev, ddi, path, None);
+
+    // EstablishCredential is a no-session command; the harness ignores
+    // the returned id so any sentinel value is fine.
+    0
+}
+
+fn helper_smoke_establish_credential(
+    dev: &<DdiTest as Ddi>::Dev,
+    encrypted_credential: DdiEncryptedEstablishCredential,
+    pub_key: DdiDerPublicKey,
+) -> Result<DdiEstablishCredentialCmdResp, DdiError> {
+    let masked_bk3 = helper_get_or_init_bk3(dev);
+    let (signature, pota_pub_key) = helper_get_pota_endorsement(dev);
+
+    helper_establish_credential(
+        dev,
+        None,
+        Some(DdiApiRev { major: 1, minor: 0 }),
+        encrypted_credential,
+        pub_key,
+        masked_bk3,
+        MborByteArray::from_slice(&[]).expect("Failed to create empty BMK"),
+        MborByteArray::from_slice(&[]).expect("Failed to create empty masked unwrapping key"),
+        MborByteArray::from_slice(&signature).expect("Failed to create signed PID"),
+        DdiDerPublicKey {
+            der: MborByteArray::from_slice(&pota_pub_key)
+                .expect("Failed to create MborByteArray from POTA ECC public key"),
+            key_kind: DdiKeyType::Ecc384Public,
+        },
+    )
+}
+
+#[test]
+fn test_establish_credential_smoke() {
+    ddi_dev_test(setup, common_cleanup, |dev, _ddi, _path, _| {
+        let (encrypted_credential, pub_key) =
+            encrypt_userid_pin_for_establish_cred(dev, TEST_CRED_ID, TEST_CRED_PIN);
+
+        let resp = helper_smoke_establish_credential(dev, encrypted_credential, pub_key).unwrap();
+
+        assert!(resp.hdr.sess_id.is_none());
+        assert_eq!(resp.hdr.op, DdiOp::EstablishCredential);
+        assert_eq!(resp.hdr.status, DdiStatus::Success);
+
+        // Step 13 of the firmware handler always emits a freshly
+        // generated masking key wrapped under BK; the blob must be
+        // non-empty so the host can persist it as the partition BMK
+        // for later re-imports.
+        assert!(
+            !resp.data.bmk.is_empty(),
+            "EstablishCredential response should carry a non-empty BMK"
+        );
+    });
+}
+
+#[test]
+fn test_establish_credential_null_id_smoke() {
+    ddi_dev_test(setup, common_cleanup, |dev, _ddi, _path, _| {
+        let (encrypted_credential, pub_key) =
+            encrypt_userid_pin_for_establish_cred(dev, [0; 16], TEST_CRED_PIN);
+
+        let err = helper_smoke_establish_credential(dev, encrypted_credential, pub_key)
+            .expect_err("null user ID must be rejected");
+
+        assert!(
+            matches!(err, DdiError::DdiStatus(DdiStatus::InvalidAppCredentials)),
+            "expected InvalidAppCredentials, got {:?}",
+            err
+        );
+    });
+}
+
+#[test]
+fn test_establish_credential_null_pin_smoke() {
+    ddi_dev_test(setup, common_cleanup, |dev, _ddi, _path, _| {
+        let (encrypted_credential, pub_key) =
+            encrypt_userid_pin_for_establish_cred(dev, TEST_CRED_ID, [0; 16]);
+
+        let err = helper_smoke_establish_credential(dev, encrypted_credential, pub_key)
+            .expect_err("null user PIN must be rejected");
+
+        assert!(
+            matches!(err, DdiError::DdiStatus(DdiStatus::InvalidAppCredentials)),
+            "expected InvalidAppCredentials, got {:?}",
+            err
+        );
+    });
+}

--- a/fw/core/ddi/mbor/api/src/decoder.rs
+++ b/fw/core/ddi/mbor/api/src/decoder.rs
@@ -12,7 +12,7 @@ pub struct DdiDecoder<'b> {
 }
 
 impl<'b> DdiDecoder<'b> {
-    pub fn new(buf: &'b DmaBuf) -> Self {
+    pub fn new(buf: &'b mut DmaBuf) -> Self {
         Self {
             in_len: buf.len(),
             decoder: MborDecoder::new(buf),

--- a/fw/core/ddi/mbor/codec/src/decode.rs
+++ b/fw/core/ddi/mbor/codec/src/decode.rs
@@ -125,55 +125,56 @@ impl<const N: usize> MborDecode<'_> for [u8; N] {
 
 /// Decoder for AZIHSM Binary Object Representation (MBOR).
 ///
-/// Borrows the input buffer and returns sub-slices on decode, enabling
-/// zero-copy access to byte array fields.
+/// Owns the input buffer mutably and peels disjoint sub-slices off the
+/// front via `split_at_mut` on each read, enabling zero-copy access to
+/// byte-array fields with **mutable** sub-references that the handler
+/// can decrypt / mutate in place.
 pub struct MborDecoder<'a> {
-    buffer: &'a DmaBuf,
-    pos: usize,
+    /// Remaining un-consumed portion of the input buffer.
+    ///
+    /// `None` only transiently during split operations; between any
+    /// pair of public method calls this is always `Some`.
+    remaining: Option<&'a mut DmaBuf>,
+    /// Total length of the original input buffer; used to compute
+    /// [`position`](Self::position) without retaining the original
+    /// buffer.
+    initial_len: usize,
 }
 
 impl<'a> MborDecoder<'a> {
     /// Create a new decoder over `buf`.
-    pub fn new(buf: &'a DmaBuf) -> Self {
+    pub fn new(buf: &'a mut DmaBuf) -> Self {
+        let initial_len = buf.len();
         Self {
-            buffer: buf,
-            pos: 0,
+            remaining: Some(buf),
+            initial_len,
         }
     }
 
     /// Current read position (bytes consumed so far).
     pub fn position(&self) -> usize {
-        self.pos
+        self.initial_len - self.remaining.as_ref().map_or(0, |b| b.len())
     }
 
     /// Peek at the next MBOR-encoded `u8` value without consuming it.
     /// Returns `None` if there are fewer than 2 bytes remaining.
-    pub fn peek_u8(&mut self) -> Option<u8> {
-        if let Ok(bytes) = self.bytes(2) {
-            // Skipping the first byte check (marker) for performance reasons.
-            self.pos -= 2;
-            Some(bytes[1])
-        } else {
-            None
-        }
+    pub fn peek_u8(&self) -> Option<u8> {
+        // Skipping the first byte check (marker) for performance reasons.
+        self.remaining.as_ref().and_then(|b| b.get(1)).copied()
     }
 
     /// Peek at the next raw byte without consuming it.
     /// Returns `None` if the buffer is exhausted.
-    pub fn peek_byte(&mut self) -> Option<u8> {
-        if let Ok(byte) = self.byte() {
-            self.pos -= 1;
-            Some(byte)
-        } else {
-            None
-        }
+    pub fn peek_byte(&self) -> Option<u8> {
+        self.remaining.as_ref().and_then(|b| b.first()).copied()
     }
 
-    /// Decode a variable-length byte field and return a borrowed sub-slice
-    /// of the input buffer (zero-copy). Accepts and skips padding.
+    /// Decode a variable-length byte field and return a mutable
+    /// borrowed sub-slice of the input buffer (zero-copy). Accepts
+    /// and skips padding.
     ///
     /// Returns `(padding, data_slice)`.
-    pub fn decode_byte_slice(&mut self) -> Result<(u8, &'a DmaBuf), MborDecodeError> {
+    pub fn decode_byte_slice(&mut self) -> Result<(u8, &'a mut DmaBuf), MborDecodeError> {
         let marker = self.byte()?;
         if marker & BYTES_MARKER != BYTES_MARKER {
             return Err(MborDecodeError::ExpectedU8);
@@ -187,29 +188,29 @@ impl<'a> MborDecoder<'a> {
         // Skip padding bytes
         self.skip(pad as usize)?;
 
-        // Return borrowed slice — zero-copy
+        // Return mutable borrowed slice — zero-copy
         let data = self.bytes(len as usize)?;
         Ok((pad, data))
     }
 
-    /// Decode a fixed-length byte field with no padding (zero-copy).
+    /// Decode a fixed-length byte field as a mutable sub-slice
+    /// (zero-copy).
     ///
-    /// Rejects any padding in the marker and verifies the length matches
-    /// `expected_len` exactly. This mirrors the old `[u8; N]` decode
-    /// behavior.
+    /// Verifies the length matches `expected_len` exactly. Skips any
+    /// alignment padding emitted by the host (`MborByteArray<N>` and
+    /// `[u8; N]` differ here: the former pads to 4-byte alignment, the
+    /// latter does not). Padding skip is a no-op when the host emitted
+    /// no padding, so this works for both wire shapes.
     pub fn decode_byte_slice_exact(
         &mut self,
         expected_len: usize,
-    ) -> Result<&'a DmaBuf, MborDecodeError> {
+    ) -> Result<&'a mut DmaBuf, MborDecodeError> {
         let marker = self.byte()?;
         if marker & BYTES_MARKER != BYTES_MARKER {
             return Err(MborDecodeError::ExpectedU8);
         }
 
         let pad = marker & BYTES_PAD_MASK;
-        if pad != 0 {
-            return Err(MborDecodeError::InvalidPadding);
-        }
 
         let len_bytes: &[u8] = self.bytes(core::mem::size_of::<u16>())?;
         let len = u16::from_be_bytes(len_bytes.try_into().or(Err(MborDecodeError::DecodeU16))?);
@@ -218,32 +219,40 @@ impl<'a> MborDecoder<'a> {
             return Err(MborDecodeError::InvalidLen);
         }
 
+        // Skip alignment padding (zero for `[u8; N]`, 0–3 for `MborByteArray<N>`).
+        self.skip(pad as usize)?;
+
         self.bytes(len as usize)
     }
 
     // ── Private helpers ────────────────────────────────────────────
 
     pub(crate) fn byte(&mut self) -> Result<u8, MborDecodeError> {
-        const LEN: usize = core::mem::size_of::<u8>();
-        Ok(self.bytes(LEN)?[0])
+        Ok(self.bytes(1)?[0])
     }
 
+    /// Peel `len` bytes off the front of the remaining buffer and
+    /// return them as a disjoint mutable sub-slice.
     #[inline(always)]
-    pub(crate) fn bytes(&mut self, len: usize) -> Result<&'a DmaBuf, MborDecodeError> {
-        if len + self.pos > self.buffer.len() {
+    pub(crate) fn bytes(&mut self, len: usize) -> Result<&'a mut DmaBuf, MborDecodeError> {
+        let buf = self
+            .remaining
+            .take()
+            .ok_or(MborDecodeError::BufferUnderFlow)?;
+        if buf.len() < len {
+            // Restore the buffer so the decoder is still usable.
+            self.remaining = Some(buf);
             return Err(MborDecodeError::BufferUnderFlow);
         }
-        let bytes = &self.buffer[self.pos..self.pos + len];
-        self.pos += len;
-        Ok(bytes)
+        let (head, tail) = buf.split_at_mut(len);
+        self.remaining = Some(tail);
+        Ok(head)
     }
 
     pub(crate) fn skip(&mut self, len: usize) -> Result<(), MborDecodeError> {
-        if len + self.pos > self.buffer.len() {
-            return Err(MborDecodeError::BufferUnderFlow);
-        }
-        self.pos += len;
-        Ok(())
+        // Re-use `bytes` for the underflow check + split, then drop
+        // the returned slice.
+        self.bytes(len).map(|_| ())
     }
 }
 
@@ -258,99 +267,102 @@ mod tests {
 
     /// In tests, local arrays aren't DMA memory, but we need `&DmaBuf`
     /// to construct a decoder. This is safe in tests — no real DMA hw.
-    fn dma(buf: &[u8]) -> &DmaBuf {
+    fn dma(buf: &mut [u8]) -> &mut DmaBuf {
         // SAFETY: In tests, no real DMA hardware is involved. The
-        // `DmaBuf::from_raw` transmute is safe because the data is only
-        // read by the decoder, not submitted to a DMA engine.
-        unsafe { DmaBuf::from_raw(buf) }
+        // `DmaBuf::from_raw_mut` transmute is safe because the data
+        // is only read/written by the decoder, not submitted to a
+        // DMA engine.
+        unsafe { DmaBuf::from_raw_mut(buf) }
     }
 
     #[test]
     fn decode_bool() {
-        let buf = [0x15]; // true
-        let mut dec = MborDecoder::new(dma(&buf));
+        let mut buf = [0x15]; // true
+        let mut dec = MborDecoder::new(dma(&mut buf));
         assert!(bool::mbor_decode(&mut dec).unwrap());
 
-        let buf = [0x14]; // false
-        let mut dec = MborDecoder::new(dma(&buf));
+        let mut buf = [0x14]; // false
+        let mut dec = MborDecoder::new(dma(&mut buf));
         assert!(!bool::mbor_decode(&mut dec).unwrap());
     }
 
     #[test]
     fn decode_u8() {
-        let buf = [U8_MARKER, 42];
-        let mut dec = MborDecoder::new(dma(&buf));
+        let mut buf = [U8_MARKER, 42];
+        let mut dec = MborDecoder::new(dma(&mut buf));
         assert_eq!(u8::mbor_decode(&mut dec).unwrap(), 42);
     }
 
     #[test]
     fn decode_u16() {
-        let buf = [U16_MARKER, 0x12, 0x34];
-        let mut dec = MborDecoder::new(dma(&buf));
+        let mut buf = [U16_MARKER, 0x12, 0x34];
+        let mut dec = MborDecoder::new(dma(&mut buf));
         assert_eq!(u16::mbor_decode(&mut dec).unwrap(), 0x1234);
     }
 
     #[test]
     fn decode_u32() {
-        let buf = [U32_MARKER, 0xDE, 0xAD, 0xBE, 0xEF];
-        let mut dec = MborDecoder::new(dma(&buf));
+        let mut buf = [U32_MARKER, 0xDE, 0xAD, 0xBE, 0xEF];
+        let mut dec = MborDecoder::new(dma(&mut buf));
         assert_eq!(u32::mbor_decode(&mut dec).unwrap(), 0xDEADBEEF);
     }
 
     #[test]
     fn decode_u64() {
-        let buf = [U64_MARKER, 0, 0, 0, 0, 0, 0, 0, 1];
-        let mut dec = MborDecoder::new(dma(&buf));
+        let mut buf = [U64_MARKER, 0, 0, 0, 0, 0, 0, 0, 1];
+        let mut dec = MborDecoder::new(dma(&mut buf));
         assert_eq!(u64::mbor_decode(&mut dec).unwrap(), 1);
     }
 
     #[test]
     fn decode_map() {
-        let buf = [MAP_MARKER | 5];
-        let mut dec = MborDecoder::new(dma(&buf));
+        let mut buf = [MAP_MARKER | 5];
+        let mut dec = MborDecoder::new(dma(&mut buf));
         let m = MborMap::mbor_decode(&mut dec).unwrap();
         assert_eq!(m.0, 5);
     }
 
     #[test]
     fn decode_fixed_array() {
-        let buf = [BYTES_MARKER, 0, 3, 0xAA, 0xBB, 0xCC];
-        let mut dec = MborDecoder::new(dma(&buf));
+        let mut buf = [BYTES_MARKER, 0, 3, 0xAA, 0xBB, 0xCC];
+        let mut dec = MborDecoder::new(dma(&mut buf));
         let arr: [u8; 3] = MborDecode::mbor_decode(&mut dec).unwrap();
         assert_eq!(arr, [0xAA, 0xBB, 0xCC]);
     }
 
     #[test]
     fn decode_byte_slice_zero_copy() {
-        let buf = [BYTES_MARKER, 0, 4, 1, 2, 3, 4];
-        let mut dec = MborDecoder::new(dma(&buf));
+        let mut buf = [BYTES_MARKER, 0, 4, 1, 2, 3, 4];
+        let mut dec = MborDecoder::new(dma(&mut buf));
         let (pad, slice) = dec.decode_byte_slice().unwrap();
         assert_eq!(pad, 0);
-        assert_eq!(slice.deref(), &[1, 2, 3, 4]);
+        let s: &[u8] = slice.deref();
+        assert_eq!(s, &[1, 2, 3, 4]);
         assert_eq!(slice.as_ptr(), buf[3..].as_ptr());
     }
 
     #[test]
     fn decode_byte_slice_with_padding() {
         // marker=0x81 (pad=1), len=3, pad_byte=0, data=[0xAA, 0xBB, 0xCC]
-        let buf = [BYTES_MARKER | 1, 0, 3, 0, 0xAA, 0xBB, 0xCC];
-        let mut dec = MborDecoder::new(dma(&buf));
+        let mut buf = [BYTES_MARKER | 1, 0, 3, 0, 0xAA, 0xBB, 0xCC];
+        let mut dec = MborDecoder::new(dma(&mut buf));
         let (pad, slice) = dec.decode_byte_slice().unwrap();
         assert_eq!(pad, 1);
-        assert_eq!(slice.deref(), &[0xAA, 0xBB, 0xCC]);
+        let s: &[u8] = slice.deref();
+        assert_eq!(s, &[0xAA, 0xBB, 0xCC]);
     }
 
     #[test]
     fn decode_buffer_underflow() {
-        let buf = [U32_MARKER, 0xDE]; // too short for u32
-        let mut dec = MborDecoder::new(dma(&buf));
+        let mut buf = [U32_MARKER, 0xDE]; // too short for u32
+        let mut dec = MborDecoder::new(dma(&mut buf));
         assert!(u32::mbor_decode(&mut dec).is_err());
     }
 
     #[test]
     fn peek_u8_does_not_consume() {
-        let buf = [U8_MARKER, 99];
-        let mut dec = MborDecoder::new(dma(&buf));
+        let mut buf = [U8_MARKER, 99];
+        let mut dec = MborDecoder::new(dma(&mut buf));
         assert_eq!(dec.peek_u8(), Some(99));
         assert_eq!(dec.position(), 0);
         assert_eq!(u8::mbor_decode(&mut dec).unwrap(), 99);
@@ -358,8 +370,8 @@ mod tests {
 
     #[test]
     fn peek_byte_does_not_consume() {
-        let buf = [MAP_MARKER | 2];
-        let mut dec = MborDecoder::new(dma(&buf));
+        let mut buf = [MAP_MARKER | 2];
+        let dec = MborDecoder::new(dma(&mut buf));
         assert_eq!(dec.peek_byte(), Some(MAP_MARKER | 2));
         assert_eq!(dec.position(), 0);
     }
@@ -369,27 +381,31 @@ mod tests {
     #[test]
     fn decode_byte_slice_exact_ok() {
         // No padding, len=4, data=[1,2,3,4]
-        let buf = [BYTES_MARKER, 0, 4, 1, 2, 3, 4];
-        let mut dec = MborDecoder::new(dma(&buf));
+        let mut buf = [BYTES_MARKER, 0, 4, 1, 2, 3, 4];
+        let mut dec = MborDecoder::new(dma(&mut buf));
         let slice = dec.decode_byte_slice_exact(4).unwrap();
-        assert_eq!(slice.deref(), &[1, 2, 3, 4]);
+        let s: &[u8] = slice.deref();
+        assert_eq!(s, &[1, 2, 3, 4]);
         assert_eq!(slice.as_ptr(), buf[3..].as_ptr());
     }
 
     #[test]
     fn decode_byte_slice_exact_wrong_len() {
         // Data is 4 bytes but we expect 3
-        let buf = [BYTES_MARKER, 0, 4, 1, 2, 3, 4];
-        let mut dec = MborDecoder::new(dma(&buf));
+        let mut buf = [BYTES_MARKER, 0, 4, 1, 2, 3, 4];
+        let mut dec = MborDecoder::new(dma(&mut buf));
         assert!(dec.decode_byte_slice_exact(3).is_err());
     }
 
     #[test]
-    fn decode_byte_slice_exact_rejects_padding() {
-        // marker=0x81 (pad=1) — exact decode rejects padding
-        let buf = [BYTES_MARKER | 1, 0, 3, 0, 0xAA, 0xBB, 0xCC];
-        let mut dec = MborDecoder::new(dma(&buf));
-        assert!(dec.decode_byte_slice_exact(3).is_err());
+    fn decode_byte_slice_exact_accepts_padding() {
+        // marker=0x81 (pad=1) — exact decode now accepts padding
+        // (matches `MborByteArray<N>` wire encoding from the host SDK)
+        let mut buf = [BYTES_MARKER | 1, 0, 3, 0, 0xAA, 0xBB, 0xCC];
+        let mut dec = MborDecoder::new(dma(&mut buf));
+        let slice = dec.decode_byte_slice_exact(3).unwrap();
+        let s: &[u8] = slice.deref();
+        assert_eq!(s, &[0xAA, 0xBB, 0xCC]);
     }
 
     // ── Round-trip tests: encode then decode ───────────────────────
@@ -402,9 +418,10 @@ mod tests {
         crate::MborByteSlice(&data).mbor_encode(&mut enc).unwrap();
         let pos = enc.position();
 
-        let mut dec = MborDecoder::new(dma(&buf[..pos]));
+        let mut dec = MborDecoder::new(dma(&mut buf[..pos]));
         let slice = dec.decode_byte_slice_exact(4).unwrap();
-        assert_eq!(slice.deref(), &data);
+        let s: &[u8] = slice.deref();
+        assert_eq!(s, &data);
     }
 
     #[test]
@@ -417,14 +434,15 @@ mod tests {
             .unwrap();
         let pos = enc.position();
 
-        let mut dec = MborDecoder::new(dma(&buf[..pos]));
+        let mut dec = MborDecoder::new(dma(&mut buf[..pos]));
         let (pad, slice) = dec.decode_byte_slice().unwrap();
         assert_eq!(pad, 1);
-        assert_eq!(slice.deref(), &data);
+        let s: &[u8] = slice.deref();
+        assert_eq!(s, &data);
     }
 
     #[test]
-    fn padded_encode_rejected_by_exact_decode() {
+    fn padded_encode_accepted_by_exact_decode() {
         let data = [0xBB; 8];
         let mut buf = [0u8; 32];
         let mut enc = crate::MborEncoder::new(&mut buf);
@@ -433,8 +451,10 @@ mod tests {
             .unwrap();
         let pos = enc.position();
 
-        let mut dec = MborDecoder::new(dma(&buf[..pos]));
-        assert!(dec.decode_byte_slice_exact(8).is_err());
+        let mut dec = MborDecoder::new(dma(&mut buf[..pos]));
+        let slice = dec.decode_byte_slice_exact(8).unwrap();
+        let s: &[u8] = slice.deref();
+        assert_eq!(s, &data);
     }
 
     #[test]
@@ -445,9 +465,10 @@ mod tests {
         crate::MborByteSlice(&data).mbor_encode(&mut enc).unwrap();
         let pos = enc.position();
 
-        let mut dec = MborDecoder::new(dma(&buf[..pos]));
+        let mut dec = MborDecoder::new(dma(&mut buf[..pos]));
         let (pad, slice) = dec.decode_byte_slice().unwrap();
         assert_eq!(pad, 0);
-        assert_eq!(slice.deref(), &data);
+        let s: &[u8] = slice.deref();
+        assert_eq!(s, &data);
     }
 }

--- a/fw/core/ddi/mbor/codec/tests/cross_compat.rs
+++ b/fw/core/ddi/mbor/codec/tests/cross_compat.rs
@@ -17,11 +17,11 @@ use azihsm_fw_ddi_mbor as new;
 use azihsm_fw_hsm_pal_traits::DmaBuf;
 
 /// Test helper: brand a `&[u8]` as `&DmaBuf`. Safe in tests — no real DMA hw.
-fn dma(buf: &[u8]) -> &DmaBuf {
+fn dma(buf: &mut [u8]) -> &mut DmaBuf {
     // SAFETY: In tests, no real DMA hardware is involved. The
-    // `DmaBuf::from_raw` transmute is safe because the data is only
-    // read by the decoder, not submitted to a DMA engine.
-    unsafe { DmaBuf::from_raw(buf) }
+    // `DmaBuf::from_raw_mut` transmute is safe because the data is
+    // only read/written by the decoder, not submitted to a DMA engine.
+    unsafe { DmaBuf::from_raw_mut(buf) }
 }
 
 /// Helper to create an old MborEncoder, supplying the extra `pre_encode` flag
@@ -50,7 +50,7 @@ fn old_encode_bool_new_decode() {
     let mut enc = old_encoder(&mut buf);
     old::MborEncode::mbor_encode(&true, &mut enc).unwrap();
 
-    let mut dec = new::MborDecoder::new(dma(&buf));
+    let mut dec = new::MborDecoder::new(dma(&mut buf));
     assert!(<bool as new::MborDecode>::mbor_decode(&mut dec).unwrap());
 }
 
@@ -60,7 +60,7 @@ fn old_encode_u8_new_decode() {
     let mut enc = old_encoder(&mut buf);
     old::MborEncode::mbor_encode(&42u8, &mut enc).unwrap();
 
-    let mut dec = new::MborDecoder::new(dma(&buf));
+    let mut dec = new::MborDecoder::new(dma(&mut buf));
     assert_eq!(<u8 as new::MborDecode>::mbor_decode(&mut dec).unwrap(), 42);
 }
 
@@ -70,7 +70,7 @@ fn old_encode_u16_new_decode() {
     let mut enc = old_encoder(&mut buf);
     old::MborEncode::mbor_encode(&0x1234u16, &mut enc).unwrap();
 
-    let mut dec = new::MborDecoder::new(dma(&buf));
+    let mut dec = new::MborDecoder::new(dma(&mut buf));
     assert_eq!(
         <u16 as new::MborDecode>::mbor_decode(&mut dec).unwrap(),
         0x1234
@@ -83,7 +83,7 @@ fn old_encode_u32_new_decode() {
     let mut enc = old_encoder(&mut buf);
     old::MborEncode::mbor_encode(&0xDEADBEEFu32, &mut enc).unwrap();
 
-    let mut dec = new::MborDecoder::new(dma(&buf));
+    let mut dec = new::MborDecoder::new(dma(&mut buf));
     assert_eq!(
         <u32 as new::MborDecode>::mbor_decode(&mut dec).unwrap(),
         0xDEADBEEF
@@ -96,7 +96,7 @@ fn old_encode_u64_new_decode() {
     let mut enc = old_encoder(&mut buf);
     old::MborEncode::mbor_encode(&0x0102030405060708u64, &mut enc).unwrap();
 
-    let mut dec = new::MborDecoder::new(dma(&buf));
+    let mut dec = new::MborDecoder::new(dma(&mut buf));
     assert_eq!(
         <u64 as new::MborDecode>::mbor_decode(&mut dec).unwrap(),
         0x0102030405060708
@@ -109,7 +109,7 @@ fn old_encode_map_new_decode() {
     let mut enc = old_encoder(&mut buf);
     old::MborEncode::mbor_encode(&old::MborMap(7), &mut enc).unwrap();
 
-    let mut dec = new::MborDecoder::new(dma(&buf));
+    let mut dec = new::MborDecoder::new(dma(&mut buf));
     let m = <new::MborMap as new::MborDecode>::mbor_decode(&mut dec).unwrap();
     assert_eq!(m.0, 7);
 }
@@ -150,9 +150,10 @@ fn old_byte_slice_new_decode_exact() {
     let pos = enc.position();
 
     // New exact decode (no padding expected)
-    let mut dec = new::MborDecoder::new(&dma(&buf)[..pos]);
+    let mut dec = new::MborDecoder::new(&mut dma(&mut buf)[..pos]);
     let slice = dec.decode_byte_slice_exact(4).unwrap();
-    assert_eq!(slice.deref(), &data);
+    let s: &[u8] = slice.deref();
+    assert_eq!(s, &data);
 }
 
 #[test]
@@ -164,10 +165,11 @@ fn old_byte_slice_new_decode_variable() {
     let pos = enc.position();
 
     // New variable decode also works (pad=0)
-    let mut dec = new::MborDecoder::new(&dma(&buf)[..pos]);
+    let mut dec = new::MborDecoder::new(&mut dma(&mut buf)[..pos]);
     let (pad, slice) = dec.decode_byte_slice().unwrap();
     assert_eq!(pad, 0);
-    assert_eq!(slice.deref(), &data);
+    let s: &[u8] = slice.deref();
+    assert_eq!(s, &data);
 }
 
 // ── Byte arrays: old encode (MborPaddedByteArray, with padding) → new decode ──
@@ -187,14 +189,19 @@ fn old_padded_array_new_decode_variable() {
     let pos = enc.position();
 
     // New variable decode handles padding
-    let mut dec = new::MborDecoder::new(&dma(&buf)[..pos]);
+    let mut dec = new::MborDecoder::new(&mut dma(&mut buf)[..pos]);
     let (pad, slice) = dec.decode_byte_slice().unwrap();
     assert_eq!(pad, 1);
-    assert_eq!(slice.deref(), &[0x55; 10]);
+    let s: &[u8] = slice.deref();
+    assert_eq!(s, &[0x55; 10]);
 }
 
 #[test]
-fn old_padded_array_new_exact_decode_rejects() {
+fn old_padded_array_new_exact_decode_accepts() {
+    // Host SDK encodes `MborByteArray<N>` with 4-byte alignment padding.
+    // FW's `decode_byte_slice_exact` must accept that wire shape — it's the
+    // exact same encoding used by `[u8; N]` when `pad == 0`, so the decoder
+    // tolerates any pad value (0..=3) and asserts the data length.
     let data_src = [0x77u8; 8];
     let arr = old_byte_array::<8>(&data_src);
     let padded = old::MborPaddedByteArray(&arr, 2);
@@ -207,9 +214,10 @@ fn old_padded_array_new_exact_decode_rejects() {
     old::MborEncode::mbor_encode(&padded, &mut enc).unwrap();
     let pos = enc.position();
 
-    // Exact decode rejects padding — correct behavior
-    let mut dec = new::MborDecoder::new(&dma(&buf)[..pos]);
-    assert!(dec.decode_byte_slice_exact(8).is_err());
+    let mut dec = new::MborDecoder::new(&mut dma(&mut buf)[..pos]);
+    let slice = dec.decode_byte_slice_exact(8).unwrap();
+    let s: &[u8] = slice.deref();
+    assert_eq!(s, &data_src);
 }
 
 // ── Byte slices: new encode → old decode ──────────────────────────────
@@ -257,7 +265,7 @@ fn old_encode_struct_new_decode() {
     let pos = enc.position();
 
     // Decode with new
-    let mut dec = new::MborDecoder::new(&dma(&buf)[..pos]);
+    let mut dec = new::MborDecoder::new(&mut dma(&mut buf)[..pos]);
     let m = <new::MborMap as new::MborDecode>::mbor_decode(&mut dec).unwrap();
     assert_eq!(m.0, 2);
     assert_eq!(<u8 as new::MborDecode>::mbor_decode(&mut dec).unwrap(), 0);

--- a/fw/core/ddi/mbor/types/src/aes_encrypt_decrypt.rs
+++ b/fw/core/ddi/mbor/types/src/aes_encrypt_decrypt.rs
@@ -13,9 +13,9 @@ pub struct DdiAesEncryptDecryptReq<'a> {
     #[ddi(id = 2)]
     pub op: DdiAesOp,
     #[ddi(id = 3, max_len = 1024)]
-    pub msg: &'a DmaBuf,
+    pub msg: &'a mut DmaBuf,
     #[ddi(id = 4, max_len = 16)]
-    pub iv: &'a DmaBuf,
+    pub iv: &'a mut DmaBuf,
 }
 
 impl DdiAesEncryptDecryptReq<'_> {

--- a/fw/core/ddi/mbor/types/src/attest_key.rs
+++ b/fw/core/ddi/mbor/types/src/attest_key.rs
@@ -11,7 +11,7 @@ pub struct DdiAttestKeyReq<'a> {
     #[ddi(id = 1)]
     pub key_id: u16,
     #[ddi(id = 2, max_len = 128)]
-    pub report_data: &'a DmaBuf,
+    pub report_data: &'a mut DmaBuf,
 }
 
 impl DdiAttestKeyReq<'_> {

--- a/fw/core/ddi/mbor/types/src/change_pin.rs
+++ b/fw/core/ddi/mbor/types/src/change_pin.rs
@@ -9,13 +9,13 @@ use crate::*;
 #[ddi(map)]
 pub struct DdiEncryptedPin<'a> {
     #[ddi(id = 2, len = 16)]
-    pub encrypted_pin: &'a DmaBuf,
+    pub encrypted_pin: &'a mut DmaBuf,
     #[ddi(id = 3, len = 16)]
-    pub iv: &'a DmaBuf,
+    pub iv: &'a mut DmaBuf,
     #[ddi(id = 4, len = 32)]
-    pub nonce: &'a DmaBuf,
+    pub nonce: &'a mut DmaBuf,
     #[ddi(id = 5, len = 48)]
-    pub tag: &'a DmaBuf,
+    pub tag: &'a mut DmaBuf,
 }
 
 #[derive(Debug, Ddi)]

--- a/fw/core/ddi/mbor/types/src/derive_hkdf.rs
+++ b/fw/core/ddi/mbor/types/src/derive_hkdf.rs
@@ -13,9 +13,9 @@ pub struct DdiHkdfDeriveReq<'a> {
     #[ddi(id = 2)]
     pub hash_algorithm: DdiHashAlgorithm,
     #[ddi(id = 3, max_len = 256)]
-    pub salt: Option<&'a DmaBuf>,
+    pub salt: Option<&'a mut DmaBuf>,
     #[ddi(id = 4, max_len = 256)]
-    pub info: Option<&'a DmaBuf>,
+    pub info: Option<&'a mut DmaBuf>,
     #[ddi(id = 5)]
     pub key_type: DdiKeyType,
     #[ddi(id = 6)]

--- a/fw/core/ddi/mbor/types/src/derive_kbkdf.rs
+++ b/fw/core/ddi/mbor/types/src/derive_kbkdf.rs
@@ -13,9 +13,9 @@ pub struct DdiKbkdfCounterHmacDeriveReq<'a> {
     #[ddi(id = 2)]
     pub hash_algorithm: DdiHashAlgorithm,
     #[ddi(id = 3, max_len = 256)]
-    pub label: Option<&'a DmaBuf>,
+    pub label: Option<&'a mut DmaBuf>,
     #[ddi(id = 4, max_len = 256)]
-    pub context: Option<&'a DmaBuf>,
+    pub context: Option<&'a mut DmaBuf>,
     #[ddi(id = 5)]
     pub key_type: DdiKeyType,
     #[ddi(id = 6)]

--- a/fw/core/ddi/mbor/types/src/ecc_sign.rs
+++ b/fw/core/ddi/mbor/types/src/ecc_sign.rs
@@ -11,7 +11,7 @@ pub struct DdiEccSignReq<'a> {
     #[ddi(id = 1)]
     pub key_id: u16,
     #[ddi(id = 2, max_len = 96)]
-    pub digest: &'a DmaBuf,
+    pub digest: &'a mut DmaBuf,
     #[ddi(id = 3)]
     pub digest_algo: DdiHashAlgorithm,
 }

--- a/fw/core/ddi/mbor/types/src/ecdh_key_exchange.rs
+++ b/fw/core/ddi/mbor/types/src/ecdh_key_exchange.rs
@@ -11,7 +11,7 @@ pub struct DdiEcdhKeyExchangeReq<'a> {
     #[ddi(id = 1)]
     pub priv_key_id: u16,
     #[ddi(id = 2, max_len = 192)]
-    pub pub_key_der: &'a DmaBuf,
+    pub pub_key_der: &'a mut DmaBuf,
     #[ddi(id = 3)]
     pub key_type: DdiKeyType,
     #[ddi(id = 4)]

--- a/fw/core/ddi/mbor/types/src/establish_credential.rs
+++ b/fw/core/ddi/mbor/types/src/establish_credential.rs
@@ -14,13 +14,13 @@ pub struct DdiEstablishCredentialReq<'a> {
     #[ddi(id = 2)]
     pub pub_key: DdiPublicKey<'a>,
     #[ddi(id = 3, max_len = 1024)]
-    pub masked_bk3: &'a DmaBuf,
+    pub masked_bk3: &'a mut DmaBuf,
     #[ddi(id = 4, max_len = 1024)]
-    pub bmk: &'a DmaBuf,
+    pub bmk: &'a mut DmaBuf,
     #[ddi(id = 5, max_len = 1024)]
-    pub masked_unwrapping_key: &'a DmaBuf,
+    pub masked_unwrapping_key: &'a mut DmaBuf,
     #[ddi(id = 6, max_len = 1024)]
-    pub pota_sig: &'a DmaBuf,
+    pub pota_sig: &'a mut DmaBuf,
     #[ddi(id = 7)]
     pub pota_pub_key: DdiPublicKey<'a>,
 }

--- a/fw/core/ddi/mbor/types/src/hmac.rs
+++ b/fw/core/ddi/mbor/types/src/hmac.rs
@@ -11,7 +11,7 @@ pub struct DdiHmacReq<'a> {
     #[ddi(id = 1)]
     pub key_id: u16,
     #[ddi(id = 2, max_len = 1024)]
-    pub msg: &'a DmaBuf,
+    pub msg: &'a mut DmaBuf,
 }
 
 #[derive(Debug, Ddi)]

--- a/fw/core/ddi/mbor/types/src/init_bk3.rs
+++ b/fw/core/ddi/mbor/types/src/init_bk3.rs
@@ -9,7 +9,7 @@ use crate::*;
 #[ddi(map)]
 pub struct DdiInitBk3Req<'a> {
     #[ddi(id = 1, len = 48)]
-    pub bk3: &'a DmaBuf,
+    pub bk3: &'a mut DmaBuf,
 }
 
 #[derive(Debug, Ddi)]

--- a/fw/core/ddi/mbor/types/src/lib.rs
+++ b/fw/core/ddi/mbor/types/src/lib.rs
@@ -331,7 +331,7 @@ pub struct DdiRespExt {}
 #[ddi(map)]
 pub struct DdiPublicKey<'a> {
     #[ddi(id = 1, max_len = 768)]
-    pub raw: &'a DmaBuf,
+    pub raw: &'a mut DmaBuf,
     #[ddi(id = 2)]
     pub key_kind: DdiKeyType,
 }
@@ -345,7 +345,7 @@ pub struct DdiKeyProperties<'a> {
     #[ddi(id = 2)]
     pub key_availability: DdiKeyAvailability,
     #[ddi(id = 3, max_len = 128)]
-    pub key_label: &'a DmaBuf,
+    pub key_label: &'a mut DmaBuf,
 }
 
 /// Target key metadata (16-byte bitflag blob).
@@ -363,7 +363,7 @@ pub struct DdiTargetKeyProperties<'a> {
     #[ddi(id = 1)]
     pub key_metadata: DdiTargetKeyMetadata,
     #[ddi(id = 2, max_len = 128)]
-    pub key_label: &'a DmaBuf,
+    pub key_label: &'a mut DmaBuf,
 }
 
 // ── ddi_op_req_resp! macro ─────────────────────────────────────────────

--- a/fw/core/ddi/mbor/types/src/open_session.rs
+++ b/fw/core/ddi/mbor/types/src/open_session.rs
@@ -9,32 +9,32 @@ use crate::*;
 #[ddi(map)]
 pub struct DdiEncryptedEstablishCredential<'a> {
     #[ddi(id = 1, len = 16)]
-    pub encrypted_id: &'a DmaBuf,
+    pub encrypted_id: &'a mut DmaBuf,
     #[ddi(id = 2, len = 16)]
-    pub encrypted_pin: &'a DmaBuf,
+    pub encrypted_pin: &'a mut DmaBuf,
     #[ddi(id = 3, len = 16)]
-    pub iv: &'a DmaBuf,
+    pub iv: &'a mut DmaBuf,
     #[ddi(id = 4, len = 32)]
-    pub nonce: &'a DmaBuf,
+    pub nonce: &'a mut DmaBuf,
     #[ddi(id = 5, len = 48)]
-    pub tag: &'a DmaBuf,
+    pub tag: &'a mut DmaBuf,
 }
 
 #[derive(Debug, Ddi)]
 #[ddi(map)]
 pub struct DdiEncryptedSessionCredential<'a> {
     #[ddi(id = 1, len = 16)]
-    pub encrypted_id: &'a DmaBuf,
+    pub encrypted_id: &'a mut DmaBuf,
     #[ddi(id = 2, len = 16)]
-    pub encrypted_pin: &'a DmaBuf,
+    pub encrypted_pin: &'a mut DmaBuf,
     #[ddi(id = 3, len = 48)]
-    pub encrypted_seed: &'a DmaBuf,
+    pub encrypted_seed: &'a mut DmaBuf,
     #[ddi(id = 4, len = 16)]
-    pub iv: &'a DmaBuf,
+    pub iv: &'a mut DmaBuf,
     #[ddi(id = 5, len = 32)]
-    pub nonce: &'a DmaBuf,
+    pub nonce: &'a mut DmaBuf,
     #[ddi(id = 6, len = 48)]
-    pub tag: &'a DmaBuf,
+    pub tag: &'a mut DmaBuf,
 }
 
 #[derive(Debug, Ddi)]

--- a/fw/core/ddi/mbor/types/src/reopen_session.rs
+++ b/fw/core/ddi/mbor/types/src/reopen_session.rs
@@ -14,7 +14,7 @@ pub struct DdiReopenSessionReq<'a> {
     #[ddi(id = 2)]
     pub pub_key: DdiPublicKey<'a>,
     #[ddi(id = 3, max_len = 1024)]
-    pub bmk_session: &'a DmaBuf,
+    pub bmk_session: &'a mut DmaBuf,
 }
 
 #[derive(Debug, Ddi)]

--- a/fw/core/ddi/mbor/types/src/rsa_mod_exp.rs
+++ b/fw/core/ddi/mbor/types/src/rsa_mod_exp.rs
@@ -11,7 +11,7 @@ pub struct DdiRsaModExpReq<'a> {
     #[ddi(id = 1)]
     pub key_id: u16,
     #[ddi(id = 2, max_len = 512)]
-    pub y: &'a DmaBuf,
+    pub y: &'a mut DmaBuf,
     #[ddi(id = 3)]
     pub op_type: DdiRsaOpType,
 }

--- a/fw/core/ddi/mbor/types/src/rsa_unwrap.rs
+++ b/fw/core/ddi/mbor/types/src/rsa_unwrap.rs
@@ -11,7 +11,7 @@ pub struct DdiRsaUnwrapReq<'a> {
     #[ddi(id = 1)]
     pub key_id: u16,
     #[ddi(id = 2, max_len = 3072)]
-    pub wrapped_blob: &'a DmaBuf,
+    pub wrapped_blob: &'a mut DmaBuf,
     #[ddi(id = 3)]
     pub wrapped_blob_key_class: DdiKeyClass,
     #[ddi(id = 4)]

--- a/fw/core/ddi/mbor/types/src/set_sealed_bk3.rs
+++ b/fw/core/ddi/mbor/types/src/set_sealed_bk3.rs
@@ -9,7 +9,7 @@ use crate::*;
 #[ddi(map)]
 pub struct DdiSetSealedBk3Req<'a> {
     #[ddi(id = 1, max_len = 1024)]
-    pub sealed_bk3: &'a DmaBuf,
+    pub sealed_bk3: &'a mut DmaBuf,
 }
 
 #[derive(Debug, Ddi)]

--- a/fw/core/ddi/mbor/types/src/sha_digest.rs
+++ b/fw/core/ddi/mbor/types/src/sha_digest.rs
@@ -11,7 +11,7 @@ pub struct DdiShaDigestReq<'a> {
     #[ddi(id = 1)]
     pub sha_mode: DdiHashAlgorithm,
     #[ddi(id = 2, max_len = 1024)]
-    pub msg: &'a DmaBuf,
+    pub msg: &'a mut DmaBuf,
 }
 
 #[derive(Debug, Ddi)]

--- a/fw/core/ddi/mbor/types/src/unmask_key.rs
+++ b/fw/core/ddi/mbor/types/src/unmask_key.rs
@@ -9,7 +9,7 @@ use crate::*;
 #[ddi(map)]
 pub struct DdiUnmaskKeyReq<'a> {
     #[ddi(id = 1, max_len = 3072)]
-    pub masked_key: &'a DmaBuf,
+    pub masked_key: &'a mut DmaBuf,
 }
 
 #[derive(Debug, Ddi)]

--- a/fw/core/lib/src/ddi/mbor/establish_credential.rs
+++ b/fw/core/lib/src/ddi/mbor/establish_credential.rs
@@ -1,0 +1,628 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! DDI EstablishCredential command handler.
+//!
+//! Authenticates the host's encrypted credential using an ECDH-derived
+//! key, stores the decrypted user ID and PIN, then provisions the
+//! partition with a masking key (MK) and returns a BMK envelope for
+//! later recovery.
+
+use core::ops::Deref;
+
+use azihsm_fw_core_crypto_masked_key::mask_cbc;
+use azihsm_fw_core_crypto_masked_key::unmask_cbc_in_place;
+use azihsm_fw_core_crypto_masked_key::MASKING_KEY_AES_CBC_256_HMAC_384_LEN;
+use azihsm_fw_ddi_mbor_types::establish_credential::DdiEstablishCredentialReq;
+use azihsm_fw_ddi_mbor_types::establish_credential::DdiEstablishCredentialResp;
+use azihsm_fw_ddi_mbor_types::masked_key::DdiMaskedKeyMetadata;
+use azihsm_fw_ddi_mbor_types::open_session::DdiEncryptedEstablishCredential;
+use azihsm_fw_ddi_mbor_types::DdiKeyType;
+
+use super::*;
+
+// ── Field sizes ──────────────────────────────────────────────────────
+
+/// Credential field length (user ID or PIN), one AES block.
+const CRED_FIELD_LEN: usize = 16;
+
+/// AES key length (low half of HKDF OKM).
+const AES_KEY_LEN: usize = 32;
+
+/// BK3 plaintext length in bytes — matches `BK3_LEN` in
+/// [`init_bk3`](super::init_bk3).
+const BK3_LEN: usize = 48;
+
+/// Partition `BK` and `MK` length: 80 bytes = 32-byte AES-256 key
+/// ‖ 48-byte HMAC-SHA-384 key.  Identical to the HKDF-Expand OKM
+/// length used for the credential keys.
+const BK_LEN: usize = MASKING_KEY_AES_CBC_256_HMAC_384_LEN;
+
+// ── Labels and metadata ──────────────────────────────────────────────
+
+/// KBKDF label for the BK3 session key derivation.
+const SESSION_BK3_LABEL: &[u8] = b"SESSION_BK3";
+
+/// KBKDF label prefix for the partition `BK` derivation.  The full
+/// label is `PARTITION_BK_LABEL ‖ body.pota_pub_key.raw`.
+const PARTITION_BK_LABEL: &[u8] = b"PARTITION_BK";
+
+/// Cleartext label embedded in the BMK metadata identifying the
+/// wrapped key as the partition masking key (MK).
+const MK_KEY_LABEL: &[u8] = b"MK";
+
+/// PKCS#11-style vault attributes recorded on the partition `MK`.
+///
+/// `MK` is the per-partition masking key used to envelope subordinate
+/// vault keys.  It is created (or imported) here and persisted via
+/// [`HsmPart::part_set_mk_key_id`].  It never leaves the device.
+///
+/// The `local` bit is intentionally cleared even on the
+/// generate-fresh path so the same blob round-trips through the
+/// reimport-from-BMK path bit-identically.
+const MK_VAULT_ATTRS: HsmVaultKeyAttrs = HsmVaultKeyAttrs::new()
+    .with_internal(true)
+    .with_never_extractable(true)
+    .with_encrypt(true)
+    .with_decrypt(true);
+
+/// Handle `DdiEstablishCredentialCmd`.
+///
+/// Implements protocol steps 1-13 (step 12 — optional unwrapping key
+/// import — is rejected up-front with `UnsupportedCmd` until the
+/// underlying vault primitives land).
+///
+/// All partition state mutations are batched into the final
+/// atomic-commit block; any failure in steps 8-13 leaves partition
+/// state untouched apart from the nonce refresh in step 6 (which is
+/// required even on failure to prevent replay of the authenticated
+/// request).
+pub(crate) async fn establish_credential<'p, P: HsmPal>(
+    pal: &'p P,
+    io: &impl HsmIo,
+    decoder: &mut DdiDecoder<'_>,
+    hdr: &DdiReqHdr,
+) -> HsmResult<&'p DmaBuf> {
+    let mut body: DdiEstablishCredentialReq = decoder.decode_data()?;
+
+    let _lock = pal.partition_lock(io).await?;
+
+    check_fail_fast(pal, io, &body)?;
+
+    // ── Step 2: POTA signature verification ──────────────────────────
+    verify_pota_signature(pal, io, body.pota_pub_key.raw, body.pota_sig).await?;
+
+    // ── Steps 3-4: ECDH + HKDF → 80-byte OKM (aes_key ‖ hmac_key) ────
+    let okm = pal.dma_alloc(io, BK_LEN)?;
+    derive_credential_keys(
+        pal,
+        io,
+        body.pub_key.raw,
+        body.encrypted_credential.nonce,
+        okm,
+    )
+    .await?;
+    let (aes_key, hmac_key) = okm.split_at(AES_KEY_LEN);
+
+    // ── Step 5: HMAC verify the credential ───────────────────────────
+    //
+    // The partition lock acquired above serializes all state-modifying
+    // handlers on this partition, and the initial fail-fast above ran
+    // under the same lock, so no further nonce or credential-set
+    // re-check is needed here.
+    verify_credential_hmac(pal, io, &body.encrypted_credential, hmac_key).await?;
+
+    // ── Step 6: Reset nonce, then AES-CBC decrypt id and pin ─────────
+    //
+    // Reset the partition nonce *before* decrypting / committing the
+    // credential so the nonce that authenticated this request cannot
+    // be replayed if a later step fails partway through.
+    pal.part_nonce_refresh(io)?;
+    decrypt_credential(pal, io, &mut body.encrypted_credential, aes_key).await?;
+
+    // Fail-fast on null id or pin before doing the rest of the
+    // provisioning work.  `part_set_credential` (called at the final
+    // commit) also rejects null credentials; this early check
+    // preserves the historical error ordering and avoids wasting
+    // BK3 / MK / BMK derivation effort on requests we know will be
+    // rejected.
+    let id: &[u8] = body.encrypted_credential.encrypted_id.deref();
+    let pin: &[u8] = body.encrypted_credential.encrypted_pin.deref();
+    if id == [0u8; CRED_FIELD_LEN] || pin == [0u8; CRED_FIELD_LEN] {
+        return Err(HsmError::InvalidAppCredentials);
+    }
+
+    // Credential commit (`part_set_credential` / `part_clear_establish_cred_key`)
+    // and BK3 session commit (`part_set_bk3_session`) are intentionally
+    // deferred to the final atomic-commit block at the end of this
+    // handler.  Deferring lets a failure in steps 8-13 (e.g. tampered
+    // `masked_bk3`) leave the partition in its pre-call state — apart
+    // from the refreshed nonce — so the host can retry without re-
+    // running `InitBk3` or losing access to the establish-cred
+    // encryption key.
+
+    // ── Step 8: Unmask BK3 ───────────────────────────────────────────
+    let bk3 = pal.dma_alloc(io, BK3_LEN)?;
+    unmask_partition_bk3(pal, io, body.masked_bk3, bk3).await?;
+
+    // ── Step 9: Derive BK3 session key ───────────────────────────────
+    let bk3_session = pal.dma_alloc(io, BK3_LEN)?;
+    derive_bk3_session(pal, io, bk3, bk3_session).await?;
+    // Note: `part_set_bk3_session` is deferred to the final atomic
+    // commit below so a failure in steps 10-13 leaves the partition's
+    // `bk3_session_set` flag unchanged.
+
+    // ── Step 10: Derive partition BK ─────────────────────────────────
+    let svn = pal.part_svn(io)?;
+    let bks2_id = pal.part_bks2_id(io)?;
+    let bk = pal.dma_alloc(io, BK_LEN)?;
+    derive_partition_bk(pal, io, bk3, body.pota_pub_key.raw, svn, bks2_id, bk).await?;
+
+    // ── Step 11: Provision the partition masking key (MK) ────────────
+    //
+    // TODO(svn-rotation): for cross-SVN/BKS lineage compatibility,
+    // the recovery path should parse the cleartext metadata embedded
+    // in `body.bmk` to retrieve the BMK's `svn`/`bks2_index` and
+    // derive its `bk` with those selectors, instead of reusing the
+    // `bk` derived from the current selectors in step 10.  Emu has a
+    // single lineage so this is a no-op today.
+    let mk_guard = provision_mk(pal, io, body.bmk, bk).await?;
+    let mk_key_id = mk_guard.key_id();
+
+    // ── Step 13: Envelope MK into BMK and emit the response ──────────
+    let resp = encode_bmk_response(pal, io, hdr, bk, mk_key_id, svn, bks2_id).await?;
+
+    // ── Atomic commit ────────────────────────────────────────────────
+    //
+    // All partition-state mutations are batched here so that any
+    // failure in steps 8-13 (e.g. tampered `masked_bk3`, derivation
+    // failure, response encode failure) leaves the partition in its
+    // pre-call state — apart from the nonce refresh in step 6, which
+    // is required even on failure to prevent replay of the original
+    // request.
+    //
+    // Under the partition lock, every call below is effectively
+    // infallible:
+    // - `part_set_credential` validates length and non-zero id/pin;
+    //   both are pre-checked above so this cannot fail here.
+    // - `part_set_bk3_session` validates length (48 B); `bk3_session`
+    //   is allocated with `BK3_LEN = 48`.
+    // - `part_clear_establish_cred_key` and `part_set_mk_key_id` only
+    //   fail if the partition is disabled, which is prevented by the
+    //   partition-enabled check at the start of `handle_io`.
+    //
+    // `part_set_credential` is committed first so a (theoretical)
+    // failure here triggers `mk_guard`'s Drop, which removes the
+    // provisional MK vault entry. The establish-cred encryption key
+    // is cleared only after the credential commit succeeds, so the
+    // host can always retry on failure.
+    pal.part_set_credential(io, id, pin)?;
+    pal.part_set_bk3_session(io, bk3_session)?;
+    pal.part_clear_establish_cred_key(io)?;
+    pal.part_set_mk_key_id(io, mk_key_id)?;
+    mk_guard.dismiss();
+
+    Ok(resp)
+}
+
+/// Performs all fail-fast checks before any cryptographic work.
+///
+/// Must be called under the partition lock so the partition-state
+/// checks (nonce, credential-set, provisioned) stay consistent with
+/// the atomic-commit gates at the end of the handler.
+///
+/// Errors are returned in the protocol-preferred order:
+/// - `NonceMismatch` — request's authenticated nonce no longer
+///   matches the partition's current nonce.
+/// - `VaultAppLimitReached` — user credential is already set.
+/// - `PartitionAlreadyProvisioned` — partition already has a
+///   masking key.
+/// - `InvalidKeyType` — `pub_key` / `pota_pub_key` are not P-384.
+/// - `InvalidArg` — raw key / signature lengths don't match P-384
+///   (`pub_key.raw`, `pota_pub_key.raw`, `pota_sig`).  The MBOR
+///   decoder already bounds `masked_bk3` / `bmk` to `max_len = 1024`
+///   per the type definition, so no separate upper-bound check is
+///   needed for those.
+/// - `UnsupportedCmd` — optional unwrapping-key import was requested
+///   (not yet implemented; TODO: step 12).
+fn check_fail_fast<P: HsmPal>(
+    pal: &P,
+    io: &impl HsmIo,
+    body: &DdiEstablishCredentialReq<'_>,
+) -> HsmResult<()> {
+    pal.part_verify_nonce(io, body.encrypted_credential.nonce)?;
+
+    if pal.part_is_credential_set(io)? {
+        return Err(HsmError::VaultAppLimitReached);
+    }
+    if pal.part_is_provisioned(io)? {
+        return Err(HsmError::PartitionAlreadyProvisioned);
+    }
+
+    if body.pub_key.key_kind != DdiKeyType::Ecc384Public
+        || body.pota_pub_key.key_kind != DdiKeyType::Ecc384Public
+    {
+        return Err(HsmError::InvalidKeyType);
+    }
+
+    let p384_pub_key_len = HsmEccCurve::P384.pub_key_len();
+    if body.pub_key.raw.len() != p384_pub_key_len
+        || body.pota_pub_key.raw.len() != p384_pub_key_len
+        || body.pota_sig.len() != HsmEccCurve::P384.sig_len()
+    {
+        return Err(HsmError::InvalidArg);
+    }
+
+    if !body.masked_unwrapping_key.is_empty() {
+        return Err(HsmError::UnsupportedCmd);
+    }
+
+    Ok(())
+}
+
+/// Verifies the POTA signature over the partition identity public key.
+///
+/// The signature is computed by the host over
+/// `SHA-384( 0x04 ‖ x ‖ y )`, the SEC1-uncompressed form of the
+/// partition identity P-384 public key (big-endian).  We materialize
+/// the same 97-byte form locally and verify the supplied signature
+/// against it.
+async fn verify_pota_signature<P: HsmPal>(
+    pal: &P,
+    io: &impl HsmIo,
+    signer_pub_key_raw: &DmaBuf,
+    signature_raw: &DmaBuf,
+) -> HsmResult<()> {
+    // `part_id_pub_key` returns the raw `x ‖ y` form (96 B); prepend
+    // the SEC1 `0x04` uncompressed-point tag in a fresh DMA buffer.
+    let id_pub_key_len = pal.part_id_pub_key(io, None)?;
+    let id_uncompressed = pal.dma_alloc(io, id_pub_key_len + 1)?;
+    id_uncompressed[0] = 0x04;
+    pal.part_id_pub_key(io, Some(&mut id_uncompressed[1..]))?;
+
+    let digest = pal.dma_alloc(io, HsmHashAlgo::Sha384.digest_len())?;
+    pal.hash(io, HsmHashAlgo::Sha384, id_uncompressed, digest, true)
+        .await?;
+
+    if !pal
+        .ecc_verify(
+            io,
+            HsmEccCurve::P384,
+            signer_pub_key_raw,
+            digest,
+            signature_raw,
+        )
+        .await?
+    {
+        return Err(HsmError::EccVerifyFailed);
+    }
+    Ok(())
+}
+
+/// Derives the AES-256 ‖ HMAC-SHA-384 OKM used to authenticate and
+/// decrypt the credential payload, writing the result into `okm_out`.
+///
+/// Performs ECDH-P384 between the device's `EstablishCred` private key
+/// (held in the vault) and the host's ephemeral public key, then
+/// HKDF-SHA-384 with empty salt and `info = nonce` to produce the
+/// 80-byte OKM.  The caller splits the OKM into a 32-byte AES key
+/// (low half) and a 48-byte HMAC key (high half).
+///
+/// `okm_out` must be exactly [`BK_LEN`] (80) bytes.
+async fn derive_credential_keys<P: HsmPal>(
+    pal: &P,
+    io: &impl HsmIo,
+    host_eph_pub_key_raw: &DmaBuf,
+    nonce: &DmaBuf,
+    okm_out: &mut DmaBuf,
+) -> HsmResult<()> {
+    let est_cred_key_id = pal
+        .part_establish_cred_key_id(io)?
+        .ok_or(HsmError::KeyNotFound)?;
+
+    let secret = pal.dma_alloc(io, HsmEccCurve::P384.secret_len())?;
+    {
+        let priv_key = pal.vault_key(io, est_cred_key_id)?;
+        pal.ecdh_derive(
+            io,
+            HsmEccCurve::P384,
+            priv_key,
+            host_eph_pub_key_raw,
+            secret,
+        )
+        .await?;
+    }
+
+    // HKDF-Extract with empty salt (RFC 5869 §2.2).  `split_at_mut(0)`
+    // yields a zero-length DmaBuf for the salt argument.
+    let prk_area = pal.dma_alloc(io, HsmHashAlgo::Sha384.digest_len())?;
+    let (empty_salt, prk) = prk_area.split_at_mut(0);
+    pal.hkdf_extract(io, HsmHashAlgo::Sha384, empty_salt, secret, prk)
+        .await?;
+
+    pal.hkdf_expand(io, HsmHashAlgo::Sha384, prk, nonce, okm_out)
+        .await
+}
+
+/// HMAC-SHA-384 verifies the encrypted credential's tag over
+/// `enc_id ‖ enc_pin ‖ iv ‖ nonce`.
+///
+/// `hmac_key` must be at least 48 bytes (the HMAC-SHA-384 key).
+async fn verify_credential_hmac<P: HsmPal>(
+    pal: &P,
+    io: &impl HsmIo,
+    enc_cred: &DdiEncryptedEstablishCredential<'_>,
+    hmac_key: &DmaBuf,
+) -> HsmResult<()> {
+    let id_len = enc_cred.encrypted_id.len();
+    let pin_len = enc_cred.encrypted_pin.len();
+    let iv_len = enc_cred.iv.len();
+    let nonce_len = enc_cred.nonce.len();
+
+    let hmac_input = pal.dma_alloc(io, id_len + pin_len + iv_len + nonce_len)?;
+    let (id_dst, rest) = hmac_input.split_at_mut(id_len);
+    let (pin_dst, rest) = rest.split_at_mut(pin_len);
+    let (iv_dst, nonce_dst) = rest.split_at_mut(iv_len);
+    id_dst.copy_from_slice(enc_cred.encrypted_id);
+    pin_dst.copy_from_slice(enc_cred.encrypted_pin);
+    iv_dst.copy_from_slice(enc_cred.iv);
+    nonce_dst.copy_from_slice(enc_cred.nonce);
+
+    if !pal
+        .hmac_verify(io, HsmHashAlgo::Sha384, hmac_key, hmac_input, enc_cred.tag)
+        .await?
+    {
+        return Err(HsmError::PinDecryptionFailed);
+    }
+    Ok(())
+}
+
+/// AES-CBC-256 decrypts the host-supplied `enc_id` and `enc_pin`
+/// **in place** inside the request buffer.
+///
+/// The host (`crates/cred_encrypt`) encrypts id and pin with a single
+/// mutable AES-CBC stream under `iv = enc_cred.iv`:
+///
+/// - Block 1 ciphertext = `enc_id` = `AES_E(aes_key, id XOR iv)`
+/// - Block 2 ciphertext = `enc_pin` = `AES_E(aes_key, pin XOR enc_id)`
+///
+/// Decrypting block 2 needs `enc_id`'s **ciphertext** as the chaining
+/// IV.  We use the AES engine's `iv_out` parameter to snapshot that
+/// ciphertext into a fresh 16-byte DMA buffer *before* in-place
+/// decryption overwrites `enc_id` with its plaintext, then feed the
+/// snapshot back as `iv_in` for the second call.  Both 16-byte fields
+/// end up overwritten with their respective plaintexts inside the
+/// request buffer — no scratch buffer for ciphertext is needed.
+async fn decrypt_credential<P: HsmPal>(
+    pal: &P,
+    io: &impl HsmIo,
+    enc_cred: &mut DdiEncryptedEstablishCredential<'_>,
+    aes_key: &DmaBuf,
+) -> HsmResult<()> {
+    let iv_chain = pal.dma_alloc(io, enc_cred.iv.len())?;
+
+    // Block 1: AES-CBC decrypt `enc_id` in place, snapshotting the
+    // original ciphertext into `iv_chain` for use as the next IV.
+    pal.aes_cbc_enc_dec_in_place(
+        io,
+        AesOp::Decrypt,
+        aes_key,
+        enc_cred.encrypted_id,
+        enc_cred.iv,
+        Some(iv_chain),
+    )
+    .await?;
+
+    // Block 2: AES-CBC decrypt `enc_pin` in place with `iv_chain`.
+    pal.aes_cbc_enc_dec_in_place(
+        io,
+        AesOp::Decrypt,
+        aes_key,
+        enc_cred.encrypted_pin,
+        iv_chain,
+        None,
+    )
+    .await
+}
+
+/// Unmasks the partition `BK3` blob in place using `BK_BOOT` and
+/// writes the 48-byte recovered plaintext into `bk3_out`.
+///
+/// `masked_bk3` is the envelope produced by a prior `InitBk3` call:
+/// BK3 plaintext sealed under the partition's `BK_BOOT` (an 80-byte
+/// AES-CBC-256 + HMAC-SHA-384 masking key).
+///
+/// `unmask_cbc_in_place` decrypts the ciphertext slot inside the
+/// blob in place, so this helper takes the blob as `&mut DmaBuf` and
+/// the caller passes `body.masked_bk3` (whose decoded byte-slice
+/// field is mutable — see the MBOR mut-decoder refactor) directly.
+/// No staging allocation or input copy is needed.  After unmask, the
+/// 48-byte BK3 plaintext is copied out to `bk3_out` so the caller
+/// can hold it for the remaining handler steps.
+///
+/// `bk3_out` must be exactly [`BK3_LEN`] (48) bytes.
+async fn unmask_partition_bk3<P: HsmPal>(
+    pal: &P,
+    io: &impl HsmIo,
+    masked_bk3: &mut DmaBuf,
+    bk3_out: &mut DmaBuf,
+) -> HsmResult<()> {
+    let bk_boot_len = pal.part_bk_boot(io, None)?;
+    let bk_boot = pal.dma_alloc(io, bk_boot_len)?;
+    pal.part_bk_boot(io, Some(bk_boot))?;
+
+    let layout = unmask_cbc_in_place(pal, io, bk_boot, masked_bk3).await?;
+    if layout.plaintext_max_len < BK3_LEN {
+        return Err(HsmError::MaskedKeyDecodeFailed);
+    }
+    bk3_out
+        .copy_from_slice(&masked_bk3[layout.plaintext_offset..layout.plaintext_offset + BK3_LEN]);
+    Ok(())
+}
+
+/// Derives the 48-byte BK3 session key into `bk3_session_out`.
+///
+/// SP 800-108 KBKDF with HMAC-SHA-384 keyed on `bk3`,
+/// `label = "SESSION_BK3"`, empty `context`, 48-byte output.
+///
+/// `bk3_session_out` must be exactly [`BK3_LEN`] (48) bytes.
+async fn derive_bk3_session<P: HsmPal>(
+    pal: &P,
+    io: &impl HsmIo,
+    bk3: &DmaBuf,
+    bk3_session_out: &mut DmaBuf,
+) -> HsmResult<()> {
+    let session_label = pal.dma_alloc(io, SESSION_BK3_LABEL.len())?;
+    session_label.copy_from_slice(SESSION_BK3_LABEL);
+
+    // Empty 0-length `&DmaBuf` for `context` — borrowed off `bk3` to
+    // avoid a separate DMA allocation just for an empty buffer.
+    let (empty_context, _) = bk3.split_at(0);
+
+    pal.sp800_108_kdf(
+        io,
+        HsmHashAlgo::Sha384,
+        bk3,
+        session_label,
+        empty_context,
+        bk3_session_out,
+    )
+    .await
+}
+
+/// Derives the 80-byte partition `BK` into `bk_out`.
+///
+/// SP 800-108 KBKDF-HMAC-SHA-384 keyed on `bk3` with
+/// `label = "PARTITION_BK" ‖ signer_pub_key` and
+/// `context = BKS1 ‖ BKS2` (contributed by the PAL via
+/// [`HsmPart::derive_masking_key`]).
+///
+/// [`HsmPart::derive_masking_key`] takes `label: &[u8]` (not
+/// `&DmaBuf`), so the label is built on the stack — no DMA alloc
+/// needed for it.
+///
+/// `signer_pub_key` must be exactly 96 bytes (P-384 raw `x ‖ y`).
+/// `bk_out` must be exactly [`BK_LEN`] (80) bytes.
+async fn derive_partition_bk<P: HsmPal>(
+    pal: &P,
+    io: &impl HsmIo,
+    bk3: &DmaBuf,
+    signer_pub_key: &DmaBuf,
+    svn: u64,
+    bks2_id: u16,
+    bk_out: &mut DmaBuf,
+) -> HsmResult<()> {
+    let mut bk_label = [0u8; PARTITION_BK_LABEL.len() + 96];
+    bk_label[..PARTITION_BK_LABEL.len()].copy_from_slice(PARTITION_BK_LABEL);
+    bk_label[PARTITION_BK_LABEL.len()..].copy_from_slice(signer_pub_key);
+
+    pal.derive_masking_key(io, bk3, &bk_label, &[], svn, bks2_id, bk_out)
+        .await
+}
+
+/// Provisions the partition masking key (MK) in the vault.
+///
+/// - **Empty `bmk`**: first ever EstablishCredential on this
+///   partition.  Generate a fresh 80-byte MK from the on-device
+///   CSPRNG and land it in the vault.
+/// - **Non-empty `bmk`**: host is replaying a previously recorded
+///   BMK after a reset.  Recover MK by authenticated AES-CBC unmask
+///   under `bk` (the partition `BK` from step 10), performed in
+///   place inside the request buffer — the caller passes
+///   `body.bmk` (whose decoded byte-slice field is mutable — see
+///   the MBOR mut-decoder refactor) directly.  No staging
+///   allocation or input copy is needed; `vault_key_create` copies
+///   the recovered MK plaintext into vault storage.
+///
+/// Both paths land MK in the vault via [`HsmVault::vault_key_create`]
+/// and return an RAII guard so any subsequent failure rolls the
+/// provisional entry back.
+async fn provision_mk<'p, P: HsmPal>(
+    pal: &'p P,
+    io: &impl HsmIo,
+    bmk: &mut DmaBuf,
+    bk: &DmaBuf,
+) -> HsmResult<<P as HsmVault>::KeyGuard<'p>> {
+    if bmk.is_empty() {
+        let mk_buf = pal.dma_alloc(io, BK_LEN)?;
+        pal.rng_fill_bytes(io, mk_buf)?;
+        return pal.vault_key_create(
+            io,
+            mk_buf,
+            HsmVaultKeyKind::MaskingKey,
+            None,
+            MK_VAULT_ATTRS,
+            &[],
+        );
+    }
+
+    let layout = unmask_cbc_in_place(pal, io, bk, bmk).await?;
+    if layout.plaintext_max_len < BK_LEN {
+        return Err(HsmError::MaskedKeyDecodeFailed);
+    }
+    let mk_pt = &bmk[layout.plaintext_offset..layout.plaintext_offset + BK_LEN];
+    pal.vault_key_create(
+        io,
+        mk_pt,
+        HsmVaultKeyKind::MaskingKey,
+        None,
+        MK_VAULT_ATTRS,
+        &[],
+    )
+}
+
+/// Envelopes the vault-resident `MK` (referenced by `mk_key_id`) under
+/// `bk`, reserves the response frame, and writes the BMK envelope into
+/// it.  Returns the response buffer.
+///
+/// On-wire metadata layout (binds the import path's expectations):
+///
+/// - `key_attributes` — zero blob.  The on-wire metadata advertises
+///   **no** PKCS#11 attributes; the import path re-applies
+///   [`MK_VAULT_ATTRS`] when bringing MK back into the vault.
+/// - `bks2_index = Some(bks2_id)` — current selector; identifies
+///   which BKS2 row anchors `bk`.
+/// - `key_label = b"MK"` — fixed role tag.
+/// - `key_length = BK_LEN` — plaintext length before AES-CBC pad.
+async fn encode_bmk_response<'p, P: HsmPal>(
+    pal: &'p P,
+    io: &impl HsmIo,
+    hdr: &DdiReqHdr,
+    bk: &DmaBuf,
+    mk_key_id: HsmKeyId,
+    svn: u64,
+    bks2_id: u16,
+) -> HsmResult<&'p DmaBuf> {
+    let bmk_metadata = DdiMaskedKeyMetadata {
+        svn,
+        key_type: DdiKeyType::AesCbc256Hmac384,
+        key_attributes: HsmVaultKeyAttrs::new().into(),
+        bks2_index: Some(bks2_id),
+        rsvd: None,
+        key_label: MK_KEY_LABEL,
+        key_length: BK_LEN as u16,
+    };
+
+    // Borrow MK from the vault so `mask_cbc` reads it through a
+    // `&DmaBuf` view rather than retaining the original input buffer.
+    let mk_dma = pal.vault_key(io, mk_key_id)?;
+
+    // Size-query the BMK envelope length (no crypto performed).
+    let bmk_len = mask_cbc(pal, io, bk, mk_dma, &bmk_metadata, None).await?;
+
+    // Reserve the response buffer (encoder-frame-then-fill pattern).
+    let (resp, layout) = pal.dma_alloc_var_with(io, |buf| {
+        let mut encoder =
+            super::encode_resp_hdr(&super::success_hdr(hdr, DdiOp::EstablishCredential), buf)?;
+        let layout = DdiEstablishCredentialResp::reserve(&mut encoder, bmk_len)?;
+        Ok((encoder.position(), layout))
+    })?;
+    let frame = DdiEstablishCredentialResp::from_layout(resp, &layout);
+
+    // `mask_cbc` requires `out[..total_len]` to be zero on entry; the
+    // MBOR `reserve_offset` path advances the cursor without clearing
+    // the reserved data region, so explicitly zero it here.
+    frame.bmk.fill(0);
+    mask_cbc(pal, io, bk, mk_dma, &bmk_metadata, Some(frame.bmk)).await?;
+    Ok(resp)
+}

--- a/fw/core/lib/src/ddi/mbor/establish_credential.rs
+++ b/fw/core/lib/src/ddi/mbor/establish_credential.rs
@@ -26,9 +26,6 @@ use super::*;
 /// Credential field length (user ID or PIN), one AES block.
 const CRED_FIELD_LEN: usize = 16;
 
-/// AES key length (low half of HKDF OKM).
-const AES_KEY_LEN: usize = 32;
-
 /// BK3 plaintext length in bytes — matches `BK3_LEN` in
 /// [`init_bk3`](super::init_bk3).
 const BK3_LEN: usize = 48;
@@ -102,7 +99,9 @@ pub(crate) async fn establish_credential<'p, P: HsmPal>(
         okm,
     )
     .await?;
-    let (aes_key, hmac_key) = okm.split_at(AES_KEY_LEN);
+    // HMAC-SHA-384 key length matches the digest length; AES key is
+    // the leading remainder of the 80-byte OKM.
+    let (aes_key, hmac_key) = okm.split_at(okm.len() - HsmHashAlgo::Sha384.digest_len());
 
     // ── Step 5: HMAC verify the credential ───────────────────────────
     //

--- a/fw/core/lib/src/ddi/mbor/get_api_rev.rs
+++ b/fw/core/lib/src/ddi/mbor/get_api_rev.rs
@@ -38,8 +38,8 @@ pub(crate) fn get_api_rev<'p, P: HsmPal>(
     let _body: DdiGetApiRevReq = decoder.decode_data()?;
 
     let resp_data = DdiGetApiRevResp {
-        min: DdiApiRev { major: 1, minor: 0 },
-        max: DdiApiRev { major: 1, minor: 0 },
+        min: super::DDI_API_REV_MIN,
+        max: super::DDI_API_REV_MAX,
     };
 
     let resp = pal.dma_alloc_var(io, |buf| {

--- a/fw/core/lib/src/ddi/mbor/mod.rs
+++ b/fw/core/lib/src/ddi/mbor/mod.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+pub(crate) mod establish_credential;
 pub(crate) mod get_api_rev;
 pub(crate) mod get_cert_chain_info;
 pub(crate) mod get_certificate;
@@ -16,6 +17,7 @@ use azihsm_fw_ddi_mbor_api::DdiDecoder;
 use azihsm_fw_ddi_mbor_api::DdiEncoder;
 use azihsm_fw_ddi_mbor_types::error::DdiErrResp;
 use azihsm_fw_ddi_mbor_types::*;
+pub(crate) use establish_credential::*;
 pub(crate) use get_api_rev::*;
 pub(crate) use get_cert_chain_info::*;
 pub(crate) use get_certificate::*;
@@ -27,6 +29,33 @@ pub(crate) use set_sealed_bk3::*;
 pub(crate) use sha_digest::*;
 
 use super::*;
+
+/// Minimum DDI API revision accepted by this firmware.
+pub(crate) const DDI_API_REV_MIN: DdiApiRev = DdiApiRev { major: 1, minor: 0 };
+
+/// Maximum DDI API revision accepted by this firmware.
+pub(crate) const DDI_API_REV_MAX: DdiApiRev = DdiApiRev { major: 1, minor: 0 };
+
+/// Central DDI API revision check.
+///
+/// All commands except [`DdiOp::GetApiRev`] must carry `hdr.rev` set to a
+/// supported revision. `GetApiRev` is the bootstrap command — the host
+/// does not yet know the supported revision, so its `hdr.rev` must be
+/// `None` (enforced inside its handler).
+///
+/// Returns [`HsmError::UnsupportedRevision`] if `hdr.rev` is missing or
+/// outside the supported range.
+#[inline]
+fn check_api_rev(hdr: &DdiReqHdr) -> HsmResult<()> {
+    if hdr.op == DdiOp::GetApiRev {
+        return Ok(());
+    }
+    let rev = hdr.rev.ok_or(HsmError::UnsupportedRevision)?;
+    if rev < DDI_API_REV_MIN || rev > DDI_API_REV_MAX {
+        return Err(HsmError::UnsupportedRevision);
+    }
+    Ok(())
+}
 
 /// Dispatch a DDI command to its handler.
 ///
@@ -42,6 +71,8 @@ pub(crate) async fn dispatch<'p, P: HsmPal>(
     decoder: &mut DdiDecoder<'_>,
     hdr: &DdiReqHdr,
 ) -> HsmResult<&'p DmaBuf> {
+    check_api_rev(hdr)?;
+
     match hdr.op {
         DdiOp::GetApiRev => get_api_rev(pal, io, decoder, hdr),
         DdiOp::GetDeviceInfo => get_device_info(pal, io, decoder, hdr),
@@ -54,6 +85,7 @@ pub(crate) async fn dispatch<'p, P: HsmPal>(
         DdiOp::GetSealedBk3 => get_sealed_bk3(pal, io, decoder, hdr),
         DdiOp::SetSealedBk3 => set_sealed_bk3(pal, io, decoder, hdr),
         DdiOp::InitBk3 => init_bk3(pal, io, decoder, hdr).await,
+        DdiOp::EstablishCredential => establish_credential(pal, io, decoder, hdr).await,
         _ => Err(HsmError::UnsupportedCmd),
     }
 }

--- a/fw/core/lib/src/io.rs
+++ b/fw/core/lib/src/io.rs
@@ -155,7 +155,7 @@ impl<P: HsmPal> Hsm<P> {
 
         // ── Phase 2: decode + validate + dispatch (no yield) ───────
         let (resp, session_ctrl) = {
-            let req = &req_buf[..params.src_len];
+            let req = &mut req_buf[..params.src_len];
             let mut decoder = DdiDecoder::new(req);
             let hdr: DdiReqHdr = decoder.decode_hdr().op_err(
                 "core",

--- a/fw/core/lib/src/op.rs
+++ b/fw/core/lib/src/op.rs
@@ -595,6 +595,7 @@ impl SessionCtrl {
             | DdiOp::GetSealedBk3
             | DdiOp::InitBk3
             | DdiOp::SetSealedBk3
+            | DdiOp::EstablishCredential
             | DdiOp::ShaDigest => Self::NoSession,
             DdiOp::OpenSession => Self::Open,
             DdiOp::CloseSession => Self::Close,

--- a/fw/pal/traits/src/crypto/ecc.rs
+++ b/fw/pal/traits/src/crypto/ecc.rs
@@ -184,10 +184,17 @@ pub trait HsmEcc {
     /// - `curve` — NIST curve the public key is on; determines the
     ///   expected signature length.
     /// - `pub_key` — verification key; uncompressed `x || y`,
-    ///   `curve.pub_key_len()` bytes.
-    /// - `hash` — message digest that was signed.
+    ///   `curve.pub_key_len()` bytes.  **Each coordinate is in
+    ///   little-endian byte order** — matches the on-wire DDI
+    ///   representation and real PKA hardware.  Implementations that
+    ///   delegate to a big-endian-native primitive (e.g. OpenSSL) must
+    ///   reverse each coordinate internally.
+    /// - `hash` — message digest that was signed.  Raw digest bytes;
+    ///   no endianness conversion is applied.
     /// - `signature` — signature to verify; must be exactly
-    ///   `curve.sig_len()` bytes.
+    ///   `curve.sig_len()` bytes (`r || s`).  **Each component is in
+    ///   little-endian byte order** — matches the on-wire DDI
+    ///   representation and real PKA hardware.
     ///
     /// # Returns
     ///
@@ -215,7 +222,11 @@ pub trait HsmEcc {
     /// - `priv_key` — local private scalar; must be exactly
     ///   `curve.priv_key_len()` bytes.
     /// - `pub_key` — remote uncompressed point; must be exactly
-    ///   `curve.pub_key_len()` bytes.
+    ///   `curve.pub_key_len()` bytes (`x || y`).  **Each coordinate
+    ///   is in little-endian byte order** — matches the on-wire DDI
+    ///   representation and real PKA hardware.  Implementations that
+    ///   delegate to a big-endian-native primitive (e.g. OpenSSL) must
+    ///   reverse each coordinate internally.
     /// - `secret` — output buffer; must be at least
     ///   `curve.secret_len()` bytes.  On success, holds the
     ///   x-coordinate of the shared point.

--- a/fw/pal/traits/src/part.rs
+++ b/fw/pal/traits/src/part.rs
@@ -728,6 +728,87 @@ pub trait HsmPartitionManager {
         bks2_index: u16,
         output: &mut DmaBuf,
     ) -> HsmResult<()>;
+
+    // ------------------------------------------------------------------
+    // Establish-credential and provisioning state
+    // ------------------------------------------------------------------
+
+    /// Verifies that the provided nonce matches the partition's current
+    /// nonce.
+    ///
+    /// Returns `Ok(())` if the nonces match, or
+    /// `Err(HsmError::NonceMismatch)` if they differ.  The check is
+    /// constant-time where supported by the platform.
+    ///
+    /// # Parameters
+    ///
+    /// - `io` — caller's I/O context.
+    /// - `nonce` — 32-byte nonce to compare against the partition's
+    ///   stored nonce.
+    fn part_verify_nonce(&self, io: &impl HsmIo, nonce: &[u8]) -> HsmResult<()>;
+
+    /// Stores the user credential (ID and PIN) for the partition.
+    ///
+    /// Write-once per credential lifecycle: if credentials are already
+    /// set, returns [`HsmError::VaultAppLimitReached`] (matching the
+    /// `verify_cred_is_not_set` behavior in real firmware).  The PAL is
+    /// responsible for storing the credential securely and clearing it
+    /// on partition disable/deprovision.
+    ///
+    /// Both `id` and `pin` are exactly 16 bytes (AES block size).  An
+    /// all-zero `id` or `pin` is rejected with
+    /// [`HsmError::InvalidAppCredentials`], matching the reference
+    /// firmware's `cred_mgr::change_user_cred` invariant.  The all-zero
+    /// value is also the sentinel that `part_is_credential_set` uses
+    /// for "unset", so accepting it would corrupt the lifecycle.
+    ///
+    /// # Parameters
+    ///
+    /// - `io` — caller's I/O context.
+    /// - `id` — 16-byte user credential identifier (non-zero).
+    /// - `pin` — 16-byte user credential PIN (non-zero).
+    fn part_set_credential(&self, io: &impl HsmIo, id: &[u8], pin: &[u8]) -> HsmResult<()>;
+
+    /// Returns whether the partition's user credential is already set.
+    fn part_is_credential_set(&self, io: &impl HsmIo) -> HsmResult<bool>;
+
+    /// Returns whether the partition has been fully provisioned.
+    ///
+    /// A partition is provisioned when it has a masking key (MK)
+    /// imported into its vault.  This flag is the gate that
+    /// `EstablishCredential` uses to prevent double-provisioning.
+    fn part_is_provisioned(&self, io: &impl HsmIo) -> HsmResult<bool>;
+
+    /// Stores the BK3 session key (48 bytes) for the partition.
+    ///
+    /// The BK3 session key is derived from BK3 via SP 800-108 KDF
+    /// during `EstablishCredential` and used for subsequent session
+    /// operations.
+    ///
+    /// # Parameters
+    ///
+    /// - `io` — caller's I/O context.
+    /// - `data` — 48-byte BK3 session key.
+    fn part_set_bk3_session(&self, io: &impl HsmIo, data: &[u8]) -> HsmResult<()>;
+
+    /// Returns the vault key ID of the partition's masking key (MK),
+    /// or `None` if no MK has been imported.
+    fn part_mk_key_id(&self, io: &impl HsmIo) -> HsmResult<Option<HsmKeyId>>;
+
+    /// Stores the vault key ID of the partition's masking key (MK).
+    ///
+    /// Set once during `EstablishCredential` provisioning.  After this
+    /// call, [`part_is_provisioned`](Self::part_is_provisioned) returns
+    /// `true` and [`part_mk_key_id`](Self::part_mk_key_id) returns the
+    /// stored ID.
+    fn part_set_mk_key_id(&self, io: &impl HsmIo, key_id: HsmKeyId) -> HsmResult<()>;
+
+    /// Returns the vault key ID of the partition's unwrapping key, or
+    /// `None` if no unwrapping key has been imported.
+    fn part_unwrapping_key_id(&self, io: &impl HsmIo) -> HsmResult<Option<HsmKeyId>>;
+
+    /// Stores the vault key ID of the partition's unwrapping key.
+    fn part_set_unwrapping_key_id(&self, io: &impl HsmIo, key_id: HsmKeyId) -> HsmResult<()>;
 }
 
 /// Length of the per-partition `BK_BOOT` boot-key material in bytes.

--- a/fw/plat/std/pal/src/buf_pool.rs
+++ b/fw/plat/std/pal/src/buf_pool.rs
@@ -136,11 +136,39 @@ impl BufferPool {
 
     /// Free a buffer slot back to the pool.
     ///
-    /// Sets the slot's bit in the free bitmap and wakes any task
-    /// suspended in [`alloc`](Self::alloc).  Watermarks for the slot
-    /// are *not* reset here; they will be reset on the next
+    /// Zeroes the regions of the slot's NonDma and Dma buffers that
+    /// this IO actually touched (using the bump watermarks as
+    /// high-water marks) before clearing the free bit.  This
+    /// preserves the invariant that every fresh `dma_alloc` /
+    /// `nondma_alloc` returns zeroed memory, which is required by
+    /// zero-on-entry contracts (e.g. `mask_cbc`'s `out[..total_len]
+    /// must be zero on entry`) and prevents stale crypto material
+    /// from outliving an IO.  Watermarks are then reset on the next
     /// [`alloc`](Self::alloc).
+    ///
+    /// Sets the slot's bit in the free bitmap and wakes any task
+    /// suspended in [`alloc`](Self::alloc).
+    ///
+    /// # Safety
+    ///
+    /// Callers must guarantee that no outstanding `&mut [u8]` views
+    /// into this slot's buffers exist — i.e. `free` is invoked only
+    /// after the owning IO's handler has returned and its [`HsmIo`]
+    /// has been consumed.  This is the same exclusivity discipline
+    /// the bump allocator relies on; the Embassy executor is
+    /// single-threaded, so once the handler returns no aliasing
+    /// borrow can outlive it.
     pub fn free(&self, idx: u16) {
+        let i = idx as usize;
+        let nondma_hi = self.nondma_marks[i].get().min(NONDMA_BUF_SIZE);
+        let dma_hi = self.dma_marks[i].get().min(DMA_BUF_SIZE);
+        // SAFETY: no outstanding borrows — see method-level Safety.
+        unsafe {
+            let nondma = &mut *self.nondma_bufs[i].get();
+            nondma[..nondma_hi].fill(0);
+            let dma = &mut *self.dma_bufs[i].get();
+            dma[..dma_hi].fill(0);
+        }
         self.free_mask.set(self.free_mask.get() | (1u64 << idx));
         self.waker.borrow_mut().wake();
     }

--- a/fw/plat/std/pal/src/ecc.rs
+++ b/fw/plat/std/pal/src/ecc.rs
@@ -105,29 +105,98 @@ impl HsmEcc for StdHsmPal {
     }
 
     /// Raw EC verify a signature over a pre-computed hash digest.
+    ///
+    /// Per the [`HsmEcc::ecc_verify`] trait contract, `pub_key` is the
+    /// raw uncompressed point `x || y` with **each coordinate in
+    /// little-endian** byte order, and `signature` is `r || s` with
+    /// each component in little-endian.  OpenSSL is big-endian-native
+    /// for elliptic-curve scalars, so we reverse each component before
+    /// constructing the verification inputs.
     async fn ecc_verify(
         &self,
         _io: &impl HsmIo,
-        _curve: HsmEccCurve,
+        curve: HsmEccCurve,
         pub_key: &DmaBuf,
         hash: &DmaBuf,
         signature: &DmaBuf,
     ) -> HsmResult<bool> {
-        let key = EccPublicKey::from_bytes(pub_key).map_err(|_| HsmError::InvalidArg)?;
-        self.ecc.ecc_verify(&key, hash, signature).await
+        let coord_len = curve.priv_key_len();
+        let pub_key_len = curve.pub_key_len();
+        let sig_len = curve.sig_len();
+
+        if pub_key.len() < pub_key_len || signature.len() < sig_len {
+            return Err(HsmError::InvalidArg);
+        }
+
+        // Reverse each coord from wire-LE to OpenSSL-BE.
+        let (x_le, y_le) = pub_key[..pub_key_len].split_at(coord_len);
+        let mut x_be = [0u8; 66];
+        let mut y_be = [0u8; 66];
+        for (dst, src) in x_be[..coord_len].iter_mut().zip(x_le.iter().rev()) {
+            *dst = *src;
+        }
+        for (dst, src) in y_be[..coord_len].iter_mut().zip(y_le.iter().rev()) {
+            *dst = *src;
+        }
+
+        let key = EccPublicKey::from_coordinates(
+            to_ecc_curve(curve),
+            &x_be[..coord_len],
+            &y_be[..coord_len],
+        )
+        .map_err(|_| HsmError::InvalidArg)?;
+
+        // Reverse each sig half from wire-LE to OpenSSL-BE.
+        let (r_le, s_le) = signature[..sig_len].split_at(coord_len);
+        let mut sig_be = [0u8; 132];
+        for (dst, src) in sig_be[..coord_len].iter_mut().zip(r_le.iter().rev()) {
+            *dst = *src;
+        }
+        for (dst, src) in sig_be[coord_len..sig_len].iter_mut().zip(s_le.iter().rev()) {
+            *dst = *src;
+        }
+
+        self.ecc.ecc_verify(&key, hash, &sig_be[..sig_len]).await
     }
 
     /// ECDH key agreement — derives a shared secret.
+    ///
+    /// Per the [`HsmEcc::ecdh_derive`] trait contract, `pub_key` is the
+    /// raw uncompressed point `x || y` with **each coordinate in
+    /// little-endian** byte order.  We reverse each coordinate before
+    /// handing to OpenSSL.
     async fn ecdh_derive(
         &self,
         _io: &impl HsmIo,
-        _curve: HsmEccCurve,
+        curve: HsmEccCurve,
         priv_key: &DmaBuf,
         pub_key: &DmaBuf,
         secret: &mut DmaBuf,
     ) -> HsmResult<()> {
+        let coord_len = curve.priv_key_len();
+        let pub_key_len = curve.pub_key_len();
+        if pub_key.len() < pub_key_len {
+            return Err(HsmError::InvalidArg);
+        }
+
         let pk = EccPrivateKey::from_bytes(priv_key).map_err(|_| HsmError::InvalidArg)?;
-        let pubk = EccPublicKey::from_bytes(pub_key).map_err(|_| HsmError::InvalidArg)?;
-        self.ecc.ecdh_derive(&pk, &pubk, secret).await
+
+        let (x_le, y_le) = pub_key[..pub_key_len].split_at(coord_len);
+        let mut x_be = [0u8; 66];
+        let mut y_be = [0u8; 66];
+        for (dst, src) in x_be[..coord_len].iter_mut().zip(x_le.iter().rev()) {
+            *dst = *src;
+        }
+        for (dst, src) in y_be[..coord_len].iter_mut().zip(y_le.iter().rev()) {
+            *dst = *src;
+        }
+        let pubk = EccPublicKey::from_coordinates(
+            to_ecc_curve(curve),
+            &x_be[..coord_len],
+            &y_be[..coord_len],
+        )
+        .map_err(|_| HsmError::InvalidArg)?;
+
+        self.ecc.ecdh_derive(&pk, &pubk, &mut secret[..]).await
     }
 }

--- a/fw/plat/std/pal/src/part.rs
+++ b/fw/plat/std/pal/src/part.rs
@@ -262,6 +262,29 @@ pub(crate) struct PartitionEntry {
     /// `part_mark_bk3_initialized`.  Acts as the authoritative
     /// one-shot gate for `InitBk3`.
     bk3_initialized: bool,
+
+    /// User credential ID (16 bytes).  Zeroed until set by
+    /// `part_set_credential`.
+    credential_id: [u8; 16],
+
+    /// User credential PIN (16 bytes).  Zeroed until set by
+    /// `part_set_credential`.
+    credential_pin: [u8; 16],
+
+    /// Whether the user credential has been set for this incarnation.
+    credential_set: bool,
+
+    /// BK3 session key (48 bytes), derived during EstablishCredential.
+    bk3_session: [u8; 48],
+
+    /// Whether `bk3_session` has been populated.
+    bk3_session_set: bool,
+
+    /// Vault key ID of the partition masking key (MK).
+    mk_key_id: Option<HsmKeyId>,
+
+    /// Vault key ID of the partition unwrapping key.
+    unwrapping_key_id: Option<HsmKeyId>,
 }
 
 impl Default for PartitionEntry {
@@ -289,6 +312,13 @@ impl Default for PartitionEntry {
             masked_bk_boot_len: 0,
             vm_launch_guid: [0u8; VM_LAUNCH_GUID_LEN],
             bk3_initialized: false,
+            credential_id: [0u8; 16],
+            credential_pin: [0u8; 16],
+            credential_set: false,
+            bk3_session: [0u8; 48],
+            bk3_session_set: false,
+            mk_key_id: None,
+            unwrapping_key_id: None,
         }
     }
 }
@@ -435,12 +465,16 @@ impl HsmPartitionManager for StdHsmPal {
         io: &impl HsmIo,
         out: Option<&mut [u8]>,
     ) -> HsmResult<usize> {
-        copy_out(
-            &self
-                .enabled_part(u8::from(io.pid()))?
-                .establish_cred_pub_key,
-            out,
-        )
+        // Stored internally as big-endian `x ∥ y` (OpenSSL convention).
+        // The wire contract — matching real PKA hardware — is
+        // little-endian, and the host-side `post_decode_fn` on
+        // `DdiDerPublicKey` reverses each coord back to big-endian
+        // before DER-encoding.  Reverse each coord here so the wire
+        // bytes are LE.
+        let raw = &self
+            .enabled_part(u8::from(io.pid()))?
+            .establish_cred_pub_key;
+        copy_out_pub_key_le(raw, out)
     }
 
     fn part_session_enc_key_id(&self, io: &impl HsmIo) -> HsmResult<HsmKeyId> {
@@ -612,6 +646,72 @@ impl HsmPartitionManager for StdHsmPal {
         self.sp800_108_kdf(io, HsmHashAlgo::Sha384, key_dma, label_dma, ctx_dma, output)
             .await
     }
+
+    fn part_verify_nonce(&self, io: &impl HsmIo, nonce: &[u8]) -> HsmResult<()> {
+        let part = self.enabled_part(u8::from(io.pid()))?;
+        if part.nonce != nonce {
+            return Err(HsmError::NonceMismatch);
+        }
+        Ok(())
+    }
+
+    fn part_set_credential(&self, io: &impl HsmIo, id: &[u8], pin: &[u8]) -> HsmResult<()> {
+        if id.len() != 16 || pin.len() != 16 {
+            return Err(HsmError::InvalidArg);
+        }
+        let part = self.enabled_part_mut(u8::from(io.pid()))?;
+        if part.credential_set {
+            return Err(HsmError::VaultAppLimitReached);
+        }
+        // Reject all-zero ID or PIN — matches the reference firmware's
+        // `cred_mgr::change_user_cred` invariant and is also what
+        // `verify_user_cred_is_set` uses as the sentinel for "unset".
+        if id == [0u8; 16].as_slice() || pin == [0u8; 16].as_slice() {
+            return Err(HsmError::InvalidAppCredentials);
+        }
+        part.credential_id.copy_from_slice(id);
+        part.credential_pin.copy_from_slice(pin);
+        part.credential_set = true;
+        Ok(())
+    }
+
+    fn part_is_credential_set(&self, io: &impl HsmIo) -> HsmResult<bool> {
+        Ok(self.enabled_part(u8::from(io.pid()))?.credential_set)
+    }
+
+    fn part_is_provisioned(&self, io: &impl HsmIo) -> HsmResult<bool> {
+        Ok(self.enabled_part(u8::from(io.pid()))?.mk_key_id.is_some())
+    }
+
+    fn part_set_bk3_session(&self, io: &impl HsmIo, data: &[u8]) -> HsmResult<()> {
+        if data.len() != 48 {
+            return Err(HsmError::InvalidArg);
+        }
+        let part = self.enabled_part_mut(u8::from(io.pid()))?;
+        part.bk3_session.copy_from_slice(data);
+        part.bk3_session_set = true;
+        Ok(())
+    }
+
+    fn part_mk_key_id(&self, io: &impl HsmIo) -> HsmResult<Option<HsmKeyId>> {
+        Ok(self.enabled_part(u8::from(io.pid()))?.mk_key_id)
+    }
+
+    fn part_set_mk_key_id(&self, io: &impl HsmIo, key_id: HsmKeyId) -> HsmResult<()> {
+        let part = self.enabled_part_mut(u8::from(io.pid()))?;
+        part.mk_key_id = Some(key_id);
+        Ok(())
+    }
+
+    fn part_unwrapping_key_id(&self, io: &impl HsmIo) -> HsmResult<Option<HsmKeyId>> {
+        Ok(self.enabled_part(u8::from(io.pid()))?.unwrapping_key_id)
+    }
+
+    fn part_set_unwrapping_key_id(&self, io: &impl HsmIo, key_id: HsmKeyId) -> HsmResult<()> {
+        let part = self.enabled_part_mut(u8::from(io.pid()))?;
+        part.unwrapping_key_id = Some(key_id);
+        Ok(())
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -701,6 +801,37 @@ fn copy_out(data: &[u8], out: Option<&mut [u8]>) -> HsmResult<usize> {
         buf[..data.len()].copy_from_slice(data);
     }
     Ok(data.len())
+}
+
+/// Copy a raw P-384 public key (`x ∥ y`, big-endian) into `out`,
+/// reversing each coord so the bytes on the wire are little-endian.
+///
+/// This is the byte-order pivot point between the firmware's internal
+/// big-endian representation (matches OpenSSL conventions and is used
+/// by cert generation and other crypto consumers) and the wire contract
+/// expected by the host-side `post_decode_fn` on
+/// [`DdiDerPublicKey`](azihsm_ddi_types::DdiDerPublicKey), which expects
+/// little-endian raw coords (matching real PKA hardware) and reverses
+/// them back to big-endian before DER-encoding.
+///
+/// `data` must be exactly `P384_PUB_KEY_LEN` bytes; returns
+/// [`HsmError::InvalidArg`] when `out` is too small.
+fn copy_out_pub_key_le(data: &[u8; P384_PUB_KEY_LEN], out: Option<&mut [u8]>) -> HsmResult<usize> {
+    if let Some(buf) = out {
+        if buf.len() < P384_PUB_KEY_LEN {
+            return Err(HsmError::InvalidArg);
+        }
+        let half = P384_PUB_KEY_LEN / 2;
+        let (x_be, y_be) = data.split_at(half);
+        let (x_out, y_out) = buf.split_at_mut(half);
+        for (dst, src) in x_out.iter_mut().zip(x_be.iter().rev()) {
+            *dst = *src;
+        }
+        for (dst, src) in y_out[..half].iter_mut().zip(y_be.iter().rev()) {
+            *dst = *src;
+        }
+    }
+    Ok(P384_PUB_KEY_LEN)
 }
 
 // ---------------------------------------------------------------------------
@@ -956,7 +1087,11 @@ impl StdHsmPal {
         pk.to_bytes(Some(&mut priv_buf[..priv_len]))
             .map_err(|_| HsmError::EccToDerError)?;
 
-        // Export raw P-384 public key coordinates (x ∥ y).
+        // Export raw P-384 public key coordinates (x ∥ y) in big-endian
+        // form — matches OpenSSL conventions and is the form expected by
+        // internal consumers (cert generation, POTA hash).  Wire-facing
+        // PAL accessors (e.g. [`part_establish_cred_pub_key`]) handle
+        // BE→LE conversion at the response boundary.
         let half = P384_PUB_KEY_LEN / 2;
         let (x_buf, y_buf) = pub_key_out.split_at_mut(half);
         pubk.coord(Some((x_buf, y_buf)))
@@ -1005,5 +1140,17 @@ impl StdHsmPal {
         entry.masked_bk_boot_len = 0;
         entry.vm_launch_guid.fill(0);
         entry.bk3_initialized = false;
+
+        entry.credential_id.fill(0);
+        entry.credential_pin.fill(0);
+        entry.credential_set = false;
+        entry.bk3_session.fill(0);
+        entry.bk3_session_set = false;
+        if let Some(kid) = entry.mk_key_id.take() {
+            let _ = entry.vault.delete(kid);
+        }
+        if let Some(kid) = entry.unwrapping_key_id.take() {
+            let _ = entry.vault.delete(kid);
+        }
     }
 }


### PR DESCRIPTION
Adds the firmware-side handler for the EstablishCredential DDI command. Authenticates a host-supplied encrypted credential against the device's establish-cred ECC key, stores the decrypted user id and PIN, and provisions the partition with a masking key (MK) plus a BMK envelope returned to the host for recovery.

Implements protocol steps 1-13 with the exception of step 12 (optional unwrapping-key import), which is rejected up-front with UnsupportedCmd until the underlying vault primitives land.

Memory model:
- Two DMA allocations total: one working buffer carved into 4 named persistent slots plus shared scratch, and the response frame (`dma_alloc_var_with`).  Working-buffer scratch length is computed dynamically by `scratch_required` from the actual queried/measured dimensions (BK_BOOT length, masked-blob lengths, P-384 / SHA-384 fixed sizes), not from a hardcoded constant.
- The 80-byte `okm_or_bk` slot is intentionally aliased between two roles: holds the HKDF OKM (aes_key ‖ hmac_key) during steps 4-6, then is overwritten with the partition `BK` during steps 10-13.  Reduces persistent working footprint by 80 B.
- Helpers (`verify_pota_signature`, `derive_credential_keys`, `authenticate_and_decrypt_credential`, `unmask_partition_bk3`, `derive_bk3_session`, `derive_partition_bk`, `provision_mk`, `encode_bmk_response`) do not self-allocate; each takes the output slot(s) and a shared scratch sub-slice from the caller.
- HMAC verification and AES-CBC decryption share `scratch[..32]`: step 5 stages `enc_id ‖ enc_pin ‖ iv ‖ nonce` for HMAC, and step 6's non-in-place AES-CBC reads the leading 32 bytes as ciphertext, decrypting directly into `cred_buf` with no extra copy.

Crypto / protocol notes:
- POTA signature is verified over `SHA-384( 0x04 ‖ x ‖ y )` of the partition identity P-384 public key (SEC1 uncompressed).
- ECDH-P384 + HKDF-SHA-384 with empty salt and `info = nonce` produces the 80-B credential OKM (32-B AES + 48-B HMAC).
- Partition nonce is refreshed *before* AES-CBC decrypt so the authenticated nonce cannot be replayed if a later step fails.
- Null id / null PIN rejection enforced both in `authenticate_and_decrypt_credential` (after AES decrypt) and in the StdPal `part_set_credential` implementation so direct PAL callers also get `InvalidAppCredentials` instead of storing a sentinel.
- Untrusted input lengths (`pub_key.raw`, `pota_pub_key.raw`, `pota_sig`) are validated against `HsmEccCurve::P384` lengths before any DMA splitting so the working-buffer layout cannot panic on slice arithmetic.  `masked_bk3` / `bmk` are already bounded by the MBOR `max_len = 1024` on the request type.

Atomicity:
- All partition state mutations (`part_set_credential`, `part_set_bk3_session`, `part_clear_establish_cred_key`, `part_set_mk_key_id`) are batched into a final atomic-commit block at the end of the handler.  Any failure in steps 8-13 (e.g. tampered `masked_bk3`) leaves the partition in its pre-call state apart from the nonce refresh in step 6, so the host can safely retry without re-running InitBk3.
- The provisional MK vault entry returned by `provision_mk` is held via an RAII `KeyGuard`; `dismiss()` is called only after the final commit succeeds.

Dispatch-layer change:
- Adds a central DDI API revision check at the top of `dispatch`: every op except `GetApiRev` must carry `hdr.rev` set to a supported revision (DDI_API_REV_MIN..=DDI_API_REV_MAX). Returns `UnsupportedRevision` otherwise.

PAL surface:
- 9 new methods on HsmPartitionManager (BK_BOOT access, BK3 session storage, MK key-id, nonce verify/refresh, credential set, etc.).
- ECDH derive + ECC verify added to the ECC PAL trait.
- StdPal implements all new methods.

Tests:
- New integration smoke tests: happy path, null-id rejection, null-pin rejection.
- establish_credential::* integration suite: 34 / 34 pass on mock. Emu has 4 known failures blocked on unrelated upstream handlers (GetSessionEncryptionKey, OpenSession) or pre-existing validation gaps for invalid P-384 points.
- Full smoke suite: 13 / 13 pass on both mock and emu.