### PR TITLE
[fix] Only apply cert-chain size hint on real shortage

### DIFF
--- a/api/native/src/partition_props.rs
+++ b/api/native/src/partition_props.rs
@@ -239,8 +239,9 @@ fn copy_to_part_prop(part_prop: &mut AzihsmPartProp, bytes: &[u8]) -> Result<(),
 ///
 /// If `part_prop.len` is large enough to hold `bytes`, the copy succeeds and `part_prop.len`
 /// is set to the actual byte count. If the caller's buffer is too small, `part_prop.len` is set
-/// to `max(bytes.len(), suggested_len)` and [`AzihsmStatus::BufferTooSmall`] is returned. The
-/// suggestion is advisory only — a caller buffer that already fits `bytes` never fails, even if
+/// to `max(bytes.len(), suggested_len)`, capped at `u32::MAX` if needed, and
+/// [`AzihsmStatus::BufferTooSmall`] is returned. The suggestion is advisory only — a caller
+/// buffer that already fits `bytes` never fails, even if
 /// it is smaller than `suggested_len`.
 fn copy_to_part_prop_with_len_hint(
     part_prop: &mut AzihsmPartProp,
@@ -250,7 +251,8 @@ fn copy_to_part_prop_with_len_hint(
     let required_len = u32::try_from(bytes.len()).map_err(|_| AzihsmStatus::InvalidArgument)?;
 
     if part_prop.len < required_len {
-        part_prop.len = suggested_len as u32;
+        let reported_len = suggested_len.max(bytes.len());
+        part_prop.len = u32::try_from(reported_len).unwrap_or(u32::MAX);
         Err(AzihsmStatus::BufferTooSmall)?;
     }
 
@@ -315,4 +317,44 @@ where
     let actual_size = getter(Some(buffer_slice))?;
     part_prop.len = actual_size as u32;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn len_hint_shortage_reports_at_least_required_len() {
+        let bytes = [0u8; 4];
+        let mut part_prop = AzihsmPartProp {
+            id: AzihsmPartPropId::Type,
+            val: std::ptr::null_mut(),
+            len: 0,
+        };
+
+        let result = copy_to_part_prop_with_len_hint(&mut part_prop, &bytes, 2);
+
+        assert_eq!(result, Err(AzihsmStatus::BufferTooSmall));
+        assert_eq!(part_prop.len, bytes.len() as u32);
+    }
+
+    #[test]
+    #[cfg(target_pointer_width = "64")]
+    fn len_hint_shortage_saturates_oversized_suggestion() {
+        let bytes = [0u8; 4];
+        let mut part_prop = AzihsmPartProp {
+            id: AzihsmPartPropId::Type,
+            val: std::ptr::null_mut(),
+            len: 0,
+        };
+
+        let result = copy_to_part_prop_with_len_hint(
+            &mut part_prop,
+            &bytes,
+            (u32::MAX as usize).saturating_add(1),
+        );
+
+        assert_eq!(result, Err(AzihsmStatus::BufferTooSmall));
+        assert_eq!(part_prop.len, u32::MAX);
+    }
 }

--- a/api/native/src/partition_props.rs
+++ b/api/native/src/partition_props.rs
@@ -235,23 +235,25 @@ fn copy_to_part_prop(part_prop: &mut AzihsmPartProp, bytes: &[u8]) -> Result<(),
     copy_to_part_prop_with_len_hint(part_prop, bytes, bytes.len())
 }
 
-/// Copy a byte slice into a partition property buffer with a caller-visible minimum buffer length.
+/// Copy a byte slice into a partition property buffer, reporting a larger size hint on shortage.
 ///
