### PR TITLE
Slim CI restructuring: SDK-only rust.yml + provider.yml for OpenSSL integration

### DIFF
--- a/.github/workflows/provider.yml
+++ b/.github/workflows/provider.yml
@@ -1,0 +1,332 @@
+name: Provider (OpenSSL integration)
+
+# This workflow is intentionally NOT triggered by GitHub events (no push /
+# pull_request / merge_group / schedule).  It is designed to be run locally
+# via `act`:
+#
+#   docker pull catthehacker/ubuntu:act-22.04
+#   docker pull catthehacker/ubuntu:act-24.04
+#   act --reuse -W .github/workflows/provider.yml -j openssl-3-0 \
+#     -P ubuntu-22.04=catthehacker/ubuntu:act-22.04 \
+#     -P ubuntu-24.04=catthehacker/ubuntu:act-24.04
+#   # ... same with -j openssl-3-5
+#
+# It is the blueprint for a future nightly GitHub CI run; once trigger
+# conditions are added, the two jobs cover the OpenSSL ABI versions we
+# support and should run unchanged on GitHub-hosted runners.
+#
+# Architectural choice: two separate jobs (not a matrix) with different
+# `runs-on:` containers, so we can switch each job to use the container's
+# system OpenSSL once that version is acceptable for our needs.  For
+# now each job installs a pinned OpenSSL via `xtask custom-openssl` —
+# necessary today because no Ubuntu LTS ships OpenSSL 3.5 as system.
+# The pinned-install layer is bracketed with `# === TEMPORARY ===`
+# markers per job; deleting that block reverts the job to system OpenSSL
+# via `host_openssl::check_openssl`'s well-known prefix scan.
+#
+# Steps that are present specifically so this workflow also runs under
+# `act` (and which are harmless / idempotent no-ops on GitHub-hosted
+# runners) are marked with an "act-compat:" comment.
+
+on:
+  workflow_dispatch:
+
+env:
+  CARGO_TERM_COLOR: always
+  CACHE_KEY_ID: 84f8acac52412db91407ab9f85776987da17d42f
+
+jobs:
+  openssl-3-0:
+    runs-on: ubuntu-22.04
+    # ubuntu-22.04 (jammy) ships system libssl 3.0.2 while we pin custom
+    # OpenSSL to 3.0.13.  apt-installed `nginx` links against system libssl
+    # 3.0.2, then dlopens our provider (built against 3.0.13), and
+    # OSSL_STORE_load() fails on the version skew when loading an azihsm
+    # masked key.  Mark non-blocking until this is resolved (either by
+    # pinning custom to 3.0.2, or moving the job to ubuntu-24.04 whose
+    # system libssl already matches 3.0.13).
+    continue-on-error: true
+    env:
+      OPENSSL_VERSION: "3.0.13"
+      OPENSSL_INSTALL: target/openssl-custom/3.0.13
+      AZIHSM_TEST_OPENSSL_MAJOR_MINOR: "3.0"
+    steps:
+    - uses: actions/checkout@v6
+
+    - name: Install apt packages
+      # act-compat: `xxd` is preinstalled on GitHub-hosted Ubuntu (via the
+      # vim-common base) but absent from the catthehacker/ubuntu:act-* image.
+      # Installing it explicitly is harmless on GitHub (apt-get install on an
+      # already-installed package is a no-op) and required under act for the
+      # wrapped-key CLI tests (testfiles/{ec,rsa}/import_wrapped_key/...).
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y --no-install-recommends \
+          build-essential cmake pkg-config libbsd-dev ca-certificates curl gnupg \
+          xxd
+
+    # act-compat: GitHub-hosted runners come with Rust preinstalled, but
+    # act's catthehacker images don't.  This step is a no-op on GitHub
+    # (where `cargo` is already on PATH) and installs rustup under act.
+    # rust-toolchain.toml then triggers rustup to install the pinned
+    # version on the first cargo invocation.
+    - name: Install Rust (if missing)
+      run: |
+        if ! command -v cargo >/dev/null 2>&1; then
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
+            | sh -s -- -y --default-toolchain none --profile minimal
+          echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
+        fi
+
+    - name: Restore Cargo cache
+      id: cargo-cache
+      uses: actions/cache/restore@v5
+      with:
+        path: |
+          ~/.cargo/bin/
+          ~/.cargo/registry/index/
+          ~/.cargo/registry/cache/
+          ~/.cargo/git/db/
+        key: ${{ runner.os }}-cargo-${{ env.CACHE_KEY_ID }}
+        fail-on-cache-miss: false
+
+    # === TEMPORARY: pinned OpenSSL install ============================
+    # Once Ubuntu ships OpenSSL ${{ env.OPENSSL_VERSION }} as system on
+    # this runner (or a version we accept), delete the three steps in
+    # this block (Cache, Install, Set OPENSSL_DIR).  host_openssl.rs
+    # falls through to the well-known prefix scan and picks up the
+    # container's system OpenSSL automatically.
+
+    - name: Cache custom OpenSSL ${{ env.OPENSSL_VERSION }}
+      id: cache-openssl
+      uses: actions/cache@v5
+      with:
+        path: ${{ env.OPENSSL_INSTALL }}
+        key: openssl-custom-${{ env.OPENSSL_VERSION }}-linux-x64
+
+    - name: Install custom OpenSSL ${{ env.OPENSSL_VERSION }}
+      if: steps.cache-openssl.outputs.cache-hit != 'true'
+      run: cargo xtask custom-openssl --version ${{ env.OPENSSL_VERSION }}
+
+    - name: Set OPENSSL_DIR
+      run: echo "OPENSSL_DIR=${{ github.workspace }}/${{ env.OPENSSL_INSTALL }}" >> "$GITHUB_ENV"
+
+    # === END TEMPORARY ================================================
+
+    - name: Install dev tools
+      if: steps.cargo-cache.outputs.cache-hit != 'true'
+      run: cargo xtask setup
+
+    - name: Build provider stack
+      # Two per-package `cargo build` invocations (matching main's deleted
+      # provider_integration pattern).  The provider has azihsm_api_native
+      # as a build-dependency, and `mock` doesn't propagate across build-dep
+      # edges, so we build api_native with `--features mock` first then the
+      # provider on top.  Output lands in the workspace's default
+      # `target/debug/` — exactly where the integration test harnesses'
+      # default `PROVIDER_PATH` looks.  `cargo xtask build` is NOT used
+      # here because it redirects to `target/xtask/debug/`.
+      run: |
+        cargo build -p azihsm_api_native --features mock
+        cargo build -p azihsm_ossl_provider --features mock
+
+    - name: Generate dev key material
+      env:
+        LD_LIBRARY_PATH: ${{ env.OPENSSL_DIR }}/lib
+      run: |
+        OSSL=$OPENSSL_DIR/bin/openssl
+        # act-compat: clean derived files from any previous provider init.
+        # On GitHub-hosted runners these never exist (fresh VM per run);
+        # `rm -f` on missing files is a no-op.  Under `act --reuse` they
+        # persist between runs and cause MUK/MOBK mismatches against a
+        # freshly-initialised mock simulator.
+        rm -f bmk.bin muk.bin mobk.bin
+        printf '\x70\xFC\xF7\x30\xB8\x76\x42\x38\xB8\x35\x80\x10\xCE\x8A\x3F\x76' > credentials_id.bin
+        printf '\xDB\x3D\xC7\x7F\xC2\x2E\x43\x00\x80\xD4\x1B\x31\xB6\xF0\x48\x00' > credentials_pin.bin
+        $OSSL rand -out obk.bin 48
+        $OSSL ecparam -name secp384r1 -genkey -noout | $OSSL ec -outform DER -out pota_private_key.der 2>/dev/null
+        $OSSL ec -in pota_private_key.der -inform DER -pubout -outform DER -out pota_public_key.der 2>/dev/null
+        chmod 600 credentials_id.bin credentials_pin.bin obk.bin pota_private_key.der pota_public_key.der
+
+    - name: Smoke test provider
+      env:
+        LD_LIBRARY_PATH: ${{ env.OPENSSL_DIR }}/lib:${{ github.workspace }}/target/debug
+        AZIHSM_CREDENTIALS_ID: "70fcf730b8764238b8358010ce8a3f76"
+        AZIHSM_CREDENTIALS_PIN: "db3dc77fc22e430080d41b31b6f04800"
+      run: |
+        $OPENSSL_DIR/bin/openssl genpkey \
+          -provider-path ${{ github.workspace }}/target/debug \
+          -provider default -provider azihsm_provider \
+          -propquery "?provider=azihsm" \
+          -algorithm EC -pkeyopt group:P-384 \
+          -outform DER -out /dev/null -text
+
+    - name: Run CLI integration tests
+      env:
+        AZIHSM_CREDENTIALS_ID: "70fcf730b8764238b8358010ce8a3f76"
+        AZIHSM_CREDENTIALS_PIN: "db3dc77fc22e430080d41b31b6f04800"
+      run: cargo xtask integration-tests --suite cli
+
+    - name: Run C API integration tests
+      env:
+        AZIHSM_CREDENTIALS_ID: "70fcf730b8764238b8358010ce8a3f76"
+        AZIHSM_CREDENTIALS_PIN: "db3dc77fc22e430080d41b31b6f04800"
+      run: cargo xtask integration-tests --suite capi
+
+    - name: Install libazihsm_api_native for NGINX tests
+      run: |
+        sudo cp ${{ github.workspace }}/target/debug/libazihsm_api_native.so /usr/lib/
+        sudo ldconfig
+
+    - name: Install nginx mainline
+      run: |
+        # act-compat: `gpg --dearmor` prompts on /dev/tty when the output
+        # file already exists, which breaks under `act --reuse` (no tty).
+        # On GitHub-hosted runners the file never pre-exists (fresh VM).
+        # `rm -f` on a missing file is a no-op.
+        sudo rm -f /usr/share/keyrings/nginx-archive-keyring.gpg
+        curl -fsSL https://nginx.org/keys/nginx_signing.key \
+          | sudo gpg --dearmor -o /usr/share/keyrings/nginx-archive-keyring.gpg
+        echo "deb [signed-by=/usr/share/keyrings/nginx-archive-keyring.gpg] \
+          https://nginx.org/packages/mainline/ubuntu jammy nginx" \
+          | sudo tee /etc/apt/sources.list.d/nginx.list
+        sudo apt-get update
+        sudo apt-get install -y --no-install-recommends nginx
+
+    - name: NGINX integration tests
+      env:
+        AZIHSM_CREDENTIALS_ID: "70fcf730b8764238b8358010ce8a3f76"
+        AZIHSM_CREDENTIALS_PIN: "db3dc77fc22e430080d41b31b6f04800"
+      run: cargo xtask integration-tests --suite nginx
+
+  openssl-3-5:
+    runs-on: ubuntu-24.04
+    # 3.5 support is still stabilising in the SDK; don't fail the workflow
+    # until tests are reliable in this container.
+    continue-on-error: true
+    env:
+      OPENSSL_VERSION: "3.5.4"
+      OPENSSL_INSTALL: target/openssl-custom/3.5.4
+      AZIHSM_TEST_OPENSSL_MAJOR_MINOR: "3.5"
+    steps:
+    - uses: actions/checkout@v6
+
+    - name: Install apt packages
+      # act-compat: see the openssl-3-0 job above for the `xxd` rationale.
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y --no-install-recommends \
+          build-essential cmake pkg-config libbsd-dev ca-certificates curl gnupg \
+          xxd
+
+    # act-compat: see the openssl-3-0 job above for the Rust-install rationale.
+    - name: Install Rust (if missing)
+      run: |
+        if ! command -v cargo >/dev/null 2>&1; then
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
+            | sh -s -- -y --default-toolchain none --profile minimal
+          echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
+        fi
+
+    - name: Restore Cargo cache
+      id: cargo-cache
+      uses: actions/cache/restore@v5
+      with:
+        path: |
+          ~/.cargo/bin/
+          ~/.cargo/registry/index/
+          ~/.cargo/registry/cache/
+          ~/.cargo/git/db/
+        key: ${{ runner.os }}-cargo-${{ env.CACHE_KEY_ID }}
+        fail-on-cache-miss: false
+
+    # === TEMPORARY: pinned OpenSSL install ============================
+    # Once Ubuntu ships OpenSSL 3.5.x as system on this runner, delete
+    # the three steps in this block (Cache, Install, Set OPENSSL_DIR).
+    # host_openssl.rs falls through to the well-known prefix scan.
+
+    - name: Cache custom OpenSSL ${{ env.OPENSSL_VERSION }}
+      id: cache-openssl
+      uses: actions/cache@v5
+      with:
+        path: ${{ env.OPENSSL_INSTALL }}
+        key: openssl-custom-${{ env.OPENSSL_VERSION }}-linux-x64
+
+    - name: Install custom OpenSSL ${{ env.OPENSSL_VERSION }}
+      if: steps.cache-openssl.outputs.cache-hit != 'true'
+      run: cargo xtask custom-openssl --version ${{ env.OPENSSL_VERSION }}
+
+    - name: Set OPENSSL_DIR
+      run: echo "OPENSSL_DIR=${{ github.workspace }}/${{ env.OPENSSL_INSTALL }}" >> "$GITHUB_ENV"
+
+    # === END TEMPORARY ================================================
+
+    - name: Install dev tools
+      if: steps.cargo-cache.outputs.cache-hit != 'true'
+      run: cargo xtask setup
+
+    - name: Build provider stack
+      # See openssl-3-0 job for the per-package build rationale.
+      run: |
+        cargo build -p azihsm_api_native --features mock
+        cargo build -p azihsm_ossl_provider --features mock
+
+    - name: Generate dev key material
+      env:
+        LD_LIBRARY_PATH: ${{ env.OPENSSL_DIR }}/lib
+      run: |
+        OSSL=$OPENSSL_DIR/bin/openssl
+        # act-compat: see openssl-3-0 job for the rm -f rationale.
+        rm -f bmk.bin muk.bin mobk.bin
+        printf '\x70\xFC\xF7\x30\xB8\x76\x42\x38\xB8\x35\x80\x10\xCE\x8A\x3F\x76' > credentials_id.bin
+        printf '\xDB\x3D\xC7\x7F\xC2\x2E\x43\x00\x80\xD4\x1B\x31\xB6\xF0\x48\x00' > credentials_pin.bin
+        $OSSL rand -out obk.bin 48
+        $OSSL ecparam -name secp384r1 -genkey -noout | $OSSL ec -outform DER -out pota_private_key.der 2>/dev/null
+        $OSSL ec -in pota_private_key.der -inform DER -pubout -outform DER -out pota_public_key.der 2>/dev/null
+        chmod 600 credentials_id.bin credentials_pin.bin obk.bin pota_private_key.der pota_public_key.der
+
+    - name: Smoke test provider
+      env:
+        LD_LIBRARY_PATH: ${{ env.OPENSSL_DIR }}/lib:${{ github.workspace }}/target/debug
+        AZIHSM_CREDENTIALS_ID: "70fcf730b8764238b8358010ce8a3f76"
+        AZIHSM_CREDENTIALS_PIN: "db3dc77fc22e430080d41b31b6f04800"
+      run: |
+        $OPENSSL_DIR/bin/openssl genpkey \
+          -provider-path ${{ github.workspace }}/target/debug \
+          -provider default -provider azihsm_provider \
+          -propquery "?provider=azihsm" \
+          -algorithm EC -pkeyopt group:P-384 \
+          -outform DER -out /dev/null -text
+
+    - name: Run CLI integration tests
+      env:
+        AZIHSM_CREDENTIALS_ID: "70fcf730b8764238b8358010ce8a3f76"
+        AZIHSM_CREDENTIALS_PIN: "db3dc77fc22e430080d41b31b6f04800"
+      run: cargo xtask integration-tests --suite cli
+
+    - name: Run C API integration tests
+      env:
+        AZIHSM_CREDENTIALS_ID: "70fcf730b8764238b8358010ce8a3f76"
+        AZIHSM_CREDENTIALS_PIN: "db3dc77fc22e430080d41b31b6f04800"
+      run: cargo xtask integration-tests --suite capi
+
+    - name: Install libazihsm_api_native for NGINX tests
+      run: |
+        sudo cp ${{ github.workspace }}/target/debug/libazihsm_api_native.so /usr/lib/
+        sudo ldconfig
+
+    - name: Install nginx mainline
+      run: |
+        curl -fsSL https://nginx.org/keys/nginx_signing.key \
+          | sudo gpg --dearmor -o /usr/share/keyrings/nginx-archive-keyring.gpg
+        echo "deb [signed-by=/usr/share/keyrings/nginx-archive-keyring.gpg] \
+          https://nginx.org/packages/mainline/ubuntu noble nginx" \
+          | sudo tee /etc/apt/sources.list.d/nginx.list
+        sudo apt-get update
+        sudo apt-get install -y --no-install-recommends nginx
+
+    - name: NGINX integration tests
+      env:
+        AZIHSM_CREDENTIALS_ID: "70fcf730b8764238b8358010ce8a3f76"
+        AZIHSM_CREDENTIALS_PIN: "db3dc77fc22e430080d41b31b6f04800"
+      run: cargo xtask integration-tests --suite nginx

