### PR TITLE
Fix for decoding TBOR nested structs

### DIFF
--- a/fw/core/ddi/tbor/api/tests/derive_tests.rs
+++ b/fw/core/ddi/tbor/api/tests/derive_tests.rs
@@ -1173,6 +1173,192 @@ fn nested_include_constants() {
     assert_eq!(FullHeader::TOC_COUNT, 2 + KeyInfo::TOC_COUNT);
 }
 
+// ── Typed decode of include groups ────────────────────────────────────
+
+#[test]
+fn include_group_typed_decode() {
+    let mut buf = [0u8; 512];
+    let frame = IncludeReq::encode(&mut buf)
+        .unwrap()
+        .header(|h| {
+            h.session(azihsm_fw_ddi_tbor_api::SessionId(7))?
+                .key(azihsm_fw_ddi_tbor_api::KeyId(42))?
+                .algorithm(3)
+        })
+        .unwrap()
+        .payload(b"test data")
+        .unwrap()
+        .finish();
+
+    // Typed Layer-2 decode (exercises the group's `validate` helper and
+    // the generated sub-view accessor).
+    let view = IncludeReq::decode(frame.as_bytes()).unwrap();
+    let header = view.header();
+    assert_eq!(header.session().0, 7);
+    assert_eq!(header.key().0, 42);
+    assert_eq!(header.algorithm(), 3);
+    assert_eq!(view.payload(), b"test data");
+}
+
+#[test]
+fn nested_include_typed_decode() {
+    let mut buf = [0u8; 512];
+    let frame = NestedIncludeReq::encode(&mut buf)
+        .unwrap()
+        .header(|h| {
+            h.session(azihsm_fw_ddi_tbor_api::SessionId(99))?
+                .key_info(|k: KeyInfoEnc<'_, KeyInfoS0>| {
+                    k.key(azihsm_fw_ddi_tbor_api::KeyId(5))?.key_type(2)
+                })?
+                .algorithm(3)
+        })
+        .unwrap()
+        .payload(b"nested!")
+        .unwrap()
+        .finish();
+
+    // Typed decode must succeed: previously `FullHeader::validate`
+    // treated the nested `KeyInfo` TOC entries as scalar placeholders
+    // (type 0) and rejected them.
+    let view = NestedIncludeReq::decode(frame.as_bytes()).unwrap();
+    let header = view.header();
+    assert_eq!(header.session().0, 99);
+    let key_info = header.key_info();
+    assert_eq!(key_info.key().0, 5);
+    assert_eq!(key_info.key_type(), 2);
+    assert_eq!(header.algorithm(), 3);
+    assert_eq!(view.payload(), b"nested!");
+}
+
+// ── Optional include field groups ─────────────────────────────────────
+
+#[tbor(fields)]
+pub struct OptInfo {
+    #[tbor(key_id)]
+    key: u16,
+    flag: u8,
+}
+
+#[tbor(opcode = 0x72)]
+pub struct OptIncludeReq<'a> {
+    #[tbor(include)]
+    info: Option<OptInfo>,
+    #[tbor(max_len = 256)]
+    payload: &'a [u8],
+}
+
+#[test]
+fn optional_include_present_decode() {
+    fn fill_info<'a>(
+        i: OptInfoEnc<'a, OptInfoS0>,
+    ) -> Result<OptInfoEnc<'a, OptInfoDone>, azihsm_fw_ddi_tbor::EncodeError> {
+        i.key(azihsm_fw_ddi_tbor_api::KeyId(9))?.flag(1)
+    }
+
+    let mut buf = [0u8; 512];
+    let frame = OptIncludeReq::encode(&mut buf)
+        .unwrap()
+        .info(Some(fill_info))
+        .unwrap()
+        .payload(b"hi")
+        .unwrap()
+        .finish();
+
+    let view = OptIncludeReq::decode(frame.as_bytes()).unwrap();
+    let info = view.info().expect("group present");
+    assert_eq!(info.key().0, 9);
+    assert_eq!(info.flag(), 1);
+    assert_eq!(view.payload(), b"hi");
+}
+
+#[test]
+fn optional_include_omitted_decode() {
+    let mut buf = [0u8; 512];
+    // Skip the optional group entirely; the encoder writes `None` to
+    // every one of its TOC entries.
+    let frame = OptIncludeReq::encode(&mut buf)
+        .unwrap()
+        .payload(b"hi")
+        .unwrap()
+        .finish();
+
+    // Previously this failed to decode: `OptInfo::validate` rejected the
+    // all-`None` group because `key`/`flag` are required inner fields.
+    let view = OptIncludeReq::decode(frame.as_bytes()).unwrap();
+    assert!(view.info().is_none());
+    assert_eq!(view.payload(), b"hi");
+}
+
+// ── Length constraints inside include groups ──────────────────────────
+
+#[tbor(fields)]
+pub struct StrictBufGroup<'a> {
+    #[tbor(session_id)]
+    tag: u16,
+    #[tbor(max_len = 8)]
+    data: &'a [u8],
+}
+
+#[tbor(opcode = 0x73)]
+pub struct StrictBufReq<'a> {
+    #[tbor(include)]
+    grp: StrictBufGroup<'a>,
+}
+
+// Same wire layout and opcode but a looser length cap, used to forge a
+// structurally-valid frame whose group buffer exceeds the strict cap.
+#[tbor(fields)]
+pub struct LooseBufGroup<'a> {
+    #[tbor(session_id)]
+    tag: u16,
+    #[tbor(max_len = 64)]
+    data: &'a [u8],
+}
+
+#[tbor(opcode = 0x73)]
+pub struct LooseBufReq<'a> {
+    #[tbor(include)]
+    grp: LooseBufGroup<'a>,
+}
+
+#[test]
+fn include_group_len_check_passes() {
+    let mut buf = [0u8; 256];
+    let frame = StrictBufReq::encode(&mut buf)
+        .unwrap()
+        .grp(|g: StrictBufGroupEnc<'_, StrictBufGroupS0>| {
+            g.tag(azihsm_fw_ddi_tbor_api::SessionId(1))?.data(b"ok")
+        })
+        .unwrap()
+        .finish();
+
+    let view = StrictBufReq::decode(frame.as_bytes()).unwrap();
+    assert_eq!(view.grp().tag().0, 1);
+    assert_eq!(view.grp().data(), b"ok");
+}
+
+#[test]
+fn include_group_len_check_rejects_oversize() {
+    let mut buf = [0u8; 256];
+    let frame = LooseBufReq::encode(&mut buf)
+        .unwrap()
+        .grp(|g: LooseBufGroupEnc<'_, LooseBufGroupS0>| {
+            g.tag(azihsm_fw_ddi_tbor_api::SessionId(1))?
+                .data(&[0u8; 20])
+        })
+        .unwrap()
+        .finish();
+
+    // The wire layout/opcode match `StrictBufReq`, but its group caps
+    // `data` at 8 bytes. The length constraint is now enforced inside
+    // the group's `validate` helper.
+    let err = StrictBufReq::decode(frame.as_bytes()).unwrap_err();
+    assert!(matches!(
+        err,
+        azihsm_fw_ddi_tbor::DecodeError::InvalidFixedLength { .. }
+    ));
+}
+
 // ── Trait-based dispatch ──────────────────────────────────────────────
 
 use azihsm_fw_ddi_tbor_api::TborRequest;