-/// When `part_prop.len` is smaller than `min_buffer_len`, this returns
-/// [`AzihsmStatus::BufferTooSmall`] and updates `part_prop.len` to `min_buffer_len`. On success,
-/// it copies `bytes` into the caller buffer and updates `part_prop.len` to the actual byte count.
+/// If `part_prop.len` is large enough to hold `bytes`, the copy succeeds and `part_prop.len`
+/// is set to the actual byte count. If the caller's buffer is too small, `part_prop.len` is set
+/// to `max(bytes.len(), suggested_len)` and [`AzihsmStatus::BufferTooSmall`] is returned. The
+/// suggestion is advisory only — a caller buffer that already fits `bytes` never fails, even if
+/// it is smaller than `suggested_len`.
 fn copy_to_part_prop_with_len_hint(
     part_prop: &mut AzihsmPartProp,
     bytes: &[u8],
-    min_buffer_len: usize,
+    suggested_len: usize,
 ) -> Result<(), AzihsmStatus> {
     let required_len = u32::try_from(bytes.len()).map_err(|_| AzihsmStatus::InvalidArgument)?;
-    let min_buffer_len = u32::try_from(min_buffer_len)
-        .unwrap_or(u32::MAX)
-        .max(required_len);
 
-    if part_prop.len < min_buffer_len {
-        part_prop.len = min_buffer_len;
+    if part_prop.len < required_len {
+        let suggested_len = u32::try_from(suggested_len)
+            .unwrap_or(u32::MAX)
+            .max(required_len);
+        part_prop.len = suggested_len;
         Err(AzihsmStatus::BufferTooSmall)?;
     }
 

--- a/api/native/src/partition_props.rs
+++ b/api/native/src/partition_props.rs
@@ -250,10 +250,7 @@ fn copy_to_part_prop_with_len_hint(
     let required_len = u32::try_from(bytes.len()).map_err(|_| AzihsmStatus::InvalidArgument)?;
 
     if part_prop.len < required_len {
-        let suggested_len = u32::try_from(suggested_len)
-            .unwrap_or(u32::MAX)
-            .max(required_len);
-        part_prop.len = suggested_len;
+        part_prop.len = suggested_len as u32;
         Err(AzihsmStatus::BufferTooSmall)?;
     }
 

--- a/api/tests/cpp/partition_tests.cpp
+++ b/api/tests/cpp/partition_tests.cpp
@@ -636,6 +636,17 @@ TEST(azihsm_part, get_prop_manufacturer_cert_buffer_too_small)
         auto err = azihsm_part_get_prop(part.get(), &prop);
         ASSERT_EQ(err, AZIHSM_STATUS_BUFFER_TOO_SMALL);
         ASSERT_GE(prop.len, actual_size);
+
+        // Retry with the hinted size must succeed, covering the retry contract.
+        uint32_t retry_size = prop.len;
+        std::vector<uint8_t> retry_buffer(retry_size);
+        prop = { AZIHSM_PART_PROP_ID_MANUFACTURER_CERT_CHAIN,
+                 retry_buffer.data(),
+                 retry_size };
+        err = azihsm_part_get_prop(part.get(), &prop);
+        ASSERT_EQ(err, AZIHSM_STATUS_SUCCESS);
+        ASSERT_GT(prop.len, 0u);
+        ASSERT_LE(prop.len, retry_size);
     });
 }
 

--- a/api/tests/cpp/partition_tests.cpp
+++ b/api/tests/cpp/partition_tests.cpp
@@ -640,9 +640,7 @@ TEST(azihsm_part, get_prop_manufacturer_cert_buffer_too_small)
         // Retry with the hinted size must succeed, covering the retry contract.
         uint32_t retry_size = prop.len;
         std::vector<uint8_t> retry_buffer(retry_size);
-        prop = { AZIHSM_PART_PROP_ID_MANUFACTURER_CERT_CHAIN,
-                 retry_buffer.data(),
-                 retry_size };
+        prop = { AZIHSM_PART_PROP_ID_MANUFACTURER_CERT_CHAIN, retry_buffer.data(), retry_size };
         err = azihsm_part_get_prop(part.get(), &prop);
         ASSERT_EQ(err, AZIHSM_STATUS_SUCCESS);
         ASSERT_GT(prop.len, 0u);
@@ -685,13 +683,12 @@ TEST(azihsm_part, get_prop_manufacturer_cert_buffer_below_hint_succeeds)
                 ASSERT_LE(prop.len, actual_size);
                 return;
             }
-        }
 
-        ASSERT_EQ(err, AZIHSM_STATUS_BUFFER_TOO_SMALL);
+            ASSERT_EQ(err, AZIHSM_STATUS_BUFFER_TOO_SMALL);
         }
 
         FAIL() << "manufacturer certificate chain changed while testing below-hint buffer";
-});
+    });
 }
 
 TEST(azihsm_part, get_prop_backup_masking_key)

