### PR TITLE
feat(fw): implement DDI AesGenerateKey + AesEncryptDecrypt (CBC) hand…

### DIFF
--- a/ddi/mbor/types/tests/azihsm_ddi_tests.rs
+++ b/ddi/mbor/types/tests/azihsm_ddi_tests.rs
@@ -5,8 +5,10 @@
 #[cfg(test)]
 mod integration {
     pub mod aes_cbc;
+    pub mod aes_cbc_smoke;
     pub mod aes_gcm_bulk_stress;
     pub mod aes_generate;
+    pub mod aes_generate_smoke;
     pub mod aes_xts_bulk_stress;
     pub mod aes_xts_encrypt_decrypt;
     pub mod attest_key;

--- a/ddi/mbor/types/tests/integration/aes_cbc_smoke.rs
+++ b/ddi/mbor/types/tests/integration/aes_cbc_smoke.rs
@@ -1,0 +1,156 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! AesEncryptDecrypt (CBC) smoke tests for the emu backend.
+//!
+//! - Happy path: generate an AES-128 key, encrypt a one-block
+//!   message, then decrypt the ciphertext and assert we recover the
+//!   original plaintext.
+//! - Without a session: rejected by the host-side dev validator
+//!   before the request reaches firmware.
+//! - With an unknown key id: rejected with `KeyNotFound` /
+//!   `InvalidKeyNumber`.
+
+#![cfg(test)]
+
+use azihsm_ddi::*;
+use azihsm_ddi_mbor_codec::MborByteArray;
+use azihsm_ddi_mbor_test_helpers::helper_key_properties;
+use azihsm_ddi_mbor_types::*;
+use test_with_tracing::test;
+
+use super::common::*;
+
+#[test]
+fn test_aes_cbc_encrypt_decrypt_smoke() {
+    ddi_dev_test(
+        common_setup,
+        common_cleanup,
+        |dev, _ddi, _path, session_id| {
+            let key_props =
+                helper_key_properties(DdiKeyUsage::EncryptDecrypt, DdiKeyAvailability::App);
+            let key_id = helper_aes_generate(
+                dev,
+                Some(session_id),
+                Some(DdiApiRev { major: 1, minor: 0 }),
+                DdiAesKeySize::Aes128,
+                None,
+                key_props,
+            )
+            .unwrap()
+            .data
+            .key_id;
+
+            let plaintext = [0xa5u8; 16];
+            let iv = [0u8; 16];
+
+            let enc_resp = helper_aes_encrypt_decrypt(
+                dev,
+                Some(session_id),
+                Some(DdiApiRev { major: 1, minor: 0 }),
+                key_id,
+                DdiAesOp::Encrypt,
+                MborByteArray::from_slice(&plaintext).unwrap(),
+                MborByteArray::from_slice(&iv).unwrap(),
+            )
+            .unwrap();
+
+            assert_eq!(enc_resp.hdr.op, DdiOp::AesEncryptDecrypt);
+            assert_eq!(enc_resp.hdr.status, DdiStatus::Success);
+            let ciphertext: Vec<u8> = enc_resp.data.msg.as_slice().to_vec();
+            assert_eq!(ciphertext.len(), 16);
+            assert_ne!(
+                ciphertext,
+                &plaintext[..],
+                "ciphertext must differ from plaintext"
+            );
+
+            let dec_resp = helper_aes_encrypt_decrypt(
+                dev,
+                Some(session_id),
+                Some(DdiApiRev { major: 1, minor: 0 }),
+                key_id,
+                DdiAesOp::Decrypt,
+                MborByteArray::from_slice(&ciphertext).unwrap(),
+                MborByteArray::from_slice(&iv).unwrap(),
+            )
+            .unwrap();
+
+            assert_eq!(dec_resp.hdr.status, DdiStatus::Success);
+            assert_eq!(
+                dec_resp.data.msg.as_slice(),
+                &plaintext[..],
+                "decryption must recover the original plaintext"
+            );
+        },
+    );
+}
+
+#[test]
+fn test_aes_cbc_no_session_smoke() {
+    ddi_dev_test(
+        common_setup,
+        common_cleanup,
+        |dev, _ddi, _path, _session_id| {
+            let plaintext = [0xa5u8; 16];
+            let iv = [0u8; 16];
+            let err = helper_aes_encrypt_decrypt(
+                dev,
+                None,
+                Some(DdiApiRev { major: 1, minor: 0 }),
+                1, /* any key id — the request never reaches firmware */
+                DdiAesOp::Encrypt,
+                MborByteArray::from_slice(&plaintext).unwrap(),
+                MborByteArray::from_slice(&iv).unwrap(),
+            )
+            .expect_err("AesEncryptDecrypt must be rejected without a session");
+
+            // The host-side dev validator rejects InSession commands sent
+            // with sess_id=None before the request reaches firmware.
+            assert!(
+                matches!(
+                    err,
+                    DdiError::DdiStatus(DdiStatus::FileHandleSessionIdDoesNotMatch)
+                ),
+                "expected FileHandleSessionIdDoesNotMatch, got {:?}",
+                err
+            );
+        },
+    );
+}
+
+#[test]
+fn test_aes_cbc_unknown_key_smoke() {
+    ddi_dev_test(
+        common_setup,
+        common_cleanup,
+        |dev, _ddi, _path, session_id| {
+            let plaintext = [0xa5u8; 16];
+            let iv = [0u8; 16];
+            let err = helper_aes_encrypt_decrypt(
+                dev,
+                Some(session_id),
+                Some(DdiApiRev { major: 1, minor: 0 }),
+                0xFFFF, /* unknown key id */
+                DdiAesOp::Encrypt,
+                MborByteArray::from_slice(&plaintext).unwrap(),
+                MborByteArray::from_slice(&iv).unwrap(),
+            )
+            .expect_err("AesEncryptDecrypt must reject an unknown key id");
+
+            // The exact error code differs across backends — emu's
+            // vault returns `KeyNotFound`, the mock returns
+            // `InvalidKeyNumber`.  Both are acceptable as long as the
+            // request fails.
+            assert!(
+                matches!(
+                    err,
+                    DdiError::DdiStatus(DdiStatus::KeyNotFound)
+                        | DdiError::DdiStatus(DdiStatus::InvalidKeyNumber)
+                ),
+                "expected KeyNotFound or InvalidKeyNumber, got {:?}",
+                err
+            );
+        },
+    );
+}

--- a/ddi/mbor/types/tests/integration/aes_generate_smoke.rs
+++ b/ddi/mbor/types/tests/integration/aes_generate_smoke.rs
@@ -1,0 +1,80 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! AesGenerateKey smoke tests for the emu backend.
+//!
+//! - Happy path: generate an AES-128 encrypt/decrypt key in an open
+//!   session and confirm the response carries a non-zero `key_id`
+//!   and the expected (empty placeholder) masked-key envelope.
+//! - Without a session: rejected by the host-side dev validator
+//!   before the request reaches firmware.
+
+#![cfg(test)]
+
+use azihsm_ddi::*;
+use azihsm_ddi_mbor_test_helpers::helper_key_properties;
+use azihsm_ddi_mbor_types::*;
+use test_with_tracing::test;
+
+use super::common::*;
+
+#[test]
+fn test_aes_generate_smoke() {
+    ddi_dev_test(
+        common_setup,
+        common_cleanup,
+        |dev, _ddi, _path, session_id| {
+            let key_props =
+                helper_key_properties(DdiKeyUsage::EncryptDecrypt, DdiKeyAvailability::App);
+            let resp = helper_aes_generate(
+                dev,
+                Some(session_id),
+                Some(DdiApiRev { major: 1, minor: 0 }),
+                DdiAesKeySize::Aes128,
+                None,
+                key_props,
+            )
+            .unwrap();
+
+            assert_eq!(resp.hdr.op, DdiOp::AesGenerateKey);
+            assert_eq!(resp.hdr.status, DdiStatus::Success);
+            assert_ne!(resp.data.key_id, 0, "key_id must be non-zero");
+            assert!(
+                resp.data.bulk_key_id.is_none(),
+                "non-bulk AES request must carry bulk_key_id = None"
+            );
+        },
+    );
+}
+
+#[test]
+fn test_aes_generate_no_session_smoke() {
+    ddi_dev_test(
+        common_setup,
+        common_cleanup,
+        |dev, _ddi, _path, _session_id| {
+            let key_props =
+                helper_key_properties(DdiKeyUsage::EncryptDecrypt, DdiKeyAvailability::App);
+            let err = helper_aes_generate(
+                dev,
+                None,
+                Some(DdiApiRev { major: 1, minor: 0 }),
+                DdiAesKeySize::Aes128,
+                None,
+                key_props,
+            )
+            .expect_err("AesGenerateKey must be rejected without a session");
+
+            // The host-side dev validator rejects InSession commands sent
+            // with sess_id=None before the request reaches firmware.
+            assert!(
+                matches!(
+                    err,
+                    DdiError::DdiStatus(DdiStatus::FileHandleSessionIdDoesNotMatch)
+                ),
+                "expected FileHandleSessionIdDoesNotMatch, got {:?}",
+                err
+            );
+        },
+    );
+}

--- a/fw/core/ddi/mbor/types/src/lib.rs
+++ b/fw/core/ddi/mbor/types/src/lib.rs
@@ -443,9 +443,11 @@ mod tests {
     /// The blob byte pattern below corresponds to a metadata payload
     /// with bits 0, 2, 4, 6, 8 set (alternating in byte 0 — `0x55`
     /// — and bit 0 of byte 1 — `0x01`).  Any reordering / shifting
-    /// of the `BIT_FLAG_*` constants on either side of the wire will
-    /// fail this test.  Keep in lockstep with the host-side test in
-    /// `ddi/mbor/types/src/metadata.rs`.
+    /// of the `BIT_FLAG_*` constants on the firmware side will fail
+    /// this test.  The asserted positions must match the host-side
+    /// `BIT_FLAG_*` definitions in `ddi/mbor/types/src/metadata.rs`
+    /// (lines 19-27 at time of writing) — those constants are the
+    /// wire contract this test pins against.
     #[test]
     fn metadata_bit_positions_match_host_wire_contract() {
         let m = DdiTargetKeyMetadata {

--- a/fw/core/ddi/mbor/types/src/lib.rs
+++ b/fw/core/ddi/mbor/types/src/lib.rs
@@ -356,6 +356,117 @@ pub struct DdiTargetKeyMetadata {
     pub blob: [u8; 16],
 }
 
+/// Bit accessors for the wire-format target key metadata blob.
+///
+/// These bit positions are the wire contract between host and
+/// firmware — they MUST match the host-side definitions in
+/// `ddi/mbor/types/src/metadata.rs` exactly.  Both crates decode the
+/// same 16-byte payload sent over the wire from the host, so any
+/// drift will silently corrupt the firmware's interpretation of a
+/// key's requested permissions.
+///
+/// The full set of flags is mirrored here (including `MODIFIABLE`
+/// and `WRAP`) even though our handlers do not yet read every one,
+/// so the constants stay in lockstep with the host.  The
+/// `metadata_bit_positions_match_host_wire_contract` test below
+/// pins the positions against a known blob pattern.
+impl DdiTargetKeyMetadata {
+    const BIT_FLAG_SESSION: usize = 0;
+    const BIT_FLAG_MODIFIABLE: usize = 1;
+    const BIT_FLAG_ENCRYPT: usize = 2;
+    const BIT_FLAG_DECRYPT: usize = 3;
+    const BIT_FLAG_SIGN: usize = 4;
+    const BIT_FLAG_VERIFY: usize = 5;
+    const BIT_FLAG_DERIVE: usize = 6;
+    const BIT_FLAG_WRAP: usize = 7;
+    const BIT_FLAG_UNWRAP: usize = 8;
+
+    #[inline]
+    fn get_bit(&self, bit: usize) -> bool {
+        let index = bit / u8::BITS as usize;
+        let bit = bit % u8::BITS as usize;
+        (self.blob[index] & (1 << bit)) != 0
+    }
+
+    /// Flag indicating the key is a session-scoped key.
+    pub fn session(&self) -> bool {
+        self.get_bit(Self::BIT_FLAG_SESSION)
+    }
+
+    /// Flag indicating the key is modifiable.
+    pub fn modifiable(&self) -> bool {
+        self.get_bit(Self::BIT_FLAG_MODIFIABLE)
+    }
+
+    /// Flag indicating the key can be used for encryption.
+    pub fn encrypt(&self) -> bool {
+        self.get_bit(Self::BIT_FLAG_ENCRYPT)
+    }
+
+    /// Flag indicating the key can be used for decryption.
+    pub fn decrypt(&self) -> bool {
+        self.get_bit(Self::BIT_FLAG_DECRYPT)
+    }
+
+    /// Flag indicating the key can be used for signing.
+    pub fn sign(&self) -> bool {
+        self.get_bit(Self::BIT_FLAG_SIGN)
+    }
+
+    /// Flag indicating the key can be used for verification.
+    pub fn verify(&self) -> bool {
+        self.get_bit(Self::BIT_FLAG_VERIFY)
+    }
+
+    /// Flag indicating the key can be used for deriving other keys.
+    pub fn derive(&self) -> bool {
+        self.get_bit(Self::BIT_FLAG_DERIVE)
+    }
+
+    /// Flag indicating the key can be used for wrapping.
+    pub fn wrap(&self) -> bool {
+        self.get_bit(Self::BIT_FLAG_WRAP)
+    }
+
+    /// Flag indicating the key can be used for unwrapping.
+    pub fn unwrap(&self) -> bool {
+        self.get_bit(Self::BIT_FLAG_UNWRAP)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Pin the wire bit positions of every defined flag.
+    ///
+    /// The blob byte pattern below corresponds to a metadata payload
+    /// with bits 0, 2, 4, 6, 8 set (alternating in byte 0 — `0x55`
+    /// — and bit 0 of byte 1 — `0x01`).  Any reordering / shifting
+    /// of the `BIT_FLAG_*` constants on either side of the wire will
+    /// fail this test.  Keep in lockstep with the host-side test in
+    /// `ddi/mbor/types/src/metadata.rs`.
+    #[test]
+    fn metadata_bit_positions_match_host_wire_contract() {
+        let m = DdiTargetKeyMetadata {
+            blob: [
+                0x55, 0x01, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            ],
+        };
+        // Byte 0 — `0x55` = bits 0, 2, 4, 6
+        assert!(m.session(), "BIT_FLAG_SESSION = 0");
+        assert!(!m.modifiable(), "BIT_FLAG_MODIFIABLE = 1");
+        assert!(m.encrypt(), "BIT_FLAG_ENCRYPT = 2");
+        assert!(!m.decrypt(), "BIT_FLAG_DECRYPT = 3");
+        assert!(m.sign(), "BIT_FLAG_SIGN = 4");
+        assert!(!m.verify(), "BIT_FLAG_VERIFY = 5");
+        assert!(m.derive(), "BIT_FLAG_DERIVE = 6");
+        assert!(!m.wrap(), "BIT_FLAG_WRAP = 7");
+        // Byte 1 — `0x01` = bit 8
+        assert!(m.unwrap(), "BIT_FLAG_UNWRAP = 8");
+    }
+}
+
 /// Target key properties for key creation/unwrap.
 #[derive(Debug, Ddi)]
 #[ddi(map)]

--- a/fw/core/ddi/mbor/types/src/lib.rs
+++ b/fw/core/ddi/mbor/types/src/lib.rs
@@ -449,9 +449,7 @@ mod tests {
     #[test]
     fn metadata_bit_positions_match_host_wire_contract() {
         let m = DdiTargetKeyMetadata {
-            blob: [
-                0x55, 0x01, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-            ],
+            blob: [0x55, 0x01, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
         };
         // Byte 0 — `0x55` = bits 0, 2, 4, 6
         assert!(m.session(), "BIT_FLAG_SESSION = 0");

--- a/fw/core/lib/src/ddi/mbor/aes_encrypt_decrypt.rs
+++ b/fw/core/lib/src/ddi/mbor/aes_encrypt_decrypt.rs
@@ -1,0 +1,107 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! DDI AesEncryptDecrypt command handler.
+//!
+//! Within an open session, AES-CBC encrypt or decrypt the host-
+//! supplied message buffer using a vault-resident AES-128 / 192 /
+//! 256 key and a host-supplied 16-byte IV.  The transformed message
+//! plus the updated chaining IV are returned so the host can chain
+//! subsequent CBC blocks.
+
+use azihsm_fw_ddi_mbor_types::aes_encrypt_decrypt::DdiAesEncryptDecryptReq;
+use azihsm_fw_ddi_mbor_types::aes_encrypt_decrypt::DdiAesEncryptDecryptResp;
+use azihsm_fw_ddi_mbor_types::DdiAesOp;
+
+use super::*;
+
+/// AES-CBC block size in bytes — also the required IV length.
+const AES_BLOCK_LEN: usize = 16;
+
+/// Maximum AES-CBC message length per request, matching the host
+/// `DdiAesEncryptDecryptReq::MAX_MSG_SIZE`.
+const MAX_MSG_LEN: usize = 1024;
+
+/// Handle `DdiAesEncryptDecryptCmd`.
+pub(crate) async fn aes_encrypt_decrypt<'p, P: HsmPal>(
+    pal: &'p P,
+    io: &impl HsmIo,
+    decoder: &mut DdiDecoder<'_>,
+    hdr: &DdiReqHdr,
+) -> HsmResult<&'p DmaBuf> {
+    let body: DdiAesEncryptDecryptReq = decoder.decode_data()?;
+
+    let sess_id = hdr.sess_id.ok_or(HsmError::SessionExpected)?;
+
+    let op = ddi_to_pal_aes_op(body.op)?;
+
+    // IV must be exactly one block, message must be non-empty,
+    // multiple of one block, and within the wire max.
+    if body.iv.len() != AES_BLOCK_LEN {
+        return Err(HsmError::InvalidArg);
+    }
+    if body.msg.is_empty()
+        || !body.msg.len().is_multiple_of(AES_BLOCK_LEN)
+        || body.msg.len() > MAX_MSG_LEN
+    {
+        return Err(HsmError::InvalidArg);
+    }
+    let msg_len = body.msg.len();
+
+    // Look up the vault key; reject anything that is not a non-bulk
+    // AES key, or that lacks the attribute matching the requested
+    // direction (Encrypt needs `encrypt`, Decrypt needs `decrypt`).
+    let key_id = HsmKeyId::from(body.key_id);
+    let vault_kind = pal.vault_key_kind(io, key_id)?;
+    assert_aes_kind(vault_kind)?;
+    let vault_attrs = pal.vault_key_attrs(io, key_id)?;
+    let required_attr = match op {
+        AesOp::Encrypt => vault_attrs.encrypt(),
+        AesOp::Decrypt => vault_attrs.decrypt(),
+    };
+    if !required_attr {
+        return Err(HsmError::InvalidPermissions);
+    }
+    let key = pal.vault_key(io, key_id)?;
+
+    // Reserve the response with the exact wire sizes, copy the
+    // request message + IV into the response slots, and run the
+    // in-place AES-CBC transform directly inside those slots — no
+    // scratch buffer needed.  The encoder layout produces disjoint
+    // `&mut DmaBuf` views for `msg` and `iv`, so we can pass both to
+    // the PAL call without overlap.
+    let (resp, layout) = pal.dma_alloc_var_with(io, |buf| {
+        let mut encoder = super::encode_resp_hdr(
+            &super::success_hdr_sess(hdr, DdiOp::AesEncryptDecrypt, sess_id),
+            buf,
+        )?;
+        let layout = DdiAesEncryptDecryptResp::reserve(&mut encoder, msg_len, AES_BLOCK_LEN)?;
+        Ok((encoder.position(), layout))
+    })?;
+    let frame = DdiAesEncryptDecryptResp::from_layout(resp, &layout);
+    frame.msg.copy_from_slice(&body.msg[..msg_len]);
+    pal.aes_cbc_enc_dec_in_place(io, op, key, frame.msg, body.iv, Some(frame.iv))
+        .await?;
+
+    Ok(resp)
+}
+
+/// Map a `DdiAesOp` to the PAL [`AesOp`].
+fn ddi_to_pal_aes_op(op: DdiAesOp) -> HsmResult<AesOp> {
+    match op {
+        DdiAesOp::Encrypt => Ok(AesOp::Encrypt),
+        DdiAesOp::Decrypt => Ok(AesOp::Decrypt),
+        _ => Err(HsmError::InvalidArg),
+    }
+}
+
+/// Reject vault key kinds that are not a non-bulk AES key.
+///
+/// Bulk AES kinds (XTS / GCM) are excluded because they are used by
+/// dedicated bulk handlers, not the generic AES-CBC path here.
+fn assert_aes_kind(kind: HsmVaultKeyKind) -> HsmResult<()> {
+    match kind {
+        HsmVaultKeyKind::Aes128 | HsmVaultKeyKind::Aes192 | HsmVaultKeyKind::Aes256 => Ok(()),
+        _ => Err(HsmError::InvalidKeyType),
+    }
+}

--- a/fw/core/lib/src/ddi/mbor/aes_encrypt_decrypt.rs
+++ b/fw/core/lib/src/ddi/mbor/aes_encrypt_decrypt.rs
@@ -18,10 +18,6 @@ use super::*;
 /// AES-CBC block size in bytes — also the required IV length.
 const AES_BLOCK_LEN: usize = 16;
 
-/// Maximum AES-CBC message length per request, matching the host
-/// `DdiAesEncryptDecryptReq::MAX_MSG_SIZE`.
-const MAX_MSG_LEN: usize = 1024;
-
 /// Handle `DdiAesEncryptDecryptCmd`.
 pub(crate) async fn aes_encrypt_decrypt<'p, P: HsmPal>(
     pal: &'p P,
@@ -36,13 +32,14 @@ pub(crate) async fn aes_encrypt_decrypt<'p, P: HsmPal>(
     let op = ddi_to_pal_aes_op(body.op)?;
 
     // IV must be exactly one block, message must be non-empty,
-    // multiple of one block, and within the wire max.
+    // multiple of one block, and within the wire max (single source
+    // of truth: `DdiAesEncryptDecryptReq::MAX_MSG_SIZE`).
     if body.iv.len() != AES_BLOCK_LEN {
         return Err(HsmError::InvalidArg);
     }
     if body.msg.is_empty()
         || !body.msg.len().is_multiple_of(AES_BLOCK_LEN)
-        || body.msg.len() > MAX_MSG_LEN
+        || body.msg.len() > DdiAesEncryptDecryptReq::MAX_MSG_SIZE
     {
         return Err(HsmError::InvalidArg);
     }
@@ -64,12 +61,16 @@ pub(crate) async fn aes_encrypt_decrypt<'p, P: HsmPal>(
     }
     let key = pal.vault_key(io, key_id)?;
 
-    // Reserve the response with the exact wire sizes, copy the
-    // request message + IV into the response slots, and run the
-    // in-place AES-CBC transform directly inside those slots — no
-    // scratch buffer needed.  The encoder layout produces disjoint
-    // `&mut DmaBuf` views for `msg` and `iv`, so we can pass both to
-    // the PAL call without overlap.
+    // Reserve the response with the exact wire sizes, then run the
+    // AES-CBC transform with the slots wired up as follows:
+    //   - request msg is staged into the response `msg` slot, which
+    //     is then transformed in place;
+    //   - request iv is consumed as the input IV (`iv_in`);
+    //   - the updated chaining IV produced by the AES engine is
+    //     written directly into the response `iv` slot.
+    // No scratch buffers are needed: the encoder layout produces
+    // disjoint `&mut DmaBuf` views for `msg` and `iv`, so we can
+    // pass both to the PAL call without overlap.
     let (resp, layout) = pal.dma_alloc_var_with(io, |buf| {
         let mut encoder = super::encode_resp_hdr(
             &super::success_hdr_sess(hdr, DdiOp::AesEncryptDecrypt, sess_id),

--- a/fw/core/lib/src/ddi/mbor/aes_generate_key.rs
+++ b/fw/core/lib/src/ddi/mbor/aes_generate_key.rs
@@ -1,0 +1,138 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! DDI AesGenerateKey command handler.
+//!
+//! Within an open session, generate a fresh random AES key (128 /
+//! 192 / 256 bits), persist it in the partition vault — optionally
+//! session-scoped so it is torn down by
+//! [`CloseSession`](super::close_session) — and return the assigned
+//! `key_id` plus an (empty placeholder) masked-key envelope that the
+//! host may re-import on a future session.
+//!
+//! Scope: non-bulk AES key kinds only.  XTS / GCM bulk variants are
+//! rejected with `InvalidArg`.
+
+use azihsm_fw_ddi_mbor_types::aes_generate_key::DdiAesGenerateKeyReq;
+use azihsm_fw_ddi_mbor_types::aes_generate_key::DdiAesGenerateKeyResp;
+use azihsm_fw_ddi_mbor_types::DdiAesKeySize;
+
+use super::*;
+
+/// Handle `DdiAesGenerateKeyCmd`.
+///
+/// No `partition_lock` is needed: this handler does not perform any
+/// multi-step read-then-mutate against partition state.  Its single
+/// state mutation — `vault_key_create` — is sync and atomic.
+pub(crate) async fn aes_generate_key<'p, P: HsmPal>(
+    pal: &'p P,
+    io: &impl HsmIo,
+    decoder: &mut DdiDecoder<'_>,
+    hdr: &DdiReqHdr,
+) -> HsmResult<&'p DmaBuf> {
+    let body: DdiAesGenerateKeyReq = decoder.decode_data()?;
+
+    let sess_id = hdr.sess_id.ok_or(HsmError::SessionExpected)?;
+
+    let (key_len, vault_kind) = aes_key_size_to_kind(body.key_size)?;
+    let attrs = build_attrs_for_aes(&body.key_properties.key_metadata)?;
+
+    // Session-only keys are anonymous — disallow a host-supplied
+    // `key_tag` because the key cannot be looked up across sessions.
+    if attrs.session() && body.key_tag.is_some() {
+        return Err(HsmError::InvalidArg);
+    }
+
+    // Generate the random AES key bytes into a scratch buffer.  The
+    // PAL's `aes_gen_key` wraps the CSPRNG and validates the buffer
+    // length, so the handler just sizes the buffer per the requested
+    // key kind.
+    let key_buf = pal.dma_alloc(io, key_len)?;
+    pal.aes_gen_key(io, key_buf).await?;
+
+    // Store in the vault, session-scoped iff requested.  RAII guard
+    // rolls the entry back if the response encoding below fails.
+    let session_binding = attrs.session().then_some(HsmSessId::from(sess_id));
+    let guard = pal.vault_key_create(
+        io,
+        key_buf,
+        vault_kind,
+        session_binding,
+        attrs,
+        body.key_properties.key_label,
+    )?;
+    let key_id: u16 = guard.key_id().into();
+
+    // Build the response.  `masked_key` is the host's opaque
+    // re-import blob; firmware-side masking against the session BK is
+    // pending the corresponding `UnmaskKey` handler — emit an empty
+    // placeholder for now so the response is wire-valid.  `bulk_key_id`
+    // is reserved for the AES-XTS / AES-GCM bulk variants which this
+    // handler rejects; non-bulk keys always report `None`.
+    let resp = pal.dma_alloc_var(io, |buf| {
+        super::encode_resp(
+            &super::success_hdr_sess(hdr, DdiOp::AesGenerateKey, sess_id),
+            &DdiAesGenerateKeyResp {
+                key_id,
+                bulk_key_id: None,
+                masked_key: &[],
+            },
+            buf,
+        )
+    })?;
+
+    // Commit the vault entry.
+    let _ = guard.dismiss();
+
+    Ok(resp)
+}
+
+/// Map a `DdiAesKeySize` to its raw key byte length + private
+/// [`HsmVaultKeyKind`].  Bulk AES key kinds (XTS / GCM) are rejected
+/// — handled by separate future handlers.
+fn aes_key_size_to_kind(size: DdiAesKeySize) -> HsmResult<(usize, HsmVaultKeyKind)> {
+    match size {
+        DdiAesKeySize::Aes128 => Ok((16, HsmVaultKeyKind::Aes128)),
+        DdiAesKeySize::Aes192 => Ok((24, HsmVaultKeyKind::Aes192)),
+        DdiAesKeySize::Aes256 => Ok((32, HsmVaultKeyKind::Aes256)),
+        _ => Err(HsmError::InvalidArg),
+    }
+}
+
+/// Translate the requested `key_metadata` bitflags into a vault
+/// attribute set for a non-bulk AES key.
+///
+/// AES (non-bulk) keys can only carry the `EncryptDecrypt` usage.
+/// Any other single-usage request (sign+verify, derive, unwrap) is
+/// rejected with `InvalidPermissions`, mirroring the reference
+/// firmware's `Kind::allows_usage` check.
+///
+/// Internally-generated keys always carry `local = true`.
+fn build_attrs_for_aes(
+    metadata: &azihsm_fw_ddi_mbor_types::DdiTargetKeyMetadata,
+) -> HsmResult<HsmVaultKeyAttrs> {
+    let mut attrs = HsmVaultKeyAttrs::new().with_local(true);
+
+    let sign_verify = metadata.sign() && metadata.verify();
+    let encrypt_decrypt = metadata.encrypt() && metadata.decrypt();
+    let derive = metadata.derive();
+    let unwrap = metadata.unwrap();
+
+    // Exactly one usage.
+    let usage_count =
+        (sign_verify as u8) + (encrypt_decrypt as u8) + (derive as u8) + (unwrap as u8);
+    if usage_count != 1 {
+        return Err(HsmError::InvalidPermissions);
+    }
+
+    if !encrypt_decrypt {
+        return Err(HsmError::InvalidPermissions);
+    }
+    attrs = attrs.with_encrypt(true).with_decrypt(true);
+
+    if metadata.session() {
+        attrs = attrs.with_session(true);
+    }
+
+    Ok(attrs)
+}

--- a/fw/core/lib/src/ddi/mbor/aes_generate_key.rs
+++ b/fw/core/lib/src/ddi/mbor/aes_generate_key.rs
@@ -103,8 +103,8 @@ fn aes_key_size_to_kind(size: DdiAesKeySize) -> HsmResult<(usize, HsmVaultKeyKin
 /// attribute set for a non-bulk AES key.
 ///
 /// AES (non-bulk) keys can only carry the `EncryptDecrypt` usage.
-/// Any other single-usage request (sign+verify, derive, unwrap) is
-/// rejected with `InvalidPermissions`, mirroring the reference
+/// Any other usage flag — sign, verify, derive, wrap, or unwrap —
+/// is rejected with `InvalidPermissions`, mirroring the reference
 /// firmware's `Kind::allows_usage` check.
 ///
 /// Internally-generated keys always carry `local = true`.
@@ -116,11 +116,18 @@ fn build_attrs_for_aes(
     let sign_verify = metadata.sign() && metadata.verify();
     let encrypt_decrypt = metadata.encrypt() && metadata.decrypt();
     let derive = metadata.derive();
+    let wrap = metadata.wrap();
     let unwrap = metadata.unwrap();
 
-    // Exactly one usage.
-    let usage_count =
-        (sign_verify as u8) + (encrypt_decrypt as u8) + (derive as u8) + (unwrap as u8);
+    // Exactly one usage — all five mutually-exclusive usage flags are
+    // counted so a host that piles on extras (e.g.
+    // encrypt+decrypt+wrap) is rejected instead of silently dropping
+    // the unsupported bits.
+    let usage_count = (sign_verify as u8)
+        + (encrypt_decrypt as u8)
+        + (derive as u8)
+        + (wrap as u8)
+        + (unwrap as u8);
     if usage_count != 1 {
         return Err(HsmError::InvalidPermissions);
     }

--- a/fw/core/lib/src/ddi/mbor/mod.rs
+++ b/fw/core/lib/src/ddi/mbor/mod.rs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+pub(crate) mod aes_encrypt_decrypt;
+pub(crate) mod aes_generate_key;
 pub(crate) mod close_session;
 pub(crate) mod establish_credential;
 pub(crate) mod get_api_rev;
@@ -15,6 +17,8 @@ pub(crate) mod open_session;
 pub(crate) mod set_sealed_bk3;
 pub(crate) mod sha_digest;
 
+pub(crate) use aes_encrypt_decrypt::*;
+pub(crate) use aes_generate_key::*;
 use azihsm_fw_ddi_mbor::*;
 use azihsm_fw_ddi_mbor_api::DdiDecoder;
 use azihsm_fw_ddi_mbor_api::DdiEncoder;
@@ -108,6 +112,8 @@ pub(crate) async fn dispatch<'p, P: HsmPal>(
         DdiOp::EstablishCredential => establish_credential(pal, io, decoder, hdr).await,
         DdiOp::OpenSession => open_session(pal, io, decoder, hdr).await,
         DdiOp::CloseSession => close_session(pal, io, decoder, hdr),
+        DdiOp::AesGenerateKey => aes_generate_key(pal, io, decoder, hdr).await,
+        DdiOp::AesEncryptDecrypt => aes_encrypt_decrypt(pal, io, decoder, hdr).await,
         _ => Err(HsmError::UnsupportedCmd),
     }
 }


### PR DESCRIPTION
AesGenerateKey generates a fresh random AES-128 / 192 / 256 key in the partition vault (optionally session-scoped so it is torn down by CloseSession) and returns the assigned key_id plus a placeholder masked_key envelope.  Bulk AES variants (XTS / GCM) are out of scope and rejected with InvalidArg.

AesEncryptDecrypt performs AES-CBC encrypt or decrypt on a host-supplied message buffer using a vault-resident AES key and a host-supplied 16-byte IV.  The transformed message plus the updated chaining IV are returned so the host can chain subsequent CBC blocks.

Handler details:

- AesGenerateKey:
  - Validates the key_size is non-bulk (Aes128/192/256).
  - Translates DdiTargetKeyMetadata flags into vault attrs; only the EncryptDecrypt usage is valid for AES, anything else returns InvalidPermissions.
  - Session-only keys cannot carry an explicit key_tag (matches test_aes_generate_session_only_key_with_key_tag).
  - Fills a scratch DMA buffer with rng_fill_bytes, then vault_key_create with the appropriate Aes{128,192,256} kind and session binding.
  - bulk_key_id is always None for non-bulk requests.
- AesEncryptDecrypt:
  - Validates the op enum (Encrypt / Decrypt).
  - Validates IV is exactly one AES block, message is non-empty, block-aligned, and within the 1024 B wire max.
  - Looks up the vault key and rejects non-AES kinds with InvalidKeyType.
  - Op-aware permission check: Encrypt requires the encrypt attribute bit, Decrypt requires the decrypt bit.
  - Runs aes_cbc_enc_dec_in_place directly inside the response msg / iv slots — no scratch buffers — and emits the updated chaining IV so the host can stitch multi-block sequences.

New type surface:

- fw-side DdiTargetKeyMetadata bit accessors (session / sign / verify / encrypt / decrypt / derive / unwrap), mirroring the host-side helpers so handlers can read the requested key-usage flags without poking the raw 16-byte blob.

Adds 4 smoke tests (generate happy + generate without session; cbc encrypt+decrypt roundtrip + cbc without session + cbc unknown-key) and brings 24 of the 25 emu integration tests in the aes_generate + aes_cbc modules to passing — the lone failure (test_aes_cbc_encrypt_decrypt_incorrect_key_type) depends on the EccGenerateKeyPair handler, which is in a separate stash branch.