### PR TITLE
docs: document fork-and-pull contributor workflow

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,6 +9,17 @@ When you submit a pull request, a CLA-bot will automatically determine whether y
 to provide a CLA and decorate the PR appropriately (e.g., label, comment). Simply follow the
 instructions provided by the bot. You will only need to do this once across all repositories using our CLA.
 
+This project uses the "fork-and-pull" development model. See
+[GitHub forks](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks)
+for more information on forks. Please follow these steps to merge your changes into
+[Azure/azihsm-sdk](https://github.com/Azure/azihsm-sdk):
+1. [Fork and clone](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/fork-a-repo#forking-a-repository)
+   the [Azure/azihsm-sdk](https://github.com/Azure/azihsm-sdk) repository.
+2. Create a topic branch off `main` in your fork, develop your code, commit your changes, and push the branch to your fork.
+3. Open a pull request against the `main` branch of [Azure/azihsm-sdk](https://github.com/Azure/azihsm-sdk)
+   [from your fork](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request-from-a-fork).
+4. Go through the PR review process.
+
 This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/).
 For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/)
 or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

--- a/README.md
+++ b/README.md
@@ -112,6 +112,9 @@ When you submit a pull request, a CLA bot will automatically determine whether y
 a CLA and decorate the PR appropriately (e.g., status check, comment). Simply follow the instructions
 provided by the bot. You will only need to do this once across all repos using our CLA.
 
+See [CONTRIBUTING.md](./CONTRIBUTING.md) for the fork-and-pull workflow and step-by-step PR
+submission guide.
+
 This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/).
 For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or
 contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.


### PR DESCRIPTION
Add a small fork-and-pull workflow section to CONTRIBUTING.md (after the CLA paragraphs) covering the four standard steps: fork+clone, topic branch off main, open a PR from the fork against the main branch of Azure/azihsm-sdk, and iterate through review.

Also add a one-line pointer in README.md's Contributing section directing readers to CONTRIBUTING.md for the workflow details.