--- a/api/tests/cpp/partition_tests.cpp
+++ b/api/tests/cpp/partition_tests.cpp
@@ -515,21 +515,65 @@ TEST(azihsm_part, get_prop_manufacturer_cert_buffer_too_small)
     part_list.for_each_part([](std::vector<azihsm_char> &path) {
         auto part = PartitionHandle(path);
 
-        // First get the required size
+        // Discover the actual payload size via a successful fetch using the
+        // size hint returned by the nullptr query.
         azihsm_part_prop prop = { AZIHSM_PART_PROP_ID_MANUFACTURER_CERT_CHAIN, nullptr, 0 };
         auto err = azihsm_part_get_prop(part.get(), &prop);
         ASSERT_EQ(err, AZIHSM_STATUS_BUFFER_TOO_SMALL);
-        uint32_t required_size = prop.len;
-        ASSERT_GT(required_size, 0);
+        uint32_t size_hint = prop.len;
+        ASSERT_GT(size_hint, 0);
 
-        // Provide buffer that's too small
-        std::vector<uint8_t> buffer(required_size - 1);
-        prop.val = buffer.data();
-        prop.len = static_cast<uint32_t>(buffer.size());
+        std::vector<uint8_t> hint_buffer(size_hint);
+        prop.val = hint_buffer.data();
+        err = azihsm_part_get_prop(part.get(), &prop);
+        ASSERT_EQ(err, AZIHSM_STATUS_SUCCESS);
+        uint32_t actual_size = prop.len;
+        ASSERT_GT(actual_size, 0);
 
+        // A caller buffer strictly smaller than the actual payload must fail
+        // and the API must report a size hint that is at least the actual
+        // payload size so a retry with the hinted size succeeds.
+        std::vector<uint8_t> too_small(actual_size - 1);
+        prop.val = too_small.data();
+        prop.len = static_cast<uint32_t>(too_small.size());
         err = azihsm_part_get_prop(part.get(), &prop);
         ASSERT_EQ(err, AZIHSM_STATUS_BUFFER_TOO_SMALL);
-        ASSERT_EQ(prop.len, required_size); // Should return required size
+        ASSERT_GE(prop.len, actual_size);
+    });
+}
+
+// A caller buffer that fits the actual payload but is smaller than the
+// advisory size hint must still succeed. The hint is advisory headroom for
+// cert-chain growth across resets; it must not cause spurious failures when
+// the buffer already fits the current payload.
+TEST(azihsm_part, get_prop_manufacturer_cert_buffer_below_hint_succeeds)
+{
+    auto part_list = PartitionListHandle();
+
+    part_list.for_each_part([](std::vector<azihsm_char> &path) {
+        auto part = PartitionHandle(path);
+
+        azihsm_part_prop prop = { AZIHSM_PART_PROP_ID_MANUFACTURER_CERT_CHAIN, nullptr, 0 };
+        auto err = azihsm_part_get_prop(part.get(), &prop);
+        ASSERT_EQ(err, AZIHSM_STATUS_BUFFER_TOO_SMALL);
+        uint32_t size_hint = prop.len;
+        ASSERT_GT(size_hint, 0);
+
+        std::vector<uint8_t> hint_buffer(size_hint);
+        prop.val = hint_buffer.data();
+        err = azihsm_part_get_prop(part.get(), &prop);
+        ASSERT_EQ(err, AZIHSM_STATUS_SUCCESS);
+        uint32_t actual_size = prop.len;
+        ASSERT_GT(actual_size, 0);
+        ASSERT_LT(actual_size, size_hint);
+
+        // Buffer sized exactly to the actual payload (below the hint) must succeed.
+        std::vector<uint8_t> exact_buffer(actual_size);
+        prop.val = exact_buffer.data();
+        prop.len = static_cast<uint32_t>(exact_buffer.size());
+        err = azihsm_part_get_prop(part.get(), &prop);
+        ASSERT_EQ(err, AZIHSM_STATUS_SUCCESS);
+        ASSERT_EQ(prop.len, actual_size);
     });
 }
 

--- a/api/tests/cpp/partition_tests.cpp
+++ b/api/tests/cpp/partition_tests.cpp
@@ -674,13 +674,13 @@ TEST(azihsm_part, get_prop_manufacturer_cert_buffer_below_hint_succeeds)
                 ASSERT_LE(prop.len, actual_size);
                 return;
             }
-            }
+        }
 
-            ASSERT_EQ(err, AZIHSM_STATUS_BUFFER_TOO_SMALL);
+        ASSERT_EQ(err, AZIHSM_STATUS_BUFFER_TOO_SMALL);
         }
 
         FAIL() << "manufacturer certificate chain changed while testing below-hint buffer";
