### PR TITLE
feat(fw): implement DDI GetSessionEncryptionKey handler

### DIFF
--- a/ddi/mbor/types/tests/azihsm_ddi_tests.rs
+++ b/ddi/mbor/types/tests/azihsm_ddi_tests.rs
@@ -33,6 +33,7 @@ mod integration {
     pub mod get_device_info;
     pub mod get_establish_cred_encryption_key;
     pub mod get_session_encryption_key;
+    pub mod get_session_encryption_key_smoke;
     pub mod get_unwrapping_key;
     pub mod hmac;
     pub mod init_bk3_smoke;

--- a/ddi/mbor/types/tests/integration/get_session_encryption_key_smoke.rs
+++ b/ddi/mbor/types/tests/integration/get_session_encryption_key_smoke.rs
@@ -1,0 +1,81 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! GetSessionEncryptionKey smoke tests for the emu backend.
+//!
+//! Exercises the GetSessionEncryptionKey firmware command from the
+//! host side end-to-end:
+//!
+//! - Happy path: after a credential has been established, the command
+//!   returns a non-empty session encryption public key, a non-empty
+//!   nonce, and a non-empty signature over the public key.
+//! - Before establishment: the command is rejected with
+//!   `CredentialsNotEstablished` (the host has no use for a session
+//!   encryption key without a credential to wrap into `OpenSession`).
+
+#![cfg(test)]
+
+use azihsm_ddi::*;
+use azihsm_ddi_mbor_types::*;
+use test_with_tracing::test;
+
+use super::common::*;
+
+pub fn setup(dev: &mut <DdiTest as Ddi>::Dev, ddi: &DdiTest, path: &str) -> u16 {
+    common_cleanup(dev, ddi, path, None);
+
+    // GetSessionEncryptionKey is a no-session command; the harness
+    // ignores the returned id so any sentinel value is fine.
+    0
+}
+
+#[test]
+fn test_get_session_encryption_key_smoke() {
+    ddi_dev_test(setup, common_cleanup, |dev, _ddi, _path, _| {
+        helper_common_establish_credential(dev, TEST_CRED_ID, TEST_CRED_PIN);
+
+        let resp =
+            helper_get_session_encryption_key(dev, None, Some(DdiApiRev { major: 1, minor: 0 }))
+                .unwrap();
+
+        assert!(resp.hdr.sess_id.is_none());
+        assert_eq!(resp.hdr.op, DdiOp::GetSessionEncryptionKey);
+        assert_eq!(resp.hdr.status, DdiStatus::Success);
+
+        assert!(
+            !resp.data.pub_key.der.is_empty(),
+            "session encryption pub_key must be non-empty"
+        );
+        assert!(
+            !resp.data.nonce.is_empty(),
+            "session encryption nonce must be non-empty"
+        );
+
+        // The signature is only populated by real or emulated devices;
+        // the mock dispatcher returns an empty placeholder.
+        if get_device_kind(dev) != DdiDeviceKind::Virtual {
+            assert!(
+                !resp.data.pub_key_signature.is_empty(),
+                "session encryption pub_key_signature must be non-empty"
+            );
+        }
+    });
+}
+
+#[test]
+fn test_get_session_encryption_key_without_establish_cred_smoke() {
+    ddi_dev_test(setup, common_cleanup, |dev, _ddi, _path, _| {
+        let err =
+            helper_get_session_encryption_key(dev, None, Some(DdiApiRev { major: 1, minor: 0 }))
+                .expect_err("must be rejected before EstablishCredential");
+
+        assert!(
+            matches!(
+                err,
+                DdiError::DdiStatus(DdiStatus::CredentialsNotEstablished)
+            ),
+            "expected CredentialsNotEstablished, got {:?}",
+            err
+        );
+    });
+}

--- a/fw/core/ddi/mbor/types/src/get_session_encryption_key.rs
+++ b/fw/core/ddi/mbor/types/src/get_session_encryption_key.rs
@@ -12,7 +12,7 @@ pub struct DdiGetSessionEncryptionKeyReq {}
 #[derive(Debug, Ddi)]
 #[ddi(map)]
 pub struct DdiGetSessionEncryptionKeyResp<'a> {
-    #[ddi(id = 1)]
+    #[ddi(id = 1, frame)]
     pub pub_key: DdiPublicKey<'a>,
     #[ddi(id = 2, len = 32)]
     pub nonce: &'a [u8],

--- a/fw/core/lib/src/ddi/mbor/get_session_encryption_key.rs
+++ b/fw/core/lib/src/ddi/mbor/get_session_encryption_key.rs
@@ -1,0 +1,87 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! DDI GetSessionEncryptionKey command handler.
+//!
+//! Returns the session-encryption public key, a nonce, and a signature
+//! over the public key (signed with the partition identity key). This
+//! is a NoSession command and is the bootstrap for [`OpenSession`]:
+//! the host uses the returned public key + nonce to wrap the session
+//! credential it then sends in [`OpenSession`].
+//!
+//! Uses the encode-frame-then-fill pattern: all variable fields are
+//! filled directly into the encoder-reserved slots — zero intermediate
+//! copies.
+
+use azihsm_fw_ddi_mbor_types::get_session_encryption_key::DdiGetSessionEncryptionKeyReq;
+use azihsm_fw_ddi_mbor_types::get_session_encryption_key::DdiGetSessionEncryptionKeyResp;
+use azihsm_fw_ddi_mbor_types::DdiPublicKeyFrameParams;
+
+use super::*;
+
+/// Handle DdiGetSessionEncryptionKeyCmd.
+///
+/// Fails up-front with [`HsmError::CredentialsNotEstablished`] if the
+/// partition does not yet have a user credential — the session
+/// encryption key is meaningless before a credential is established
+/// (the host would have nothing to wrap into the OpenSession request).
+///
+/// Unlike the `EstablishCred` encryption key, the session encryption
+/// key is **persistent** across sessions — it is created at partition
+/// enable and kept for the lifetime of the partition.  No clearing or
+/// rotation is performed here.
+pub(crate) async fn get_session_encryption_key<'p, P: HsmPal>(
+    pal: &'p P,
+    io: &impl HsmIo,
+    decoder: &mut DdiDecoder<'_>,
+    hdr: &DdiReqHdr,
+) -> HsmResult<&'p DmaBuf> {
+    let _body: DdiGetSessionEncryptionKeyReq = decoder.decode_data()?;
+
+    if !pal.part_is_credential_set(io)? {
+        return Err(HsmError::CredentialsNotEstablished);
+    }
+
+    // Query sizes, then encode header + frame with reserved slots.
+    let pub_key_len = pal.part_session_enc_pub_key(io, None)?;
+    let nonce_len = pal.part_nonce(io, None)?;
+
+    let digest = pal.dma_alloc(io, HsmHashAlgo::Sha384.digest_len())?;
+    let id_priv_key = pal.vault_key(io, pal.part_id_key_id(io)?)?;
+
+    let (resp, layout) = pal.dma_alloc_var_with(io, |buf| {
+        let mut encoder = super::encode_resp_hdr(
+            &super::success_hdr(hdr, DdiOp::GetSessionEncryptionKey),
+            buf,
+        )?;
+        let layout = DdiGetSessionEncryptionKeyResp::reserve(
+            &mut encoder,
+            DdiPublicKeyFrameParams {
+                raw_len: pub_key_len,
+                key_kind: DdiKeyType::Ecc384Public,
+            },
+            nonce_len,
+            HsmEccCurve::P384.sig_len(),
+        )?;
+        Ok((encoder.position(), layout))
+    })?;
+    let frame = DdiGetSessionEncryptionKeyResp::from_layout(resp, &layout);
+
+    // Fill public key and nonce in-place.
+    pal.part_session_enc_pub_key(io, Some(frame.pub_key.raw))?;
+    pal.part_nonce(io, Some(frame.nonce))?;
+
+    // Hash pub key, then sign directly into the signature slot.
+    pal.hash(io, HsmHashAlgo::Sha384, frame.pub_key.raw, digest, true)
+        .await?;
+    pal.ecc_sign(
+        io,
+        HsmEccCurve::P384,
+        id_priv_key,
+        digest,
+        frame.pub_key_signature,
+    )
+    .await?;
+
+    Ok(resp)
+}

