### PR TITLE
[test] Remove mock-specific resiliency backoff tuning

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -5,12 +5,6 @@
 # file (saved to target/nextest/<profile>/<path>) during the rust.yml workflow.
 
 # profile for running all mock tests
-# Resiliency stress tests are timing-sensitive; reserve the whole runner so
-# they do not run in parallel with any other test or each other.
-[[profile.ci-mock.overrides]]
-filter = "test(resiliency::stress::) or test(_resiliency_stress::)"
-threads-required = "num-cpus"
-
 [profile.ci-mock.junit]
 path = "junit.xml"
 

--- a/api/lib/src/resiliency.rs
+++ b/api/lib/src/resiliency.rs
@@ -352,15 +352,7 @@ pub const MAX_RETRIES: u32 = 5;
 /// Default base delay in milliseconds for exponential backoff.
 /// Each iteration doubles: 400 → 800 → 1600 → 3200 → 6400 ms, plus
 /// random jitter of 0–[`BACKOFF_JITTER_MS`] to avoid thundering-herd retries.
-///
-/// When compiled with `mock` (test builds only) the base is
-/// reduced to 8 ms so that retry tests complete quickly while
-/// still exercising realistic backoff behavior.
-#[cfg(not(feature = "mock"))]
 pub(crate) const BACKOFF_BASE_MS: u64 = 400;
-
-#[cfg(feature = "mock")]
-pub(crate) const BACKOFF_BASE_MS: u64 = 8;
 
 /// Maximum random jitter added to each backoff delay (in milliseconds).
 ///
@@ -368,14 +360,7 @@ pub(crate) const BACKOFF_BASE_MS: u64 = 8;
 /// the exponential delay so that concurrent callers don't all retry at
 /// exactly the same instant.
 ///
-/// When compiled with `mock` (test builds only) jitter is reduced
-/// to 2 ms, preserving the 4:1 base-to-jitter ratio while keeping
-/// tests fast.
-#[cfg(not(feature = "mock"))]
 pub(crate) const BACKOFF_JITTER_MS: u64 = 100;
-
-#[cfg(feature = "mock")]
-pub(crate) const BACKOFF_JITTER_MS: u64 = 2;
 
 /// Applies exponential backoff with jitter and sleeps for the computed
 /// duration.

--- a/api/tests/src/resiliency/stress/tests.rs
+++ b/api/tests/src/resiliency/stress/tests.rs
@@ -57,7 +57,7 @@ const ITERATIONS_PER_WORKER: usize = 500;
 /// `resiliency.rs` under `cfg(feature = "mock")`), and
 /// `SessionNeedsRenegotiation` retries without backoff.
 /// With 4 workers all serializing through `restore_partition`,
-/// recovery completes quickly. 1 second is high enough for
+/// recovery completes quickly. 3 seconds is high enough for
 /// recovery to finish, but low enough that workers encounter
 /// multiple Resets during their run.
 ///
@@ -65,7 +65,7 @@ const ITERATIONS_PER_WORKER: usize = 500;
 /// up to ~5 seconds to complete. The interval must be longer than
 /// that to avoid spurious `IOAbortInProgress` errors.
 #[cfg(feature = "mock")]
-const RESET_INTERVAL_MS: u64 = 1000;
+const RESET_INTERVAL_MS: u64 = 3000;
 #[cfg(not(feature = "mock"))]
 const RESET_INTERVAL_MS: u64 = 7000;
 


### PR DESCRIPTION
Use the standard retry backoff constants for mock builds, increase the resiliency stress reset interval to match the longer timing, and remove the nextest serialization override for those stress tests.