-    });
+});
 }
 
 TEST(azihsm_part, get_prop_backup_masking_key)

--- a/api/tests/cpp/partition_tests.cpp
+++ b/api/tests/cpp/partition_tests.cpp
@@ -670,8 +670,10 @@ TEST(azihsm_part, get_prop_manufacturer_cert_buffer_below_hint_succeeds)
             auto err = azihsm_part_get_prop(part.get(), &prop);
             if (err == AZIHSM_STATUS_SUCCESS)
             {
-                ASSERT_EQ(prop.len, actual_size);
+                ASSERT_GT(prop.len, 0u);
+                ASSERT_LE(prop.len, actual_size);
                 return;
+            }
             }
 
             ASSERT_EQ(err, AZIHSM_STATUS_BUFFER_TOO_SMALL);

--- a/api/tests/cpp/partition_tests.cpp
+++ b/api/tests/cpp/partition_tests.cpp
@@ -17,7 +17,10 @@ namespace
 
 uint32_t manufacturer_cert_chain_size_hint(uint32_t actual_size)
 {
-    return actual_size + (actual_size / 2) + (actual_size % 2);
+    constexpr uint32_t u32_max = static_cast<uint32_t>(-1);
+    const uint64_t actual = actual_size;
+    const uint64_t hint = actual + (actual / 2) + (actual % 2);
+    return hint > u32_max ? u32_max : static_cast<uint32_t>(hint);
 }
 
 bool get_manufacturer_cert_chain_size_hint(azihsm_handle part, uint32_t &size_hint)

--- a/api/tests/cpp/partition_tests.cpp
+++ b/api/tests/cpp/partition_tests.cpp
@@ -5,11 +5,120 @@
 #include <gtest/gtest.h>
 #include <scope_guard.hpp>
 #include <thread>
+#include <vector>
 
 #include "handle/part_handle.hpp"
 #include "handle/part_list_handle.hpp"
 #include "utils/resiliency_config.hpp"
 #include "utils/utils.hpp"