--- a/fw/core/lib/src/ddi/mbor/get_session_encryption_key.rs
+++ b/fw/core/lib/src/ddi/mbor/get_session_encryption_key.rs
@@ -5,9 +5,9 @@
 //!
 //! Returns the session-encryption public key, a nonce, and a signature
 //! over the public key (signed with the partition identity key). This
-//! is a NoSession command and is the bootstrap for [`OpenSession`]:
+//! is a NoSession command and is the bootstrap for [`DdiOp::OpenSession`]:
 //! the host uses the returned public key + nonce to wrap the session
-//! credential it then sends in [`OpenSession`].
+//! credential it then sends in [`DdiOp::OpenSession`].
 //!
 //! Uses the encode-frame-then-fill pattern: all variable fields are
 //! filled directly into the encoder-reserved slots — zero intermediate

--- a/fw/core/lib/src/ddi/mbor/mod.rs
+++ b/fw/core/lib/src/ddi/mbor/mod.rs
@@ -8,6 +8,7 @@ pub(crate) mod get_certificate;
 pub(crate) mod get_device_info;
 pub(crate) mod get_establish_cred_encryption_key;
 pub(crate) mod get_sealed_bk3;
+pub(crate) mod get_session_encryption_key;
 pub(crate) mod init_bk3;
 pub(crate) mod set_sealed_bk3;
 pub(crate) mod sha_digest;