--- a/README.md
+++ b/README.md
@@ -98,6 +98,75 @@ cargo xtask precheck --all
 
 It will run all necessary checks to ensure code quality before committing. It will not auto fix linting, formatting or copyright issues.
 
+## CI Workflows
+
+Two GitHub Actions workflows live under `.github/workflows/`:
+
+- [`rust.yml`](.github/workflows/rust.yml) — runs on every push / PR / merge
+  group. SDK-only: copyright, audit, fmt, clippy, mock tests (table-4 /
+  table-64 / tbor-emu), coverage, Windows build. Does not install OpenSSL
+  or run the provider.
+- [`provider.yml`](.github/workflows/provider.yml) — heavy provider +
+  OpenSSL integration. Two jobs (`openssl-3-0` on Ubuntu 22.04 pinned to
+  OpenSSL 3.0.13, `openssl-3-5` on Ubuntu 24.04 pinned to OpenSSL 3.5.4).
+  Triggered only by `workflow_dispatch`; designed to be run locally via
+  [`act`](https://github.com/nektos/act) (see below) and intended as the
+  blueprint for a future nightly CI run.
+
+### Running `provider.yml` locally with `act`
+
+One-time setup: install [`act`](https://github.com/nektos/act/#installation),
+ensure Docker is up, and pull the runner images. The default `act` image
+(`node:16-bullseye-slim`) is too small — it has no `sudo`/`apt`, so the
+apt-install step would fail immediately. Use the matching
+[`catthehacker/ubuntu`](https://github.com/catthehacker/docker_images)
+images that ship a real Ubuntu userland:
+
+```bash
+docker pull catthehacker/ubuntu:act-22.04
+docker pull catthehacker/ubuntu:act-24.04
+```
+
+Then run a job, mapping each `runs-on:` value with `-P`:
+
+```bash
+act --reuse -W .github/workflows/provider.yml -j openssl-3-0 \
+  -P ubuntu-22.04=catthehacker/ubuntu:act-22.04 \
+  -P ubuntu-24.04=catthehacker/ubuntu:act-24.04
+
+act --reuse -W .github/workflows/provider.yml -j openssl-3-5 \
+  -P ubuntu-22.04=catthehacker/ubuntu:act-22.04 \
+  -P ubuntu-24.04=catthehacker/ubuntu:act-24.04
+```
+
+`--reuse` keeps the container across invocations so the cold install
+(rustup install, dev-tool `cargo install`s, custom OpenSSL build from
+source — together ~10–15 min the first time) does not repeat.
+
+Each job sets `AZIHSM_TEST_OPENSSL_MAJOR_MINOR` (e.g., `"3.0"` or `"3.5"`)
+so the test suites can skip cases that require a different OpenSSL
+major.minor — see [xtask/README.md](xtask/README.md#integration-tests)
+for the skip conventions used by the CLI, CAPI, and NGINX harnesses.
+
+Steps in `provider.yml` marked `act-compat:` exist solely so the
+workflow runs under `act`; they are idempotent no-ops on GitHub-hosted
+runners (which come with Rust, `xxd`, etc. preinstalled).
+
+### Why each job pins its OpenSSL version (and how that disappears later)
+
+`provider.yml` calls `cargo xtask custom-openssl --version <X.Y.Z>` in
+each job to install a workspace-local OpenSSL into
+`target/openssl-custom/<version>/`, then exports `OPENSSL_DIR` to point
+there. This is a **temporary bridge**: until Ubuntu LTS ships OpenSSL
+3.5 as system, the openssl-3-5 job has no other way to test 3.5
+features. The openssl-3-0 job pins to 3.0.13 (matching what Ubuntu 24.04
+ships) so the eventual switch to system OpenSSL is uneventful.
+
+The pinned-install layer is bracketed with `# === TEMPORARY ===`
+markers in each job. Deleting the bracketed block per job reverts that
+job to system OpenSSL via `host_openssl::check_openssl`'s well-known
+prefix scan (`/usr`, `/usr/local`, …).
+
 ## License
 
 See [LICENSE](./LICENSE) for details.

--- a/plugins/ossl_prov/README.md
+++ b/plugins/ossl_prov/README.md
@@ -715,3 +715,54 @@ openssl mac -digest SHA256 ${PROV} \
     -in data.bin \
     HMAC
 ```
+
+## Integration tests and CI
+
+The three integration test crates under `plugins/ossl_prov/integration-tests/`
+exercise the provider through OpenSSL:
+
+- `provider-integration-tests-cli` — lit-driven shell scripts (`.sh` files
+  under `openssl-cli/testfiles/`)
+- `provider-integration-tests-capi` — libtest-mimic + Google Test (C++)
+- `provider-integration-tests-nginx` — libtest-mimic, runs a real NGINX
+  daemon with the provider loaded
+
+Run any of them via the xtask wrapper, which sets up `OPENSSL_BIN` /
+`OPENSSL_LIB` / `OPENSSL_DIR` for the harnesses from whatever
+`host_openssl::check_openssl` discovers:
+
+```bash
+# All three suites
+cargo xtask integration-tests
+
+# Just one
+cargo xtask integration-tests --suite cli   # | capi | nginx
+```
+
+The provider must be built first: `cargo xtask build --features mock`.
+
+### Version gating for 3.5-only tests
+
+Tests that require OpenSSL 3.5 use one of three skip mechanisms so the
+3.0 CI lane runs cleanly:
+
+- **C++ tests**: `#if OPENSSL_VERSION_MINOR >= 5` — compile-time, from
+  the headers the provider links against.
+- **C++ tests (runtime)**: suffix the gtest case name with
+  `_RequiresOpenssl35` — the CAPI harness reports it as `ignored` when
+  `AZIHSM_TEST_OPENSSL_MAJOR_MINOR="3.0"`.
+- **Shell tests**: source `env.sh` and call `skip_below_ossl_3_5` near
+  the top. The helper exits 0 (lit treats this as a passing skip) when
+  the running `openssl version` is below 3.5.
+- **NGINX assertion scripts**: name the script `*_requires_openssl_3_5.sh`
+  — the NGINX harness prints `[SKIP]` for it under the same env var.
+
+### CI workflow
+
+Provider integration runs in [`.github/workflows/provider.yml`](../../.github/workflows/provider.yml),
+not in the main `rust.yml`.  The workflow has two jobs (`openssl-3-0`
+and `openssl-3-5`), each pinning its OpenSSL version via
+`xtask custom-openssl`.  The workflow is `workflow_dispatch`-only today
+and is designed to run locally via [`act`](https://github.com/nektos/act);
+see the [repo root README](../../README.md#running-provideryml-locally-with-act)
+for the local-run recipe.

--- a/plugins/ossl_prov/integration-tests/nginx/src/nginx_tests.rs
+++ b/plugins/ossl_prov/integration-tests/nginx/src/nginx_tests.rs
@@ -57,6 +57,22 @@ mod integration {
         "negative_provider_required.sh",
     ];
 
+    /// Returns true if an assertion script should be skipped because the
+    /// current OpenSSL ABI cannot run it.
+    ///
+    /// Read from `AZIHSM_TEST_OPENSSL_MAJOR_MINOR` (set by `provider.yml`
+    /// per job).  When the env var is unset, no skips happen.
+    ///
+    /// Convention: name a script `*_requires_openssl_3_5.sh` to mark it
+    /// as 3.5-only.  When running against OpenSSL 3.0, such scripts are
+    /// reported as `[SKIP]` instead of executed.
+    fn should_skip_script_for_current_openssl(script_name: &str) -> bool {
+        let Ok(ver) = env::var("AZIHSM_TEST_OPENSSL_MAJOR_MINOR") else {
+            return false;
+        };
+        ver == "3.0" && script_name.contains("_requires_openssl_3_5")
+    }
+
     /// Run the full NGINX integration test suite.
     pub fn run(args: Arguments) {
         let testfiles_dir = get_testfiles_dir();
@@ -94,6 +110,10 @@ mod integration {
 
         let mut first_failure: Option<Failed> = None;
         for script in ASSERTION_SCRIPTS {
+            if should_skip_script_for_current_openssl(script) {
+                println!("[SKIP] {script} (requires OpenSSL >= 3.5)");
+                continue;
+            }
             let script_path = testfiles_dir.join(script);
             match run_test_script(&script_path, &keymat_dir, &provider_so, &nginx_conf) {
                 Ok(()) => println!("[PASS] {script}"),

--- a/plugins/ossl_prov/integration-tests/openssl-capi/cpp/openssl_capi_integration_tests.rs
+++ b/plugins/ossl_prov/integration-tests/openssl-capi/cpp/openssl_capi_integration_tests.rs
@@ -378,6 +378,29 @@ azihsm-api-revision = 1.0
         stdout
     }
 
+    /// Returns true if a discovered gtest case should be skipped because
+    /// the current OpenSSL ABI cannot run it.
+    ///
+    /// Read from `AZIHSM_TEST_OPENSSL_MAJOR_MINOR` (set by `provider.yml`
+    /// per job).  When the env var is unset, no skips happen — so a plain
+    /// `cargo xtask integration-tests` run against a single OpenSSL version
+    /// still runs the full suite.
+    ///
+    /// Convention: tag a C++ gtest case with the `_RequiresOpenssl35`
+    /// suffix to mark it as 3.5-only.  When running against OpenSSL 3.0,
+    /// such cases are reported as `ignored` instead of executed.
+    ///
+    /// Example C++ definition:
+    /// ```cpp
+    /// TEST(EcKeys, GenerateMlDsa_RequiresOpenssl35) { ... }
+    /// ```
+    fn should_skip_for_current_openssl(test_name: &str) -> bool {
+        let Ok(ver) = env::var("AZIHSM_TEST_OPENSSL_MAJOR_MINOR") else {
+            return false;
+        };
+        ver == "3.0" && test_name.contains("_RequiresOpenssl35")
+    }
+
     /// Parses the gtest list output and creates test trials.
     fn parse_gtest_list(
         output: &str,
@@ -395,6 +418,10 @@ azihsm-api-revision = 1.0
                 current_suite = line.trim_end_matches('.').to_string();
             } else if !line.trim().is_empty() {
                 let test_name = format!("{}::{}", current_suite, line.trim());
+                if should_skip_for_current_openssl(&test_name) {
+                    tests.push(Trial::test(test_name, || Ok(())).with_ignored_flag(true));
+                    continue;
+                }
                 let path = path.clone();
                 let ld_path = ld_library_path.clone();
                 let creds = credentials.clone();

--- a/plugins/ossl_prov/integration-tests/openssl-cli/testfiles/env.sh
+++ b/plugins/ossl_prov/integration-tests/openssl-cli/testfiles/env.sh
@@ -120,3 +120,27 @@ azihsm-api-revision = 1.0
 EOF
 
 export OPENSSL_CONF="$AZIHSM_KEY_DIR/openssl.cnf"
+
+# --- Version gating helpers ---
+# Skip the test if OpenSSL is older than the given <major>.<minor>.  Used by
+# lit .sh scripts that exercise features only available in newer OpenSSL.
+# Exits 0 (lit treats this as a passing skip) so the rest of the suite
+# continues.
+#
+#   require_ossl_version 3 5
+require_ossl_version() {
+    local req_major=$1 req_minor=$2
+    local ver
+    ver=$("$OPENSSL_BIN" version | awk '{print $2}')
+    local cur_major cur_minor
+    cur_major=$(echo "$ver" | cut -d. -f1)
+    cur_minor=$(echo "$ver" | cut -d. -f2)
+    if [ "$cur_major" -lt "$req_major" ] || \
+       { [ "$cur_major" -eq "$req_major" ] && [ "$cur_minor" -lt "$req_minor" ]; }; then
+        echo "SKIP: requires OpenSSL >= $req_major.$req_minor (have $ver)"
+        exit 0
+    fi
+}
+
+# Convenience: skip the test unless OpenSSL is at least 3.5.
+skip_below_ossl_3_5() { require_ossl_version 3 5; }

--- a/xtask/README.md
+++ b/xtask/README.md
@@ -66,6 +66,73 @@ Build and run all tests with code coverage enabled. Generates a cobertura XML, J
 cargo xtask coverage
 ```
 
+### custom-openssl
+
+Build a pinned OpenSSL 3.x release into `target/openssl-custom/<version>/`.
+A temporary bridge for testing against OpenSSL versions that aren't yet
+available as the container's system OpenSSL (notably 3.5.x). The install
+tree is entirely workspace-local; nothing is installed to system paths.
+
+```bash
+# Install OpenSSL 3.5.4
+cargo xtask custom-openssl --version 3.5.4
+
+# Override the install prefix
+cargo xtask custom-openssl --version 3.0.13 --prefix /tmp/ssl
+
+# Rebuild even if already installed
+cargo xtask custom-openssl --version 3.5.4 --force
+```
+
+After installation, point `OPENSSL_DIR` at the printed prefix so
+`host_openssl::check_openssl` picks it up:
+
+```bash
+export OPENSSL_DIR=$(cargo xtask custom-openssl --version 3.5.4 | tail -1)
+```
+
+Allowlisted versions only — see `SUPPORTED_VERSIONS` in
+`xtask/src/custom_openssl.rs`. Add new (version, sha256) tuples there when
+needed.
+
+### integration-tests
+
+Run the provider integration suites (CLI, CAPI, NGINX) against the host's
+OpenSSL (discovered via `host_openssl::check_openssl`: `OPENSSL_DIR`, then
+`pkg-config`, then well-known prefixes).
+
+```bash
+# Run all three suites against the host's OpenSSL
+cargo xtask integration-tests
+
+# Run a single suite
+cargo xtask integration-tests --suite cli
+cargo xtask integration-tests --suite capi
+cargo xtask integration-tests --suite nginx
+```
+
+To test against a specific pinned OpenSSL (e.g., 3.5.4), install it via
+`custom-openssl` and export `OPENSSL_DIR` first.
+
+The provider stack must be built up front: `cargo xtask build --features mock`.
+
+#### Skipping tests that require a specific OpenSSL version
+
+Set `AZIHSM_TEST_OPENSSL_MAJOR_MINOR` (e.g., `"3.0"` or `"3.5"`) to drive
+per-suite skip conventions:
+
+- **CAPI**: any gtest case whose name contains `_RequiresOpenssl35` is
+  reported as `ignored` when the env var is `"3.0"`.
+- **NGINX**: any assertion script whose filename contains
+  `_requires_openssl_3_5` prints `[SKIP]` and is not executed when the
+  env var is `"3.0"`.
+- **CLI**: a lit `.sh` script can call `skip_below_ossl_3_5` (defined in
+  `testfiles/env.sh`) near the top to exit 0 when `openssl version` is
+  below 3.5.  This is a build-/runtime check independent of the env var.
+
+`.github/workflows/provider.yml` sets `AZIHSM_TEST_OPENSSL_MAJOR_MINOR`
+per job automatically.
+
 ## Command Details
 
 - **precheck**: Combines setup, copyright, audit, fmt, clippy, and nextest stages for comprehensive validation
@@ -73,6 +140,8 @@ cargo xtask coverage
 - **fmt**: Uses `cargo fmt` to check/fix Rust code formatting
 - **copyright**: Ensures all source files have proper Microsoft copyright headers
 - **coverage**: Build/run all tests with code coverage enabled
+- **custom-openssl**: Build a pinned OpenSSL release into `target/openssl-custom/<version>/`
+- **integration-tests**: Run provider integration suites (CLI, CAPI, NGINX) via `--suite <name>`
 
 ## Dependencies
 

--- a/xtask/src/custom_openssl.rs
+++ b/xtask/src/custom_openssl.rs
@@ -1,0 +1,246 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#![warn(missing_docs)]
+#![forbid(unsafe_code)]
+
+//! Build a specific OpenSSL 3.x release into a workspace-local prefix.
+//!
+//! This command is a **temporary bridge** for the period where the SDK has
+//! to be tested against OpenSSL versions that aren't yet available as the
+//! system OpenSSL on any Ubuntu LTS we target (notably 3.5.x).  Once the
+//! desired version ships as the container's system OpenSSL, the relevant
+//! CI step (and the `OPENSSL_DIR` export that follows it) can be deleted
+//! and `host_openssl::check_openssl` will fall through to the well-known
+//! prefix scan.
+//!
+//! Output layout:
+//!
+//! ```text
+//! target/openssl-custom/<version>/
+//!     bin/openssl
+//!     include/openssl/opensslv.h
+//!     lib/libcrypto.so.3
+//!     lib/libssl.so.3
+//!     ssl/openssl.cnf
+//! ```
+//!
+//! The directory tree is entirely self-contained; nothing is installed
+//! into system paths (no `sudo install`, no `ldconfig`).  Callers point
+//! `OPENSSL_DIR` at the printed prefix to make `host_openssl` honour it.
+
+use std::path::PathBuf;
+
+use clap::Parser;
+
+use crate::Xtask;
+use crate::XtaskCtx;
+
+/// Tarball download URL template (interpolates `{version}` twice).
+#[cfg(target_os = "linux")]
+const TARBALL_URL_TEMPLATE: &str =
+    "https://github.com/openssl/openssl/releases/download/openssl-{version}/openssl-{version}.tar.gz";
+
+/// Supported OpenSSL versions and their official tarball SHA-256 hashes.
+/// Add new entries here as new versions are needed for CI.
+#[cfg(target_os = "linux")]
+const SUPPORTED_VERSIONS: &[(&str, &str)] = &[
+    (
+        "3.0.13",
+        "88525753f79d3bec27d2fa7c66aa0b92b3aa9498dafd93d7cfa4b3780cdae313",
+    ),
+    (
+        "3.5.4",
+        "967311f84955316969bdb1d8d4b983718ef42338639c621ec4c34fddef355e99",
+    ),
+];
+
+/// Install a pinned OpenSSL release into `target/openssl-custom/<version>/`.
+///
+/// Idempotent: if the install directory already contains a matching
+/// `opensslv.h`, the command exits without rebuilding.  Use `--force` to
+/// rebuild anyway.
+///
+/// Linux-only.  On other platforms the command is a no-op that logs a
+/// skip notice.
+#[derive(Parser)]
+#[clap(about = "Build a pinned OpenSSL release into target/openssl-custom/<version>")]
+pub struct CustomOpenssl {
+    /// OpenSSL version to install (e.g., "3.0.13", "3.5.4").  Must be on
+    /// the supported-versions allowlist.
+    #[clap(long)]
+    pub version: String,
+
+    /// Override the install prefix.  Defaults to
+    /// `<workspace>/target/openssl-custom/<version>/`.
+    #[clap(long)]
+    pub prefix: Option<PathBuf>,
+
+    /// Rebuild even if the install directory already exists with a
+    /// matching `opensslv.h`.
+    #[clap(long)]
+    pub force: bool,
+}
+
+impl Xtask for CustomOpenssl {
+    fn run(self, _ctx: XtaskCtx) -> anyhow::Result<()> {
+        #[cfg(not(target_os = "linux"))]
+        {
+            log::warn!(
+                "skipping custom-openssl: only supported on Linux (got {})",
+                std::env::consts::OS
+            );
+            Ok(())
+        }
+
+        #[cfg(target_os = "linux")]
+        {
+            install(&self.version, self.prefix.as_deref(), self.force, &_ctx)
+        }
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn sha256_for(version: &str) -> anyhow::Result<&'static str> {
+    SUPPORTED_VERSIONS
+        .iter()
+        .find(|(v, _)| *v == version)
+        .map(|(_, hash)| *hash)
+        .ok_or_else(|| {
+            let supported: Vec<&str> = SUPPORTED_VERSIONS.iter().map(|(v, _)| *v).collect();
+            anyhow::anyhow!(
+                "unsupported OpenSSL version {version:?}. \
+                 Supported versions: {}.  Add a new (version, sha256) tuple to \
+                 SUPPORTED_VERSIONS in xtask/src/custom_openssl.rs.",
+                supported.join(", ")
+            )
+        })
+}
+
+#[cfg(target_os = "linux")]
+fn default_prefix(version: &str, ctx: &XtaskCtx) -> PathBuf {
+    ctx.root.join("target").join("openssl-custom").join(version)
+}
+
+/// Returns true when the install dir already contains an `opensslv.h`
+/// whose `OPENSSL_VERSION_STR` matches `expected_version` (e.g., `"3.5.4"`).
+/// Used to skip the build under `actions/cache` hits where the cache
+/// restoration leaves a complete prefix on disk.
+#[cfg(target_os = "linux")]
+fn already_installed(prefix: &std::path::Path, expected_version: &str) -> bool {
+    let header = prefix.join("include/openssl/opensslv.h");
+    let Ok(contents) = std::fs::read_to_string(&header) else {
+        return false;
+    };
+    // Looking for: `# define OPENSSL_VERSION_STR "3.5.4"`
+    for line in contents.lines() {
+        let line = line.trim_start();
+        let Some(rest) = line.strip_prefix('#') else {
+            continue;
+        };
+        let rest = rest.trim_start();
+        let Some(rest) = rest.strip_prefix("define") else {
+            continue;
+        };
+        let rest = rest.trim_start();
+        let Some(rest) = rest.strip_prefix("OPENSSL_VERSION_STR") else {
+            continue;
+        };
+        let rest = rest.trim_start();
+        let Some(rest) = rest.strip_prefix('"') else {
+            continue;
+        };
+        let Some(end) = rest.find('"') else {
+            continue;
+        };
+        return &rest[..end] == expected_version;
+    }
+    false
+}
+
+#[cfg(target_os = "linux")]
+fn install(
+    version: &str,
+    prefix_override: Option<&std::path::Path>,
+    force: bool,
+    ctx: &XtaskCtx,
+) -> anyhow::Result<()> {
+    use anyhow::Context as _;
+    use xshell::cmd;
+    use xshell::Shell;
+
+    let expected_hash = sha256_for(version)?;
+
+    let install_dir = match prefix_override {
+        Some(p) => p.to_path_buf(),
+        None => default_prefix(version, ctx),
+    };
+
+    if !force && already_installed(&install_dir, version) {
+        log::info!(
+            "OpenSSL {version} already installed at {} (skipping build)",
+            install_dir.display(),
+        );
+        // Still print the path so callers always have a stable contract.
+        println!("{}", install_dir.display());
+        return Ok(());
+    }
+
+    let prefix = install_dir.display();
+    log::info!("building OpenSSL {version} into {prefix}");
+
+    // Preflight: check required tools before starting a long build.
+    let sh = Shell::new()?;
+    for tool in ["curl", "sha256sum", "tar", "make", "cc", "perl"] {
+        if cmd!(sh, "which {tool}").quiet().run().is_err() {
+            anyhow::bail!(
+                "required tool `{tool}` not found.  Install build prerequisites: \
+                 sudo apt-get install build-essential coreutils curl perl tar"
+            );
+        }
+    }
+
+    let url = TARBALL_URL_TEMPLATE.replace("{version}", version);
+    let tarball = format!("/tmp/openssl-{version}.tar.gz");
+    let src_dir = format!("/tmp/openssl-{version}");
+
+    log::info!("downloading OpenSSL {version}...");
+    cmd!(sh, "curl -fsSL -o {tarball} {url}").run()?;
+
+    let checksum_output = cmd!(sh, "sha256sum {tarball}").read()?;
+    let actual_hash = checksum_output
+        .split_whitespace()
+        .next()
+        .context("failed to parse sha256sum output")?;
+    anyhow::ensure!(
+        actual_hash == expected_hash,
+        "SHA-256 mismatch for {tarball}: expected {expected_hash}, got {actual_hash}"
+    );
+
+    cmd!(sh, "rm -rf {src_dir}").run()?;
+    cmd!(sh, "tar xz -C /tmp -f {tarball}").run()?;
+
+    // Wipe any partial previous install to avoid mixed-version state.
+    if install_dir.exists() {
+        std::fs::remove_dir_all(&install_dir)
+            .with_context(|| format!("failed to remove existing {}", install_dir.display()))?;
+    }
+    if let Some(parent) = install_dir.parent() {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("failed to create install parent {}", parent.display()))?;
+    }
+
+    sh.change_dir(&src_dir);
+    cmd!(sh, "./Configure --prefix={install_dir} --libdir=lib").run()?;
+
+    let nproc = cmd!(sh, "nproc").read()?;
+    let nproc = nproc.trim();
+    cmd!(sh, "make -j{nproc}").run()?;
+    cmd!(sh, "make install_sw").run()?;
+
+    log::info!("OpenSSL {version} installed to {prefix}");
+    // Print the absolute install path on the last stdout line so scripted
+    // callers (CI workflows, makefiles) can capture it without parsing logs.
+    println!("{}", install_dir.display());
+    Ok(())
+}

--- a/xtask/src/integration_tests.rs
+++ b/xtask/src/integration_tests.rs
@@ -5,32 +5,142 @@
 #![forbid(unsafe_code)]
 
 use clap::Parser;
+use clap::ValueEnum;
 
 use crate::Xtask;
 use crate::XtaskCtx;
 
-/// Xtask to run integration tests.
+/// Which provider integration suite(s) to run.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, ValueEnum)]
+pub enum Suite {
+    /// OpenSSL CLI tests via lit (`provider-integration-tests-cli`).
+    Cli,
+    /// OpenSSL C API tests via libtest-mimic + gtest (`provider-integration-tests-capi`).
+    Capi,
+    /// NGINX tests via libtest-mimic (`provider-integration-tests-nginx`).
+    Nginx,
+    /// Run all three suites in order: cli, capi, nginx.
+    All,
+}
+
+/// Run the OpenSSL provider integration tests.
 ///
-/// Currently a no-op. The provider integration test passes (CLI, CAPI,
-/// nginx) are temporarily disabled while the OpenSSL provider build
-/// coupling with `libazihsm_api_native` is being reworked. The command
-/// remains in the xtask surface so CI / scripted invocations stay
-/// stable; it logs a skip notice and returns success.
+/// Discovers OpenSSL via [`crate::host_openssl::check_openssl`] (respects
+/// `OPENSSL_DIR` first, falls back to `pkg-config` and well-known
+/// prefixes).  Cleans `target/test-keymat/` before each run for fresh
+/// per-run isolation.  Sets `OPENSSL_BIN` / `OPENSSL_LIB` / `OPENSSL_DIR`
+/// for the test harnesses if they aren't already set.
 ///
-/// Re-enable by restoring the nextest invocations in this file once
-/// the build coupling rework lands.
+/// The provider stack itself is **not** built here — callers must run
+/// `cargo xtask build --features mock` (or equivalent) beforehand.
+/// Keeping the build out of this command means a partial integration run
+/// (e.g., `--suite nginx` only) doesn't recompile the world.
 #[derive(Parser)]
-#[clap(about = "Run Integration Tests (currently disabled)")]
-pub struct IntegrationTest {}
+#[clap(about = "Run Integration Tests")]
+pub struct IntegrationTest {
+    /// Which suite to run.  Defaults to `all` (cli + capi + nginx).
+    #[clap(long, value_enum, default_value_t = Suite::All)]
+    pub suite: Suite,
+}
 
 impl Xtask for IntegrationTest {
     fn run(self, _ctx: XtaskCtx) -> anyhow::Result<()> {
-        log::warn!(
-            "skipping provider integration tests: temporarily disabled \
-             while OpenSSL provider build coupling with libazihsm_api_native \
-             is reworked. Re-enable by restoring the nextest invocations in \
-             xtask/src/integration_tests.rs once the rework lands."
-        );
-        Ok(())
+        log::trace!("start testing");
+
+        #[cfg(not(target_os = "linux"))]
+        {
+            log::warn!("skipping provider integration tests: only supported on Linux");
+            Ok(())
+        }
+
+        #[cfg(target_os = "linux")]
+        {
+            let openssl_dir = crate::host_openssl::check_openssl()?;
+
+            if std::env::var("OPENSSL_BIN").is_err() {
+                std::env::set_var("OPENSSL_BIN", openssl_dir.join("bin/openssl"));
+            }
+            if std::env::var("OPENSSL_DIR").is_err() {
+                std::env::set_var("OPENSSL_DIR", &openssl_dir);
+            }
+
+            // Compute the OpenSSL lib dir for both `OPENSSL_LIB` (read by the
+            // env.sh / CAPI / NGINX harnesses) and `LD_LIBRARY_PATH` (read
+            // directly by the dynamic linker for every `openssl` subprocess
+            // spawn).  Both are necessary: the openssl binary itself needs
+            // libcrypto.so.3 to load (LD_LIBRARY_PATH), and the harnesses
+            // need to know which lib dir to forward (OPENSSL_LIB).  Probe
+            // lib64 first (RHEL/Fedora), then fall back to lib.  `target/debug`
+            // is appended for `libazihsm_api_native.so` resolution.
+            let cargo_debug = _ctx.root.join("target").join("debug");
+            let openssl_lib_dir = {
+                let lib64 = openssl_dir.join("lib64");
+                let lib = openssl_dir.join("lib");
+                if lib64.is_dir() {
+                    Some(lib64)
+                } else if lib.is_dir() {
+                    Some(lib)
+                } else {
+                    log::warn!(
+                        "neither {}/lib64 nor {}/lib exists",
+                        openssl_dir.display(),
+                        openssl_dir.display()
+                    );
+                    None
+                }
+            };
+            if let Some(ref p) = openssl_lib_dir {
+                let combined = format!("{}:{}", p.display(), cargo_debug.display());
+                if std::env::var("OPENSSL_LIB").is_err() {
+                    std::env::set_var("OPENSSL_LIB", &combined);
+                }
+                // Always prepend to LD_LIBRARY_PATH so the custom openssl
+                // binary's libcrypto resolves to our install, not the system
+                // one (which may lack newer symbols).  Prepending keeps any
+                // existing LD_LIBRARY_PATH content reachable as a fallback.
+                let existing = std::env::var("LD_LIBRARY_PATH").unwrap_or_default();
+                let new_ld = if existing.is_empty() {
+                    combined
+                } else {
+                    format!("{combined}:{existing}")
+                };
+                std::env::set_var("LD_LIBRARY_PATH", new_ld);
+            }
+
+            // Test key material is regenerated per run by each harness; the
+            // wrapping clean below ensures no stale state from a prior run
+            // leaks across processes.
+            let keymat_dir = _ctx.root.join("target").join("test-keymat");
+            if keymat_dir.exists() {
+                std::fs::remove_dir_all(&keymat_dir)?;
+                log::trace!(
+                    "cleaned previous test key material at {}",
+                    keymat_dir.display()
+                );
+            }
+
+            let run_pkg = |pkg: &str, ctx: XtaskCtx| -> anyhow::Result<()> {
+                crate::nextest::Nextest {
+                    features: Some("integration".to_string()),
+                    package: Some(pkg.to_string()),
+                    no_default_features: false,
+                    filterset: None,
+                    profile: Some("ci-provider-integration".to_string()),
+                    exclude: vec![],
+                }
+                .run(ctx)
+            };
+
+            match self.suite {
+                Suite::Cli => run_pkg("provider-integration-tests-cli", _ctx),
+                Suite::Capi => run_pkg("provider-integration-tests-capi", _ctx),
+                Suite::Nginx => run_pkg("provider-integration-tests-nginx", _ctx),
+                Suite::All => {
+                    run_pkg("provider-integration-tests-cli", _ctx.clone())?;
+                    run_pkg("provider-integration-tests-capi", _ctx.clone())?;
+                    run_pkg("provider-integration-tests-nginx", _ctx)
+                }
+            }
+        }
     }
 }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -25,6 +25,7 @@ pub mod common;
 mod copyright;
 mod coverage;
 mod coverage_report;
+mod custom_openssl;
 mod fmt;
 mod host_openssl;
 mod install;
@@ -71,6 +72,7 @@ enum Commands {
     Copyright(copyright::Copyright),
     Coverage(coverage::Coverage),
     CoverageReport(coverage_report::CoverageReport),
+    CustomOpenssl(custom_openssl::CustomOpenssl),
     Fmt(fmt::Fmt),
     IntegrationTests(integration_tests::IntegrationTest),
     Nextest(nextest::Nextest),
@@ -112,6 +114,7 @@ fn try_main() -> anyhow::Result<()> {
         Commands::Copyright(task) => task.run(ctx),
         Commands::Coverage(task) => task.run(ctx),
         Commands::CoverageReport(task) => task.run(ctx),
+        Commands::CustomOpenssl(task) => task.run(ctx),
         Commands::Fmt(task) => task.run(ctx),
         Commands::IntegrationTests(task) => task.run(ctx),
         Commands::Precheck(task) => task.run(ctx),


### PR DESCRIPTION
## Summary

GitHub CI's `rust.yml` currently runs three jobs: `build_ubuntu`, `provider_integration`, and `build_windows`. The `provider_integration` job (and OpenSSL bits leaking into `build_ubuntu`) makes every push/PR several minutes longer than it needs to be because it installs OpenSSL from source, builds the provider, generates dev keymat, installs nginx, and runs CLI/CAPI/NGINX integration suites. That cadence is wrong for day-to-day PR feedback — the right home for those checks is a nightly run.

This PR prepares the split:

- **`rust.yml` becomes SDK-only** — copyright / audit / fmt / clippy / mock tests (table-4, table-64, res-test) / coverage / Windows. No OpenSSL anywhere.
- **`provider.yml` is new** — heavy provider + OpenSSL integration, two distinct jobs (`openssl-3-0` on `ubuntu-22.04`, `openssl-3-5` on `ubuntu-24.04`). Triggered only by `workflow_dispatch`; designed to run locally via `act` and intended as the blueprint for a future nightly CI run.
- **`cargo xtask precheck` is no longer aware of provider / OpenSSL** — `--openssl-version` and `--skip-openssl` flags removed, default `--nextest` body no longer invokes `IntegrationTest`, inner `Setup` pinned to `skip_openssl: true`. `cargo xtask precheck` on a clean tree never tries to download OpenSSL.

## What stays / moves / goes away

| Concern | Before | After |
|---|---|---|
| SDK checks (copyright/audit/fmt/clippy/mock tests/coverage/Windows) | `rust.yml` | `rust.yml` (kept) |
| OpenSSL install in `build_ubuntu` | yes | removed |
| `provider_integration` job | `rust.yml` | moved to `provider.yml` |
| Provider integration in `xtask precheck` default body | yes | removed |
| Multi-version (`--openssl-version`) plumbing in xtask | yes | kept (used by `provider.yml`) |
| ABI-versioned target trees + harness path lookups | yes | kept |

## Architectural choice: two jobs per OpenSSL version (not a matrix)

`provider.yml` uses two distinct jobs rather than a `strategy: matrix` so each job can pin its own `runs-on:` container. The eventual goal is to drop the explicit OpenSSL install in each container and use the container's system OpenSSL (jammy ships 3.0.x; future Ubuntu may ship 3.5.x). System OpenSSL has out-of-scope issues for now, so both jobs still install OpenSSL explicitly — but the two-container architecture is in place.

Each job exports `AZIHSM_TEST_OPENSSL_MAJOR_MINOR` (`"3.0"` or `"3.5"`) so test harnesses can skip cases that don't apply to the running version. `openssl-3-5` keeps `continue-on-error: true` while 3.5 stabilises.

## xtask changes

- **`integration-tests`** gains a `--suite <cli|capi|nginx|all>` flag (default `all`). `provider.yml` runs each suite as a separate step for clearer failure attribution.
- **`precheck`** drops `--openssl-version` and `--skip-openssl`. Dedicated provider workflow remains via direct invocation:
  - `cargo xtask setup --openssl-version <ver>`
  - `cargo xtask build --openssl-version <ver>`
  - `cargo xtask integration-tests --openssl-version <ver> [--suite ...]`

## Test-skip primitives

The plan was to introduce skip primitives (not yet tag any tests):

- **CLI (lit)** — re-uses the existing `skip_below_ossl_3_5` helper in `plugins/ossl_prov/integration-tests/openssl-cli/testfiles/env.sh` (parses `openssl version` directly).
- **CAPI (libtest-mimic + gtest)** — `should_skip_for_current_openssl()` in `plugins/ossl_prov/integration-tests/openssl-capi/cpp/openssl_capi_integration_tests.rs` reports any gtest case whose name contains `_RequiresOpenssl35` as `ignored` when `AZIHSM_TEST_OPENSSL_MAJOR_MINOR="3.0"`.
- **NGINX (libtest-mimic)** — `should_skip_script_for_current_openssl()` in `plugins/ossl_prov/integration-tests/nginx/src/nginx_tests.rs` prints `[SKIP]` for any assertion script whose name contains `_requires_openssl_3_5` under the same condition.

Annotating actual 3.5-only tests is out of scope for this PR — it happens as 3.5-specific tests get written.

## Why this branch is based on `azihsm-sdk-ossl-3-5` (not `main`)

`azihsm-sdk-slim-ci` sits 8 commits ahead of `main`. Those 8 commits add the ABI-versioned target tree, harness path lookups for ABI dirs, `--openssl-version` plumbing, Corrosion deadlock fix, and the `skip_below_ossl_3_5` helper — exactly the infrastructure the new `provider.yml` needs. Resetting to `main` would force re-implementing all of it before `provider.yml` could even be functional, so we keep the base.

## Test plan

- [x] `cargo build -p xtask` succeeds
- [x] `cargo check -p provider-integration-tests-nginx --features integration` succeeds
- [x] `cargo check -p provider-integration-tests-capi --features integration` succeeds
- [x] `cargo clippy -p xtask -p provider-integration-tests-nginx -p provider-integration-tests-capi --all-targets -- -D warnings` clean
- [x] `cargo xtask precheck --help` no longer exposes `--openssl-version` / `--skip-openssl`
- [x] `cargo xtask integration-tests --help` exposes new `--suite` flag
- [x] `cargo xtask precheck --fmt` runs cleanly
- [x] `act -W .github/workflows/rust.yml --list` shows only `build_ubuntu` + `build_windows` (on push/PR/merge_group/schedule)
- [x] `act -W .github/workflows/provider.yml --list` shows `openssl-3-0` + `openssl-3-5` (on `workflow_dispatch` only — not triggered automatically)
- [ ] **`act -W .github/workflows/provider.yml -j openssl-3-0` end-to-end** — local execution still has issues - [ ] **`act -W .github/workflows/provider.yml -j openssl-3-5` end-to-end** — same
- [ ] Negative check: tag one canary gtest case `*_RequiresOpenssl35`, confirm it shows up as `ignored` when run under the 3.0 job

## Notes

- This PR does not yet enable `provider.yml` in GitHub CI. Adding a `schedule:` trigger to make it nightly is intentionally deferred so reviewers can decide the cadence separately.
- The 8 commits inherited from `azihsm-sdk-ossl-3-5` are still present in this branch - #333 could be closed.