+
+namespace
+{
+
+uint32_t manufacturer_cert_chain_size_hint(uint32_t actual_size)
+{
+    return actual_size + (actual_size / 2) + (actual_size % 2);
+}
+
+bool get_manufacturer_cert_chain_size_hint(azihsm_handle part, uint32_t &size_hint)
+{
+    azihsm_part_prop prop = { AZIHSM_PART_PROP_ID_MANUFACTURER_CERT_CHAIN, nullptr, 0 };
+    auto err = azihsm_part_get_prop(part, &prop);
+    if (err != AZIHSM_STATUS_BUFFER_TOO_SMALL)
+    {
+        ADD_FAILURE() << "Expected manufacturer cert-chain size query to return BUFFER_TOO_SMALL";
+        return false;
+    }
+    if (prop.len == 0)
+    {
+        ADD_FAILURE() << "Expected manufacturer cert-chain size hint to be non-zero";
+        return false;
+    }
+
+    size_hint = prop.len;
+    return true;
+}
+
+bool get_manufacturer_cert_chain_with_retry(
+    azihsm_handle part,
+    uint32_t size_hint,
+    std::vector<uint8_t> &buffer
+)
+{
+    for (auto attempt = 0u; attempt < 8; ++attempt)
+    {
+        buffer.assign(size_hint, 0);
+        azihsm_part_prop prop = { AZIHSM_PART_PROP_ID_MANUFACTURER_CERT_CHAIN,
+                                  buffer.data(),
+                                  size_hint };
+        auto err = azihsm_part_get_prop(part, &prop);
+        if (err == AZIHSM_STATUS_SUCCESS)
+        {
+            if (prop.len == 0)
+            {
+                ADD_FAILURE() << "Expected manufacturer cert-chain payload to be non-zero";
+                return false;
+            }
+
+            buffer.resize(prop.len);
+            return true;
+        }
+
+        if (err != AZIHSM_STATUS_BUFFER_TOO_SMALL)
+        {
+            ADD_FAILURE() << "Expected success or BUFFER_TOO_SMALL";
+            return false;
+        }
+        if (prop.len <= size_hint)
+        {
+            ADD_FAILURE() << "Expected BUFFER_TOO_SMALL to increase the hint";
+            return false;
+        }
+
+        size_hint = prop.len;
+    }
+
+    ADD_FAILURE() << "Manufacturer cert-chain fetch did not stabilize after retries";
+    return false;
+}
+
+bool get_stable_manufacturer_cert_chain_snapshot(
+    azihsm_handle part,
+    std::vector<uint8_t> &buffer,
+    uint32_t &size_hint
+)
+{
+    for (auto attempt = 0u; attempt < 8; ++attempt)
+    {
+        uint32_t initial_size_hint = 0;
+        if (!get_manufacturer_cert_chain_size_hint(part, initial_size_hint))
+        {
+            return false;
+        }
+        if (!get_manufacturer_cert_chain_with_retry(part, initial_size_hint, buffer))
+        {
+            return false;
+        }
+
+        uint32_t current_size_hint = 0;
+        if (!get_manufacturer_cert_chain_size_hint(part, current_size_hint))
+        {
+            return false;
+        }
+
+        uint32_t actual_size = static_cast<uint32_t>(buffer.size());
+        if (current_size_hint == manufacturer_cert_chain_size_hint(actual_size))
+        {
+            size_hint = current_size_hint;
+            return true;
+        }
+    }
+
+    ADD_FAILURE() << "Manufacturer cert-chain size changed while reading a stable snapshot";
+    return false;
+}
+
+} // namespace
 
 TEST(azihsm_part, get_list)
 {
@@ -490,20 +599,12 @@ TEST(azihsm_part, get_prop_manufacturer_cert_returns_larger_size_hint)
     part_list.for_each_part([](std::vector<azihsm_char> &path) {
         auto part = PartitionHandle(path);
 
-        azihsm_part_prop prop = { AZIHSM_PART_PROP_ID_MANUFACTURER_CERT_CHAIN, nullptr, 0 };
-        auto err = azihsm_part_get_prop(part.get(), &prop);
-        ASSERT_EQ(err, AZIHSM_STATUS_BUFFER_TOO_SMALL);
-        uint32_t size_hint = prop.len;
-        ASSERT_GT(size_hint, 0);
+        std::vector<uint8_t> buffer;
+        uint32_t size_hint = 0;
+        ASSERT_TRUE(get_stable_manufacturer_cert_chain_snapshot(part.get(), buffer, size_hint));
+        uint32_t actual_size = static_cast<uint32_t>(buffer.size());
 
-        std::vector<azihsm_char> buffer(size_hint);
-        prop.val = buffer.data();
-        err = azihsm_part_get_prop(part.get(), &prop);
-        ASSERT_EQ(err, AZIHSM_STATUS_SUCCESS);
-        uint32_t actual_size = prop.len;
-        ASSERT_GT(actual_size, 0);
-
-        uint32_t expected_size_hint = actual_size + (actual_size / 2) + (actual_size % 2);
+        uint32_t expected_size_hint = manufacturer_cert_chain_size_hint(actual_size);
         ASSERT_EQ(size_hint, expected_size_hint);
     });
 }
@@ -515,28 +616,21 @@ TEST(azihsm_part, get_prop_manufacturer_cert_buffer_too_small)
     part_list.for_each_part([](std::vector<azihsm_char> &path) {
         auto part = PartitionHandle(path);
 
-        // Discover the actual payload size via a successful fetch using the
-        // size hint returned by the nullptr query.
-        azihsm_part_prop prop = { AZIHSM_PART_PROP_ID_MANUFACTURER_CERT_CHAIN, nullptr, 0 };
-        auto err = azihsm_part_get_prop(part.get(), &prop);
-        ASSERT_EQ(err, AZIHSM_STATUS_BUFFER_TOO_SMALL);
-        uint32_t size_hint = prop.len;
-        ASSERT_GT(size_hint, 0);
-
-        std::vector<uint8_t> hint_buffer(size_hint);
-        prop.val = hint_buffer.data();
-        err = azihsm_part_get_prop(part.get(), &prop);
-        ASSERT_EQ(err, AZIHSM_STATUS_SUCCESS);
-        uint32_t actual_size = prop.len;
-        ASSERT_GT(actual_size, 0);
+        std::vector<uint8_t> hint_buffer;
+        uint32_t size_hint = 0;
+        ASSERT_TRUE(get_stable_manufacturer_cert_chain_snapshot(part.get(), hint_buffer, size_hint)
+        );
+        uint32_t actual_size = static_cast<uint32_t>(hint_buffer.size());
+        ASSERT_GT(actual_size, 1);
 
         // A caller buffer strictly smaller than the actual payload must fail
         // and the API must report a size hint that is at least the actual
         // payload size so a retry with the hinted size succeeds.
         std::vector<uint8_t> too_small(actual_size - 1);
-        prop.val = too_small.data();
-        prop.len = static_cast<uint32_t>(too_small.size());
-        err = azihsm_part_get_prop(part.get(), &prop);
+        azihsm_part_prop prop = { AZIHSM_PART_PROP_ID_MANUFACTURER_CERT_CHAIN,
+                                  too_small.data(),
+                                  static_cast<uint32_t>(too_small.size()) };
+        auto err = azihsm_part_get_prop(part.get(), &prop);
         ASSERT_EQ(err, AZIHSM_STATUS_BUFFER_TOO_SMALL);
         ASSERT_GE(prop.len, actual_size);
     });
