### PR TITLE
Fix DRBG-during-init failure in the OpenSSL provider

### DIFF
--- a/plugins/ossl_prov/inc/azihsm_ossl_base.h
+++ b/plugins/ossl_prov/inc/azihsm_ossl_base.h
@@ -121,7 +121,8 @@ typedef struct
                                       * always have a provider to service them. */
     azihsm_handle device;
     azihsm_handle session;
-    bool session_opening; /* re-entry guard for azihsm_ensure_session */
+    bool session_opening;        /* re-entry guard for azihsm_ensure_session */
+    CRYPTO_RWLOCK *session_lock; /* serializes lazy session-open */
     AZIHSM_CONFIG config;
     struct
     {

--- a/plugins/ossl_prov/inc/azihsm_ossl_base.h
+++ b/plugins/ossl_prov/inc/azihsm_ossl_base.h
@@ -121,7 +121,6 @@ typedef struct
                                       * always have a provider to service them. */
     azihsm_handle device;
     azihsm_handle session;
-    bool session_opening;        /* re-entry guard for azihsm_ensure_session */
     CRYPTO_RWLOCK *session_lock; /* serializes lazy session-open */
     AZIHSM_CONFIG config;
     struct

--- a/plugins/ossl_prov/inc/azihsm_ossl_base.h
+++ b/plugins/ossl_prov/inc/azihsm_ossl_base.h
@@ -121,6 +121,7 @@ typedef struct
                                       * always have a provider to service them. */
     azihsm_handle device;
     azihsm_handle session;
+    bool session_opening; /* re-entry guard for azihsm_ensure_session */
     AZIHSM_CONFIG config;
     struct
     {

--- a/plugins/ossl_prov/inc/azihsm_ossl_base.h.in
+++ b/plugins/ossl_prov/inc/azihsm_ossl_base.h.in
@@ -121,7 +121,8 @@ typedef struct
                                       * always have a provider to service them. */
     azihsm_handle device;
     azihsm_handle session;
-    bool session_opening; /* re-entry guard for azihsm_ensure_session */
+    bool session_opening;        /* re-entry guard for azihsm_ensure_session */
+    CRYPTO_RWLOCK *session_lock; /* serializes lazy session-open */
     AZIHSM_CONFIG config;
     struct
     {

--- a/plugins/ossl_prov/inc/azihsm_ossl_base.h.in
+++ b/plugins/ossl_prov/inc/azihsm_ossl_base.h.in
@@ -121,7 +121,6 @@ typedef struct
                                       * always have a provider to service them. */
     azihsm_handle device;
     azihsm_handle session;
-    bool session_opening;        /* re-entry guard for azihsm_ensure_session */
     CRYPTO_RWLOCK *session_lock; /* serializes lazy session-open */
     AZIHSM_CONFIG config;
     struct

--- a/plugins/ossl_prov/inc/azihsm_ossl_base.h.in
+++ b/plugins/ossl_prov/inc/azihsm_ossl_base.h.in
@@ -121,6 +121,7 @@ typedef struct
                                       * always have a provider to service them. */
     azihsm_handle device;
     azihsm_handle session;
+    bool session_opening; /* re-entry guard for azihsm_ensure_session */
     AZIHSM_CONFIG config;
     struct
     {

--- a/plugins/ossl_prov/inc/azihsm_ossl_hsm.h
+++ b/plugins/ossl_prov/inc/azihsm_ossl_hsm.h
@@ -23,6 +23,9 @@ azihsm_status azihsm_open_device_and_session(
     struct azihsm_resiliency_ctx **resiliency_ctx
 );
 
+/* Lazy device+session open. */
+azihsm_status azihsm_ensure_session(AZIHSM_OSSL_PROV_CTX *provctx);
+
 /*
  * Compute POTA endorsement for the current device.
  *

--- a/plugins/ossl_prov/inc/azihsm_ossl_hsm.h
+++ b/plugins/ossl_prov/inc/azihsm_ossl_hsm.h
@@ -23,7 +23,17 @@ azihsm_status azihsm_open_device_and_session(
     struct azihsm_resiliency_ctx **resiliency_ctx
 );
 
-/* Lazy device+session open. */
+/*
+ * Lazy device+session open.
+ *
+ * Ensures the provider context has an open HSM device + session, opening it
+ * on first call. After a successful return the caller may read provctx->session
+ * directly.
+ *
+ * Must NOT be called from the provider's OSSL_FUNC_PROVIDER_QUERY_OPERATION
+ * dispatch hook — see azihsm_ossl_query_operation() for the re-entrancy
+ * rationale.
+ */
 azihsm_status azihsm_ensure_session(AZIHSM_OSSL_PROV_CTX *provctx);
 
 /*

--- a/plugins/ossl_prov/src/azihsm_ossl_base.c
+++ b/plugins/ossl_prov/src/azihsm_ossl_base.c
@@ -293,29 +293,26 @@ static OSSL_STATUS azihsm_ossl_get_params(ossl_unused void *provctx, OSSL_PARAM 
 }
 
 static const OSSL_ALGORITHM *azihsm_ossl_query_operation(
-    void *provctx,
+    ossl_unused void *provctx,
     int operation_id,
     int *no_store
 )
 {
-    AZIHSM_OSSL_PROV_CTX *ctx = provctx;
-
-    /* While the session is being opened, claim no algorithms so the
-     * SDK's libcrypto fetches don't recurse back into our half-loaded
-     * dispatch tables.  no_store keeps libcrypto from caching this
-     * empty view past session-open. */
-    if (ctx != NULL && ctx->session_opening)
-    {
-        *no_store = 1;
-        return NULL;
-    }
-
-    if (azihsm_ensure_session(ctx) != AZIHSM_STATUS_SUCCESS)
-    {
-        return NULL;
-    }
-
-    // Dispatch tables do not change and may be cached
+    /* query_operation is a pure discovery callback.  OpenSSL invokes it from
+     * inside libcrypto initialisation paths — notably EVP_RAND_instantiate,
+     * which fetches its AES cipher provider while the global DRBG is being
+     * brought up.  Any work performed here that calls back into libcrypto
+     * (for example opening the HSM session, which in turn instantiates the
+     * simulator backend and asks libcrypto for random bytes / EC keys) would
+     * re-enter the very initialisation path that is on the stack, deadlock
+     * the OpenSSL Once cell guarding DRBG init, and ultimately poison the
+     * lazy-initialised dispatcher in the mock DDI.  See the integration test
+     * `nginx_tests` and the design note in azihsm_ossl_hsm.c
+     * (azihsm_ensure_session) for the full backtrace.
+     *
+     * The dispatch tables are static, so we always return them
+     * unconditionally and defer azihsm_ensure_session() to each algorithm's
+     * first real entry point (newctx / open / init). */
     *no_store = 0;
     switch (operation_id)
     {
@@ -339,9 +336,9 @@ static const OSSL_ALGORITHM *azihsm_ossl_query_operation(
         return azihsm_ossl_encoders;
     case OSSL_OP_STORE:
         return azihsm_ossl_store;
+    default:
+        return NULL;
     }
-
-    return NULL;
 }
 
 static OSSL_STATUS azihsm_ossl_get_capabilities(

--- a/plugins/ossl_prov/src/azihsm_ossl_base.c
+++ b/plugins/ossl_prov/src/azihsm_ossl_base.c
@@ -240,6 +240,7 @@ static void azihsm_ossl_teardown(AZIHSM_OSSL_PROV_CTX *provctx)
         provctx->unwrapping_key.priv = 0;
     }
     CRYPTO_THREAD_lock_free(provctx->unwrapping_key.lock);
+    CRYPTO_THREAD_lock_free(provctx->session_lock);
 
     /* Destroy resiliency context before closing the device */
     if (provctx->resiliency_ctx != NULL)
@@ -785,6 +786,17 @@ OSSL_STATUS OSSL_provider_init(
         return OSSL_FAILURE;
     }
 
+    ctx->session_lock = CRYPTO_THREAD_lock_new();
+    if (ctx->session_lock == NULL)
+    {
+        ERR_raise(ERR_LIB_PROV, ERR_R_MALLOC_FAILURE);
+        CRYPTO_THREAD_lock_free(ctx->unwrapping_key.lock);
+        OSSL_PROVIDER_unload(ctx->default_provider);
+        OSSL_LIB_CTX_free(ctx->libctx);
+        OPENSSL_free(ctx);
+        return OSSL_FAILURE;
+    }
+
     /* Find get_params_fn from the core dispatch table for config parsing */
     for (in_iter = in; in_iter->function_id != 0; in_iter++)
     {
@@ -798,6 +810,7 @@ OSSL_STATUS OSSL_provider_init(
     /* Parse configuration from openssl.cnf and environment variables */
     if (parse_provider_config(&ctx->config, handle, get_params_fn) != OSSL_SUCCESS)
     {
+        CRYPTO_THREAD_lock_free(ctx->session_lock);
         CRYPTO_THREAD_lock_free(ctx->unwrapping_key.lock);
         OSSL_PROVIDER_unload(ctx->default_provider);
         OSSL_LIB_CTX_free(ctx->libctx);
@@ -819,6 +832,7 @@ OSSL_STATUS OSSL_provider_init(
             AZIHSM_API_REVISION_MAX_MAJOR,
             AZIHSM_API_REVISION_MAX_MINOR
         );
+        CRYPTO_THREAD_lock_free(ctx->session_lock);
         CRYPTO_THREAD_lock_free(ctx->unwrapping_key.lock);
         OSSL_PROVIDER_unload(ctx->default_provider);
         OSSL_LIB_CTX_free(ctx->libctx);
@@ -845,6 +859,7 @@ OSSL_STATUS OSSL_provider_init(
                 "unsafe resiliency storage dir '%s'",
                 dir
             );
+            CRYPTO_THREAD_lock_free(ctx->session_lock);
             CRYPTO_THREAD_lock_free(ctx->unwrapping_key.lock);
             OSSL_PROVIDER_unload(ctx->default_provider);
             OSSL_LIB_CTX_free(ctx->libctx);
@@ -864,6 +879,7 @@ OSSL_STATUS OSSL_provider_init(
                 PROV_R_INVALID_CONFIG_DATA,
                 "Resiliency storage dir path too long"
             );
+            CRYPTO_THREAD_lock_free(ctx->session_lock);
             CRYPTO_THREAD_lock_free(ctx->unwrapping_key.lock);
             OSSL_PROVIDER_unload(ctx->default_provider);
             OSSL_LIB_CTX_free(ctx->libctx);

--- a/plugins/ossl_prov/src/azihsm_ossl_base.c
+++ b/plugins/ossl_prov/src/azihsm_ossl_base.c
@@ -297,7 +297,19 @@ static const OSSL_ALGORITHM *azihsm_ossl_query_operation(
     int *no_store
 )
 {
-    if (azihsm_ensure_session((AZIHSM_OSSL_PROV_CTX *)provctx) != AZIHSM_STATUS_SUCCESS)
+    AZIHSM_OSSL_PROV_CTX *ctx = provctx;
+
+    /* While the session is being opened, claim no algorithms so the
+     * SDK's libcrypto fetches don't recurse back into our half-loaded
+     * dispatch tables.  no_store keeps libcrypto from caching this
+     * empty view past session-open. */
+    if (ctx != NULL && ctx->session_opening)
+    {
+        *no_store = 1;
+        return NULL;
+    }
+
+    if (azihsm_ensure_session(ctx) != AZIHSM_STATUS_SUCCESS)
     {
         return NULL;
     }

--- a/plugins/ossl_prov/src/azihsm_ossl_base.c
+++ b/plugins/ossl_prov/src/azihsm_ossl_base.c
@@ -761,37 +761,27 @@ OSSL_STATUS OSSL_provider_init(
     if (ctx->libctx == NULL)
     {
         ERR_raise(ERR_LIB_PROV, ERR_R_INTERNAL_ERROR);
-        OPENSSL_free(ctx);
-        return OSSL_FAILURE;
+        goto cleanup;
     }
 
     ctx->default_provider = ensure_default_provider();
     if (ctx->default_provider == NULL)
     {
-        OSSL_LIB_CTX_free(ctx->libctx);
-        OPENSSL_free(ctx);
-        return OSSL_FAILURE;
+        goto cleanup;
     }
 
     ctx->unwrapping_key.lock = CRYPTO_THREAD_lock_new();
     if (ctx->unwrapping_key.lock == NULL)
     {
         ERR_raise(ERR_LIB_PROV, ERR_R_MALLOC_FAILURE);
-        OSSL_PROVIDER_unload(ctx->default_provider);
-        OSSL_LIB_CTX_free(ctx->libctx);
-        OPENSSL_free(ctx);
-        return OSSL_FAILURE;
+        goto cleanup;
     }
 
     ctx->session_lock = CRYPTO_THREAD_lock_new();
     if (ctx->session_lock == NULL)
     {
         ERR_raise(ERR_LIB_PROV, ERR_R_MALLOC_FAILURE);
-        CRYPTO_THREAD_lock_free(ctx->unwrapping_key.lock);
-        OSSL_PROVIDER_unload(ctx->default_provider);
-        OSSL_LIB_CTX_free(ctx->libctx);
-        OPENSSL_free(ctx);
-        return OSSL_FAILURE;
+        goto cleanup;
     }
 
     /* Find get_params_fn from the core dispatch table for config parsing */
@@ -807,12 +797,7 @@ OSSL_STATUS OSSL_provider_init(
     /* Parse configuration from openssl.cnf and environment variables */
     if (parse_provider_config(&ctx->config, handle, get_params_fn) != OSSL_SUCCESS)
     {
-        CRYPTO_THREAD_lock_free(ctx->session_lock);
-        CRYPTO_THREAD_lock_free(ctx->unwrapping_key.lock);
-        OSSL_PROVIDER_unload(ctx->default_provider);
-        OSSL_LIB_CTX_free(ctx->libctx);
-        OPENSSL_free(ctx);
-        return OSSL_FAILURE;
+        goto cleanup;
     }
 
     /* Validate API revision is within supported range */
@@ -829,12 +814,7 @@ OSSL_STATUS OSSL_provider_init(
             AZIHSM_API_REVISION_MAX_MAJOR,
             AZIHSM_API_REVISION_MAX_MINOR
         );
-        CRYPTO_THREAD_lock_free(ctx->session_lock);
-        CRYPTO_THREAD_lock_free(ctx->unwrapping_key.lock);
-        OSSL_PROVIDER_unload(ctx->default_provider);
-        OSSL_LIB_CTX_free(ctx->libctx);
-        OPENSSL_free(ctx);
-        return OSSL_FAILURE;
+        goto cleanup;
     }
 
     /* Check if resiliency is enabled via environment variable */
@@ -856,12 +836,7 @@ OSSL_STATUS OSSL_provider_init(
                 "unsafe resiliency storage dir '%s'",
                 dir
             );
-            CRYPTO_THREAD_lock_free(ctx->session_lock);
-            CRYPTO_THREAD_lock_free(ctx->unwrapping_key.lock);
-            OSSL_PROVIDER_unload(ctx->default_provider);
-            OSSL_LIB_CTX_free(ctx->libctx);
-            OPENSSL_free(ctx);
-            return OSSL_FAILURE;
+            goto cleanup;
         }
         int ret = snprintf(
             ctx->config.resiliency_storage_dir,
@@ -876,12 +851,7 @@ OSSL_STATUS OSSL_provider_init(
                 PROV_R_INVALID_CONFIG_DATA,
                 "Resiliency storage dir path too long"
             );
-            CRYPTO_THREAD_lock_free(ctx->session_lock);
-            CRYPTO_THREAD_lock_free(ctx->unwrapping_key.lock);
-            OSSL_PROVIDER_unload(ctx->default_provider);
-            OSSL_LIB_CTX_free(ctx->libctx);
-            OPENSSL_free(ctx);
-            return OSSL_FAILURE;
+            goto cleanup;
         }
     }
 
@@ -891,6 +861,17 @@ OSSL_STATUS OSSL_provider_init(
     *out = azihsm_ossl_base_dispatch;
 
     return OSSL_SUCCESS;
+
+cleanup:
+    CRYPTO_THREAD_lock_free(ctx->session_lock);
+    CRYPTO_THREAD_lock_free(ctx->unwrapping_key.lock);
+    if (ctx->default_provider != NULL)
+    {
+        OSSL_PROVIDER_unload(ctx->default_provider);
+    }
+    OSSL_LIB_CTX_free(ctx->libctx);
+    OPENSSL_free(ctx);
+    return OSSL_FAILURE;
 }
 
 #if OPENSSL_VERSION_MAJOR == 3 && OPENSSL_VERSION_MINOR == 0

--- a/plugins/ossl_prov/src/azihsm_ossl_base.c
+++ b/plugins/ossl_prov/src/azihsm_ossl_base.c
@@ -292,11 +292,16 @@ static OSSL_STATUS azihsm_ossl_get_params(ossl_unused void *provctx, OSSL_PARAM 
 }
 
 static const OSSL_ALGORITHM *azihsm_ossl_query_operation(
-    ossl_unused void *provctx,
+    void *provctx,
     int operation_id,
     int *no_store
 )
 {
+    if (azihsm_ensure_session((AZIHSM_OSSL_PROV_CTX *)provctx) != AZIHSM_STATUS_SUCCESS)
+    {
+        return NULL;
+    }
+
     // Dispatch tables do not change and may be cached
     *no_store = 0;
     switch (operation_id)
@@ -731,7 +736,6 @@ OSSL_STATUS OSSL_provider_init(
 )
 {
     AZIHSM_OSSL_PROV_CTX *ctx;
-    azihsm_status status;
     const OSSL_DISPATCH *in_iter;
     OSSL_FUNC_core_get_params_fn *get_params_fn = NULL;
 
@@ -856,23 +860,7 @@ OSSL_STATUS OSSL_provider_init(
         }
     }
 
-    status = azihsm_open_device_and_session(
-        &ctx->config,
-        &ctx->device,
-        &ctx->session,
-        &ctx->resiliency_ctx
-    );
-
-    if (status != AZIHSM_STATUS_SUCCESS)
-    {
-        ERR_raise(ERR_LIB_PROV, ERR_R_INIT_FAIL);
-
-        CRYPTO_THREAD_lock_free(ctx->unwrapping_key.lock);
-        OSSL_PROVIDER_unload(ctx->default_provider);
-        OSSL_LIB_CTX_free(ctx->libctx);
-        OPENSSL_free(ctx);
-        return OSSL_FAILURE;
-    }
+    /* Open is deferred to azihsm_ensure_session. */
 
     *provctx = ctx;
     *out = azihsm_ossl_base_dispatch;

--- a/plugins/ossl_prov/src/azihsm_ossl_digest.c
+++ b/plugins/ossl_prov/src/azihsm_ossl_digest.c
@@ -54,6 +54,14 @@ static void *azihsm_ossl_digest_newctx_algo(void *provctx, int algo_id, uint32_t
     }
 
     dctx->ctx_handle = 0;
+    /* Lazy HSM session open is deferred from query_operation to here so
+     * libcrypto can finish its own initialisation (e.g. DRBG bootstrap)
+     * without us re-entering it. */
+    if (azihsm_ensure_session(prov_ctx) != AZIHSM_STATUS_SUCCESS)
+    {
+        OPENSSL_free(dctx);
+        return NULL;
+    }
     dctx->session_handle = prov_ctx->session;
     dctx->digest_size = digest_size;
     dctx->algo_id = algo_id;

--- a/plugins/ossl_prov/src/azihsm_ossl_encoder_ec.c
+++ b/plugins/ossl_prov/src/azihsm_ossl_encoder_ec.c
@@ -9,9 +9,9 @@
 #include <openssl/proverr.h>
 
 #include "azihsm_ossl_base.h"
-#include "azihsm_ossl_hsm.h"
 #include "azihsm_ossl_ec.h"
 #include "azihsm_ossl_helpers.h"
+#include "azihsm_ossl_hsm.h"
 
 typedef struct
 {

--- a/plugins/ossl_prov/src/azihsm_ossl_encoder_ec.c
+++ b/plugins/ossl_prov/src/azihsm_ossl_encoder_ec.c
@@ -9,6 +9,7 @@
 #include <openssl/proverr.h>
 
 #include "azihsm_ossl_base.h"
+#include "azihsm_ossl_hsm.h"
 #include "azihsm_ossl_ec.h"
 #include "azihsm_ossl_helpers.h"
 
@@ -45,6 +46,15 @@ static AIHSM_ENCODER_CTX *azihsm_ossl_encoder_newctx(AZIHSM_OSSL_PROV_CTX *provc
 
     if ((ectx = OPENSSL_zalloc(sizeof(AIHSM_ENCODER_CTX))) == NULL)
     {
+        return NULL;
+    }
+
+    /* Lazy HSM session open is deferred from query_operation to here so
+     * libcrypto can finish its own initialisation (e.g. DRBG bootstrap)
+     * without us re-entering it. */
+    if (azihsm_ensure_session(provctx) != AZIHSM_STATUS_SUCCESS)
+    {
+        OPENSSL_free(ectx);
         return NULL;
     }
 

--- a/plugins/ossl_prov/src/azihsm_ossl_encoder_rsa.c
+++ b/plugins/ossl_prov/src/azihsm_ossl_encoder_rsa.c
@@ -9,8 +9,8 @@
 #include <openssl/proverr.h>
 
 #include "azihsm_ossl_base.h"
-#include "azihsm_ossl_hsm.h"
 #include "azihsm_ossl_helpers.h"
+#include "azihsm_ossl_hsm.h"
 #include "azihsm_ossl_rsa.h"
 
 typedef struct

--- a/plugins/ossl_prov/src/azihsm_ossl_encoder_rsa.c
+++ b/plugins/ossl_prov/src/azihsm_ossl_encoder_rsa.c
@@ -9,6 +9,7 @@
 #include <openssl/proverr.h>
 
 #include "azihsm_ossl_base.h"
+#include "azihsm_ossl_hsm.h"
 #include "azihsm_ossl_helpers.h"
 #include "azihsm_ossl_rsa.h"
 
@@ -68,6 +69,15 @@ static AIHSM_ENCODER_CTX *azihsm_ossl_encoder_newctx(AZIHSM_OSSL_PROV_CTX *provc
 
     if ((ectx = OPENSSL_zalloc(sizeof(AIHSM_ENCODER_CTX))) == NULL)
     {
+        return NULL;
+    }
+
+    /* Lazy HSM session open is deferred from query_operation to here so
+     * libcrypto can finish its own initialisation (e.g. DRBG bootstrap)
+     * without us re-entering it. */
+    if (azihsm_ensure_session(provctx) != AZIHSM_STATUS_SUCCESS)
+    {
+        OPENSSL_free(ectx);
         return NULL;
     }
 

--- a/plugins/ossl_prov/src/azihsm_ossl_hsm.c
+++ b/plugins/ossl_prov/src/azihsm_ossl_hsm.c
@@ -1223,6 +1223,35 @@ void azihsm_close_device_and_session(azihsm_handle device, azihsm_handle session
     azihsm_part_close(device);
 }
 
+azihsm_status azihsm_ensure_session(AZIHSM_OSSL_PROV_CTX *provctx)
+{
+    azihsm_status status;
+
+    if (provctx == NULL)
+    {
+        return AZIHSM_STATUS_INVALID_ARGUMENT;
+    }
+    if (provctx->session != 0)
+    {
+        return AZIHSM_STATUS_SUCCESS;
+    }
+    if (provctx->session_opening)
+    {
+        return AZIHSM_STATUS_SUCCESS;
+    }
+
+    provctx->session_opening = true;
+    status = azihsm_open_device_and_session(
+        &provctx->config,
+        &provctx->device,
+        &provctx->session,
+        &provctx->resiliency_ctx
+    );
+    provctx->session_opening = false;
+
+    return status;
+}
+
 /*
  * Wrap a PKCS#8 DER buffer with the HSM's RSA-AES wrapping key, then unwrap
  * into the HSM to produce key handles.

--- a/plugins/ossl_prov/src/azihsm_ossl_hsm.c
+++ b/plugins/ossl_prov/src/azihsm_ossl_hsm.c
@@ -1228,10 +1228,10 @@ void azihsm_close_device_and_session(azihsm_handle device, azihsm_handle session
     }
 }
 
-/* Per-thread re-entry guard: set while this thread is opening the session, so
- * a libcrypto fetch the open triggers on the same thread fails fast instead of
- * recursing into the non-recursive session lock. */
-static __thread bool azihsm_session_opening = false;
+/* The context this thread is currently opening a session for, so a libcrypto
+ * fetch the open triggers re-enters that same context and fails fast instead of
+ * recursing into its non-recursive lock.  Other contexts are unaffected. */
+static __thread AZIHSM_OSSL_PROV_CTX *azihsm_opening_ctx = NULL;
 
 azihsm_status azihsm_ensure_session(AZIHSM_OSSL_PROV_CTX *provctx)
 {
@@ -1242,8 +1242,8 @@ azihsm_status azihsm_ensure_session(AZIHSM_OSSL_PROV_CTX *provctx)
         return AZIHSM_STATUS_INVALID_ARGUMENT;
     }
 
-    /* Re-entrant call on the opening thread: must not touch the session lock. */
-    if (azihsm_session_opening)
+    /* Re-entrant call on the context being opened: must not touch its lock. */
+    if (azihsm_opening_ctx == provctx)
     {
         ERR_raise_data(
             ERR_LIB_PROV,
@@ -1279,7 +1279,8 @@ azihsm_status azihsm_ensure_session(AZIHSM_OSSL_PROV_CTX *provctx)
         return AZIHSM_STATUS_SUCCESS;
     }
 
-    azihsm_session_opening = true;
+    AZIHSM_OSSL_PROV_CTX *prev_opening = azihsm_opening_ctx;
+    azihsm_opening_ctx = provctx;
 
     /* Prime the default libctx's DRBG: the SDK open below draws randomness
      * via bare RAND_bytes, whose lazy DRBG instantiation otherwise fails
@@ -1287,7 +1288,7 @@ azihsm_status azihsm_ensure_session(AZIHSM_OSSL_PROV_CTX *provctx)
     unsigned char primer[1];
     if (RAND_bytes(primer, sizeof(primer)) != 1)
     {
-        azihsm_session_opening = false;
+        azihsm_opening_ctx = prev_opening;
         CRYPTO_THREAD_unlock(provctx->session_lock);
         return AZIHSM_STATUS_INTERNAL_ERROR;
     }
@@ -1299,7 +1300,7 @@ azihsm_status azihsm_ensure_session(AZIHSM_OSSL_PROV_CTX *provctx)
         &provctx->session,
         &provctx->resiliency_ctx
     );
-    azihsm_session_opening = false;
+    azihsm_opening_ctx = prev_opening;
 
     CRYPTO_THREAD_unlock(provctx->session_lock);
 

--- a/plugins/ossl_prov/src/azihsm_ossl_hsm.c
+++ b/plugins/ossl_prov/src/azihsm_ossl_hsm.c
@@ -1218,10 +1218,20 @@ cleanup:
 
 void azihsm_close_device_and_session(azihsm_handle device, azihsm_handle session)
 {
-
-    azihsm_sess_close(session);
-    azihsm_part_close(device);
+    if (session != 0)
+    {
+        azihsm_sess_close(session);
+    }
+    if (device != 0)
+    {
+        azihsm_part_close(device);
+    }
 }
+
+/* Per-thread re-entry guard: set while this thread is opening the session, so
+ * a libcrypto fetch the open triggers on the same thread fails fast instead of
+ * recursing into the non-recursive session lock. */
+static __thread bool azihsm_session_opening = false;
 
 azihsm_status azihsm_ensure_session(AZIHSM_OSSL_PROV_CTX *provctx)
 {
@@ -1232,20 +1242,8 @@ azihsm_status azihsm_ensure_session(AZIHSM_OSSL_PROV_CTX *provctx)
         return AZIHSM_STATUS_INVALID_ARGUMENT;
     }
 
-    /* Fast path: session already open. */
-    if (provctx->session != 0)
-    {
-        return AZIHSM_STATUS_SUCCESS;
-    }
-
-    /* Re-entrancy: a code path reached during the open itself is asking
-     * for the session.  We cannot satisfy it (the handle is still being
-     * produced) and we must not recurse into azihsm_open_device_and_session.
-     * Checked before taking the (non-recursive) session lock, since a
-     * re-entrant call is on the same thread that already holds it and would
-     * otherwise self-deadlock.  Fail loudly so the caller's operation aborts
-     * cleanly instead of silently proceeding with session == 0. */
-    if (provctx->session_opening)
+    /* Re-entrant call on the opening thread: must not touch the session lock. */
+    if (azihsm_session_opening)
     {
         ERR_raise_data(
             ERR_LIB_PROV,
@@ -1254,6 +1252,19 @@ azihsm_status azihsm_ensure_session(AZIHSM_OSSL_PROV_CTX *provctx)
         );
         return AZIHSM_STATUS_INVALID_CONTEXT_STATE;
     }
+
+    /* Fast path: session already open. */
+    if (!CRYPTO_THREAD_read_lock(provctx->session_lock))
+    {
+        ERR_raise_data(ERR_LIB_PROV, ERR_R_INTERNAL_ERROR, "failed to acquire session lock");
+        return AZIHSM_STATUS_INTERNAL_ERROR;
+    }
+    if (provctx->session != 0)
+    {
+        CRYPTO_THREAD_unlock(provctx->session_lock);
+        return AZIHSM_STATUS_SUCCESS;
+    }
+    CRYPTO_THREAD_unlock(provctx->session_lock);
 
     if (!CRYPTO_THREAD_write_lock(provctx->session_lock))
     {
@@ -1268,21 +1279,15 @@ azihsm_status azihsm_ensure_session(AZIHSM_OSSL_PROV_CTX *provctx)
         return AZIHSM_STATUS_SUCCESS;
     }
 
-    /* Set before the open so query_operation's lock-free re-entry guard is
-     * active for every libcrypto fetch the open triggers on this thread. */
-    provctx->session_opening = true;
+    azihsm_session_opening = true;
 
-    /* Pre-instantiate the libctx's primary DRBG.  The SDK open below
-     * eventually triggers a deep RAND_priv_bytes fetch that lazily
-     * instantiates the DRBG on the calling thread; on some hosts
-     * (e.g. nginx's config-validation thread) that lazy path fails.
-     * Doing it here moves the instantiation to a stable shallow
-     * frame, after which subsequent RAND calls reuse the cached
-     * primary. */
+    /* Prime the default libctx's DRBG: the SDK open below draws randomness
+     * via bare RAND_bytes, whose lazy DRBG instantiation otherwise fails
+     * deep in the open on some hosts (e.g. nginx's config thread). */
     unsigned char primer[1];
     if (RAND_bytes(primer, sizeof(primer)) != 1)
     {
-        provctx->session_opening = false;
+        azihsm_session_opening = false;
         CRYPTO_THREAD_unlock(provctx->session_lock);
         return AZIHSM_STATUS_INTERNAL_ERROR;
     }
@@ -1294,7 +1299,7 @@ azihsm_status azihsm_ensure_session(AZIHSM_OSSL_PROV_CTX *provctx)
         &provctx->session,
         &provctx->resiliency_ctx
     );
-    provctx->session_opening = false;
+    azihsm_session_opening = false;
 
     CRYPTO_THREAD_unlock(provctx->session_lock);
 

--- a/plugins/ossl_prov/src/azihsm_ossl_hsm.c
+++ b/plugins/ossl_prov/src/azihsm_ossl_hsm.c
@@ -1238,6 +1238,23 @@ azihsm_status azihsm_ensure_session(AZIHSM_OSSL_PROV_CTX *provctx)
         return AZIHSM_STATUS_SUCCESS;
     }
 
+    /* Re-entrancy: a code path reached during the open itself is asking
+     * for the session.  We cannot satisfy it (the handle is still being
+     * produced) and we must not recurse into azihsm_open_device_and_session.
+     * Checked before taking the (non-recursive) session lock, since a
+     * re-entrant call is on the same thread that already holds it and would
+     * otherwise self-deadlock.  Fail loudly so the caller's operation aborts
+     * cleanly instead of silently proceeding with session == 0. */
+    if (provctx->session_opening)
+    {
+        ERR_raise_data(
+            ERR_LIB_PROV,
+            ERR_R_INTERNAL_ERROR,
+            "azihsm_ensure_session: re-entrant call during HSM session open"
+        );
+        return AZIHSM_STATUS_INVALID_CONTEXT_STATE;
+    }
+
     if (!CRYPTO_THREAD_write_lock(provctx->session_lock))
     {
         ERR_raise_data(ERR_LIB_PROV, ERR_R_INTERNAL_ERROR, "failed to acquire session lock");

--- a/plugins/ossl_prov/src/azihsm_ossl_hsm.c
+++ b/plugins/ossl_prov/src/azihsm_ossl_hsm.c
@@ -1231,15 +1231,28 @@ azihsm_status azihsm_ensure_session(AZIHSM_OSSL_PROV_CTX *provctx)
     {
         return AZIHSM_STATUS_INVALID_ARGUMENT;
     }
+
+    /* Fast path: session already open. */
     if (provctx->session != 0)
     {
         return AZIHSM_STATUS_SUCCESS;
     }
-    if (provctx->session_opening)
+
+    if (!CRYPTO_THREAD_write_lock(provctx->session_lock))
     {
+        ERR_raise_data(ERR_LIB_PROV, ERR_R_INTERNAL_ERROR, "failed to acquire session lock");
+        return AZIHSM_STATUS_INTERNAL_ERROR;
+    }
+
+    /* Another thread opened the session while we waited for the lock. */
+    if (provctx->session != 0)
+    {
+        CRYPTO_THREAD_unlock(provctx->session_lock);
         return AZIHSM_STATUS_SUCCESS;
     }
 
+    /* Set before the open so query_operation's lock-free re-entry guard is
+     * active for every libcrypto fetch the open triggers on this thread. */
     provctx->session_opening = true;
 
     /* Pre-instantiate the libctx's primary DRBG.  The SDK open below
@@ -1253,6 +1266,7 @@ azihsm_status azihsm_ensure_session(AZIHSM_OSSL_PROV_CTX *provctx)
     if (RAND_bytes(primer, sizeof(primer)) != 1)
     {
         provctx->session_opening = false;
+        CRYPTO_THREAD_unlock(provctx->session_lock);
         return AZIHSM_STATUS_INTERNAL_ERROR;
     }
     OPENSSL_cleanse(primer, sizeof(primer));
@@ -1264,6 +1278,8 @@ azihsm_status azihsm_ensure_session(AZIHSM_OSSL_PROV_CTX *provctx)
         &provctx->resiliency_ctx
     );
     provctx->session_opening = false;
+
+    CRYPTO_THREAD_unlock(provctx->session_lock);
 
     return status;
 }

--- a/plugins/ossl_prov/src/azihsm_ossl_hsm.c
+++ b/plugins/ossl_prov/src/azihsm_ossl_hsm.c
@@ -1241,6 +1241,22 @@ azihsm_status azihsm_ensure_session(AZIHSM_OSSL_PROV_CTX *provctx)
     }
 
     provctx->session_opening = true;
+
+    /* Pre-instantiate the libctx's primary DRBG.  The SDK open below
+     * eventually triggers a deep RAND_priv_bytes fetch that lazily
+     * instantiates the DRBG on the calling thread; on some hosts
+     * (e.g. nginx's config-validation thread) that lazy path fails.
+     * Doing it here moves the instantiation to a stable shallow
+     * frame, after which subsequent RAND calls reuse the cached
+     * primary. */
+    unsigned char primer[1];
+    if (RAND_bytes(primer, sizeof(primer)) != 1)
+    {
+        provctx->session_opening = false;
+        return AZIHSM_STATUS_INTERNAL_ERROR;
+    }
+    OPENSSL_cleanse(primer, sizeof(primer));
+
     status = azihsm_open_device_and_session(
         &provctx->config,
         &provctx->device,

--- a/plugins/ossl_prov/src/azihsm_ossl_kdf.c
+++ b/plugins/ossl_prov/src/azihsm_ossl_kdf.c
@@ -11,9 +11,9 @@
 #include <string.h>
 
 #include "azihsm_ossl_base.h"
-#include "azihsm_ossl_hsm.h"
 #include "azihsm_ossl_file_io.h"
 #include "azihsm_ossl_helpers.h"
+#include "azihsm_ossl_hsm.h"
 #include "azihsm_ossl_masked_key.h"
 #include "azihsm_ossl_pkey_param.h"
 

--- a/plugins/ossl_prov/src/azihsm_ossl_kdf.c
+++ b/plugins/ossl_prov/src/azihsm_ossl_kdf.c
@@ -11,6 +11,7 @@
 #include <string.h>
 
 #include "azihsm_ossl_base.h"
+#include "azihsm_ossl_hsm.h"
 #include "azihsm_ossl_file_io.h"
 #include "azihsm_ossl_helpers.h"
 #include "azihsm_ossl_masked_key.h"
@@ -193,6 +194,14 @@ static int load_and_unmask_ikm(AZIHSM_HKDF_CTX *ctx)
 static void *azihsm_ossl_hkdf_newctx(void *provctx)
 {
     AZIHSM_HKDF_CTX *ctx;
+
+    /* Lazy HSM session open is deferred from query_operation to here so
+     * libcrypto can finish its own initialisation (e.g. DRBG bootstrap)
+     * without us re-entering it. */
+    if (azihsm_ensure_session((AZIHSM_OSSL_PROV_CTX *)provctx) != AZIHSM_STATUS_SUCCESS)
+    {
+        return NULL;
+    }
 
     ctx = OPENSSL_zalloc(sizeof(AZIHSM_HKDF_CTX));
     if (ctx == NULL)

--- a/plugins/ossl_prov/src/azihsm_ossl_keyexch.c
+++ b/plugins/ossl_prov/src/azihsm_ossl_keyexch.c
@@ -13,6 +13,7 @@
 #include <string.h>
 
 #include "azihsm_ossl_base.h"
+#include "azihsm_ossl_hsm.h"
 #include "azihsm_ossl_ec.h"
 #include "azihsm_ossl_masked_key.h"
 #include "azihsm_ossl_pkey_param.h"
@@ -159,6 +160,14 @@ cleanup:
 static void *azihsm_ossl_keyexch_newctx(void *provctx)
 {
     AZIHSM_KEYEXCH_CTX *ctx;
+
+    /* Lazy HSM session open is deferred from query_operation to here so
+     * libcrypto can finish its own initialisation (e.g. DRBG bootstrap)
+     * without us re-entering it. */
+    if (azihsm_ensure_session((AZIHSM_OSSL_PROV_CTX *)provctx) != AZIHSM_STATUS_SUCCESS)
+    {
+        return NULL;
+    }
 
     ctx = OPENSSL_zalloc(sizeof(AZIHSM_KEYEXCH_CTX));
     if (ctx == NULL)

--- a/plugins/ossl_prov/src/azihsm_ossl_keyexch.c
+++ b/plugins/ossl_prov/src/azihsm_ossl_keyexch.c
@@ -13,8 +13,8 @@
 #include <string.h>
 
 #include "azihsm_ossl_base.h"
-#include "azihsm_ossl_hsm.h"
 #include "azihsm_ossl_ec.h"
+#include "azihsm_ossl_hsm.h"
 #include "azihsm_ossl_masked_key.h"
 #include "azihsm_ossl_pkey_param.h"
 

--- a/plugins/ossl_prov/src/azihsm_ossl_keymgmt_ec.c
+++ b/plugins/ossl_prov/src/azihsm_ossl_keymgmt_ec.c
@@ -574,6 +574,15 @@ static AIHSM_EC_GEN_CTX *azihsm_ossl_keymgmt_gen_init(
         return NULL;
     }
 
+    /* Lazy HSM session open is deferred from query_operation to here so
+     * libcrypto can finish its own initialisation (e.g. DRBG bootstrap)
+     * without us re-entering it. */
+    if (azihsm_ensure_session(provctx) != AZIHSM_STATUS_SUCCESS)
+    {
+        OPENSSL_free(genctx);
+        return NULL;
+    }
+
     genctx->session = provctx->session;
     genctx->provctx = provctx;
 

--- a/plugins/ossl_prov/src/azihsm_ossl_keymgmt_rsa.c
+++ b/plugins/ossl_prov/src/azihsm_ossl_keymgmt_rsa.c
@@ -558,8 +558,17 @@ static AZIHSM_RSA_GEN_CTX *azihsm_ossl_keymgmt_gen_init_common(
         return NULL;
     }
 
-    genctx->provctx = provctx;
+    /* Lazy HSM session open is deferred from query_operation to here so
+     * libcrypto can finish its own initialisation (e.g. DRBG bootstrap)
+     * without us re-entering it. */
+    if (azihsm_ensure_session(provctx) != AZIHSM_STATUS_SUCCESS)
+    {
+        OPENSSL_free(genctx);
+        return NULL;
+    }
+
     genctx->session = provctx->session;
+    genctx->provctx = provctx;
     genctx->key_type = key_type;
     genctx->pubkey_bits = AIHSM_RSA_PUBKEY_BITS_DEFAULT;
     genctx->key_usage = AIHSM_KEY_USAGE_DEFAULT;

--- a/plugins/ossl_prov/src/azihsm_ossl_mac.c
+++ b/plugins/ossl_prov/src/azihsm_ossl_mac.c
@@ -12,6 +12,7 @@
 #include "azihsm_ossl_base.h"
 #include "azihsm_ossl_file_io.h"
 #include "azihsm_ossl_helpers.h"
+#include "azihsm_ossl_hsm.h"
 #include "azihsm_ossl_pkey_param.h"
 
 /*
@@ -118,6 +119,14 @@ static int load_and_unmask_key(AZIHSM_HMAC_CTX *ctx)
 static void *azihsm_ossl_mac_newctx(void *provctx)
 {
     AZIHSM_HMAC_CTX *ctx;
+
+    /* Lazy HSM session open is deferred from query_operation to here so
+     * libcrypto can finish its own initialisation (e.g. DRBG bootstrap)
+     * without us re-entering it. */
+    if (azihsm_ensure_session((AZIHSM_OSSL_PROV_CTX *)provctx) != AZIHSM_STATUS_SUCCESS)
+    {
+        return NULL;
+    }
 
     ctx = OPENSSL_zalloc(sizeof(AZIHSM_HMAC_CTX));
     if (ctx == NULL)

--- a/plugins/ossl_prov/src/azihsm_ossl_store.c
+++ b/plugins/ossl_prov/src/azihsm_ossl_store.c
@@ -12,6 +12,7 @@
 #include <string.h>
 
 #include "azihsm_ossl_base.h"
+#include "azihsm_ossl_hsm.h"
 #include "azihsm_ossl_ec.h"
 #include "azihsm_ossl_file_io.h"
 #include "azihsm_ossl_pkey_param.h"
@@ -439,6 +440,14 @@ static void *azihsm_store_open(
     AZIHSM_OSSL_PROV_CTX *prov_ctx = (AZIHSM_OSSL_PROV_CTX *)provctx;
 
     if (uri == NULL)
+    {
+        return NULL;
+    }
+
+    /* Lazy HSM session open is deferred from query_operation to here so
+     * libcrypto can finish its own initialisation (e.g. DRBG bootstrap)
+     * without us re-entering it. */
+    if (azihsm_ensure_session(prov_ctx) != AZIHSM_STATUS_SUCCESS)
     {
         return NULL;
     }

--- a/plugins/ossl_prov/src/azihsm_ossl_store.c
+++ b/plugins/ossl_prov/src/azihsm_ossl_store.c
@@ -12,9 +12,9 @@
 #include <string.h>
 
 #include "azihsm_ossl_base.h"
-#include "azihsm_ossl_hsm.h"
 #include "azihsm_ossl_ec.h"
 #include "azihsm_ossl_file_io.h"
+#include "azihsm_ossl_hsm.h"
 #include "azihsm_ossl_pkey_param.h"
 #include "azihsm_ossl_rsa.h"
 #include "azihsm_ossl_store.h"


### PR DESCRIPTION
`OSSL_provider_init` opened the HSM session eagerly, which drew a seed through libcrypto's `RAND_bytes` and instantiated the libctx's primary DRBG before `main()` ran. On hosts carrying Ubuntu's downstream FIPS patch, `openssl(1)`'s `-propquery` handler then refused to bind a property query to the already-instantiated DRBG and exited with `RAND_R_ALREADY_INSTANTIATED`.

This PR defers the session-open to first algorithm use and hardens the lazy-init path.