### PR TITLE
ci: add provider integration test matrix

### DIFF
--- a/.github/workflows/provider-matrix.yml
+++ b/.github/workflows/provider-matrix.yml
@@ -87,6 +87,7 @@ jobs:
             image:         almalinux:9.2
             family:        rhel
             vault:         https://repo.almalinux.org/vault/9.2
+            gpgkey:        RPM-GPG-KEY-AlmaLinux-9
             lib_dir:       /usr/lib64
             openssl_minor: "3.0"
             nginx:         false
@@ -96,6 +97,7 @@ jobs:
             image:         rockylinux:9.2
             family:        rhel
             vault:         https://dl.rockylinux.org/vault/rocky/9.2
+            gpgkey:        RPM-GPG-KEY-Rocky-9
             lib_dir:       /usr/lib64
             openssl_minor: "3.0"
             nginx:         false
@@ -122,17 +124,21 @@ jobs:
           # The 9.2 vault preserves openssl-devel-3.0.7; the rolling el9
           # repos have been bumped to 3.5.5.
           sed -i 's/enabled=1/enabled=0/g' /etc/yum.repos.d/*.repo 2>/dev/null || true
+          # Vault packages are signed with the distro key the image ships in
+          # /etc/pki/rpm-gpg/, so signature verification stays on.
           cat > /etc/yum.repos.d/vault.repo <<EOF
           [vault-baseos]
           name=9.2 vault BaseOS
           baseurl=${{ matrix.vault }}/BaseOS/x86_64/os/
           enabled=1
-          gpgcheck=0
+          gpgcheck=1
+          gpgkey=file:///etc/pki/rpm-gpg/${{ matrix.gpgkey }}
           [vault-appstream]
           name=9.2 vault AppStream
           baseurl=${{ matrix.vault }}/AppStream/x86_64/os/
           enabled=1
-          gpgcheck=0
+          gpgcheck=1
+          gpgkey=file:///etc/pki/rpm-gpg/${{ matrix.gpgkey }}
           EOF
           dnf clean all
           # nodejs is for JS-based actions (see debian bootstrap).

--- a/.github/workflows/provider-matrix.yml
+++ b/.github/workflows/provider-matrix.yml
@@ -151,18 +151,31 @@ jobs:
       - name: Show OpenSSL version
         run: openssl version
 
-      - name: Set up Rust
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          toolchain: '1.93'
+      # Plain distro containers ship no rustup.  Install it with no default
+      # toolchain so rust-toolchain.toml stays the single source of the
+      # toolchain version (rustup auto-installs it on the first cargo call).
+      - name: Install rustup
+        run: |
+          curl --proto '=https' --tlsv1.2 -fsSL https://sh.rustup.rs \
+            | sh -s -- -y --default-toolchain none --profile minimal
+          echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
 
-      - name: Cache cargo + target/
-        uses: Swatinem/rust-cache@v2
+      - name: Cache cargo + target
+        uses: actions/cache@v5
         with:
-          shared-key: matrix-${{ matrix.distro }}
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: matrix-${{ matrix.distro }}-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml') }}
+          restore-keys: matrix-${{ matrix.distro }}-
 
+      # Installs the version pinned in xtask (CARGO_NEXTEST_VERSION); the
+      # binary persists in the ~/.cargo/bin cache above.
       - name: Install cargo-nextest
-        uses: taiki-e/install-action@nextest
+        run: cargo xtask setup --skip-taplo --skip-audit
 
       - name: Build provider
         run: |

--- a/.github/workflows/provider-matrix.yml
+++ b/.github/workflows/provider-matrix.yml
@@ -1,0 +1,207 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+#
+# Runs the OpenSSL provider integration suites (cli + capi + nginx) across
+# five OpenSSL 3.0.x distributions in parallel.  Each cell is its own job
+# and shows up as its own PR check.
+#
+# The nginx suite is exercised only on distros whose OpenSSL carries the
+# upstream STORE-dispatch fix (issue openssl#18262, fixed in 3.0.4 with
+# follow-ups through ~3.0.13).  Cells on older patchsets set
+# `matrix.nginx: false` and skip the nginx install + test entirely.
+#
+# Each cell's `matrix.openssl_minor` is exported as
+# AZIHSM_TEST_OPENSSL_MAJOR_MINOR so the suites' version-gating primitives
+# can skip tests that require a newer OpenSSL than the cell provides.
+
+name: Provider matrix
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+env:
+  CARGO_TERM_COLOR: always
+  # The capi integration tests' build.rs (and openssl-sys) need
+  # OPENSSL_DIR + OPENSSL_INCLUDE_DIR to find the system OpenSSL.
+  # OPENSSL_LIB_DIR varies between Debian's multiarch layout and RHEL's
+  # /usr/lib64, so it's set per-cell from `matrix.lib_dir`.
+  OPENSSL_DIR: /usr
+  OPENSSL_INCLUDE_DIR: /usr/include
+
+defaults:
+  run:
+    # Explicit bash for `run:` steps so the workflow behaves the same on
+    # GHA (where bash is the Linux default anyway) and under `act` (which
+    # falls back to /bin/sh).  Several steps use bash arrays.
+    shell: bash
+
+jobs:
+  matrix:
+    name: ${{ matrix.label }}
+    runs-on: ubuntu-24.04
+    container: ${{ matrix.image }}
+    env:
+      OPENSSL_LIB_DIR: ${{ matrix.lib_dir }}
+      # Exported so the suites' version-gating primitives can skip tests that
+      # require a newer OpenSSL than this cell provides.
+      AZIHSM_TEST_OPENSSL_MAJOR_MINOR: ${{ matrix.openssl_minor }}
+      # Test-runtime config consumed by the cli scripts' env.sh and the
+      # capi / nginx test harnesses.
+      OPENSSL_BIN: /usr/bin/openssl
+      OPENSSL_LIB: ${{ github.workspace }}/target/debug
+      PROVIDER_PATH: ${{ github.workspace }}/target/debug
+      PROPQUERY: '?provider=azihsm'
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - distro:        u2204
+            label:         Ubuntu 22.04 (OpenSSL 3.0.2)
+            image:         ubuntu:22.04
+            family:        debian
+            lib_dir:       /usr/lib/x86_64-linux-gnu
+            openssl_minor: "3.0"
+            nginx:         false
+
+          - distro:        u2404
+            label:         Ubuntu 24.04 (OpenSSL 3.0.13)
+            image:         ubuntu:24.04
+            family:        debian
+            lib_dir:       /usr/lib/x86_64-linux-gnu
+            openssl_minor: "3.0"
+            nginx:         true
+
+          - distro:        debian12
+            label:         Debian 12 (OpenSSL 3.0.11)
+            image:         debian:12
+            family:        debian
+            lib_dir:       /usr/lib/x86_64-linux-gnu
+            openssl_minor: "3.0"
+            nginx:         true
+
+          - distro:        alma9
+            label:         AlmaLinux 9.2 (OpenSSL 3.0.7)
+            image:         almalinux:9.2
+            family:        rhel
+            vault:         https://repo.almalinux.org/vault/9.2
+            lib_dir:       /usr/lib64
+            openssl_minor: "3.0"
+            nginx:         false
+
+          - distro:        rocky9
+            label:         Rocky 9.2 (OpenSSL 3.0.7)
+            image:         rockylinux:9.2
+            family:        rhel
+            vault:         https://dl.rockylinux.org/vault/rocky/9.2
+            lib_dir:       /usr/lib64
+            openssl_minor: "3.0"
+            nginx:         false
+
+    steps:
+      # Containers need git before actions/checkout, and the build deps
+      # before cargo can compile.  Both go in a single bootstrap step.
+      - name: Bootstrap (debian)
+        if: matrix.family == 'debian'
+        run: |
+          apt-get update
+          # nodejs is for JS-based actions (rust-cache, checkout, etc.) —
+          # GHA auto-injects node in container jobs but `act` does not.
+          # xxd (used by the import_wrapped_key cli test scripts) lives in
+          # its own package on Debian/Ubuntu.
+          apt-get install -y --no-install-recommends \
+            ca-certificates curl git nodejs \
+            build-essential cmake pkg-config perl \
+            openssl libssl-dev libbsd-dev xxd
+
+      - name: Bootstrap (rhel)
+        if: matrix.family == 'rhel'
+        run: |
+          # The 9.2 vault preserves openssl-devel-3.0.7; the rolling el9
+          # repos have been bumped to 3.5.5.
+          sed -i 's/enabled=1/enabled=0/g' /etc/yum.repos.d/*.repo 2>/dev/null || true
+          cat > /etc/yum.repos.d/vault.repo <<EOF
+          [vault-baseos]
+          name=9.2 vault BaseOS
+          baseurl=${{ matrix.vault }}/BaseOS/x86_64/os/
+          enabled=1
+          gpgcheck=0
+          [vault-appstream]
+          name=9.2 vault AppStream
+          baseurl=${{ matrix.vault }}/AppStream/x86_64/os/
+          enabled=1
+          gpgcheck=0
+          EOF
+          dnf clean all
+          # nodejs is for JS-based actions (see debian bootstrap).
+          # vim-common provides /usr/bin/xxd (used by the import_wrapped_key
+          # cli test scripts); el9 has no standalone xxd package.
+          dnf install -y --setopt=install_weak_deps=False \
+            gcc gcc-c++ make perl perl-core git nodejs \
+            pkgconf openssl openssl-devel \
+            findutils diffutils python3-pip vim-common
+          # Vault's cmake is 3.20.2; corrosion needs >= 3.22.
+          pip3 install --no-warn-script-location cmake
+          echo /usr/local/bin >> "$GITHUB_PATH"
+
+      - uses: actions/checkout@v6
+
+      - name: Show OpenSSL version
+        run: openssl version
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: '1.93'
+
+      - name: Cache cargo + target/
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: matrix-${{ matrix.distro }}
+
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@nextest
+
+      - name: Build provider
+        run: |
+          cargo build -p azihsm_api_native --features mock
+          cargo build -p azihsm_ossl_provider --features mock
+
+      # nginx 1.29.0 is the last mainline release linked only against
+      # OPENSSL_3.0.0 symbols (1.29.1+ requires 3.2.0+), so it is compatible
+      # with all the 3.0.x cells.  The mainline apt index only advertises the
+      # current release, so pin the archived .deb from the pool (which keeps
+      # every past version) directly.
+      - name: Install nginx 1.29.0
+        if: matrix.nginx
+        run: |
+          codename=$(. /etc/os-release && echo "$VERSION_CODENAME")
+          host=$(. /etc/os-release && echo "$ID")
+          curl -fsSL -o /tmp/nginx.deb \
+            "https://nginx.org/packages/mainline/${host}/pool/nginx/n/nginx/nginx_1.29.0-1~${codename}_amd64.deb"
+          apt-get install -y --no-install-recommends /tmp/nginx.deb
+
+      # Each suite is its own GHA step.  `!cancelled()` lets capi + nginx
+      # run even when cli fails, so the cell's PR check list shows three
+      # independent pass/fail indicators instead of one.
+      - name: Run cli suite
+        run: |
+          cargo nextest run --features integration \
+            -p provider-integration-tests-cli \
+            --profile ci-provider-integration --no-fail-fast
+
+      - name: Run capi suite
+        if: ${{ !cancelled() }}
+        run: |
+          cargo nextest run --features integration \
+            -p provider-integration-tests-capi \
+            --profile ci-provider-integration --no-fail-fast
+
+      - name: Run nginx suite
+        if: ${{ !cancelled() && matrix.nginx }}
+        run: |
+          cargo nextest run --features integration \
+            -p provider-integration-tests-nginx \
+            --profile ci-provider-integration --no-fail-fast

--- a/.github/workflows/provider-matrix.yml
+++ b/.github/workflows/provider-matrix.yml
@@ -5,9 +5,9 @@
 # five OpenSSL 3.0.x distributions in parallel.  Each cell is its own job
 # and shows up as its own PR check.
 #
-# The nginx suite is exercised only on distros whose OpenSSL carries the
-# upstream STORE-dispatch fix (issue openssl#18262, fixed in 3.0.4 with
-# follow-ups through ~3.0.13).  Cells on older patchsets set
+# The nginx suite runs only where OpenSSL carries the complete STORE-dispatch
+# fix (issue openssl#18262, fixed in 3.0.4 with follow-ups through ~3.0.11) —
+# the 3.0.11 / 3.0.13 cells.  The 3.0.2 cell and the 3.0.7 RHEL cells set
 # `matrix.nginx: false` and skip the nginx install + test entirely.
 #
 # Each cell's `matrix.openssl_minor` is exported as

--- a/plugins/ossl_prov/integration-tests/nginx/src/nginx_tests.rs
+++ b/plugins/ossl_prov/integration-tests/nginx/src/nginx_tests.rs
@@ -70,7 +70,7 @@ mod integration {
         let Ok(ver) = env::var("AZIHSM_TEST_OPENSSL_MAJOR_MINOR") else {
             return false;
         };
-        ver == "3.0" && script_name.contains("_requires_openssl_3_5")
+        ver == "3.0" && script_name.ends_with("_requires_openssl_3_5.sh")
     }
 
     /// Run the full NGINX integration test suite.

--- a/plugins/ossl_prov/integration-tests/nginx/src/nginx_tests.rs
+++ b/plugins/ossl_prov/integration-tests/nginx/src/nginx_tests.rs
@@ -57,6 +57,22 @@ mod integration {
         "negative_provider_required.sh",
     ];
 
+    /// Returns true if an assertion script should be skipped because the
+    /// current OpenSSL ABI cannot run it.
+    ///
+    /// Read from `AZIHSM_TEST_OPENSSL_MAJOR_MINOR` (set by
+    /// `provider-matrix.yml` per job).  When unset, no skips happen.
+    ///
+    /// Convention: name a script `*_requires_openssl_3_5.sh` to mark it
+    /// as 3.5-only.  When running against OpenSSL 3.0, such scripts are
+    /// reported as `[SKIP]` instead of executed.
+    fn should_skip_script_for_current_openssl(script_name: &str) -> bool {
+        let Ok(ver) = env::var("AZIHSM_TEST_OPENSSL_MAJOR_MINOR") else {
+            return false;
+        };
+        ver == "3.0" && script_name.contains("_requires_openssl_3_5")
+    }
+
     /// Run the full NGINX integration test suite.
     pub fn run(args: Arguments) {
         let testfiles_dir = get_testfiles_dir();
@@ -94,6 +110,10 @@ mod integration {
 
         let mut first_failure: Option<Failed> = None;
         for script in ASSERTION_SCRIPTS {
+            if should_skip_script_for_current_openssl(script) {
+                println!("[SKIP] {script} (requires OpenSSL >= 3.5)");
+                continue;
+            }
             let script_path = testfiles_dir.join(script);
             match run_test_script(&script_path, &keymat_dir, &provider_so, &nginx_conf) {
                 Ok(()) => println!("[PASS] {script}"),

--- a/plugins/ossl_prov/integration-tests/openssl-capi/cpp/openssl_capi_integration_tests.rs
+++ b/plugins/ossl_prov/integration-tests/openssl-capi/cpp/openssl_capi_integration_tests.rs
@@ -398,7 +398,7 @@ azihsm-api-revision = 1.0
         let Ok(ver) = env::var("AZIHSM_TEST_OPENSSL_MAJOR_MINOR") else {
             return false;
         };
-        ver == "3.0" && test_name.contains("_RequiresOpenssl35")
+        ver == "3.0" && test_name.ends_with("_RequiresOpenssl35")
     }
 
     /// Parses the gtest list output and creates test trials.

--- a/plugins/ossl_prov/integration-tests/openssl-capi/cpp/openssl_capi_integration_tests.rs
+++ b/plugins/ossl_prov/integration-tests/openssl-capi/cpp/openssl_capi_integration_tests.rs
@@ -378,6 +378,29 @@ azihsm-api-revision = 1.0
         stdout
     }
 
+    /// Returns true if a discovered gtest case should be skipped because
+    /// the current OpenSSL ABI cannot run it.
+    ///
+    /// Read from `AZIHSM_TEST_OPENSSL_MAJOR_MINOR` (set by
+    /// `provider-matrix.yml` per job).  When unset, no skips happen — so a plain
+    /// `cargo xtask integration-tests` run against a single OpenSSL version
+    /// still runs the full suite.
+    ///
+    /// Convention: tag a C++ gtest case with the `_RequiresOpenssl35`
+    /// suffix to mark it as 3.5-only.  When running against OpenSSL 3.0,
+    /// such cases are reported as `ignored` instead of executed.
+    ///
+    /// Example C++ definition:
+    /// ```cpp
+    /// TEST(EcKeys, GenerateMlDsa_RequiresOpenssl35) { ... }
+    /// ```
+    fn should_skip_for_current_openssl(test_name: &str) -> bool {
+        let Ok(ver) = env::var("AZIHSM_TEST_OPENSSL_MAJOR_MINOR") else {
+            return false;
+        };
+        ver == "3.0" && test_name.contains("_RequiresOpenssl35")
+    }
+
     /// Parses the gtest list output and creates test trials.
     fn parse_gtest_list(
         output: &str,
@@ -395,6 +418,10 @@ azihsm-api-revision = 1.0
                 current_suite = line.trim_end_matches('.').to_string();
             } else if !line.trim().is_empty() {
                 let test_name = format!("{}::{}", current_suite, line.trim());
+                if should_skip_for_current_openssl(&test_name) {
+                    tests.push(Trial::test(test_name, || Ok(())).with_ignored_flag(true));
+                    continue;
+                }
                 let path = path.clone();
                 let ld_path = ld_library_path.clone();
                 let creds = credentials.clone();

--- a/plugins/ossl_prov/integration-tests/openssl-cli/testfiles/env.sh
+++ b/plugins/ossl_prov/integration-tests/openssl-cli/testfiles/env.sh
@@ -120,3 +120,27 @@ azihsm-api-revision = 1.0
 EOF
 
 export OPENSSL_CONF="$AZIHSM_KEY_DIR/openssl.cnf"
+
+# --- Version gating helpers ---
+# Skip the test if OpenSSL is older than the given <major>.<minor>.  Used by
+# lit .sh scripts that exercise features only available in newer OpenSSL.
+# Exits 0 (lit treats this as a passing skip) so the rest of the suite
+# continues.
+#
+#   require_ossl_version 3 5
+require_ossl_version() {
+    local req_major=$1 req_minor=$2
+    local ver
+    ver=$("$OPENSSL_BIN" version | awk '{print $2}')
+    local cur_major cur_minor
+    cur_major=$(echo "$ver" | cut -d. -f1)
+    cur_minor=$(echo "$ver" | cut -d. -f2)
+    if [ "$cur_major" -lt "$req_major" ] || \
+       { [ "$cur_major" -eq "$req_major" ] && [ "$cur_minor" -lt "$req_minor" ]; }; then
+        echo "SKIP: requires OpenSSL >= $req_major.$req_minor (have $ver)"
+        exit 0
+    fi
+}
+
+# Convenience: skip the test unless OpenSSL is at least 3.5.
+skip_below_ossl_3_5() { require_ossl_version 3 5; }

--- a/plugins/ossl_prov/src/azihsm_ossl_hsm.c
+++ b/plugins/ossl_prov/src/azihsm_ossl_hsm.c
@@ -642,6 +642,8 @@ static azihsm_status sign_with_pota_key(
 {
     azihsm_status status = AZIHSM_STATUS_INTERNAL_ERROR;
     const unsigned char *der_ptr = priv_key_der;
+    OSSL_LIB_CTX *pota_libctx = NULL;
+    OSSL_PROVIDER *pota_default = NULL;
     EVP_PKEY *pota_pkey = NULL;
     EVP_MD_CTX *md_ctx = NULL;
     unsigned char *der_sig_buf = NULL;
@@ -653,8 +655,26 @@ static azihsm_status sign_with_pota_key(
     sig_out->ptr = NULL;
     sig_out->len = 0;
 
+    /* The POTA key is a software EC key.  Run its decode + sign in a private
+     * library context that has only the default provider, so the operation
+     * can never be routed to the azihsm provider (which the application also
+     * loads in the default libctx, and whose keymgmt carries no private
+     * component — causing intermittent "not a private key" failures). */
+    pota_libctx = OSSL_LIB_CTX_new();
+    if (pota_libctx == NULL)
+    {
+        ERR_raise(ERR_LIB_PROV, ERR_R_MALLOC_FAILURE);
+        goto cleanup;
+    }
+    pota_default = OSSL_PROVIDER_load(pota_libctx, "default");
+    if (pota_default == NULL)
+    {
+        ERR_raise(ERR_LIB_PROV, ERR_R_INTERNAL_ERROR);
+        goto cleanup;
+    }
+
     /* Decode the POTA private key from its DER representation */