--- a/fw/core/ddi/tbor/derive/src/codegen_enc.rs
+++ b/fw/core/ddi/tbor/derive/src/codegen_enc.rs
@@ -84,7 +84,7 @@ pub fn gen_encoder_and_frame(schema: &Schema) -> TokenStream {
 // ── Helper: TOC count expression ──────────────────────────────────────
 
 /// Build the compile-time `TOC_COUNT` expression including nested groups.
-fn build_toc_count_expr(layout: &TocLayout, fields: &[SchemaField]) -> TokenStream {
+pub(crate) fn build_toc_count_expr(layout: &TocLayout, fields: &[SchemaField]) -> TokenStream {
     let local_toc_count = layout.total_toc_count;
     let group_addends: Vec<_> = fields
         .iter()
@@ -230,25 +230,35 @@ fn gen_new_fn(
     }
 }
 
-// ── Helper: effective TOC index ───────────────────────────────────────
+/// Offset a base TOC-index expression by the `TOC_COUNT` of every
+/// preceding include-group field, returning the combined expression.
+///
+/// The group counts are only known to the compiler after expansion, so
+/// they are emitted symbolically (e.g. `(5usize + FooGroup::TOC_COUNT)`).
+pub(crate) fn offset_by_preceding_groups(
+    base: TokenStream,
+    preceding: &[SchemaField],
+) -> TokenStream {
+    let preceding_group_counts: Vec<_> = preceding
+        .iter()
+        .filter_map(|f| f.include_group.as_ref().map(|g| quote! { + #g::TOC_COUNT }))
+        .collect();
+    if preceding_group_counts.is_empty() {
+        base
+    } else {
+        quote! { (#base #(#preceding_group_counts)*) }
+    }
+}
 
 /// Compute the effective TOC index expression for field `i`, accounting
 /// for preceding include-group contributions.
-fn effective_toc_idx(i: usize, layout: &TocLayout, fields: &[SchemaField]) -> TokenStream {
+pub(crate) fn effective_toc_idx(
+    i: usize,
+    layout: &TocLayout,
+    fields: &[SchemaField],
+) -> TokenStream {
     let local_idx = layout.field_toc_indices[i];
-    let group_addends: Vec<_> = fields[..i]
-        .iter()
-        .filter_map(|pf| {
-            pf.include_group
-                .as_ref()
-                .map(|pg| quote! { + #pg::TOC_COUNT })
-        })
-        .collect();
-    if group_addends.is_empty() {
-        quote! { #local_idx }
-    } else {
-        quote! { (#local_idx #(#group_addends)*) }
-    }
+    offset_by_preceding_groups(quote! { #local_idx }, &fields[..i])
 }
 
 // ── Helper: emit None for skipped optional fields ─────────────────────

--- a/fw/core/ddi/tbor/derive/src/codegen_fields.rs
+++ b/fw/core/ddi/tbor/derive/src/codegen_fields.rs
@@ -414,61 +414,66 @@ pub fn gen_field_group(schema: &Schema) -> TokenStream {
     // these, an included group's constrained buffer could decode even
     // when its length violates the schema (top-level `validate` skips
     // include fields and delegates entirely to this helper).
-    let len_checks: Vec<_> = schema.fields.iter().enumerate().filter_map(|(i, field)| {
-        if field.include_group.is_some() {
-            return None;
-        }
-        if !matches!(field.wire_type, WireType::Buffer | WireType::SealedKey) {
-            return None;
-        }
-        let has_constraint =
-            field.fixed_len.is_some() || field.min_len > 0 || field.max_len < 8191;
-        if !has_constraint {
-            return None;
-        }
-        let toc_idx = effective_toc_idx(i);
-        let min_l = field.fixed_len.unwrap_or(field.min_len);
-        let max_l = field.fixed_len.unwrap_or(field.max_len);
-        if field.optional {
-            let none_type_id = 8u8;
-            Some(quote! {
-                {
-                    let actual = azihsm_fw_ddi_tbor::toc::raw_toc_entry_type(
-                        azihsm_fw_ddi_tbor::toc::read_toc_word(buf, header_len, toc_offset + #toc_idx)
-                    );
-                    if actual != #none_type_id {
-                        let len = azihsm_fw_ddi_tbor::toc::raw_toc_length(
-                            azihsm_fw_ddi_tbor::toc::read_toc_word(buf, header_len, toc_offset + #toc_idx)
+    let len_checks: Vec<_> = schema
+        .fields
+        .iter()
+        .enumerate()
+        .filter_map(|(i, field)| {
+            if field.include_group.is_some() {
+                return None;
+            }
+            if !matches!(field.wire_type, WireType::Buffer | WireType::SealedKey) {
+                return None;
+            }
+            let has_constraint =
+                field.fixed_len.is_some() || field.min_len > 0 || field.max_len < 8191;
+            if !has_constraint {
+                return None;
+            }
+            let toc_idx = effective_toc_idx(i);
+            let min_l = field.fixed_len.unwrap_or(field.min_len);
+            let max_l = field.fixed_len.unwrap_or(field.max_len);
+            if field.optional {
+                let none_type_id = 8u8;
+                Some(quote! {
+                    {
+                        let word = azihsm_fw_ddi_tbor::toc::read_toc_word(
+                            buf, header_len, toc_offset + #toc_idx,
                         );
+                        let actual = azihsm_fw_ddi_tbor::toc::raw_toc_entry_type(word);
+                        if actual != #none_type_id {
+                            let len = azihsm_fw_ddi_tbor::toc::raw_toc_length(word);
+                            if !(#min_l..=#max_l).contains(&len) {
+                                return Err(azihsm_fw_ddi_tbor::DecodeError::InvalidFixedLength {
+                                    entry_index: toc_offset + #toc_idx,
+                                    entry_type: actual,
+                                    expected: #min_l,
+                                    actual: len,
+                                });
+                            }
+                        }
+                    }
+                })
+            } else {
+                Some(quote! {
+                    {
+                        let word = azihsm_fw_ddi_tbor::toc::read_toc_word(
+                            buf, header_len, toc_offset + #toc_idx,
+                        );
+                        let len = azihsm_fw_ddi_tbor::toc::raw_toc_length(word);
                         if !(#min_l..=#max_l).contains(&len) {
                             return Err(azihsm_fw_ddi_tbor::DecodeError::InvalidFixedLength {
                                 entry_index: toc_offset + #toc_idx,
-                                entry_type: 7,
+                                entry_type: azihsm_fw_ddi_tbor::toc::raw_toc_entry_type(word),
                                 expected: #min_l,
                                 actual: len,
                             });
                         }
                     }
-                }
-            })
-        } else {
-            Some(quote! {
-                {
-                    let len = azihsm_fw_ddi_tbor::toc::raw_toc_length(
-                        azihsm_fw_ddi_tbor::toc::read_toc_word(buf, header_len, toc_offset + #toc_idx)
-                    );
-                    if !(#min_l..=#max_l).contains(&len) {
-                        return Err(azihsm_fw_ddi_tbor::DecodeError::InvalidFixedLength {
-                            entry_index: toc_offset + #toc_idx,
-                            entry_type: 7,
-                            expected: #min_l,
-                            actual: len,
-                        });
-                    }
-                }
-            })
-        }
-    }).collect();
+                })
+            }
+        })
+        .collect();
 
     quote! {
         #vis struct #name;

--- a/fw/core/ddi/tbor/derive/src/codegen_fields.rs
+++ b/fw/core/ddi/tbor/derive/src/codegen_fields.rs
@@ -13,6 +13,7 @@ use proc_macro2::TokenStream;
 use quote::format_ident;
 use quote::quote;
 
+use crate::codegen_view::group_present_expr;
 use crate::schema::*;
 
 /// Generate all code for a field group (`#[tbor(fields)]`).
@@ -326,8 +327,29 @@ pub fn gen_field_group(schema: &Schema) -> TokenStream {
 
     // ── Validation helper ─────────────────────────────────────────────
     let type_checks: Vec<_> = schema.fields.iter().enumerate().map(|(i, field)| {
-        let toc_type_id = field.toc_type_id;
         let toc_idx = effective_toc_idx(i);
+
+        // Nested include-group fields delegate to the nested group's own
+        // `validate` helper rather than being treated as scalar entries.
+        // Optional nested groups are skipped when the encoder omitted
+        // them (every group TOC entry written as `None`).
+        if let Some(group) = &field.include_group {
+            if field.optional {
+                let group_off = quote! { toc_offset + #toc_idx };
+                let present =
+                    group_present_expr(group, &quote! { buf }, &quote! { header_len }, &group_off);
+                return quote! {
+                    if #present {
+                        #group::validate(buf, header_len, #group_off)?;
+                    }
+                };
+            }
+            return quote! {
+                #group::validate(buf, header_len, toc_offset + #toc_idx)?;
+            };
+        }
+
+        let toc_type_id = field.toc_type_id;
         if field.optional {
             let none_type_id = 8u8;
             quote! {
@@ -388,6 +410,66 @@ pub fn gen_field_group(schema: &Schema) -> TokenStream {
         }
     }).collect();
 
+    // Length-constraint checks for buffer/sealed_key fields. Without
+    // these, an included group's constrained buffer could decode even
+    // when its length violates the schema (top-level `validate` skips
+    // include fields and delegates entirely to this helper).
+    let len_checks: Vec<_> = schema.fields.iter().enumerate().filter_map(|(i, field)| {
+        if field.include_group.is_some() {
+            return None;
+        }
+        if !matches!(field.wire_type, WireType::Buffer | WireType::SealedKey) {
+            return None;
+        }
+        let has_constraint =
+            field.fixed_len.is_some() || field.min_len > 0 || field.max_len < 8191;
+        if !has_constraint {
+            return None;
+        }
+        let toc_idx = effective_toc_idx(i);
+        let min_l = field.fixed_len.unwrap_or(field.min_len);
+        let max_l = field.fixed_len.unwrap_or(field.max_len);
+        if field.optional {
+            let none_type_id = 8u8;
+            Some(quote! {
+                {
+                    let actual = azihsm_fw_ddi_tbor::toc::raw_toc_entry_type(
+                        azihsm_fw_ddi_tbor::toc::read_toc_word(buf, header_len, toc_offset + #toc_idx)
+                    );
+                    if actual != #none_type_id {
+                        let len = azihsm_fw_ddi_tbor::toc::raw_toc_length(
+                            azihsm_fw_ddi_tbor::toc::read_toc_word(buf, header_len, toc_offset + #toc_idx)
+                        );
+                        if !(#min_l..=#max_l).contains(&len) {
+                            return Err(azihsm_fw_ddi_tbor::DecodeError::InvalidFixedLength {
+                                entry_index: toc_offset + #toc_idx,
+                                entry_type: 7,
+                                expected: #min_l,
+                                actual: len,
+                            });
+                        }
+                    }
+                }
+            })
+        } else {
+            Some(quote! {
+                {
+                    let len = azihsm_fw_ddi_tbor::toc::raw_toc_length(
+                        azihsm_fw_ddi_tbor::toc::read_toc_word(buf, header_len, toc_offset + #toc_idx)
+                    );
+                    if !(#min_l..=#max_l).contains(&len) {
+                        return Err(azihsm_fw_ddi_tbor::DecodeError::InvalidFixedLength {
+                            entry_index: toc_offset + #toc_idx,
+                            entry_type: 7,
+                            expected: #min_l,
+                            actual: len,
+                        });
+                    }
+                }
+            })
+        }
+    }).collect();
+
     quote! {
         #vis struct #name;
 
@@ -402,6 +484,7 @@ pub fn gen_field_group(schema: &Schema) -> TokenStream {
             pub fn validate(buf: &[u8], header_len: usize, toc_offset: usize) -> Result<(), azihsm_fw_ddi_tbor::DecodeError> {
                 #(#padding_checks)*
                 #(#type_checks)*
+                #(#len_checks)*
                 Ok(())
             }
         }
@@ -531,6 +614,38 @@ fn gen_field_write_group(
 /// Generate a view accessor for a group field.
 fn gen_group_view_accessor(field: &SchemaField, toc_idx: &TokenStream) -> TokenStream {
     let name = &field.name;
+
+    // Nested include-group fields expose the nested group's sub-view
+    // rather than a scalar accessor. Optional nested groups are reported
+    // absent when every group TOC entry is `None`.
+    if let Some(group) = &field.include_group {
+        let group_view = format_ident!("{}View", group);
+        if field.optional {
+            let group_off = quote! { self.toc_offset + #toc_idx };
+            let present = group_present_expr(
+                group,
+                &quote! { self.buf },
+                &quote! { self.header_len },
+                &group_off,
+            );
+            return quote! {
+                #[inline]
+                pub fn #name(&self) -> Option<#group_view<'a>> {
+                    if #present {
+                        Some(#group_view::__new(self.buf, self.header_len, #group_off))
+                    } else {
+                        None
+                    }
+                }
+            };
+        }
+        return quote! {
+            #[inline]
+            pub fn #name(&self) -> #group_view<'a> {
+                #group_view::__new(self.buf, self.header_len, self.toc_offset + #toc_idx)
+            }
+        };
+    }
 
     let body = match field.wire_type {
         WireType::Uint8 => quote! {

--- a/fw/core/ddi/tbor/derive/src/codegen_view.rs
+++ b/fw/core/ddi/tbor/derive/src/codegen_view.rs
@@ -107,7 +107,7 @@ fn gen_accessor(
     // Include-group fields expose the group's zero-copy sub-view rather
     // than a single primitive accessor.
     if let Some(group) = &field.include_group {
-        return gen_group_accessor(name, group, toc_index, header_len);
+        return gen_group_accessor(name, group, toc_index, header_len, field.optional);
     }
 
     let body = match field.wire_type {
@@ -197,19 +197,59 @@ fn gen_accessor(
     }
 }
 
+/// Emit a `bool` expression that is `true` when an optional include
+/// group is *present* — i.e. at least one of its `TOC_COUNT` entries at
+/// `group_off` is not `None`. The encoder omits an optional group by
+/// writing `None` to every one of its TOC entries. Entry types are read
+/// from `buf` at `header_len`.
+pub(crate) fn group_present_expr(
+    group: &syn::Ident,
+    buf: &TokenStream,
+    header_len: &TokenStream,
+    group_off: &TokenStream,
+) -> TokenStream {
+    let none_type_id = quote! { azihsm_fw_ddi_tbor::TocType::None as u8 };
+    quote! {
+        (0..#group::TOC_COUNT).any(|__k| {
+            azihsm_fw_ddi_tbor::toc::raw_toc_entry_type(
+                azihsm_fw_ddi_tbor::toc::read_toc_word(#buf, #header_len, (#group_off) + __k)
+            ) != #none_type_id
+        })
+    }
+}
+
 /// Generate an accessor that returns the group's zero-copy sub-view for
 /// an `#[tbor(include)]` field.
+///
+/// Optional groups are exposed as `Option<GroupView>`: the encoder omits
+/// a group by writing `None` to every one of its TOC entries, so the
+/// accessor reports the group absent when all entries are `None`.
 fn gen_group_accessor(
     name: &syn::Ident,
     group: &syn::Ident,
     toc_index: &TokenStream,
     header_len: &TokenStream,
+    optional: bool,
 ) -> TokenStream {
     let group_view = format_ident!("{}View", group);
-    quote! {
-        #[inline]
-        pub fn #name(&self) -> #group_view<'a> {
-            #group_view::__new(self.buf, #header_len, #toc_index)
+    if optional {
+        let present = group_present_expr(group, &quote! { self.buf }, header_len, toc_index);
+        quote! {
+            #[inline]
+            pub fn #name(&self) -> Option<#group_view<'a>> {
+                if #present {
+                    Some(#group_view::__new(self.buf, #header_len, #toc_index))
+                } else {
+                    None
+                }
+            }
+        }
+    } else {
+        quote! {
+            #[inline]
+            pub fn #name(&self) -> #group_view<'a> {
+                #group_view::__new(self.buf, #header_len, #toc_index)
+            }
         }
     }
 }
@@ -324,8 +364,25 @@ fn gen_type_checks(schema: &Schema, layout: &TocLayout) -> Vec<TokenStream> {
             let toc_idx = effective_toc_idx(i, layout, &schema.fields);
 
             // Include-group fields delegate validation of their TOC
-            // entries to the group's own `validate` helper.
+            // entries to the group's own `validate` helper. Optional
+            // groups are skipped when the encoder omitted them (every
+            // group TOC entry written as `None`); validating them would
+            // reject required inner fields and make the group
+            // undecodable.
             if let Some(group) = &field.include_group {
+                if field.optional {
+                    let present = group_present_expr(
+                        group,
+                        &quote! { raw.as_bytes() },
+                        &header_len_val,
+                        &toc_idx,
+                    );
+                    return quote! {
+                        if #present {
+                            #group::validate(raw.as_bytes(), #header_len_val, #toc_idx)?;
+                        }
+                    };
+                }
                 return quote! {
                     #group::validate(raw.as_bytes(), #header_len_val, #toc_idx)?;
                 };

--- a/fw/core/ddi/tbor/derive/src/codegen_view.rs
+++ b/fw/core/ddi/tbor/derive/src/codegen_view.rs
@@ -7,6 +7,9 @@ use proc_macro2::TokenStream;
 use quote::format_ident;
 use quote::quote;
 
+use crate::codegen_enc::build_toc_count_expr;
+use crate::codegen_enc::effective_toc_idx;
+use crate::codegen_enc::offset_by_preceding_groups;
 use crate::schema::*;
 
 /// Generate the `FooView<'a>` struct with typed, infallible accessors
@@ -26,12 +29,8 @@ pub fn gen_view(schema: &Schema) -> TokenStream {
 
     // Generate accessor methods.
     let accessors = schema.fields.iter().enumerate().map(|(i, field)| {
-        gen_accessor(
-            field,
-            layout.field_toc_indices[i],
-            &header_len,
-            schema.needs_data_start,
-        )
+        let toc_index = effective_toc_idx(i, &layout, &schema.fields);
+        gen_accessor(field, &toc_index, &header_len, schema.needs_data_start)
     });
 
     // Response-specific accessors.
@@ -99,11 +98,17 @@ pub fn gen_view(schema: &Schema) -> TokenStream {
 /// Generate a single field accessor method for the View type.
 fn gen_accessor(
     field: &SchemaField,
-    toc_index: usize,
+    toc_index: &TokenStream,
     header_len: &TokenStream,
     needs_data_start: bool,
 ) -> TokenStream {
     let name = &field.name;
+
+    // Include-group fields expose the group's zero-copy sub-view rather
+    // than a single primitive accessor.
+    if let Some(group) = &field.include_group {
+        return gen_group_accessor(name, group, toc_index, header_len);
+    }
 
     let body = match field.wire_type {
         WireType::Uint8 => quote! {
@@ -192,6 +197,23 @@ fn gen_accessor(
     }
 }
 
+/// Generate an accessor that returns the group's zero-copy sub-view for
+/// an `#[tbor(include)]` field.
+fn gen_group_accessor(
+    name: &syn::Ident,
+    group: &syn::Ident,
+    toc_index: &TokenStream,
+    header_len: &TokenStream,
+) -> TokenStream {
+    let group_view = format_ident!("{}View", group);
+    quote! {
+        #[inline]
+        pub fn #name(&self) -> #group_view<'a> {
+            #group_view::__new(self.buf, #header_len, #toc_index)
+        }
+    }
+}
+
 /// Compute the `data_start` expression used by data-section accessors.
 fn data_start_expr(header_len: &TokenStream, _needs_data_start: bool) -> TokenStream {
     // TOC count byte position:
@@ -216,7 +238,7 @@ pub fn gen_validation_standalone(schema: &Schema) -> TokenStream {
 /// Generate the full validation block for a message schema.
 fn gen_validation(schema: &Schema) -> TokenStream {
     let layout = TocLayout::compute(&schema.fields);
-    let total_toc_count = layout.total_toc_count;
+    let total_toc_count = build_toc_count_expr(&layout, &schema.fields);
 
     let (parse_call, _header_len_val, opcode_check) = match schema.kind {
         MessageKind::Request { opcode } => (
@@ -240,7 +262,7 @@ fn gen_validation(schema: &Schema) -> TokenStream {
     };
 
     let type_checks = gen_type_checks(schema, &layout);
-    let padding_checks = gen_padding_checks(&layout);
+    let padding_checks = gen_padding_checks(schema, &layout);
     let len_checks = gen_len_checks(schema, &layout);
 
     // Empty schemas synthesise a single `None` TOC placeholder; the
@@ -289,13 +311,27 @@ fn gen_validation(schema: &Schema) -> TokenStream {
 
 /// Generate TOC entry type checks for each schema field.
 fn gen_type_checks(schema: &Schema, layout: &TocLayout) -> Vec<TokenStream> {
+    let header_len_val = match schema.kind {
+        MessageKind::Request { .. } => quote! { azihsm_fw_ddi_tbor::REQ_HEADER_LEN },
+        MessageKind::Response => quote! { azihsm_fw_ddi_tbor::RESP_HEADER_LEN },
+        MessageKind::Fields => unreachable!(),
+    };
     schema
         .fields
         .iter()
         .enumerate()
         .map(|(i, field)| {
+            let toc_idx = effective_toc_idx(i, layout, &schema.fields);
+
+            // Include-group fields delegate validation of their TOC
+            // entries to the group's own `validate` helper.
+            if let Some(group) = &field.include_group {
+                return quote! {
+                    #group::validate(raw.as_bytes(), #header_len_val, #toc_idx)?;
+                };
+            }
+
             let toc_type_id = field.toc_type_id;
-            let toc_idx = layout.field_toc_indices[i];
             if field.optional {
                 let none_type_id = quote! { azihsm_fw_ddi_tbor::TocType::None as u8 };
                 quote! {
@@ -326,12 +362,14 @@ fn gen_type_checks(schema: &Schema, layout: &TocLayout) -> Vec<TokenStream> {
 }
 
 /// Generate validation checks for padding TOC entries.
-fn gen_padding_checks(layout: &TocLayout) -> Vec<TokenStream> {
+fn gen_padding_checks(schema: &Schema, layout: &TocLayout) -> Vec<TokenStream> {
     let padding_type_id = 9u8;
     layout
         .padding_positions
         .iter()
-        .map(|&(toc_idx, _)| {
+        .map(|&(toc_idx, field_idx)| {
+            let toc_idx =
+                offset_by_preceding_groups(quote! { #toc_idx }, &schema.fields[..field_idx]);
             quote! {
                 if raw.toc_entry_type(#toc_idx) != #padding_type_id {
                     return Err(azihsm_fw_ddi_tbor::DecodeError::UnexpectedTocType {
@@ -358,6 +396,9 @@ fn gen_len_checks(schema: &Schema, layout: &TocLayout) -> Vec<TokenStream> {
         .iter()
         .enumerate()
         .filter_map(|(i, field)| {
+            if field.include_group.is_some() {
+                return None;
+            }
             if !matches!(field.wire_type, WireType::Buffer | WireType::SealedKey) {
                 return None;
             }
@@ -366,7 +407,7 @@ fn gen_len_checks(schema: &Schema, layout: &TocLayout) -> Vec<TokenStream> {
             if !has_constraint {
                 return None;
             }
-            let toc_idx = layout.field_toc_indices[i];
+            let toc_idx = effective_toc_idx(i, layout, &schema.fields);
             let min_l = field.fixed_len.unwrap_or(field.min_len);
             let max_l = field.fixed_len.unwrap_or(field.max_len);
 
@@ -413,6 +454,11 @@ fn gen_display(schema: &Schema, view_name: &syn::Ident) -> TokenStream {
     let struct_name_str = schema.name.to_string();
 
     let field_displays = schema.fields.iter().map(|field| {
+        // Include-group fields expose a sub-view rather than a scalar;
+        // skip them in the flat Display rendering.
+        if field.include_group.is_some() {
+            return quote! {};
+        }
         let name = &field.name;
         let name_str = field.name.to_string();
         let pad = 16usize.saturating_sub(name_str.len());


### PR DESCRIPTION
This pull request refactors and enhances the code generation logic for TBOR schema "View" types, with a focus on improving support for `#[tbor(include)]` group fields. It introduces new helpers for computing TOC (Table of Contents) indices that correctly handle nested groups, ensures that generated accessors and validation logic are group-aware, and improves modularity by extracting and reusing logic across modules.

**Enhancements to TOC index computation and group support:**

* Refactored TOC index helpers: Extracted and made public (`pub(crate)`) the `build_toc_count_expr`, `offset_by_preceding_groups`, and `effective_toc_idx` helpers in `codegen_enc.rs`, allowing correct symbolic computation of TOC indices and counts with nested include-groups. (`[[1]](diffhunk://#diff-428ef521c31698b93136096b8e9c039647f22f2c4c96443beafd846acce0a50bL87-R87)`, `[[2]](diffhunk://#diff-428ef521c31698b93136096b8e9c039647f22f2c4c96443beafd846acce0a50bL233-R261)`)
* Updated all uses of TOC indices in `codegen_view.rs` to use the new helpers, ensuring group-aware index calculation in accessors, validation, and padding checks. (`[[1]](diffhunk://#diff-9ca5969bff6431567b788b59d40480c1e291a6887b8a74ae1b8023fe3c9bdf1bR10-R12)`, `[[2]](diffhunk://#diff-9ca5969bff6431567b788b59d40480c1e291a6887b8a74ae1b8023fe3c9bdf1bL29-R33)`, `[[3]](diffhunk://#diff-9ca5969bff6431567b788b59d40480c1e291a6887b8a74ae1b8023fe3c9bdf1bL219-R241)`, `[[4]](diffhunk://#diff-9ca5969bff6431567b788b59d40480c1e291a6887b8a74ae1b8023fe3c9bdf1bL243-R265)`, `[[5]](diffhunk://#diff-9ca5969bff6431567b788b59d40480c1e291a6887b8a74ae1b8023fe3c9bdf1bL329-R372)`)

**Improvements to generated accessors and validation:**

* Group field accessors: Added logic to generate sub-view accessors for `#[tbor(include)]` fields, returning the appropriate group view type instead of a primitive accessor. (`[[1]](diffhunk://#diff-9ca5969bff6431567b788b59d40480c1e291a6887b8a74ae1b8023fe3c9bdf1bL102-R112)`, `[[2]](diffhunk://#diff-9ca5969bff6431567b788b59d40480c1e291a6887b8a74ae1b8023fe3c9bdf1bR200-R216)`)
* Group-aware validation: Modified generated validation code so that include-group fields delegate TOC entry validation to the group's own `validate` method, and padding checks are now group-aware. (`[[1]](diffhunk://#diff-9ca5969bff6431567b788b59d40480c1e291a6887b8a74ae1b8023fe3c9bdf1bR314-L298)`, `[[2]](diffhunk://#diff-9ca5969bff6431567b788b59d40480c1e291a6887b8a74ae1b8023fe3c9bdf1bL329-R372)`)

**Other improvements:**

* Display implementation: Updated the generated `Display` impl to skip include-group fields, as they are not rendered as scalars in the flat display output. (`[fw/core/ddi/tbor/derive/src/codegen_view.rsR457-R461](diffhunk://#diff-9ca5969bff6431567b788b59d40480c1e291a6887b8a74ae1b8023fe3c9bdf1bR457-R461)`)
* Length checks: Ensured length checks are not generated for include-group fields, as their validation is handled recursively. (`[[1]](diffhunk://#diff-9ca5969bff6431567b788b59d40480c1e291a6887b8a74ae1b8023fe3c9bdf1bR399-R401)`, `[[2]](diffhunk://#diff-9ca5969bff6431567b788b59d40480c1e291a6887b8a74ae1b8023fe3c9bdf1bL369-R410)`)