@@ -24,6 +25,7 @@ pub(crate) use get_certificate::*;
 pub(crate) use get_device_info::*;
 pub(crate) use get_establish_cred_encryption_key::*;
 pub(crate) use get_sealed_bk3::*;
+pub(crate) use get_session_encryption_key::*;
 pub(crate) use init_bk3::*;
 pub(crate) use set_sealed_bk3::*;
 pub(crate) use sha_digest::*;
@@ -82,6 +84,7 @@ pub(crate) async fn dispatch<'p, P: HsmPal>(
         DdiOp::GetEstablishCredEncryptionKey => {
             get_establish_cred_encryption_key(pal, io, decoder, hdr).await
         }
+        DdiOp::GetSessionEncryptionKey => get_session_encryption_key(pal, io, decoder, hdr).await,
         DdiOp::GetSealedBk3 => get_sealed_bk3(pal, io, decoder, hdr),
         DdiOp::SetSealedBk3 => set_sealed_bk3(pal, io, decoder, hdr),
         DdiOp::InitBk3 => init_bk3(pal, io, decoder, hdr).await,

--- a/fw/core/lib/src/op.rs
+++ b/fw/core/lib/src/op.rs
@@ -592,6 +592,7 @@ impl SessionCtrl {
             | DdiOp::GetCertChainInfo
             | DdiOp::GetCertificate
             | DdiOp::GetEstablishCredEncryptionKey
+            | DdiOp::GetSessionEncryptionKey
             | DdiOp::GetSealedBk3
             | DdiOp::InitBk3
             | DdiOp::SetSealedBk3

--- a/fw/plat/std/pal/src/part.rs
+++ b/fw/plat/std/pal/src/part.rs
@@ -1162,8 +1162,7 @@ impl StdHsmPal {
         // knows the identity key was wiped and needs to be regenerated.
         // The cached leaf cert is keyed off the old id_pub_key so it
         // must also be invalidated.
-        entry.id_key_id.take();
-        entry.id_pub_key.fill(0);
+        entry.id_key_id = None;
         entry.leaf_cert[..entry.leaf_cert_len].fill(0);
         entry.leaf_cert_len = 0;
 

--- a/fw/plat/std/pal/src/part.rs
+++ b/fw/plat/std/pal/src/part.rs
@@ -488,10 +488,14 @@ impl HsmPartitionManager for StdHsmPal {
         io: &impl HsmIo,
         out: Option<&mut [u8]>,
     ) -> HsmResult<usize> {
-        copy_out(
-            &self.enabled_part(u8::from(io.pid()))?.session_enc_pub_key,
-            out,
-        )
+        // Stored internally as big-endian `x ∥ y` (OpenSSL convention).
+        // The wire contract — matching real PKA hardware — is
+        // little-endian, and the host-side `post_decode_fn` on
+        // `DdiDerPublicKey` reverses each coord back to big-endian
+        // before DER-encoding.  Reverse each coord here so the wire
+        // bytes are LE.
+        let raw = &self.enabled_part(u8::from(io.pid()))?.session_enc_pub_key;
+        copy_out_pub_key_le(raw, out)
     }
 
     fn part_clear_establish_cred_key(&self, io: &impl HsmIo) -> HsmResult<()> {
@@ -931,6 +935,32 @@ impl StdHsmPal {
             .with_local(true)
             .with_derive(true);
 
+        // If the identity key was wiped (e.g., by a prior part_disable),
+        // regenerate it before any other key — mirrors real hardware
+        // where NSSR/erase always provisions a fresh partition identity
+        // key.  Must be created first so it lands in the same vault
+        // slot the `id_key_id` field was originally bound to.
+        if table.entries[idx].id_key_id.is_none() {
+            let id_attrs = HsmVaultKeyAttrs::new()
+                .with_internal(true)
+                .with_local(true)
+                .with_sign(true);
+            let mut id_pub = [0u8; P384_PUB_KEY_LEN];
+            let id_kid = self
+                .create_internal_ecc384_key(
+                    pid,
+                    HsmVaultKeyKind::Ecc384Private,
+                    id_attrs,
+                    HsmEccPct::SignVerify,
+                    &mut id_pub,
+                )
+                .await?;
+            let table = unsafe { &mut *self.part_table.get() };
+            let entry = &mut table.entries[idx];
+            entry.id_key_id = Some(id_kid);
+            entry.id_pub_key = id_pub;
+        }
+
         // Generate establish-credential encryption ECC-384 key pair.
         let mut ec_pub = [0u8; P384_PUB_KEY_LEN];
         let ec_kid = self
@@ -1127,6 +1157,16 @@ impl StdHsmPal {
         entry.session_enc_pub_key.fill(0);
 
         entry.nonce.fill(0);
+
+        // Take id_key_id BEFORE vault.clear() so part_enable_internal
+        // knows the identity key was wiped and needs to be regenerated.
+        // The cached leaf cert is keyed off the old id_pub_key so it
+        // must also be invalidated.
+        entry.id_key_id.take();
+        entry.id_pub_key.fill(0);
+        entry.leaf_cert[..entry.leaf_cert_len].fill(0);
+        entry.leaf_cert_len = 0;
+
         entry.vault.clear();
         entry.session_table = SessionTable::new();
         entry.sealed_bk3[..entry.sealed_bk3_len as usize].fill(0);


### PR DESCRIPTION
Mirrors the existing GetEstablishCredEncryptionKey handler pattern: query → alloc → encode-frame-then-fill → sign with the partition identity key.  Fail-fast with CredentialsNotEstablished when the partition does not yet have a user credential (matches mcr-hsm reference) — the host has nothing to wrap into OpenSession without one.

Adds GetSessionEncryptionKey to the NoSession arm of SessionCtrl::from_op so the dispatcher does not reject sess_id = None.

Also fixes two pre-existing StdPal bugs surfaced by the new handler:

- part_session_enc_pub_key was not reversing BE → LE for the wire, whereas the establish-cred sibling does via copy_out_pub_key_le. This caused host-side signature verification to fail.
- clear_enabled_state's vault.clear() wiped the partition identity key, but the id_key_id field was never cleared, leaving a stale reference into the next vault incarnation after erase. part_enable_internal now regenerates the identity key when it has been wiped (mirrors real-hardware NSSR semantics), and the cached leaf cert is invalidated alongside.

Adds 2 smoke tests (happy path + CredentialsNotEstablished gate) and gets 12 emu tests to pass that previously failed (the full integration test for the new handler + the live-migration variant).