-    pota_pkey = d2i_AutoPrivateKey(NULL, &der_ptr, (long)priv_key_der_len);
+    pota_pkey = d2i_AutoPrivateKey_ex(NULL, &der_ptr, (long)priv_key_der_len, pota_libctx, NULL);
     if (pota_pkey == NULL)
     {
         ERR_raise(ERR_LIB_PROV, ERR_R_INTERNAL_ERROR);
@@ -668,7 +688,7 @@ static azihsm_status sign_with_pota_key(
         goto cleanup;
     }
 
-    if (EVP_DigestSignInit(md_ctx, NULL, EVP_sha384(), NULL, pota_pkey) != 1)
+    if (EVP_DigestSignInit_ex(md_ctx, NULL, "SHA384", pota_libctx, NULL, pota_pkey, NULL) != 1)
     {
         ERR_raise(ERR_LIB_PROV, ERR_R_INTERNAL_ERROR);
         goto cleanup;
@@ -746,6 +766,12 @@ cleanup:
     OPENSSL_clear_free(der_sig_buf, der_sig_len);
     EVP_MD_CTX_free(md_ctx);
     EVP_PKEY_free(pota_pkey);
+    /* OSSL_PROVIDER_unload is not NULL-safe; OSSL_LIB_CTX_free is. */
+    if (pota_default != NULL)
+    {
+        OSSL_PROVIDER_unload(pota_default);
+    }
+    OSSL_LIB_CTX_free(pota_libctx);
     return status;
 }
 

--- a/xtask/src/integration_tests.rs
+++ b/xtask/src/integration_tests.rs
@@ -69,7 +69,13 @@ impl Xtask for IntegrationTest {
             let openssl_dir = crate::host_openssl::check_openssl()?;
 
             if unset_or_empty("OPENSSL_BIN") {
-                std::env::set_var("OPENSSL_BIN", openssl_dir.join("bin/openssl"));
+                let bin = openssl_dir.join("bin/openssl");
+                anyhow::ensure!(
+                    bin.is_file(),
+                    "openssl binary not found at {}; install openssl or set OPENSSL_BIN",
+                    bin.display()
+                );
+                std::env::set_var("OPENSSL_BIN", bin);
             }
             if unset_or_empty("OPENSSL_DIR") {
                 std::env::set_var("OPENSSL_DIR", &openssl_dir);
@@ -102,8 +108,17 @@ impl Xtask for IntegrationTest {
             };
             if let Some(ref p) = openssl_lib_dir {
                 let combined = format!("{}:{}", p.display(), cargo_debug.display());
-                if unset_or_empty("OPENSSL_LIB") {
-                    std::env::set_var("OPENSSL_LIB", &combined);
+                // env.sh derives LD_LIBRARY_PATH from OPENSSL_LIB, so a
+                // caller-supplied value must still include target/debug for
+                // libazihsm_api_native.so resolution.
+                let dbg = cargo_debug.display().to_string();
+                match std::env::var("OPENSSL_LIB") {
+                    Ok(v) if !v.is_empty() => {
+                        if !v.split(':').any(|seg| seg == dbg) {
+                            std::env::set_var("OPENSSL_LIB", format!("{v}:{dbg}"));
+                        }
+                    }
+                    _ => std::env::set_var("OPENSSL_LIB", &combined),
                 }
                 // Always prepend to LD_LIBRARY_PATH so the custom openssl
                 // binary's libcrypto resolves to our install, not the system

--- a/xtask/src/integration_tests.rs
+++ b/xtask/src/integration_tests.rs
@@ -55,12 +55,18 @@ impl Xtask for IntegrationTest {
 
         #[cfg(target_os = "linux")]
         {
-            let openssl_dir = crate::host_openssl::check_openssl()?;
-
             // A caller may export these as an empty string (env.sh sets
             // OPENSSL_LIB="" to mean "set but empty"); treat empty as unset.
             let unset_or_empty =
                 |key: &str| std::env::var(key).map(|v| v.is_empty()).unwrap_or(true);
+
+            // check_openssl() respects OPENSSL_DIR first and would treat an
+            // empty value as a (bad) path; drop it so the fallback discovery
+            // (pkg-config, well-known prefixes) kicks in.
+            if std::env::var("OPENSSL_DIR").is_ok_and(|v| v.is_empty()) {
+                std::env::remove_var("OPENSSL_DIR");
+            }
+            let openssl_dir = crate::host_openssl::check_openssl()?;
 
             if unset_or_empty("OPENSSL_BIN") {
                 std::env::set_var("OPENSSL_BIN", openssl_dir.join("bin/openssl"));

--- a/xtask/src/integration_tests.rs
+++ b/xtask/src/integration_tests.rs
@@ -5,32 +5,147 @@
 #![forbid(unsafe_code)]
 
 use clap::Parser;
+use clap::ValueEnum;
 
 use crate::Xtask;
 use crate::XtaskCtx;
 
-/// Xtask to run integration tests.
+/// Which provider integration suite(s) to run.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, ValueEnum)]
+pub enum Suite {
+    /// OpenSSL CLI tests via lit (`provider-integration-tests-cli`).
+    Cli,
+    /// OpenSSL C API tests via libtest-mimic + gtest (`provider-integration-tests-capi`).
+    Capi,
+    /// NGINX tests via libtest-mimic (`provider-integration-tests-nginx`).
+    Nginx,
+    /// Run all three suites in order: cli, capi, nginx.
+    All,
+}
+
+/// Run the OpenSSL provider integration tests.
 ///
-/// Currently a no-op. The provider integration test passes (CLI, CAPI,
-/// nginx) are temporarily disabled while the OpenSSL provider build
-/// coupling with `libazihsm_api_native` is being reworked. The command
-/// remains in the xtask surface so CI / scripted invocations stay
-/// stable; it logs a skip notice and returns success.
+/// Discovers OpenSSL via [`crate::host_openssl::check_openssl`] (respects
+/// `OPENSSL_DIR` first, falls back to `pkg-config` and well-known
+/// prefixes).  Cleans `target/test-keymat/` before each run for fresh
+/// per-run isolation.  Sets `OPENSSL_BIN` / `OPENSSL_LIB` / `OPENSSL_DIR`
+/// for the test harnesses if they aren't already set.
 ///
-/// Re-enable by restoring the nextest invocations in this file once
-/// the build coupling rework lands.
+/// The provider stack itself is **not** built here — callers must build it
+/// into `target/debug` (`cargo build -p azihsm_ossl_provider --features mock`)
+/// beforehand.  Keeping the build out means a partial run (`--suite nginx`)
+/// doesn't recompile the world.
 #[derive(Parser)]
-#[clap(about = "Run Integration Tests (currently disabled)")]
-pub struct IntegrationTest {}
+#[clap(about = "Run Integration Tests")]
+pub struct IntegrationTest {
+    /// Which suite to run.  Defaults to `all` (cli + capi + nginx).
+    #[clap(long, value_enum, default_value_t = Suite::All)]
+    pub suite: Suite,
+}
 
 impl Xtask for IntegrationTest {
     fn run(self, _ctx: XtaskCtx) -> anyhow::Result<()> {
-        log::warn!(
-            "skipping provider integration tests: temporarily disabled \
-             while OpenSSL provider build coupling with libazihsm_api_native \
-             is reworked. Re-enable by restoring the nextest invocations in \
-             xtask/src/integration_tests.rs once the rework lands."
-        );
-        Ok(())
+        log::trace!("start testing");
+
+        #[cfg(not(target_os = "linux"))]
+        {
+            log::warn!("skipping provider integration tests: only supported on Linux");
+            Ok(())
+        }
+
+        #[cfg(target_os = "linux")]
+        {
+            let openssl_dir = crate::host_openssl::check_openssl()?;
+
+            // A caller may export these as an empty string (env.sh sets
+            // OPENSSL_LIB="" to mean "set but empty"); treat empty as unset.
+            let unset_or_empty =
+                |key: &str| std::env::var(key).map(|v| v.is_empty()).unwrap_or(true);
+
+            if unset_or_empty("OPENSSL_BIN") {
+                std::env::set_var("OPENSSL_BIN", openssl_dir.join("bin/openssl"));
+            }
+            if unset_or_empty("OPENSSL_DIR") {
+                std::env::set_var("OPENSSL_DIR", &openssl_dir);
+            }
+
+            // Compute the OpenSSL lib dir for both `OPENSSL_LIB` (read by the
+            // env.sh / CAPI / NGINX harnesses) and `LD_LIBRARY_PATH` (read
+            // directly by the dynamic linker for every `openssl` subprocess
+            // spawn).  Both are necessary: the openssl binary itself needs
+            // libcrypto.so.3 to load (LD_LIBRARY_PATH), and the harnesses
+            // need to know which lib dir to forward (OPENSSL_LIB).  Probe
+            // lib64 first (RHEL/Fedora), then fall back to lib.  `target/debug`
+            // is appended for `libazihsm_api_native.so` resolution.
+            let cargo_debug = _ctx.root.join("target").join("debug");
+            let openssl_lib_dir = {
+                let lib64 = openssl_dir.join("lib64");
+                let lib = openssl_dir.join("lib");
+                if lib64.is_dir() {
+                    Some(lib64)
+                } else if lib.is_dir() {
+                    Some(lib)
+                } else {
+                    log::warn!(
+                        "neither {}/lib64 nor {}/lib exists",
+                        openssl_dir.display(),
+                        openssl_dir.display()
+                    );
+                    None
+                }
+            };
+            if let Some(ref p) = openssl_lib_dir {
+                let combined = format!("{}:{}", p.display(), cargo_debug.display());
+                if unset_or_empty("OPENSSL_LIB") {
+                    std::env::set_var("OPENSSL_LIB", &combined);
+                }
+                // Always prepend to LD_LIBRARY_PATH so the custom openssl
+                // binary's libcrypto resolves to our install, not the system
+                // one (which may lack newer symbols).  Prepending keeps any
+                // existing LD_LIBRARY_PATH content reachable as a fallback.
+                let existing = std::env::var("LD_LIBRARY_PATH").unwrap_or_default();
+                let new_ld = if existing.is_empty() {
+                    combined
+                } else {
+                    format!("{combined}:{existing}")
+                };
+                std::env::set_var("LD_LIBRARY_PATH", new_ld);
+            }
+
+            // Test key material is regenerated per run by each harness; the
+            // wrapping clean below ensures no stale state from a prior run
+            // leaks across processes.
+            let keymat_dir = _ctx.root.join("target").join("test-keymat");
+            if keymat_dir.exists() {
+                std::fs::remove_dir_all(&keymat_dir)?;
+                log::trace!(
+                    "cleaned previous test key material at {}",
+                    keymat_dir.display()
+                );
+            }
+
+            let run_pkg = |pkg: &str, ctx: XtaskCtx| -> anyhow::Result<()> {
+                crate::nextest::Nextest {
+                    features: Some("integration".to_string()),
+                    package: Some(pkg.to_string()),
+                    no_default_features: false,
+                    filterset: None,
+                    profile: Some("ci-provider-integration".to_string()),
+                    exclude: vec![],
+                }
+                .run(ctx)
+            };
+
+            match self.suite {
+                Suite::Cli => run_pkg("provider-integration-tests-cli", _ctx),
+                Suite::Capi => run_pkg("provider-integration-tests-capi", _ctx),
+                Suite::Nginx => run_pkg("provider-integration-tests-nginx", _ctx),
+                Suite::All => {
+                    run_pkg("provider-integration-tests-cli", _ctx.clone())?;
+                    run_pkg("provider-integration-tests-capi", _ctx.clone())?;
+                    run_pkg("provider-integration-tests-nginx", _ctx)
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
Runs the OpenSSL provider integration suites (cli + capi + nginx) across five OpenSSL 3.0.x distributions in parallel. The nginx suite runs only where OpenSSL carries the complete STORE-dispatch fix (openssl#18262) — the 3.0.11/3.0.13 cells — and is skipped on 3.0.2 and the RHEL-family 3.0.7 cells.