@@ -553,27 +647,34 @@ TEST(azihsm_part, get_prop_manufacturer_cert_buffer_below_hint_succeeds)
     part_list.for_each_part([](std::vector<azihsm_char> &path) {
         auto part = PartitionHandle(path);
 
-        azihsm_part_prop prop = { AZIHSM_PART_PROP_ID_MANUFACTURER_CERT_CHAIN, nullptr, 0 };
-        auto err = azihsm_part_get_prop(part.get(), &prop);
-        ASSERT_EQ(err, AZIHSM_STATUS_BUFFER_TOO_SMALL);
-        uint32_t size_hint = prop.len;
-        ASSERT_GT(size_hint, 0);
+        uint32_t size_hint = 0;
+        uint32_t actual_size = 0;
 
-        std::vector<uint8_t> hint_buffer(size_hint);
-        prop.val = hint_buffer.data();
-        err = azihsm_part_get_prop(part.get(), &prop);
-        ASSERT_EQ(err, AZIHSM_STATUS_SUCCESS);
-        uint32_t actual_size = prop.len;
-        ASSERT_GT(actual_size, 0);
-        ASSERT_LT(actual_size, size_hint);
+        for (auto attempt = 0u; attempt < 8; ++attempt)
+        {
+            std::vector<uint8_t> hint_buffer;
+            ASSERT_TRUE(
+                get_stable_manufacturer_cert_chain_snapshot(part.get(), hint_buffer, size_hint)
+            );
+            actual_size = static_cast<uint32_t>(hint_buffer.size());
+            ASSERT_LT(actual_size, size_hint);
 
-        // Buffer sized exactly to the actual payload (below the hint) must succeed.
-        std::vector<uint8_t> exact_buffer(actual_size);
-        prop.val = exact_buffer.data();
-        prop.len = static_cast<uint32_t>(exact_buffer.size());
-        err = azihsm_part_get_prop(part.get(), &prop);
-        ASSERT_EQ(err, AZIHSM_STATUS_SUCCESS);
-        ASSERT_EQ(prop.len, actual_size);
+            // Buffer sized exactly to the actual payload (below the hint) must succeed.
+            std::vector<uint8_t> exact_buffer(actual_size);
+            azihsm_part_prop prop = { AZIHSM_PART_PROP_ID_MANUFACTURER_CERT_CHAIN,
+                                      exact_buffer.data(),
+                                      static_cast<uint32_t>(exact_buffer.size()) };
+            auto err = azihsm_part_get_prop(part.get(), &prop);
+            if (err == AZIHSM_STATUS_SUCCESS)
+            {
+                ASSERT_EQ(prop.len, actual_size);
+                return;
+            }
+
+            ASSERT_EQ(err, AZIHSM_STATUS_BUFFER_TOO_SMALL);
+        }
+
+        FAIL() << "manufacturer certificate chain changed while testing below-hint buffer";
     });
 }
 


### PR DESCRIPTION
The buffer-length hint for ManufacturerCertChain was previously enforced as a minimum required size on every BufferTooSmall path. If a reset caused the cert chain to grow between a caller's size-query and fetch, a retry buffer that already fit the new payload M could still fail with AZIHSM_STATUS_BUFFER_TOO_SMALL whenever M was below ceil(M * 1.5), and the next retry would just inflate the hint again.

Make the hint advisory: copy_to_part_prop_with_len_hint now succeeds whenever the caller buffer fits the actual bytes, and only reports max(actual, suggested) on a genuine shortage. Callers that follow the returned hint still get headroom for modest chain growth, but a buffer sized to the current payload never spuriously fails.