### PR TITLE
feat(fw): implement DDI EccGenerateKeyPair + EccSign handlers

### DIFF
--- a/ddi/mbor/types/tests/azihsm_ddi_tests.rs
+++ b/ddi/mbor/types/tests/azihsm_ddi_tests.rs
@@ -20,7 +20,9 @@ mod integration {
     pub mod delete_key;
     pub mod device_handle_session;
     pub mod ecc_generate;
+    pub mod ecc_generate_smoke;
     pub mod ecc_sign_compat;
+    pub mod ecc_sign_smoke;
     pub mod ecc_sign_stress;
     pub mod ecc_sign_verify;
     pub mod ecdh_256_key_exchange;

--- a/ddi/mbor/types/tests/integration/ecc_generate_smoke.rs
+++ b/ddi/mbor/types/tests/integration/ecc_generate_smoke.rs
@@ -1,0 +1,81 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! EccGenerateKeyPair smoke tests for the emu backend.
+//!
+//! - Happy path: generate a P-256 sign/verify key in an open session
+//!   and confirm the response carries a non-zero `private_key_id`
+//!   and a non-empty public key.
+//! - Without a session: rejected by the host-side dev validator
+//!   before the request reaches firmware.
+
+#![cfg(test)]
+
+use azihsm_ddi::*;
+use azihsm_ddi_mbor_test_helpers::helper_key_properties;
+use azihsm_ddi_mbor_types::*;
+use test_with_tracing::test;
+
+use super::common::*;
+
+#[test]
+fn test_ecc_generate_smoke() {
+    ddi_dev_test(
+        common_setup,
+        common_cleanup,
+        |dev, _ddi, _path, session_id| {
+            let key_props = helper_key_properties(DdiKeyUsage::SignVerify, DdiKeyAvailability::App);
+            let resp = helper_ecc_generate_key_pair(
+                dev,
+                Some(session_id),
+                Some(DdiApiRev { major: 1, minor: 0 }),
+                DdiEccCurve::P256,
+                None,
+                key_props,
+            )
+            .unwrap();
+
+            assert_eq!(resp.hdr.op, DdiOp::EccGenerateKeyPair);
+            assert_eq!(resp.hdr.status, DdiStatus::Success);
+            assert_ne!(
+                resp.data.private_key_id, 0,
+                "private_key_id must be non-zero"
+            );
+            assert!(
+                !resp.data.pub_key.der.as_slice().is_empty(),
+                "public key bytes must be non-empty"
+            );
+        },
+    );
+}
+
+#[test]
+fn test_ecc_generate_no_session_smoke() {
+    ddi_dev_test(
+        common_setup,
+        common_cleanup,
+        |dev, _ddi, _path, _session_id| {
+            let key_props = helper_key_properties(DdiKeyUsage::SignVerify, DdiKeyAvailability::App);
+            let err = helper_ecc_generate_key_pair(
+                dev,
+                None,
+                Some(DdiApiRev { major: 1, minor: 0 }),
+                DdiEccCurve::P256,
+                None,
+                key_props,
+            )
+            .expect_err("EccGenerateKeyPair must be rejected without a session");
+
+            // The host-side dev validator rejects InSession commands sent
+            // with sess_id=None before the request reaches firmware.
+            assert!(
+                matches!(
+                    err,
+                    DdiError::DdiStatus(DdiStatus::FileHandleSessionIdDoesNotMatch)
+                ),
+                "expected FileHandleSessionIdDoesNotMatch, got {:?}",
+                err
+            );
+        },
+    );
+}

--- a/ddi/mbor/types/tests/integration/ecc_sign_smoke.rs
+++ b/ddi/mbor/types/tests/integration/ecc_sign_smoke.rs
@@ -1,0 +1,115 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! EccSign smoke tests for the emu backend.
+//!
+//! - Happy path: generate a P-256 sign/verify key, sign a digest,
+//!   and verify the signature against the returned public key with
+//!   OpenSSL.
+//! - Sign with an unknown key id: rejected (the exact error code
+//!   differs across backends — emu returns `KeyNotFound`, the mock
+//!   returns `InvalidKeyNumber`).
+
+#![cfg(test)]
+
+use azihsm_ddi::*;
+use azihsm_ddi_mbor_codec::MborByteArray;
+use azihsm_ddi_mbor_test_helpers::helper_key_properties;
+use azihsm_ddi_mbor_types::*;
+use test_with_tracing::test;
+
+use super::common::*;
+
+#[test]
+fn test_ecc_sign_smoke() {
+    ddi_dev_test(
+        common_setup,
+        common_cleanup,
+        |dev, _ddi, _path, session_id| {
+            // Generate a P-256 sign/verify key in the open session.
+            let key_props = helper_key_properties(DdiKeyUsage::SignVerify, DdiKeyAvailability::App);
+            let gen_resp = helper_ecc_generate_key_pair(
+                dev,
+                Some(session_id),
+                Some(DdiApiRev { major: 1, minor: 0 }),
+                DdiEccCurve::P256,
+                None,
+                key_props,
+            )
+            .unwrap();
+
+            // Sign a 32-byte digest with the generated key.
+            let digest = [0xaau8; 32];
+            let sign_resp = helper_ecc_sign(
+                dev,
+                Some(session_id),
+                Some(DdiApiRev { major: 1, minor: 0 }),
+                gen_resp.data.private_key_id,
+                MborByteArray::from_slice(&digest).unwrap(),
+                DdiHashAlgorithm::Sha256,
+            )
+            .unwrap();
+
+            assert_eq!(sign_resp.hdr.op, DdiOp::EccSign);
+            assert_eq!(sign_resp.hdr.status, DdiStatus::Success);
+
+            // Signature must be 64 bytes (P-256, r||s in BE after host
+            // post_decode).
+            let sig_len = sign_resp.data.signature.len();
+            assert_eq!(sig_len, 64, "P-256 signature must be 64 bytes");
+
+            // OpenSSL verifies the signature against the returned public
+            // key and the digest we signed.  `ecc_verify_local_openssl`
+            // takes the digest as a fixed-96-byte buffer + length, so
+            // copy our 32-byte digest into a padded array.
+            #[cfg(target_os = "linux")]
+            {
+                let mut digest_padded = [0u8; 96];
+                digest_padded[..digest.len()].copy_from_slice(&digest);
+                assert!(
+                    ecc_verify_local_openssl(
+                        &sign_resp.data.signature.data()[..sig_len],
+                        &gen_resp.data.pub_key,
+                        digest_padded,
+                        digest.len(),
+                    ),
+                    "ECDSA signature must verify against the generated public key"
+                );
+            }
+        },
+    );
+}
+
+#[test]
+fn test_ecc_sign_unknown_key_smoke() {
+    ddi_dev_test(
+        common_setup,
+        common_cleanup,
+        |dev, _ddi, _path, session_id| {
+            let digest = [0xaau8; 32];
+            let err = helper_ecc_sign(
+                dev,
+                Some(session_id),
+                Some(DdiApiRev { major: 1, minor: 0 }),
+                0xFFFF, /* unknown key id */
+                MborByteArray::from_slice(&digest).unwrap(),
+                DdiHashAlgorithm::Sha256,
+            )
+            .expect_err("EccSign must reject an unknown key id");
+
+            // The exact error code differs across backends — emu's
+            // vault returns `KeyNotFound`, the mock returns
+            // `InvalidKeyNumber`.  Both are acceptable as long as the
+            // request fails.
+            assert!(
+                matches!(
+                    err,
+                    DdiError::DdiStatus(DdiStatus::KeyNotFound)
+                        | DdiError::DdiStatus(DdiStatus::InvalidKeyNumber)
+                ),
+                "expected KeyNotFound or InvalidKeyNumber, got {:?}",
+                err
+            );
+        },
+    );
+}

--- a/fw/core/crypto/hpke/src/kem.rs
+++ b/fw/core/crypto/hpke/src/kem.rs
@@ -106,20 +106,34 @@ where
     P: HsmCrypto + HsmAlloc + 'a,
 {
     let curve = suite.kem_curve();
-    let nsk = suite.nsk();
     let npk = suite.npk();
     let ndh = suite.ndh();
 
-    let keygen_buf = alloc_bytes(nsk + npk, alloc)?;
-    let (sk_e, pk_e) = pal
-        .ecc_gen_keypair(io, curve, keygen_buf, HsmEccPct::None)
+    // Query-alloc-use ECC keygen.  `priv_max` covers any PAL's
+    // private-key encoding (raw scalar for real HW, PKCS#8 DER for
+    // std); `pub_max` always equals the wire-format public-key
+    // length (== npk).
+    let (priv_max, pub_max) = pal
+        .ecc_gen_keypair(io, alloc, curve, None, HsmEccPct::None)
+        .await?;
+    let sk_e = alloc_bytes(priv_max, alloc)?;
+    let pk_e = alloc_bytes(pub_max, alloc)?;
+    let (sk_len, pk_len) = pal
+        .ecc_gen_keypair(
+            io,
+            alloc,
+            curve,
+            Some((&mut *sk_e, &mut *pk_e)),
+            HsmEccPct::None,
+        )
         .await?;
 
     let dh = alloc_bytes(ndh, alloc)?;
     let pk_r_dma = dma_copy_in(alloc, pk_r)?;
-    pal.ecdh_derive(io, curve, sk_e, pk_r_dma, dh).await?;
+    pal.ecdh_derive(io, curve, &sk_e[..sk_len], pk_r_dma, dh)
+        .await?;
 
-    enc[..npk].copy_from_slice(pk_e);
+    enc[..npk].copy_from_slice(&pk_e[..pk_len]);
 
     let kem_context = alloc_bytes(npk * 2, alloc)?;
     build_kem_context(kem_context, &enc[..npk], pk_r, None);
@@ -220,24 +234,34 @@ where
     P: HsmCrypto + HsmAlloc + 'a,
 {
     let curve = suite.kem_curve();
-    let nsk = suite.nsk();
     let npk = suite.npk();
     let ndh = suite.ndh();
 
-    let keygen_buf = alloc_bytes(nsk + npk, alloc)?;
-    let (sk_e, pk_e) = pal
-        .ecc_gen_keypair(io, curve, keygen_buf, HsmEccPct::None)
+    // Query-alloc-use ECC keygen — same flow as `encap`.
+    let (priv_max, pub_max) = pal
+        .ecc_gen_keypair(io, alloc, curve, None, HsmEccPct::None)
+        .await?;
+    let sk_e = alloc_bytes(priv_max, alloc)?;
+    let pk_e = alloc_bytes(pub_max, alloc)?;
+    let (sk_len, pk_len) = pal
+        .ecc_gen_keypair(
+            io,
+            alloc,
+            curve,
+            Some((&mut *sk_e, &mut *pk_e)),
+            HsmEccPct::None,
+        )
         .await?;
 
     let dh = alloc_bytes(ndh * 2, alloc)?;
     let pk_r_dma = dma_copy_in(alloc, pk_r)?;
     let sk_s_dma = dma_copy_in(alloc, sk_s)?;
-    pal.ecdh_derive(io, curve, sk_e, pk_r_dma, &mut dh[..ndh])
+    pal.ecdh_derive(io, curve, &sk_e[..sk_len], pk_r_dma, &mut dh[..ndh])
         .await?;
     pal.ecdh_derive(io, curve, sk_s_dma, pk_r_dma, &mut dh[ndh..])
         .await?;
 
-    enc[..npk].copy_from_slice(pk_e);
+    enc[..npk].copy_from_slice(&pk_e[..pk_len]);
 
     let kem_context = alloc_bytes(npk * 3, alloc)?;
     build_kem_context(kem_context, &enc[..npk], pk_r, Some(pk_s));

--- a/fw/core/crypto/hpke/src/kem.rs
+++ b/fw/core/crypto/hpke/src/kem.rs
@@ -26,6 +26,7 @@ use azihsm_fw_hsm_pal_traits::DmaBuf;
 use azihsm_fw_hsm_pal_traits::HsmAlloc;
 use azihsm_fw_hsm_pal_traits::HsmCrypto;
 use azihsm_fw_hsm_pal_traits::HsmEccPct;
+use azihsm_fw_hsm_pal_traits::HsmError;
 use azihsm_fw_hsm_pal_traits::HsmIo;
 use azihsm_fw_hsm_pal_traits::HsmResult;
 use azihsm_fw_hsm_pal_traits::HsmScopedAlloc;
@@ -127,13 +128,20 @@ where
             HsmEccPct::None,
         )
         .await?;
+    // Validate the PAL honored the query-alloc-use contract (pk_len
+    // must equal npk for the wire format) and the caller's `enc`
+    // buffer is large enough — fail fast before doing the ECDH so we
+    // don't burn an ephemeral keypair on a request we can't complete.
+    if pk_len != npk || enc.len() < npk {
+        return Err(HsmError::InvalidArg);
+    }
 
     let dh = alloc_bytes(ndh, alloc)?;
     let pk_r_dma = dma_copy_in(alloc, pk_r)?;
     pal.ecdh_derive(io, curve, &sk_e[..sk_len], pk_r_dma, dh)
         .await?;
 
-    enc[..npk].copy_from_slice(&pk_e[..pk_len]);
+    enc[..npk].copy_from_slice(&pk_e[..npk]);
 
     let kem_context = alloc_bytes(npk * 2, alloc)?;
     build_kem_context(kem_context, &enc[..npk], pk_r, None);
@@ -252,6 +260,10 @@ where
             HsmEccPct::None,
         )
         .await?;
+    // Same fail-fast as `encap` — validate before any ECDH work.
+    if pk_len != npk || enc.len() < npk {
+        return Err(HsmError::InvalidArg);
+    }
 
     let dh = alloc_bytes(ndh * 2, alloc)?;
     let pk_r_dma = dma_copy_in(alloc, pk_r)?;
@@ -261,7 +273,7 @@ where
     pal.ecdh_derive(io, curve, sk_s_dma, pk_r_dma, &mut dh[ndh..])
         .await?;
 
-    enc[..npk].copy_from_slice(&pk_e[..pk_len]);
+    enc[..npk].copy_from_slice(&pk_e[..npk]);
 
     let kem_context = alloc_bytes(npk * 3, alloc)?;
     build_kem_context(kem_context, &enc[..npk], pk_r, Some(pk_s));

--- a/fw/core/ddi/mbor/types/src/ecc_generate_key_pair.rs
+++ b/fw/core/ddi/mbor/types/src/ecc_generate_key_pair.rs
@@ -21,7 +21,7 @@ pub struct DdiEccGenerateKeyPairReq<'a> {
 pub struct DdiEccGenerateKeyPairResp<'a> {
     #[ddi(id = 1)]
     pub private_key_id: u16,
-    #[ddi(id = 2)]
+    #[ddi(id = 2, frame)]
     pub pub_key: DdiPublicKey<'a>,
     #[ddi(id = 3, max_len = 3072)]
     pub masked_key: &'a [u8],

--- a/fw/core/lib/src/ddi/mbor/ecc_generate_key_pair.rs
+++ b/fw/core/lib/src/ddi/mbor/ecc_generate_key_pair.rs
@@ -12,7 +12,6 @@
 
 use azihsm_fw_ddi_mbor_types::ecc_generate_key_pair::DdiEccGenerateKeyPairReq;
 use azihsm_fw_ddi_mbor_types::ecc_generate_key_pair::DdiEccGenerateKeyPairResp;
-use azihsm_fw_ddi_mbor_types::DdiEccCurve;
 use azihsm_fw_ddi_mbor_types::DdiKeyType;
 
 use super::*;
@@ -34,7 +33,7 @@ pub(crate) async fn ecc_generate_key_pair<'p, P: HsmPal>(
     let body: DdiEccGenerateKeyPairReq = decoder.decode_data()?;
 
     let sess_id = hdr.sess_id.ok_or(HsmError::SessionExpected)?;
-    let pal_curve = ddi_to_pal_curve(body.curve)?;
+    let pal_curve = super::from_ddi::curve(body.curve)?;
     let vault_kind = curve_to_vault_kind(pal_curve);
     let attrs = build_attrs_for_curve(pal_curve, &body.key_properties.key_metadata)?;
 
@@ -121,16 +120,6 @@ pub(crate) async fn ecc_generate_key_pair<'p, P: HsmPal>(
     let _ = guard.dismiss();
 
     Ok(resp)
-}
-
-/// Map a `DdiEccCurve` to its PAL-level [`HsmEccCurve`].
-fn ddi_to_pal_curve(curve: DdiEccCurve) -> HsmResult<HsmEccCurve> {
-    match curve {
-        DdiEccCurve::P256 => Ok(HsmEccCurve::P256),
-        DdiEccCurve::P384 => Ok(HsmEccCurve::P384),
-        DdiEccCurve::P521 => Ok(HsmEccCurve::P521),
-        _ => Err(HsmError::InvalidArg),
-    }
 }
 
 /// Map a `HsmEccCurve` to its private [`HsmVaultKeyKind`].

--- a/fw/core/lib/src/ddi/mbor/ecc_generate_key_pair.rs
+++ b/fw/core/lib/src/ddi/mbor/ecc_generate_key_pair.rs
@@ -1,0 +1,213 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! DDI EccGenerateKeyPair command handler.
+//!
+//! Within an open session, generate a fresh ECC keypair on the
+//! requested NIST curve (P-256 / P-384 / P-521), persist the private
+//! key in the partition vault — optionally session-scoped so it is
+//! torn down by [`CloseSession`](super::close_session) — and return
+//! the public key plus an opaque masked-key envelope the host may
+//! re-import on a future session.
+
+use azihsm_fw_ddi_mbor_types::ecc_generate_key_pair::DdiEccGenerateKeyPairReq;
+use azihsm_fw_ddi_mbor_types::ecc_generate_key_pair::DdiEccGenerateKeyPairResp;
+use azihsm_fw_ddi_mbor_types::DdiEccCurve;
+use azihsm_fw_ddi_mbor_types::DdiKeyType;
+
+use super::*;
+
+/// Handle `DdiEccGenerateKeyPairCmd`.
+///
+/// No `partition_lock` is needed: this handler does not perform any
+/// multi-step read-then-mutate against partition state.  Its single
+/// state mutation — `vault_key_create` — is sync and atomic.  A
+/// concurrent `CloseSession` racing with our `ecc_gen_keypair` await
+/// would just turn the subsequent vault create into a clean
+/// `SessionNotFound` error, never a partial commit.
+pub(crate) async fn ecc_generate_key_pair<'p, P: HsmPal>(
+    pal: &'p P,
+    io: &impl HsmIo,
+    decoder: &mut DdiDecoder<'_>,
+    hdr: &DdiReqHdr,
+) -> HsmResult<&'p DmaBuf> {
+    let body: DdiEccGenerateKeyPairReq = decoder.decode_data()?;
+
+    let sess_id = hdr.sess_id.ok_or(HsmError::SessionExpected)?;
+    let pal_curve = ddi_to_pal_curve(body.curve)?;
+    let vault_kind = curve_to_vault_kind(pal_curve);
+    let attrs = build_attrs_for_curve(pal_curve, &body.key_properties.key_metadata)?;
+
+    // Session-only keys are anonymous — disallow a host-supplied
+    // `key_tag` because the key cannot be looked up across sessions.
+    // Matches `test_ecc_generate_session_only_key_with_key_tag`.
+    if attrs.session() && body.key_tag.is_some() {
+        return Err(HsmError::InvalidArg);
+    }
+
+    // ECC key generation follows the trait's query-alloc-use flow,
+    // wrapped in a single scoped allocator: query reports the PAL's
+    // per-curve upper bounds (priv_max is PKCS#8 DER max for std /
+    // raw-scalar size for real HW; pub_max is the deterministic
+    // wire-format LE public-key length), we allocate the IO-lifetime
+    // output buffers, then use returns the actual bytes written
+    // (priv_actual ≤ priv_max for std DER; equal for real HW;
+    // pub_actual always == pub_max).
+    let (priv_key, pub_key, priv_actual, pub_actual) = pal
+        .alloc_scoped_async(io, async |a| -> HsmResult<_> {
+            let (priv_max, pub_max) = pal
+                .ecc_gen_keypair(io, a, pal_curve, None, HsmEccPct::SignVerify)
+                .await?;
+            let priv_key = pal.dma_alloc(io, priv_max)?;
+            let pub_key = pal.dma_alloc(io, pub_max)?;
+            let (priv_actual, pub_actual) = pal
+                .ecc_gen_keypair(
+                    io,
+                    a,
+                    pal_curve,
+                    Some((&mut *priv_key, &mut *pub_key)),
+                    HsmEccPct::SignVerify,
+                )
+                .await?;
+            Ok((priv_key, pub_key, priv_actual, pub_actual))
+        })
+        .await?;
+
+    // Store the private key in the vault, session-scoped iff the
+    // requested attrs say so.  RAII guard rolls the entry back if
+    // the response encoding below fails.
+    let session_binding = if attrs.session() {
+        Some(HsmSessId::from(sess_id))
+    } else {
+        None
+    };
+    let guard = pal.vault_key_create(
+        io,
+        &priv_key[..priv_actual],
+        vault_kind,
+        session_binding,
+        attrs,
+        body.key_properties.key_label,
+    )?;
+    let private_key_id: u16 = guard.key_id().into();
+
+    // Build the response.  `masked_key` is the host's opaque
+    // re-import blob; firmware-side masking against the session BK is
+    // pending the corresponding `UnmaskKey` handler — emit an empty
+    // placeholder for now so the response is wire-valid.
+    let (resp, layout) = pal.dma_alloc_var_with(io, |buf| {
+        let mut encoder = super::encode_resp_hdr(
+            &super::success_hdr_sess(hdr, DdiOp::EccGenerateKeyPair, sess_id),
+            buf,
+        )?;
+        let layout = DdiEccGenerateKeyPairResp::reserve(
+            &mut encoder,
+            private_key_id,
+            DdiPublicKeyFrameParams {
+                raw_len: pub_actual,
+                key_kind: curve_to_pub_key_kind(pal_curve),
+            },
+            0, /* masked_key length — empty placeholder */
+        )?;
+        Ok((encoder.position(), layout))
+    })?;
+    let frame = DdiEccGenerateKeyPairResp::from_layout(resp, &layout);
+
+    // PAL already emitted the public key in wire format (LE + P-521
+    // padding), so copy directly without further reordering.
+    frame.pub_key.raw.copy_from_slice(&pub_key[..pub_actual]);
+
+    // Commit the vault entry; response is now fully populated.
+    let _ = guard.dismiss();
+
+    Ok(resp)
+}
+
+/// Map a `DdiEccCurve` to its PAL-level [`HsmEccCurve`].
+fn ddi_to_pal_curve(curve: DdiEccCurve) -> HsmResult<HsmEccCurve> {
+    match curve {
+        DdiEccCurve::P256 => Ok(HsmEccCurve::P256),
+        DdiEccCurve::P384 => Ok(HsmEccCurve::P384),
+        DdiEccCurve::P521 => Ok(HsmEccCurve::P521),
+        _ => Err(HsmError::InvalidArg),
+    }
+}
+
+/// Map a `HsmEccCurve` to its private [`HsmVaultKeyKind`].
+fn curve_to_vault_kind(curve: HsmEccCurve) -> HsmVaultKeyKind {
+    match curve {
+        HsmEccCurve::P256 => HsmVaultKeyKind::Ecc256Private,
+        HsmEccCurve::P384 => HsmVaultKeyKind::Ecc384Private,
+        HsmEccCurve::P521 => HsmVaultKeyKind::Ecc521Private,
+    }
+}
+
+/// Map a `HsmEccCurve` to the corresponding public-key DDI type.
+fn curve_to_pub_key_kind(curve: HsmEccCurve) -> DdiKeyType {
+    match curve {
+        HsmEccCurve::P256 => DdiKeyType::Ecc256Public,
+        HsmEccCurve::P384 => DdiKeyType::Ecc384Public,
+        HsmEccCurve::P521 => DdiKeyType::Ecc521Public,
+    }
+}
+
+/// Translate the requested `key_metadata` bitflags into a vault
+/// attribute set.
+///
+/// Mirrors the host-side `DdiKeyProperties -> DdiTargetKeyProperties`
+/// conversion: at most one logical usage is encoded in the metadata
+/// (sign+verify, encrypt+decrypt, derive, or unwrap), and the session
+/// flag is independent.  We re-derive the usage by inspecting the
+/// individual bit flags so an inconsistent/empty metadata fails fast
+/// with `InvalidPermissions`.
+///
+/// Internally-generated keys always carry `local = true` (mirrors
+/// PKCS#11 `CKA_LOCAL`).
+fn build_attrs_for_curve(
+    curve: HsmEccCurve,
+    metadata: &azihsm_fw_ddi_mbor_types::DdiTargetKeyMetadata,
+) -> HsmResult<HsmVaultKeyAttrs> {
+    let mut attrs = HsmVaultKeyAttrs::new().with_local(true);
+
+    let sign_verify = metadata.sign() && metadata.verify();
+    let encrypt_decrypt = metadata.encrypt() && metadata.decrypt();
+    let derive = metadata.derive();
+    let unwrap = metadata.unwrap();
+    let wrap = metadata.wrap();
+
+    // Exactly one usage; the host-side helper ensures this, so a
+    // multi-usage request is malformed.  `wrap` is folded into the
+    // usage count even though no curve currently allows it, so that
+    // `sign+verify+wrap` is rejected as multi-usage rather than
+    // silently treated as plain sign+verify.
+    let usage_count = (sign_verify as u8)
+        + (encrypt_decrypt as u8)
+        + (derive as u8)
+        + (unwrap as u8)
+        + (wrap as u8);
+    if usage_count != 1 {
+        return Err(HsmError::InvalidPermissions);
+    }
+
+    // ECC keys can sign / verify / derive (ECDH).  EncryptDecrypt,
+    // Unwrap, and Wrap are not valid usages for an ECC key — let
+    // the curve dictate which usage flags are accepted, matching
+    // the reference firmware's `Kind::allows_usage` check.
+    let _ = curve; // all three NIST curves currently allow the same usages
+    if encrypt_decrypt || unwrap || wrap {
+        return Err(HsmError::InvalidPermissions);
+    }
+
+    if sign_verify {
+        attrs = attrs.with_sign(true).with_verify(true);
+    }
+    if derive {
+        attrs = attrs.with_derive(true);
+    }
+
+    if metadata.session() {
+        attrs = attrs.with_session(true);
+    }
+
+    Ok(attrs)
+}

--- a/fw/core/lib/src/ddi/mbor/ecc_sign.rs
+++ b/fw/core/lib/src/ddi/mbor/ecc_sign.rs
@@ -10,7 +10,6 @@
 
 use azihsm_fw_ddi_mbor_types::ecc_sign::DdiEccSignReq;
 use azihsm_fw_ddi_mbor_types::ecc_sign::DdiEccSignResp;
-use azihsm_fw_ddi_mbor_types::DdiHashAlgorithm;
 
 use super::*;
 
@@ -34,7 +33,7 @@ pub(crate) async fn ecc_sign<'p, P: HsmPal>(
     // responsible for any endianness flip its underlying primitive
     // requires (e.g. std PAL reverses to BE for OpenSSL; real-HW
     // PALs pass through to the PKA engine).
-    let pal_algo = ddi_to_pal_hash(body.digest_algo)?;
+    let pal_algo = super::from_ddi::hash(body.digest_algo)?;
     let real_digest_len = pal_algo.digest_len();
     if body.digest.len() < real_digest_len {
         return Err(HsmError::InvalidArg);
@@ -70,17 +69,6 @@ pub(crate) async fn ecc_sign<'p, P: HsmPal>(
     .await?;
 
     Ok(resp)
-}
-
-/// Map the DDI digest enum to its PAL counterpart.
-fn ddi_to_pal_hash(algo: DdiHashAlgorithm) -> HsmResult<HsmHashAlgo> {
-    match algo {
-        DdiHashAlgorithm::Sha1 => Ok(HsmHashAlgo::Sha1),
-        DdiHashAlgorithm::Sha256 => Ok(HsmHashAlgo::Sha256),
-        DdiHashAlgorithm::Sha384 => Ok(HsmHashAlgo::Sha384),
-        DdiHashAlgorithm::Sha512 => Ok(HsmHashAlgo::Sha512),
-        _ => Err(HsmError::InvalidArg),
-    }
 }
 
 /// Infer the ECC curve from a vault key kind.

--- a/fw/core/lib/src/ddi/mbor/ecc_sign.rs
+++ b/fw/core/lib/src/ddi/mbor/ecc_sign.rs
@@ -1,0 +1,97 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! DDI EccSign command handler.
+//!
+//! Within an open session, look up an ECC private key by id and
+//! produce a raw `r || s` signature over the host-supplied digest.
+//! The digest must already be hashed by the host — firmware does no
+//! hashing here.
+
+use azihsm_fw_ddi_mbor_types::ecc_sign::DdiEccSignReq;
+use azihsm_fw_ddi_mbor_types::ecc_sign::DdiEccSignResp;
+use azihsm_fw_ddi_mbor_types::DdiHashAlgorithm;
+
+use super::*;
+
+/// Handle `DdiEccSignCmd`.
+pub(crate) async fn ecc_sign<'p, P: HsmPal>(
+    pal: &'p P,
+    io: &impl HsmIo,
+    decoder: &mut DdiDecoder<'_>,
+    hdr: &DdiReqHdr,
+) -> HsmResult<&'p DmaBuf> {
+    let body: DdiEccSignReq = decoder.decode_data()?;
+
+    let sess_id = hdr.sess_id.ok_or(HsmError::SessionExpected)?;
+
+    // Validate the digest_algo enum is supported and pin the slice
+    // length to the algo's native digest size — the host's
+    // `digest_pre_encode` LE-reverses `input_array.len()` bytes and
+    // zero-pads the rest to 68 wire bytes, so the leading
+    // `real_digest_len` bytes are the actual digest in wire-LE form.
+    // We hand that sub-slice straight to the PAL, which is
+    // responsible for any endianness flip its underlying primitive
+    // requires (e.g. std PAL reverses to BE for OpenSSL; real-HW
+    // PALs pass through to the PKA engine).
+    let pal_algo = ddi_to_pal_hash(body.digest_algo)?;
+    let real_digest_len = pal_algo.digest_len();
+    if body.digest.len() < real_digest_len {
+        return Err(HsmError::InvalidArg);
+    }
+
+    let key_id = HsmKeyId::from(body.key_id);
+    let vault_kind = pal.vault_key_kind(io, key_id)?;
+    let curve = vault_kind_to_curve(vault_kind)?;
+    let vault_attrs = pal.vault_key_attrs(io, key_id)?;
+    if !vault_attrs.sign() {
+        return Err(HsmError::InvalidPermissions);
+    }
+    let priv_key = pal.vault_key(io, key_id)?;
+
+    // Sign directly into the wire-format signature slot.  The PAL
+    // emits `r || s` in LE with P-521 trailing pad bytes, so we just
+    // reserve `curve.wire_sig_len()` bytes and hand the slot through.
+    let wire_len = curve.wire_sig_len();
+    let (resp, layout) = pal.dma_alloc_var_with(io, |buf| {
+        let mut encoder =
+            super::encode_resp_hdr(&super::success_hdr_sess(hdr, DdiOp::EccSign, sess_id), buf)?;
+        let layout = DdiEccSignResp::reserve(&mut encoder, wire_len)?;
+        Ok((encoder.position(), layout))
+    })?;
+    let frame = DdiEccSignResp::from_layout(resp, &layout);
+    pal.ecc_sign(
+        io,
+        curve,
+        priv_key,
+        &body.digest[..real_digest_len],
+        frame.signature,
+    )
+    .await?;
+
+    Ok(resp)
+}
+
+/// Map the DDI digest enum to its PAL counterpart.
+fn ddi_to_pal_hash(algo: DdiHashAlgorithm) -> HsmResult<HsmHashAlgo> {
+    match algo {
+        DdiHashAlgorithm::Sha1 => Ok(HsmHashAlgo::Sha1),
+        DdiHashAlgorithm::Sha256 => Ok(HsmHashAlgo::Sha256),
+        DdiHashAlgorithm::Sha384 => Ok(HsmHashAlgo::Sha384),
+        DdiHashAlgorithm::Sha512 => Ok(HsmHashAlgo::Sha512),
+        _ => Err(HsmError::InvalidArg),
+    }
+}
+
+/// Infer the ECC curve from a vault key kind.
+///
+/// Returns `InvalidKeyType` if the kind is not an ECC private key —
+/// matches the test that signs against a non-ECC key.
+fn vault_kind_to_curve(kind: HsmVaultKeyKind) -> HsmResult<HsmEccCurve> {
+    match kind {
+        HsmVaultKeyKind::Ecc256Private => Ok(HsmEccCurve::P256),
+        HsmVaultKeyKind::Ecc384Private => Ok(HsmEccCurve::P384),
+        HsmVaultKeyKind::Ecc521Private => Ok(HsmEccCurve::P521),
+        _ => Err(HsmError::InvalidKeyType),
+    }
+}

--- a/fw/core/lib/src/ddi/mbor/from_ddi.rs
+++ b/fw/core/lib/src/ddi/mbor/from_ddi.rs
@@ -1,0 +1,45 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! DDI wire → firmware-internal type conversions shared by handlers.
+//!
+//! Translates enums and other small types that arrive on the DDI
+//! wire (host-facing) into their firmware-side counterparts (PAL
+//! traits, vault kinds, internal flag sets).  Multiple handlers
+//! share each mapping, so centralizing the conversions here keeps
+//! the set of supported variants — and the error code used for
+//! unsupported ones — consistent across all handlers.
+//!
+//! Functions are intentionally bare-named (`hash`, `curve`, …) so
+//! call sites read as `from_ddi::hash(algo)` / `from_ddi::curve(c)`,
+//! mirroring Rust's `From::from(value)` idiom.
+
+use azihsm_fw_ddi_mbor_types::DdiEccCurve;
+use azihsm_fw_ddi_mbor_types::DdiHashAlgorithm;
+use azihsm_fw_hsm_pal_traits::HsmEccCurve;
+use azihsm_fw_hsm_pal_traits::HsmError;
+use azihsm_fw_hsm_pal_traits::HsmHashAlgo;
+use azihsm_fw_hsm_pal_traits::HsmResult;
+
+/// Map a [`DdiHashAlgorithm`] to its [`HsmHashAlgo`] counterpart.
+/// Unsupported / unknown variants return [`HsmError::InvalidArg`].
+pub(crate) fn hash(algo: DdiHashAlgorithm) -> HsmResult<HsmHashAlgo> {
+    match algo {
+        DdiHashAlgorithm::Sha1 => Ok(HsmHashAlgo::Sha1),
+        DdiHashAlgorithm::Sha256 => Ok(HsmHashAlgo::Sha256),
+        DdiHashAlgorithm::Sha384 => Ok(HsmHashAlgo::Sha384),
+        DdiHashAlgorithm::Sha512 => Ok(HsmHashAlgo::Sha512),
+        _ => Err(HsmError::InvalidArg),
+    }
+}
+
+/// Map a [`DdiEccCurve`] to its [`HsmEccCurve`] counterpart.
+/// Unsupported / unknown variants return [`HsmError::InvalidArg`].
+pub(crate) fn curve(curve: DdiEccCurve) -> HsmResult<HsmEccCurve> {
+    match curve {
+        DdiEccCurve::P256 => Ok(HsmEccCurve::P256),
+        DdiEccCurve::P384 => Ok(HsmEccCurve::P384),
+        DdiEccCurve::P521 => Ok(HsmEccCurve::P521),
+        _ => Err(HsmError::InvalidArg),
+    }
+}

--- a/fw/core/lib/src/ddi/mbor/get_establish_cred_encryption_key.rs
+++ b/fw/core/lib/src/ddi/mbor/get_establish_cred_encryption_key.rs
@@ -59,8 +59,9 @@ pub(crate) async fn get_establish_cred_encryption_key<'p, P: HsmPal>(
     pal.part_establish_cred_pub_key(io, Some(frame.pub_key.raw))?;
     pal.part_nonce(io, Some(frame.nonce))?;
 
-    // Hash pub key, then sign directly into the signature slot.
-    pal.hash(io, HsmHashAlgo::Sha384, frame.pub_key.raw, digest, true)
+    // Hash pub key directly in wire-LE (PAL's `ecc_sign` digest
+    // contract), then sign into the signature slot.
+    pal.hash(io, HsmHashAlgo::Sha384, frame.pub_key.raw, digest, false)
         .await?;
     pal.ecc_sign(
         io,

--- a/fw/core/lib/src/ddi/mbor/get_session_encryption_key.rs
+++ b/fw/core/lib/src/ddi/mbor/get_session_encryption_key.rs
@@ -71,8 +71,9 @@ pub(crate) async fn get_session_encryption_key<'p, P: HsmPal>(
     pal.part_session_enc_pub_key(io, Some(frame.pub_key.raw))?;
     pal.part_nonce(io, Some(frame.nonce))?;
 
-    // Hash pub key, then sign directly into the signature slot.
-    pal.hash(io, HsmHashAlgo::Sha384, frame.pub_key.raw, digest, true)
+    // Hash pub key directly in wire-LE (PAL's `ecc_sign` digest
+    // contract), then sign into the signature slot.
+    pal.hash(io, HsmHashAlgo::Sha384, frame.pub_key.raw, digest, false)
         .await?;
     pal.ecc_sign(
         io,

--- a/fw/core/lib/src/ddi/mbor/mod.rs
+++ b/fw/core/lib/src/ddi/mbor/mod.rs
@@ -4,6 +4,8 @@
 pub(crate) mod aes_encrypt_decrypt;
 pub(crate) mod aes_generate_key;
 pub(crate) mod close_session;
+pub(crate) mod ecc_generate_key_pair;
+pub(crate) mod ecc_sign;
 pub(crate) mod establish_credential;
 pub(crate) mod get_api_rev;
 pub(crate) mod get_cert_chain_info;
@@ -25,6 +27,8 @@ use azihsm_fw_ddi_mbor_api::DdiEncoder;
 use azihsm_fw_ddi_mbor_types::error::DdiErrResp;
 use azihsm_fw_ddi_mbor_types::*;
 pub(crate) use close_session::*;
+pub(crate) use ecc_generate_key_pair::*;
+pub(crate) use ecc_sign::*;
 pub(crate) use establish_credential::*;
 pub(crate) use get_api_rev::*;
 pub(crate) use get_cert_chain_info::*;
@@ -114,6 +118,8 @@ pub(crate) async fn dispatch<'p, P: HsmPal>(
         DdiOp::CloseSession => close_session(pal, io, decoder, hdr),
         DdiOp::AesGenerateKey => aes_generate_key(pal, io, decoder, hdr).await,
         DdiOp::AesEncryptDecrypt => aes_encrypt_decrypt(pal, io, decoder, hdr).await,
+        DdiOp::EccGenerateKeyPair => ecc_generate_key_pair(pal, io, decoder, hdr).await,
+        DdiOp::EccSign => ecc_sign(pal, io, decoder, hdr).await,
         _ => Err(HsmError::UnsupportedCmd),
     }
 }

--- a/fw/core/lib/src/ddi/mbor/mod.rs
+++ b/fw/core/lib/src/ddi/mbor/mod.rs
@@ -7,6 +7,7 @@ pub(crate) mod close_session;
 pub(crate) mod ecc_generate_key_pair;
 pub(crate) mod ecc_sign;
 pub(crate) mod establish_credential;
+pub(crate) mod from_ddi;
 pub(crate) mod get_api_rev;
 pub(crate) mod get_cert_chain_info;
 pub(crate) mod get_certificate;

--- a/fw/core/lib/src/ddi/mbor/sha_digest.rs
+++ b/fw/core/lib/src/ddi/mbor/sha_digest.rs
@@ -17,17 +17,6 @@ use azihsm_fw_ddi_mbor_types::sha_digest::DdiShaDigestResp;
 
 use super::*;
 
-/// Map DDI hash algorithm to PAL hash algorithm.
-fn to_hsm_hash_algo(ddi: DdiHashAlgorithm) -> HsmResult<HsmHashAlgo> {
-    match ddi {
-        DdiHashAlgorithm::Sha1 => Ok(HsmHashAlgo::Sha1),
-        DdiHashAlgorithm::Sha256 => Ok(HsmHashAlgo::Sha256),
-        DdiHashAlgorithm::Sha384 => Ok(HsmHashAlgo::Sha384),
-        DdiHashAlgorithm::Sha512 => Ok(HsmHashAlgo::Sha512),
-        _ => Err(HsmError::InvalidArg),
-    }
-}
-
 /// Handle DdiShaDigestCmd.
 pub(crate) async fn sha_digest<'p, P: HsmPal>(
     pal: &'p P,
@@ -37,7 +26,7 @@ pub(crate) async fn sha_digest<'p, P: HsmPal>(
 ) -> HsmResult<&'p DmaBuf> {
     let body: DdiShaDigestReq<'_> = decoder.decode_data()?;
 
-    let algo = to_hsm_hash_algo(body.sha_mode)?;
+    let algo = super::from_ddi::hash(body.sha_mode)?;
     let digest_len = algo.digest_len();
 
     let (resp, layout) = pal.dma_alloc_var_with(io, |buf| {

--- a/fw/pal/traits/src/crypto/ecc.rs
+++ b/fw/pal/traits/src/crypto/ecc.rs
@@ -68,6 +68,33 @@ impl HsmEccCurve {
         self.priv_key_len() * 2
     }
 
+    /// Return the wire-format coordinate / signature-component byte
+    /// length per curve.
+    ///
+    /// The PAL exposes `priv_key_len()` (66 for P-521), but the wire
+    /// format pads P-521 coordinates and ECDSA signature components
+    /// to 68 bytes so each one lands on a 4-byte (32-bit) PKA word
+    /// boundary.  P-256 / P-384 are already word-aligned and need no
+    /// padding.
+    pub fn wire_coord_len(&self) -> usize {
+        match self {
+            HsmEccCurve::P521 => 68,
+            _ => self.priv_key_len(),
+        }
+    }
+
+    /// Return the wire-format public-key byte length (two padded
+    /// coordinates).  See [`HsmEccCurve::wire_coord_len`].
+    pub fn wire_pub_key_len(&self) -> usize {
+        self.wire_coord_len() * 2
+    }
+
+    /// Return the wire-format ECDSA signature byte length (two padded
+    /// components — `r || s`).  See [`HsmEccCurve::wire_coord_len`].
+    pub fn wire_sig_len(&self) -> usize {
+        self.wire_coord_len() * 2
+    }
+
     /// Return the ECDH shared secret size in bytes.
     ///
     /// The shared secret derived from ECDH is the same length as the private
@@ -78,10 +105,11 @@ impl HsmEccCurve {
 
     /// Maximum PKCS#8 DER size for a private key on this curve.
     ///
-    /// Callers use this to allocate buffers for
-    /// [`ecc_gen_keypair`](HsmEcc::ecc_gen_keypair).
-    ///
-    /// TODO: Remove this
+    /// The std PAL encodes private keys as PKCS#8 DER (variable
+    /// length); callers use this as the upper bound returned by
+    /// [`ecc_gen_keypair`](HsmEcc::ecc_gen_keypair) in query mode.
+    /// Real-HW PALs that work in raw scalars instead report
+    /// [`priv_key_len`](Self::priv_key_len) — always ≤ this max.
     pub fn priv_key_der_max(&self) -> usize {
         match self {
             HsmEccCurve::P256 => 138,
@@ -118,32 +146,63 @@ pub enum HsmEccPct {
 /// format — not DER — sized per [`HsmEccCurve::priv_key_len`] /
 /// [`HsmEccCurve::pub_key_len`].
 pub trait HsmEcc {
-    /// Generates an ECC key pair on the chosen curve and writes
-    /// `priv_key || pub_key` contiguously into `key_out`.
+    /// Generates an ECC key pair on the chosen curve, optionally
+    /// writing the keys into caller-provided buffers.
+    ///
+    /// Uses the canonical query-alloc-use workflow:
+    ///
+    /// 1. **Query** — call with `out = None`.  No key generation
+    ///    happens; the method returns `(priv_max, pub_max)` upper
+    ///    bounds the caller must allocate.  `pub_max` is always the
+    ///    deterministic `HsmEccCurve::wire_pub_key_len(curve)`;
+    ///    `priv_max` depends on the PAL's encoding — real-HW PALs
+    ///    return the raw-scalar size `HsmEccCurve::priv_key_len`
+    ///    (32 / 48 / 66 bytes), while the std PAL uses PKCS#8 DER
+    ///    and returns `HsmEccCurve::priv_key_der_max`.
+    /// 2. **Alloc** — caller allocates two DMA buffers of those
+    ///    sizes.
+    /// 3. **Use** — call with `out = Some((priv_out, pub_out))`.
+    ///    The method generates a fresh keypair (using `alloc` for
+    ///    any internal contiguous PKA scratch), writes the PAL-format
+    ///    private key into `priv_out[..priv_actual]` and the
+    ///    wire-format LE public key into `pub_out[..pub_actual]`,
+    ///    and returns the actual lengths.  Both are guaranteed to
+    ///    be `≤` the upper bounds reported by the matching query
+    ///    call (real-HW PALs always return the same value in both
+    ///    modes; std-PAL DER may be shorter than the max).
     ///
     /// # Parameters
     ///
     /// - `io` — caller's I/O context (per-IO scope).
+    /// - `alloc` — scoped allocator used by the implementation for
+    ///   any internal scratch (e.g. the contiguous `priv || pub`
+    ///   buffer real PKA hardware emits before the bytes are split
+    ///   into the caller's two output slots).  Unused in query
+    ///   mode.
     /// - `curve` — NIST curve selector.
-    /// - `key_out` — output buffer; must be at least
-    ///   `curve.priv_key_len() + curve.pub_key_len()` bytes.  On
-    ///   success, `key_out[..nsk]` holds the private scalar and
-    ///   `key_out[nsk..nsk+npk]` holds the uncompressed public point
-    ///   (`x || y`).
+    /// - `out` — `None` to query buffer sizes; `Some((priv_out,
+    ///   pub_out))` to actually generate.  Each output buffer must
+    ///   be at least as large as the corresponding length returned
+    ///   by an earlier query call.
     /// - `pct` — pairwise consistency test selector.
     ///
     /// # Returns
     ///
-    /// - `Ok((priv_key, pub_key))` — borrowed views into `key_out`.
-    /// - `Err(HsmError::InvalidArg)` — `key_out` too small.
-    /// - `Err(HsmError)` — PKA / RNG / PCT failure.
-    async fn ecc_gen_keypair<'a>(
+    /// - `Ok((priv_len, pub_len))` — in query mode, the upper-bound
+    ///   sizes the caller must allocate; in use mode, the actual
+    ///   bytes written into `priv_out` / `pub_out` (always `≤` the
+    ///   query bounds).
+    /// - `Err(HsmError::InvalidArg)` — `out` is `Some` and one of
+    ///   the buffers is shorter than the required length.
+    /// - `Err(HsmError)` — PKA / RNG / PCT / DMA failure.
+    async fn ecc_gen_keypair(
         &self,
         io: &impl HsmIo,
+        alloc: &impl HsmScopedAlloc,
         curve: HsmEccCurve,
-        key_out: &'a mut DmaBuf,
+        out: Option<(&mut DmaBuf, &mut DmaBuf)>,
         pct: HsmEccPct,
-    ) -> HsmResult<(&'a DmaBuf, &'a DmaBuf)>;
+    ) -> HsmResult<(usize, usize)>;
 
     /// Raw EC sign over a pre-computed message digest.
     ///
@@ -154,16 +213,26 @@ pub trait HsmEcc {
     ///
     /// - `io` — caller's I/O context (per-IO scope).
     /// - `curve` — NIST curve the private key is on.
-    /// - `priv_key` — signing key; must be exactly
-    ///   `curve.priv_key_len()` bytes.
-    /// - `hash` — message digest to sign.  Truncated or zero-padded
-    ///   internally if shorter/longer than the curve's order.
-    /// - `signature` — output buffer; must be at least
-    ///   `curve.sig_len()` bytes (`r || s`).
+    /// - `priv_key` — signing key (PAL-format byte blob — std uses
+    ///   PKCS#8 DER; real-HW PALs use the raw scalar).
+    /// - `hash` — message digest to sign, in **little-endian** byte
+    ///   order to match the wire-native format produced by real PKA
+    ///   hardware.  Must contain exactly the digest's native length
+    ///   (e.g. 32 bytes for SHA-256, 64 bytes for SHA-512); ECDSA
+    ///   truncates internally if longer than the curve's order.
+    ///   Implementations that delegate to a big-endian-native
+    ///   primitive (e.g. OpenSSL) must reverse the bytes internally.
+    /// - `signature` — output buffer.  On return, holds `r || s`
+    ///   with **each component in little-endian** byte order — the
+    ///   wire-native format produced by real PKA hardware.  P-521
+    ///   components occupy 68 bytes each (66 real + 2-byte trailing
+    ///   zero pad) for 32-bit word alignment.  Required length is
+    ///   `HsmEccCurve::wire_sig_len(curve)`: 64 for P-256, 96 for
+    ///   P-384, 136 for P-521.
     ///
     /// # Returns
     ///
-    /// - `Ok(())` — `signature[..sig_len]` populated.
+    /// - `Ok(())` — `signature[..wire_sig_len]` populated in LE.
     /// - `Err(HsmError::InvalidArg)` — buffer-size mismatch.
     /// - `Err(HsmError)` — PKA / RNG failure.
     async fn ecc_sign(
@@ -219,8 +288,8 @@ pub trait HsmEcc {
     ///
     /// - `io` — caller's I/O context (per-IO scope).
     /// - `curve` — NIST curve both keys are on.
-    /// - `priv_key` — local private scalar; must be exactly
-    ///   `curve.priv_key_len()` bytes.
+    /// - `priv_key` — local private key (PAL-format byte blob — std
+    ///   uses PKCS#8 DER; real-HW PALs use the raw scalar).
     /// - `pub_key` — remote uncompressed point; must be exactly
     ///   `curve.pub_key_len()` bytes (`x || y`).  **Each coordinate
     ///   is in little-endian byte order** — matches the on-wire DDI

--- a/fw/pal/traits/src/crypto/ecc.rs
+++ b/fw/pal/traits/src/crypto/ecc.rs
@@ -253,17 +253,21 @@ pub trait HsmEcc {
     /// - `curve` — NIST curve the public key is on; determines the
     ///   expected signature length.
     /// - `pub_key` — verification key; uncompressed `x || y`,
-    ///   `curve.pub_key_len()` bytes.  **Each coordinate is in
-    ///   little-endian byte order** — matches the on-wire DDI
+    ///   exactly `curve.wire_pub_key_len()` bytes.  **Each coordinate
+    ///   is in little-endian byte order** with P-521 coordinates
+    ///   padded to 68 bytes (66 real + 2-byte trailing zero pad) for
+    ///   32-bit word alignment — matches the on-wire DDI
     ///   representation and real PKA hardware.  Implementations that
-    ///   delegate to a big-endian-native primitive (e.g. OpenSSL) must
-    ///   reverse each coordinate internally.
+    ///   delegate to a big-endian-native primitive (e.g. OpenSSL)
+    ///   must strip the per-coordinate padding and reverse each
+    ///   coordinate internally.
     /// - `hash` — message digest that was signed.  Raw digest bytes;
     ///   no endianness conversion is applied.
     /// - `signature` — signature to verify; must be exactly
-    ///   `curve.sig_len()` bytes (`r || s`).  **Each component is in
-    ///   little-endian byte order** — matches the on-wire DDI
-    ///   representation and real PKA hardware.
+    ///   `curve.wire_sig_len()` bytes (`r || s`).  **Each component
+    ///   is in little-endian byte order** with P-521 components
+    ///   padded to 68 bytes — matches the on-wire DDI representation
+    ///   and real PKA hardware.
     ///
     /// # Returns
     ///
@@ -291,11 +295,14 @@ pub trait HsmEcc {
     /// - `priv_key` — local private key (PAL-format byte blob — std
     ///   uses PKCS#8 DER; real-HW PALs use the raw scalar).
     /// - `pub_key` — remote uncompressed point; must be exactly
-    ///   `curve.pub_key_len()` bytes (`x || y`).  **Each coordinate
-    ///   is in little-endian byte order** — matches the on-wire DDI
-    ///   representation and real PKA hardware.  Implementations that
-    ///   delegate to a big-endian-native primitive (e.g. OpenSSL) must
-    ///   reverse each coordinate internally.
+    ///   `curve.wire_pub_key_len()` bytes (`x || y`).  **Each
+    ///   coordinate is in little-endian byte order** with P-521
+    ///   coordinates padded to 68 bytes (66 real + 2-byte trailing
+    ///   zero pad) for 32-bit word alignment — matches the on-wire
+    ///   DDI representation and real PKA hardware.  Implementations
+    ///   that delegate to a big-endian-native primitive (e.g.
+    ///   OpenSSL) must strip the per-coordinate padding and reverse
+    ///   each coordinate internally.
     /// - `secret` — output buffer; must be at least
     ///   `curve.secret_len()` bytes.  On success, holds the
     ///   x-coordinate of the shared point.

--- a/fw/plat/std/lib/tests/echo_test.rs
+++ b/fw/plat/std/lib/tests/echo_test.rs
@@ -1229,15 +1229,36 @@ async fn get_establish_cred_encryption_key_verify_signature() {
     let pub_key_raw = data.pub_key.der.as_slice();
     let signature_raw = data.pub_key_signature.as_slice();
 
-    // 4. Hash the public key with SHA-384
+    // 4. Hash the public key with SHA-384.  Fw hashed the same
+    // wire-LE coordinate bytes (raw output of pub_key.der without
+    // post-decode), so we hash the same bytes the test reads.
     let digest = Hasher::hash_vec(&mut HashAlgo::sha384(), pub_key_raw).expect("sha384");
 
-    // 5. Verify signature: raw EC verify (digest, signature) with leaf key
+    // 5. Convert the wire-LE signature (r_le || s_le, P-384 → 48 +
+    // 48) into OpenSSL's BE `r || s`.  The DDI decoder is invoked
+    // with `post_decode = false`, so we re-do the LE→BE flip
+    // (equivalent of `ecc_signature_post_decode`) inline here.
+    assert_eq!(signature_raw.len(), 96, "P-384 wire signature length");
+    let mut signature_be = [0u8; 96];
+    for (dst, src) in signature_be[..48]
+        .iter_mut()
+        .zip(signature_raw[..48].iter().rev())
+    {
+        *dst = *src;
+    }
+    for (dst, src) in signature_be[48..96]
+        .iter_mut()
+        .zip(signature_raw[48..96].iter().rev())
+    {
+        *dst = *src;
+    }
+
+    // 6. Verify signature: raw EC verify (digest, signature) with leaf key.
     let result = Verifier::verify(
         &mut EccAlgo::default(),
         &verifier_key,
         &digest,
-        signature_raw,
+        &signature_be,
     );
     assert!(
         result.is_ok(),

--- a/fw/plat/std/pal/src/drivers/ecc.rs
+++ b/fw/plat/std/pal/src/drivers/ecc.rs
@@ -42,6 +42,29 @@ use azihsm_fw_hsm_pal_traits::*;
 
 use crate::worker::WorkerPool;
 
+// On-wire-format helpers
+//
+// The std PAL accepts inputs and produces outputs in the wire-LE
+// convention that real PKA hardware emits natively (`x_le || y_le`
+// for public keys, `r_le || s_le` for signatures, with P-521
+// components padded from 66 to 68 bytes per word).  The single
+// `reverse_copy` helper centralizes the BE↔LE byte reversal so the
+// `_le`-suffixed driver methods can stay free of byte-shuffling
+// boilerplate.
+
+/// Reverse-copy `src` into `dst[..src.len()]`.  Used for BE↔LE
+/// component swaps; the direction is symmetric.  Trailing pad bytes
+/// in `dst` (e.g. the 2-byte pad after a 66-byte P-521 coordinate
+/// inside a 68-byte word) are left untouched — callers that need
+/// them zeroed should pre-`fill(0)` the full `dst` slot.
+fn reverse_copy(dst: &mut [u8], src: &[u8]) {
+    let len = src.len();
+    debug_assert!(dst.len() >= len);
+    for (d, s) in dst[..len].iter_mut().zip(src.iter().rev()) {
+        *d = *s;
+    }
+}
+
 /// Std ECC driver — software ECC via OpenSSL with async worker dispatch.
 pub struct StdEcc {
     pool: WorkerPool,
@@ -56,6 +79,10 @@ impl StdEcc {
     /// Generate an ECC key pair asynchronously.
     ///
     /// Returns the `(EccPrivateKey, EccPublicKey)` handle pair.
+    /// Used by internal-firmware callers (`cert.rs`, `part.rs`)
+    /// that work directly in OpenSSL handles and BE coordinates;
+    /// PAL-trait callers should use [`Self::gen_keypair_le`]
+    /// instead.
     pub async fn gen_keypair(&self, curve: EccCurve) -> HsmResult<(EccPrivateKey, EccPublicKey)> {
         self.pool
             .submit_with_result(async move {
@@ -67,6 +94,37 @@ impl StdEcc {
                 Ok((priv_key, pub_key))
             })
             .await
+    }
+
+    /// Generate an ECC key pair, returning the private-key handle
+    /// and writing the public key in wire-LE `x_le || y_le` form
+    /// (with P-521 padded to 68 bytes per coordinate) into
+    /// `pub_le_out`.
+    ///
+    /// `pub_le_out.len()` must be `wire_pub_key_len(curve)`
+    /// (64 / 96 / 136 for P-256 / P-384 / P-521).
+    pub async fn gen_keypair_le(
+        &self,
+        curve: EccCurve,
+        pub_le_out: &mut [u8],
+    ) -> HsmResult<EccPrivateKey> {
+        let (priv_key, pub_key) = self.gen_keypair(curve).await?;
+        let coord_len = priv_key_len(curve);
+        let wire_coord = wire_coord_len(curve);
+        if pub_le_out.len() != wire_coord * 2 {
+            return Err(HsmError::EccGetCoordinatesError);
+        }
+        let mut x_be = [0u8; 66];
+        let mut y_be = [0u8; 66];
+        pub_key
+            .coord(Some((&mut x_be[..coord_len], &mut y_be[..coord_len])))
+            .map_err(|_| HsmError::EccGetCoordinatesError)?;
+
+        pub_le_out.fill(0);
+        let (x_dst, y_dst) = pub_le_out.split_at_mut(wire_coord);
+        reverse_copy(x_dst, &x_be[..coord_len]);
+        reverse_copy(y_dst, &y_be[..coord_len]);
+        Ok(priv_key)
     }
 
     /// Raw EC sign over a pre-computed hash digest.
@@ -99,6 +157,49 @@ impl StdEcc {
             .await
     }
 
+    /// Sign a wire-LE digest with an [`EccPrivateKey`] handle and
+    /// write the wire-LE signature (`r_le || s_le`, P-521 padded)
+    /// into `sig_le_out`.
+    ///
+    /// `sig_le_out.len()` must be `wire_sig_len(curve)`
+    /// (64 / 96 / 136 for P-256 / P-384 / P-521).  `hash_le.len()`
+    /// must not exceed SHA-512 (64 bytes); longer inputs are
+    /// rejected rather than silently truncated.
+    pub async fn ecc_sign_le(
+        &self,
+        priv_key: &EccPrivateKey,
+        hash_le: &[u8],
+        sig_le_out: &mut [u8],
+    ) -> HsmResult<()> {
+        let curve = EccKeyOp::curve(priv_key);
+        let coord_len = priv_key_len(curve);
+        let wire_coord = wire_coord_len(curve);
+        if sig_le_out.len() != wire_coord * 2 {
+            return Err(HsmError::EccSignFailed);
+        }
+        if hash_le.len() > 64 {
+            return Err(HsmError::InvalidArg);
+        }
+
+        // Reverse wire-LE digest into BE scratch for OpenSSL.
+        let mut hash_be = [0u8; 64];
+        reverse_copy(&mut hash_be[..hash_le.len()], hash_le);
+
+        let sig_be = self.ecc_sign(priv_key, &hash_be[..hash_le.len()]).await?;
+        if sig_be.len() < coord_len * 2 {
+            return Err(HsmError::EccSignFailed);
+        }
+
+        // Reverse each component into the LE wire layout.
+        sig_le_out.fill(0);
+        let (r_le_dst, rest) = sig_le_out.split_at_mut(wire_coord);
+        let (s_le_dst, _) = rest.split_at_mut(wire_coord);
+        let (r_be, s_be) = sig_be.split_at(coord_len);
+        reverse_copy(r_le_dst, r_be);
+        reverse_copy(s_le_dst, s_be);
+        Ok(())
+    }
+
     /// Raw EC verify a signature over a pre-computed hash digest.
     ///
     /// Returns `true` if the signature is valid, `false` otherwise.
@@ -118,6 +219,53 @@ impl StdEcc {
                     .map_err(|_| HsmError::EccVerifyFailed)
             })
             .await
+    }
+
+    /// Verify a wire-LE signature using a public key supplied as
+    /// raw wire-LE `x || y` coordinates.  The driver constructs the
+    /// OpenSSL pub-key handle and performs the BE↔LE conversion
+    /// internally so the PAL doesn't have to.
+    ///
+    /// `hash` is passed through to OpenSSL **unmodified** — the PAL
+    /// trait's verify contract says "Raw digest bytes; no endianness
+    /// conversion is applied", so callers pass the BE hash they got
+    /// from SHA directly.  (The asymmetry with [`Self::ecc_sign_le`]
+    /// matches the upstream trait contract; both internal
+    /// firmware callers of verify pass BE digests.)
+    ///
+    /// `pub_le.len()` must be `pub_key_len(curve)` (raw, non-padded;
+    /// 64 / 96 / 132).  `sig_le.len()` must be `sig_len(curve)`
+    /// (raw, non-padded; 64 / 96 / 132).
+    pub async fn ecc_verify_le(
+        &self,
+        curve: EccCurve,
+        pub_le: &[u8],
+        hash: &[u8],
+        sig_le: &[u8],
+    ) -> HsmResult<bool> {
+        let coord_len = priv_key_len(curve);
+        let pub_len = coord_len * 2;
+        let sig_len = coord_len * 2;
+        if pub_le.len() < pub_len || sig_le.len() < sig_len {
+            return Err(HsmError::InvalidArg);
+        }
+
+        // Reverse each pub coord and sig component from wire-LE to
+        // OpenSSL-BE.
+        let (x_le, y_le) = pub_le[..pub_len].split_at(coord_len);
+        let mut x_be = [0u8; 66];
+        let mut y_be = [0u8; 66];
+        reverse_copy(&mut x_be[..coord_len], x_le);
+        reverse_copy(&mut y_be[..coord_len], y_le);
+        let key = EccPublicKey::from_coordinates(curve, &x_be[..coord_len], &y_be[..coord_len])
+            .map_err(|_| HsmError::InvalidArg)?;
+
+        let (r_le, s_le) = sig_le[..sig_len].split_at(coord_len);
+        let mut sig_be = [0u8; 132];
+        reverse_copy(&mut sig_be[..coord_len], r_le);
+        reverse_copy(&mut sig_be[coord_len..sig_len], s_le);
+
+        self.ecc_verify(&key, hash, &sig_be[..sig_len]).await
     }
 
     /// ECDH key agreement — derives a shared secret into `secret`.
@@ -160,6 +308,63 @@ impl StdEcc {
         }
         secret[..bytes.len()].copy_from_slice(&bytes);
         Ok(())
+    }
+
+    /// ECDH key agreement using a public key supplied as raw
+    /// wire-LE `x || y` coordinates.  The driver constructs the
+    /// OpenSSL pub-key handle internally.
+    ///
+    /// `pub_le.len()` must be `pub_key_len(curve)` (raw, non-padded;
+    /// 64 / 96 / 132).  The shared secret is written into
+    /// `secret_out` in OpenSSL's native big-endian form — the trait
+    /// contract leaves the secret endianness unspecified and current
+    /// callers consume it as opaque HKDF input, so no flip is
+    /// applied.
+    pub async fn ecdh_derive_le(
+        &self,
+        priv_key: &EccPrivateKey,
+        curve: EccCurve,
+        pub_le: &[u8],
+        secret_out: &mut [u8],
+    ) -> HsmResult<()> {
+        let coord_len = priv_key_len(curve);
+        let pub_len = coord_len * 2;
+        if pub_le.len() < pub_len {
+            return Err(HsmError::InvalidArg);
+        }
+
+        let (x_le, y_le) = pub_le[..pub_len].split_at(coord_len);
+        let mut x_be = [0u8; 66];
+        let mut y_be = [0u8; 66];
+        reverse_copy(&mut x_be[..coord_len], x_le);
+        reverse_copy(&mut y_be[..coord_len], y_le);
+        let pubk = EccPublicKey::from_coordinates(curve, &x_be[..coord_len], &y_be[..coord_len])
+            .map_err(|_| HsmError::InvalidArg)?;
+
+        self.ecdh_derive(priv_key, &pubk, secret_out).await
+    }
+}
+
+/// Raw private-key (and per-coordinate) length in bytes for the
+/// given curve.  Mirrors `HsmEccCurve::priv_key_len` but defined
+/// in driver-local terms so the driver doesn't depend on the
+/// PAL-trait crate's curve enum.
+fn priv_key_len(curve: EccCurve) -> usize {
+    match curve {
+        EccCurve::P256 => 32,
+        EccCurve::P384 => 48,
+        EccCurve::P521 => 66,
+    }
+}
+
+/// Wire-format per-coordinate length, padded to 32-bit words.
+/// P-256/P-384 are already word-aligned (32 / 48); P-521 pads from
+/// 66 to 68.
+fn wire_coord_len(curve: EccCurve) -> usize {
+    match curve {
+        EccCurve::P256 => 32,
+        EccCurve::P384 => 48,
+        EccCurve::P521 => 68,
     }
 }
 

--- a/fw/plat/std/pal/src/drivers/ecc.rs
+++ b/fw/plat/std/pal/src/drivers/ecc.rs
@@ -222,9 +222,10 @@ impl StdEcc {
     }
 
     /// Verify a wire-LE signature using a public key supplied as
-    /// raw wire-LE `x || y` coordinates.  The driver constructs the
-    /// OpenSSL pub-key handle and performs the BE↔LE conversion
-    /// internally so the PAL doesn't have to.
+    /// wire-LE `x || y` coordinates.  The driver constructs the
+    /// OpenSSL pub-key handle and performs BE↔LE conversion plus
+    /// P-521 per-coordinate de-padding internally so the PAL doesn't
+    /// have to.
     ///
     /// `hash` is passed through to OpenSSL **unmodified** — the PAL
     /// trait's verify contract says "Raw digest bytes; no endianness
@@ -233,9 +234,10 @@ impl StdEcc {
     /// matches the upstream trait contract; both internal
     /// firmware callers of verify pass BE digests.)
     ///
-    /// `pub_le.len()` must be `pub_key_len(curve)` (raw, non-padded;
-    /// 64 / 96 / 132).  `sig_le.len()` must be `sig_len(curve)`
-    /// (raw, non-padded; 64 / 96 / 132).
+    /// `pub_le.len()` must be `wire_pub_key_len(curve)`
+    /// (64 / 96 / 136 for P-256 / P-384 / P-521).
+    /// `sig_le.len()` must be `wire_sig_len(curve)`
+    /// (64 / 96 / 136 for P-256 / P-384 / P-521).
     pub async fn ecc_verify_le(
         &self,
         curve: EccCurve,
@@ -244,26 +246,27 @@ impl StdEcc {
         sig_le: &[u8],
     ) -> HsmResult<bool> {
         let coord_len = priv_key_len(curve);
-        let pub_len = coord_len * 2;
-        let sig_len = coord_len * 2;
-        if pub_le.len() < pub_len || sig_le.len() < sig_len {
+        let wire_coord = wire_coord_len(curve);
+        let wire_len = wire_coord * 2;
+        if pub_le.len() < wire_len || sig_le.len() < wire_len {
             return Err(HsmError::InvalidArg);
         }
 
-        // Reverse each pub coord and sig component from wire-LE to
-        // OpenSSL-BE.
-        let (x_le, y_le) = pub_le[..pub_len].split_at(coord_len);
+        // Reverse each wire-LE coordinate (skipping any trailing
+        // padding bytes for P-521) into OpenSSL-BE form.
+        let (x_wire, y_wire) = pub_le[..wire_len].split_at(wire_coord);
         let mut x_be = [0u8; 66];
         let mut y_be = [0u8; 66];
-        reverse_copy(&mut x_be[..coord_len], x_le);
-        reverse_copy(&mut y_be[..coord_len], y_le);
+        reverse_copy(&mut x_be[..coord_len], &x_wire[..coord_len]);
+        reverse_copy(&mut y_be[..coord_len], &y_wire[..coord_len]);
         let key = EccPublicKey::from_coordinates(curve, &x_be[..coord_len], &y_be[..coord_len])
             .map_err(|_| HsmError::InvalidArg)?;
 
-        let (r_le, s_le) = sig_le[..sig_len].split_at(coord_len);
+        let (r_wire, s_wire) = sig_le[..wire_len].split_at(wire_coord);
+        let sig_len = coord_len * 2;
         let mut sig_be = [0u8; 132];
-        reverse_copy(&mut sig_be[..coord_len], r_le);
-        reverse_copy(&mut sig_be[coord_len..sig_len], s_le);
+        reverse_copy(&mut sig_be[..coord_len], &r_wire[..coord_len]);
+        reverse_copy(&mut sig_be[coord_len..sig_len], &s_wire[..coord_len]);
 
         self.ecc_verify(&key, hash, &sig_be[..sig_len]).await
     }
@@ -310,16 +313,17 @@ impl StdEcc {
         Ok(())
     }
 
-    /// ECDH key agreement using a public key supplied as raw
-    /// wire-LE `x || y` coordinates.  The driver constructs the
-    /// OpenSSL pub-key handle internally.
+    /// ECDH key agreement using a public key supplied as wire-LE
+    /// `x || y` coordinates.  The driver constructs the OpenSSL
+    /// pub-key handle internally, including stripping P-521
+    /// per-coordinate padding.
     ///
-    /// `pub_le.len()` must be `pub_key_len(curve)` (raw, non-padded;
-    /// 64 / 96 / 132).  The shared secret is written into
-    /// `secret_out` in OpenSSL's native big-endian form — the trait
-    /// contract leaves the secret endianness unspecified and current
-    /// callers consume it as opaque HKDF input, so no flip is
-    /// applied.
+    /// `pub_le.len()` must be `wire_pub_key_len(curve)`
+    /// (64 / 96 / 136 for P-256 / P-384 / P-521).  The shared
+    /// secret is written into `secret_out` in OpenSSL's native
+    /// big-endian form — the trait contract leaves the secret
+    /// endianness unspecified and current callers consume it as
+    /// opaque HKDF input, so no flip is applied.
     pub async fn ecdh_derive_le(
         &self,
         priv_key: &EccPrivateKey,
@@ -328,16 +332,17 @@ impl StdEcc {
         secret_out: &mut [u8],
     ) -> HsmResult<()> {
         let coord_len = priv_key_len(curve);
-        let pub_len = coord_len * 2;
-        if pub_le.len() < pub_len {
+        let wire_coord = wire_coord_len(curve);
+        let wire_len = wire_coord * 2;
+        if pub_le.len() < wire_len {
             return Err(HsmError::InvalidArg);
         }
 
-        let (x_le, y_le) = pub_le[..pub_len].split_at(coord_len);
+        let (x_wire, y_wire) = pub_le[..wire_len].split_at(wire_coord);
         let mut x_be = [0u8; 66];
         let mut y_be = [0u8; 66];
-        reverse_copy(&mut x_be[..coord_len], x_le);
-        reverse_copy(&mut y_be[..coord_len], y_le);
+        reverse_copy(&mut x_be[..coord_len], &x_wire[..coord_len]);
+        reverse_copy(&mut y_be[..coord_len], &y_wire[..coord_len]);
         let pubk = EccPublicKey::from_coordinates(curve, &x_be[..coord_len], &y_be[..coord_len])
             .map_err(|_| HsmError::InvalidArg)?;
 

--- a/fw/plat/std/pal/src/ecc.rs
+++ b/fw/plat/std/pal/src/ecc.rs
@@ -3,32 +3,53 @@
 
 //! [`HsmEcc`] implementation for the standard (host-native) PAL.
 //!
-//! Thin delegation layer between the trait boundary (DER byte slices)
-//! and the [`StdEcc`](crate::drivers::ecc::StdEcc) driver (OpenSSL
-//! key handles). The PAL impl is responsible for:
+//! Thin delegation layer between the trait boundary (wire-format
+//! bytes / PKCS#8 DER for private keys) and the
+//! [`StdEcc`](crate::drivers::ecc::StdEcc) driver (OpenSSL key
+//! handles).  The PAL impl is responsible for:
 //!
 //! 1. **Enum mapping** — [`HsmEccCurve`] → [`azihsm_crypto::EccCurve`].
-//! 2. **Key serialization** — exporting generated handles to DER bytes
-//!    (PKCS#8 for private, SPKI for public) in [`ecc_gen_keypair`].
-//! 3. **Key deserialization** — importing DER bytes into handles for
-//!    [`ecc_sign`], [`ecc_verify`], and [`ecdh_derive`].
+//! 2. **Private-key serialization** — exporting generated handles
+//!    to PKCS#8 DER in [`ecc_gen_keypair`] and re-importing DER
+//!    blobs in [`ecc_sign`] / [`ecdh_derive`].
+//! 3. **OpenSSL-BE ↔ wire-LE conversion** — the canonical
+//!    firmware-side wire format for public-key coordinates,
+//!    signature components, and the input digest is little-endian
+//!    (with P-521 padded to 68 bytes per word) because that is what
+//!    real PKA hardware natively consumes, so the host emits and
+//!    accepts those bytes directly.  Real-HW PALs forward the wire
+//!    bytes to PKA unmodified; this std PAL has to reverse them
+//!    back to OpenSSL's native big-endian layout (and reverse the
+//!    outputs back to wire-LE) purely because the OpenSSL backend
+//!    is BE-native — not a host-visible responsibility.
 //!
-//! ## Key formats
+//! ## Key formats at the trait boundary
 //!
 //! | Direction | Private key | Public key |
 //! |-----------|-------------|------------|
-//! | Trait → PAL (input) | PKCS#8 DER `&[u8]` | SPKI DER `&[u8]` |
-//! | PAL → Trait (output) | PKCS#8 DER `&mut [u8]` | SPKI DER `&mut [u8]` |
-//! | PAL → Driver (internal) | `EccPrivateKey` handle | `EccPublicKey` handle |
+//! | Trait → PAL (input)  | PKCS#8 DER `&DmaBuf` (variable, `≤ priv_key_der_max`) | Wire-LE `x \|\| y` `&DmaBuf` (`pub_key_len` bytes) |
+//! | PAL → Trait (output) | PKCS#8 DER `&mut DmaBuf` (variable, `≤ priv_key_der_max`) | Wire-LE `x \|\| y` `&mut DmaBuf` (`wire_pub_key_len` bytes, P-521 padded) |
+//! | PAL → Driver (internal) | `EccPrivateKey` handle | `EccPublicKey` handle (raw BE coords) |
+//!
+//! The trait-level [`HsmEcc::ecc_gen_keypair`] query mode reports
+//! [`HsmEccCurve::priv_key_der_max`] as the private-key upper bound
+//! and [`HsmEccCurve::wire_pub_key_len`] as the public-key length;
+//! the use mode returns the actual DER byte count (always
+//! ≤ the query bound) and the deterministic public-key length
+//! (equal to the query bound).  Real-HW PALs that emit raw scalars
+//! instead report [`HsmEccCurve::priv_key_len`] in both modes; the
+//! trait contract is `use ≤ query`.
 //!
 //! ## Data flow (sign example)
 //!
 //! ```text
-//! Core calls pal.ecc_sign(curve, priv_key_der, hash, sig_buf)
+//! Host LE-reverses digest + pads to wire bytes → DDI request.
+//! Core calls pal.ecc_sign(curve, priv_key_der, hash_le, sig_buf)
 //!   → EccPrivateKey::from_bytes(priv_key_der)  // DER → handle
-//!   → self.ecc.ecc_sign(&handle, hash)         // driver
-//!     → WorkerPool → OpenSSL ECDSA
-//!   → sig_buf[..len].copy_from_slice(&sig)     // result → caller
+//!   → hash_be = reverse(hash_le)               // undo host LE for OpenSSL
+//!   → self.ecc.ecc_sign(&handle, hash_be)      // driver → OpenSSL ECDSA
+//!   → sig_buf = reverse(sig_be) (per component) // re-encode for the wire
+//! // Host parses sig_buf as wire-LE (no further conversion at the host).
 //! ```
 
 use azihsm_crypto::EccCurve;
@@ -51,56 +72,144 @@ fn to_ecc_curve(curve: HsmEccCurve) -> EccCurve {
 }
 
 impl HsmEcc for StdHsmPal {
-    /// Generate an ECC key pair on the specified curve.
+    /// Generate an ECC key pair on the specified curve, query-alloc-use
+    /// style.
     ///
-    /// Delegates to [`StdEcc::gen_keypair`] which returns OpenSSL handles,
-    /// then exports the private key as PKCS#8 DER and the public key as
-    /// raw coordinates into the caller-provided buffer.
-    async fn ecc_gen_keypair<'a>(
+    /// In **query mode** (`out = None`) returns the std-PAL upper
+    /// bounds: PKCS#8 DER max for the private key
+    /// ([`HsmEccCurve::priv_key_der_max`]) and the wire-format LE
+    /// public-key length ([`HsmEccCurve::wire_pub_key_len`]).  In
+    /// **use mode** (`out = Some((priv_out, pub_out))`) it generates
+    /// a keypair via [`StdEcc::gen_keypair`], allocates a contiguous
+    /// `priv_max || pub_max` scratch from `alloc`, serializes the
+    /// keys into that scratch (private as PKCS#8 DER, public as
+    /// LE-reversed + P-521-padded coordinates), copies into the
+    /// caller's two output slots, and returns the **actual** byte
+    /// counts (DER is variable, so `priv_actual ≤ priv_max`; pub is
+    /// deterministic).  Public-key endianness matches the wire-native
+    /// format produced by real PKA hardware — see
+    /// [`HsmEcc::ecc_gen_keypair`].
+    async fn ecc_gen_keypair(
         &self,
         _io: &impl HsmIo,
+        alloc: &impl HsmScopedAlloc,
         curve: HsmEccCurve,
-        key_out: &'a mut DmaBuf,
+        out: Option<(&mut DmaBuf, &mut DmaBuf)>,
         _pct: HsmEccPct,
-    ) -> HsmResult<(&'a DmaBuf, &'a DmaBuf)> {
-        let (pk, pubk) = self.ecc.gen_keypair(to_ecc_curve(curve)).await?;
+    ) -> HsmResult<(usize, usize)> {
+        let priv_max = curve.priv_key_der_max();
+        let wire_pub_len = curve.wire_pub_key_len();
 
-        // Export private key as PKCS#8 DER.
-        let priv_len = pk.to_bytes(None).map_err(|_| HsmError::EccToDerError)?;
-        let coord_len = curve.pub_key_len();
-        if key_out.len() < priv_len + coord_len {
-            return Err(HsmError::EccInvalidKeyLength);
+        let Some((priv_out, pub_out)) = out else {
+            return Ok((priv_max, wire_pub_len));
+        };
+
+        if priv_out.len() < priv_max || pub_out.len() < wire_pub_len {
+            return Err(HsmError::InvalidArg);
         }
 
-        let (priv_key, rest) = key_out.split_at_mut(priv_len);
-        pk.to_bytes(Some(&mut priv_key[..priv_len]))
+        let (pk, pubk) = self.ecc.gen_keypair(to_ecc_curve(curve)).await?;
+
+        // Allocate the contiguous `priv || pub` scratch (sized at the
+        // PAL upper bound) a real PKA engine would write into; we then
+        // perform DER serialization + BE→LE pub-key reversal in-scratch
+        // before copying out.
+        let scratch = alloc.dma_alloc(priv_max + wire_pub_len)?;
+        let (scratch_priv, scratch_pub) = scratch.split_at_mut(priv_max);
+
+        let priv_actual = pk
+            .to_bytes(Some(&mut scratch_priv[..priv_max]))
             .map_err(|_| HsmError::EccToDerError)?;
 
-        // Export public key as raw coordinates (x ∥ y).
-        let pub_key = &mut rest[..coord_len];
-        let half = coord_len / 2;
-        let (x_buf, y_buf) = pub_key.split_at_mut(half);
-        pubk.coord(Some((&mut x_buf[..], &mut y_buf[..])))
+        // Export raw BE coordinates into stack scratch, then reverse
+        // each into the wire-format LE slot (leaving any P-521
+        // trailing pad bytes zero).
+        let coord_len = curve.priv_key_len();
+        let mut x_be = [0u8; 66];
+        let mut y_be = [0u8; 66];
+        pubk.coord(Some((&mut x_be[..coord_len], &mut y_be[..coord_len])))
             .map_err(|_| HsmError::EccToDerError)?;
 
-        Ok((&*priv_key, &*pub_key))
+        scratch_pub.fill(0);
+        let wire_coord = curve.wire_coord_len();
+        let (x_dst, y_dst) = scratch_pub.split_at_mut(wire_coord);
+        for (dst, src) in x_dst[..coord_len]
+            .iter_mut()
+            .zip(x_be[..coord_len].iter().rev())
+        {
+            *dst = *src;
+        }
+        for (dst, src) in y_dst[..coord_len]
+            .iter_mut()
+            .zip(y_be[..coord_len].iter().rev())
+        {
+            *dst = *src;
+        }
+
+        priv_out[..priv_actual].copy_from_slice(&scratch_priv[..priv_actual]);
+        pub_out[..wire_pub_len].copy_from_slice(scratch_pub);
+
+        Ok((priv_actual, wire_pub_len))
     }
 
     /// Raw EC sign over a pre-computed hash digest.
+    ///
+    /// Per the [`HsmEcc::ecc_sign`] trait contract, `hash` is the
+    /// message digest in wire-native **little-endian** byte order,
+    /// and the output signature is `r || s` with **each component
+    /// in little-endian** byte order (P-521 components padded from
+    /// 66 to 68 wire bytes).  OpenSSL is big-endian-native for both
+    /// the digest scalar and the signature components, so we reverse
+    /// the digest before signing and reverse each signature
+    /// component after signing.
     async fn ecc_sign(
         &self,
         _io: &impl HsmIo,
-        _curve: HsmEccCurve,
+        curve: HsmEccCurve,
         priv_key: &DmaBuf,
         hash: &DmaBuf,
         signature: &mut DmaBuf,
     ) -> HsmResult<()> {
+        let wire_len = curve.wire_sig_len();
+        if signature.len() < wire_len {
+            return Err(HsmError::InvalidArg);
+        }
+
         let key = EccPrivateKey::from_bytes(priv_key).map_err(|_| HsmError::InvalidArg)?;
-        let sig = self.ecc.ecc_sign(&key, hash).await?;
-        if signature.len() < sig.len() {
+
+        // Reverse wire-LE digest to OpenSSL-BE; stack scratch sized
+        // for any SHA up to SHA-512 (64 bytes).  Reject longer inputs
+        // rather than silently truncating — the trait contract is
+        // that `hash` carries exactly the digest's native length.
+        let mut hash_be = [0u8; 64];
+        let h_len = hash.len();
+        if h_len > hash_be.len() {
+            return Err(HsmError::InvalidArg);
+        }
+        for (dst, src) in hash_be[..h_len].iter_mut().zip(hash[..h_len].iter().rev()) {
+            *dst = *src;
+        }
+        let sig_be = self.ecc.ecc_sign(&key, &hash_be[..h_len]).await?;
+
+        // OpenSSL returns `r_be || s_be` of length `2 * priv_key_len`.
+        // Reverse each component into the LE wire layout, leaving the
+        // P-521 trailing pad bytes zero.
+        let pal_component = curve.priv_key_len();
+        let wire_component = curve.wire_coord_len();
+        if sig_be.len() < pal_component * 2 {
             return Err(HsmError::EccSignFailed);
         }
-        signature[..sig.len()].copy_from_slice(&sig);
+        signature[..wire_len].fill(0);
+        let (r_be, s_be) = sig_be.split_at(pal_component);
+        for (dst, src) in signature[..pal_component].iter_mut().zip(r_be.iter().rev()) {
+            *dst = *src;
+        }
+        for (dst, src) in signature[wire_component..wire_component + pal_component]
+            .iter_mut()
+            .zip(s_be.iter().rev())
+        {
+            *dst = *src;
+        }
         Ok(())
     }
 

--- a/fw/plat/std/pal/src/ecc.rs
+++ b/fw/plat/std/pal/src/ecc.rs
@@ -6,22 +6,19 @@
 //! Thin delegation layer between the trait boundary (wire-format
 //! bytes / PKCS#8 DER for private keys) and the
 //! [`StdEcc`](crate::drivers::ecc::StdEcc) driver (OpenSSL key
-//! handles).  The PAL impl is responsible for:
+//! handles + wire-LE byte interfaces).  Responsibilities at this
+//! layer are deliberately limited to:
 //!
 //! 1. **Enum mapping** — [`HsmEccCurve`] → [`azihsm_crypto::EccCurve`].
-//! 2. **Private-key serialization** — exporting generated handles
-//!    to PKCS#8 DER in [`ecc_gen_keypair`] and re-importing DER
-//!    blobs in [`ecc_sign`] / [`ecdh_derive`].
-//! 3. **OpenSSL-BE ↔ wire-LE conversion** — the canonical
-//!    firmware-side wire format for public-key coordinates,
-//!    signature components, and the input digest is little-endian
-//!    (with P-521 padded to 68 bytes per word) because that is what
-//!    real PKA hardware natively consumes, so the host emits and
-//!    accepts those bytes directly.  Real-HW PALs forward the wire
-//!    bytes to PKA unmodified; this std PAL has to reverse them
-//!    back to OpenSSL's native big-endian layout (and reverse the
-//!    outputs back to wire-LE) purely because the OpenSSL backend
-//!    is BE-native — not a host-visible responsibility.
+//! 2. **Private-key DER round-trip** — exporting a freshly generated
+//!    handle to PKCS#8 DER in [`ecc_gen_keypair`] and importing the
+//!    DER blob back into a handle in [`ecc_sign`] / [`ecdh_derive`].
+//! 3. **Delegation** — every wire-LE ↔ OpenSSL-BE byte flip lives
+//!    inside the driver's `_le`-suffixed methods, so this layer is
+//!    free of byte-shuffling boilerplate.  Real PKA hardware
+//!    consumes the wire-LE format natively; the driver-side flips
+//!    are an OpenSSL-backend artifact and not a host-visible
+//!    firmware responsibility.
 //!
 //! ## Key formats at the trait boundary
 //!
@@ -29,7 +26,8 @@
 //! |-----------|-------------|------------|
 //! | Trait → PAL (input)  | PKCS#8 DER `&DmaBuf` (variable, `≤ priv_key_der_max`) | Wire-LE `x \|\| y` `&DmaBuf` (`pub_key_len` bytes) |
 //! | PAL → Trait (output) | PKCS#8 DER `&mut DmaBuf` (variable, `≤ priv_key_der_max`) | Wire-LE `x \|\| y` `&mut DmaBuf` (`wire_pub_key_len` bytes, P-521 padded) |
-//! | PAL → Driver (internal) | `EccPrivateKey` handle | `EccPublicKey` handle (raw BE coords) |
+//! | PAL → Driver (internal) | `EccPrivateKey` handle | Wire-LE bytes (raw `_le` slices) |
+//! | Driver → OpenSSL (internal) | `EccPrivateKey` handle | `EccPublicKey` handle (raw BE coords) |
 //!
 //! The trait-level [`HsmEcc::ecc_gen_keypair`] query mode reports
 //! [`HsmEccCurve::priv_key_der_max`] as the private-key upper bound
@@ -39,23 +37,9 @@
 //! (equal to the query bound).  Real-HW PALs that emit raw scalars
 //! instead report [`HsmEccCurve::priv_key_len`] in both modes; the
 //! trait contract is `use ≤ query`.
-//!
-//! ## Data flow (sign example)
-//!
-//! ```text
-//! Host LE-reverses digest + pads to wire bytes → DDI request.
-//! Core calls pal.ecc_sign(curve, priv_key_der, hash_le, sig_buf)
-//!   → EccPrivateKey::from_bytes(priv_key_der)  // DER → handle
-//!   → hash_be = reverse(hash_le)               // undo host LE for OpenSSL
-//!   → self.ecc.ecc_sign(&handle, hash_be)      // driver → OpenSSL ECDSA
-//!   → sig_buf = reverse(sig_be) (per component) // re-encode for the wire
-//! // Host parses sig_buf as wire-LE (no further conversion at the host).
-//! ```
 
 use azihsm_crypto::EccCurve;
-use azihsm_crypto::EccKeyOp;
 use azihsm_crypto::EccPrivateKey;
-use azihsm_crypto::EccPublicKey;
 use azihsm_crypto::ExportableKey;
 use azihsm_crypto::ImportableKey;
 
@@ -79,16 +63,13 @@ impl HsmEcc for StdHsmPal {
     /// bounds: PKCS#8 DER max for the private key
     /// ([`HsmEccCurve::priv_key_der_max`]) and the wire-format LE
     /// public-key length ([`HsmEccCurve::wire_pub_key_len`]).  In
-    /// **use mode** (`out = Some((priv_out, pub_out))`) it generates
-    /// a keypair via [`StdEcc::gen_keypair`], allocates a contiguous
-    /// `priv_max || pub_max` scratch from `alloc`, serializes the
-    /// keys into that scratch (private as PKCS#8 DER, public as
-    /// LE-reversed + P-521-padded coordinates), copies into the
-    /// caller's two output slots, and returns the **actual** byte
-    /// counts (DER is variable, so `priv_actual ≤ priv_max`; pub is
-    /// deterministic).  Public-key endianness matches the wire-native
-    /// format produced by real PKA hardware — see
-    /// [`HsmEcc::ecc_gen_keypair`].
+    /// **use mode** (`out = Some((priv_out, pub_out))`) it asks the
+    /// driver to generate a fresh keypair and write the wire-LE
+    /// public key into a scoped scratch slot, then exports the
+    /// private key as PKCS#8 DER into a separate scratch slot, and
+    /// finally copies both into the caller's two output buffers.
+    /// Returns the **actual** byte counts (DER is variable, so
+    /// `priv_actual ≤ priv_max`; pub is deterministic).
     async fn ecc_gen_keypair(
         &self,
         _io: &impl HsmIo,
@@ -105,46 +86,23 @@ impl HsmEcc for StdHsmPal {
         };
 
         if priv_out.len() < priv_max || pub_out.len() < wire_pub_len {
-            return Err(HsmError::InvalidArg);
+            return Err(HsmError::EccInvalidKeyLength);
         }
 
-        let (pk, pubk) = self.ecc.gen_keypair(to_ecc_curve(curve)).await?;
-
-        // Allocate the contiguous `priv || pub` scratch (sized at the
-        // PAL upper bound) a real PKA engine would write into; we then
-        // perform DER serialization + BE→LE pub-key reversal in-scratch
-        // before copying out.
+        // Allocate the contiguous `priv || pub` scratch a real PKA
+        // engine would write into.  The driver fills the pub half
+        // directly in wire-LE form; we DER-serialize the priv half
+        // ourselves.
         let scratch = alloc.dma_alloc(priv_max + wire_pub_len)?;
         let (scratch_priv, scratch_pub) = scratch.split_at_mut(priv_max);
 
+        let pk = self
+            .ecc
+            .gen_keypair_le(to_ecc_curve(curve), scratch_pub)
+            .await?;
         let priv_actual = pk
             .to_bytes(Some(&mut scratch_priv[..priv_max]))
             .map_err(|_| HsmError::EccToDerError)?;
-
-        // Export raw BE coordinates into stack scratch, then reverse
-        // each into the wire-format LE slot (leaving any P-521
-        // trailing pad bytes zero).
-        let coord_len = curve.priv_key_len();
-        let mut x_be = [0u8; 66];
-        let mut y_be = [0u8; 66];
-        pubk.coord(Some((&mut x_be[..coord_len], &mut y_be[..coord_len])))
-            .map_err(|_| HsmError::EccToDerError)?;
-
-        scratch_pub.fill(0);
-        let wire_coord = curve.wire_coord_len();
-        let (x_dst, y_dst) = scratch_pub.split_at_mut(wire_coord);
-        for (dst, src) in x_dst[..coord_len]
-            .iter_mut()
-            .zip(x_be[..coord_len].iter().rev())
-        {
-            *dst = *src;
-        }
-        for (dst, src) in y_dst[..coord_len]
-            .iter_mut()
-            .zip(y_be[..coord_len].iter().rev())
-        {
-            *dst = *src;
-        }
 
         priv_out[..priv_actual].copy_from_slice(&scratch_priv[..priv_actual]);
         pub_out[..wire_pub_len].copy_from_slice(scratch_pub);
@@ -154,14 +112,9 @@ impl HsmEcc for StdHsmPal {
 
     /// Raw EC sign over a pre-computed hash digest.
     ///
-    /// Per the [`HsmEcc::ecc_sign`] trait contract, `hash` is the
-    /// message digest in wire-native **little-endian** byte order,
-    /// and the output signature is `r || s` with **each component
-    /// in little-endian** byte order (P-521 components padded from
-    /// 66 to 68 wire bytes).  OpenSSL is big-endian-native for both
-    /// the digest scalar and the signature components, so we reverse
-    /// the digest before signing and reverse each signature
-    /// component after signing.
+    /// Parses the PKCS#8 DER private key into an OpenSSL handle and
+    /// delegates to the driver's wire-LE sign method, which performs
+    /// the BE↔LE conversions internally.
     async fn ecc_sign(
         &self,
         _io: &impl HsmIo,
@@ -174,53 +127,17 @@ impl HsmEcc for StdHsmPal {
         if signature.len() < wire_len {
             return Err(HsmError::InvalidArg);
         }
-
         let key = EccPrivateKey::from_bytes(priv_key).map_err(|_| HsmError::InvalidArg)?;
-
-        // Reverse wire-LE digest to OpenSSL-BE; stack scratch sized
-        // for any SHA up to SHA-512 (64 bytes).  Reject longer inputs
-        // rather than silently truncating — the trait contract is
-        // that `hash` carries exactly the digest's native length.
-        let mut hash_be = [0u8; 64];
-        let h_len = hash.len();
-        if h_len > hash_be.len() {
-            return Err(HsmError::InvalidArg);
-        }
-        for (dst, src) in hash_be[..h_len].iter_mut().zip(hash[..h_len].iter().rev()) {
-            *dst = *src;
-        }
-        let sig_be = self.ecc.ecc_sign(&key, &hash_be[..h_len]).await?;
-
-        // OpenSSL returns `r_be || s_be` of length `2 * priv_key_len`.
-        // Reverse each component into the LE wire layout, leaving the
-        // P-521 trailing pad bytes zero.
-        let pal_component = curve.priv_key_len();
-        let wire_component = curve.wire_coord_len();
-        if sig_be.len() < pal_component * 2 {
-            return Err(HsmError::EccSignFailed);
-        }
-        signature[..wire_len].fill(0);
-        let (r_be, s_be) = sig_be.split_at(pal_component);
-        for (dst, src) in signature[..pal_component].iter_mut().zip(r_be.iter().rev()) {
-            *dst = *src;
-        }
-        for (dst, src) in signature[wire_component..wire_component + pal_component]
-            .iter_mut()
-            .zip(s_be.iter().rev())
-        {
-            *dst = *src;
-        }
-        Ok(())
+        self.ecc
+            .ecc_sign_le(&key, hash, &mut signature[..wire_len])
+            .await
     }
 
     /// Raw EC verify a signature over a pre-computed hash digest.
     ///
-    /// Per the [`HsmEcc::ecc_verify`] trait contract, `pub_key` is the
-    /// raw uncompressed point `x || y` with **each coordinate in
-    /// little-endian** byte order, and `signature` is `r || s` with
-    /// each component in little-endian.  OpenSSL is big-endian-native
-    /// for elliptic-curve scalars, so we reverse each component before
-    /// constructing the verification inputs.
+    /// Delegates to the driver's wire-LE verify method which
+    /// constructs the OpenSSL pub-key handle from the wire-LE
+    /// coordinates and performs BE↔LE conversions internally.
     async fn ecc_verify(
         &self,
         _io: &impl HsmIo,
@@ -229,51 +146,27 @@ impl HsmEcc for StdHsmPal {
         hash: &DmaBuf,
         signature: &DmaBuf,
     ) -> HsmResult<bool> {
-        let coord_len = curve.priv_key_len();
         let pub_key_len = curve.pub_key_len();
         let sig_len = curve.sig_len();
-
         if pub_key.len() < pub_key_len || signature.len() < sig_len {
             return Err(HsmError::InvalidArg);
         }
-
-        // Reverse each coord from wire-LE to OpenSSL-BE.
-        let (x_le, y_le) = pub_key[..pub_key_len].split_at(coord_len);
-        let mut x_be = [0u8; 66];
-        let mut y_be = [0u8; 66];
-        for (dst, src) in x_be[..coord_len].iter_mut().zip(x_le.iter().rev()) {
-            *dst = *src;
-        }
-        for (dst, src) in y_be[..coord_len].iter_mut().zip(y_le.iter().rev()) {
-            *dst = *src;
-        }
-
-        let key = EccPublicKey::from_coordinates(
-            to_ecc_curve(curve),
-            &x_be[..coord_len],
-            &y_be[..coord_len],
-        )
-        .map_err(|_| HsmError::InvalidArg)?;
-
-        // Reverse each sig half from wire-LE to OpenSSL-BE.
-        let (r_le, s_le) = signature[..sig_len].split_at(coord_len);
-        let mut sig_be = [0u8; 132];
-        for (dst, src) in sig_be[..coord_len].iter_mut().zip(r_le.iter().rev()) {
-            *dst = *src;
-        }
-        for (dst, src) in sig_be[coord_len..sig_len].iter_mut().zip(s_le.iter().rev()) {
-            *dst = *src;
-        }
-
-        self.ecc.ecc_verify(&key, hash, &sig_be[..sig_len]).await
+        self.ecc
+            .ecc_verify_le(
+                to_ecc_curve(curve),
+                &pub_key[..pub_key_len],
+                hash,
+                &signature[..sig_len],
+            )
+            .await
     }
 
     /// ECDH key agreement — derives a shared secret.
     ///
-    /// Per the [`HsmEcc::ecdh_derive`] trait contract, `pub_key` is the
-    /// raw uncompressed point `x || y` with **each coordinate in
-    /// little-endian** byte order.  We reverse each coordinate before
-    /// handing to OpenSSL.
+    /// Parses the local PKCS#8 DER private into an OpenSSL handle
+    /// and delegates to the driver's wire-LE ECDH method which
+    /// constructs the remote pub-key handle internally from the
+    /// wire-LE coordinates.
     async fn ecdh_derive(
         &self,
         _io: &impl HsmIo,
@@ -282,30 +175,18 @@ impl HsmEcc for StdHsmPal {
         pub_key: &DmaBuf,
         secret: &mut DmaBuf,
     ) -> HsmResult<()> {
-        let coord_len = curve.priv_key_len();
         let pub_key_len = curve.pub_key_len();
         if pub_key.len() < pub_key_len {
             return Err(HsmError::InvalidArg);
         }
-
         let pk = EccPrivateKey::from_bytes(priv_key).map_err(|_| HsmError::InvalidArg)?;
-
-        let (x_le, y_le) = pub_key[..pub_key_len].split_at(coord_len);
-        let mut x_be = [0u8; 66];
-        let mut y_be = [0u8; 66];
-        for (dst, src) in x_be[..coord_len].iter_mut().zip(x_le.iter().rev()) {
-            *dst = *src;
-        }
-        for (dst, src) in y_be[..coord_len].iter_mut().zip(y_le.iter().rev()) {
-            *dst = *src;
-        }
-        let pubk = EccPublicKey::from_coordinates(
-            to_ecc_curve(curve),
-            &x_be[..coord_len],
-            &y_be[..coord_len],
-        )
-        .map_err(|_| HsmError::InvalidArg)?;
-
-        self.ecc.ecdh_derive(&pk, &pubk, &mut secret[..]).await
+        self.ecc
+            .ecdh_derive_le(
+                &pk,
+                to_ecc_curve(curve),
+                &pub_key[..pub_key_len],
+                &mut secret[..],
+            )
+            .await
     }
 }

--- a/fw/plat/std/pal/src/ecc.rs
+++ b/fw/plat/std/pal/src/ecc.rs
@@ -24,9 +24,9 @@
 //!
 //! | Direction | Private key | Public key |
 //! |-----------|-------------|------------|
-//! | Trait → PAL (input)  | PKCS#8 DER `&DmaBuf` (variable, `≤ priv_key_der_max`) | Wire-LE `x \|\| y` `&DmaBuf` (`pub_key_len` bytes) |
+//! | Trait → PAL (input)  | PKCS#8 DER `&DmaBuf` (variable, `≤ priv_key_der_max`) | Wire-LE `x \|\| y` `&DmaBuf` (`wire_pub_key_len` bytes, P-521 padded) |
 //! | PAL → Trait (output) | PKCS#8 DER `&mut DmaBuf` (variable, `≤ priv_key_der_max`) | Wire-LE `x \|\| y` `&mut DmaBuf` (`wire_pub_key_len` bytes, P-521 padded) |
-//! | PAL → Driver (internal) | `EccPrivateKey` handle | Wire-LE bytes (raw `_le` slices) |
+//! | PAL → Driver (internal) | `EccPrivateKey` handle | Wire-LE bytes (`_le` slices, P-521 padded) |
 //! | Driver → OpenSSL (internal) | `EccPrivateKey` handle | `EccPublicKey` handle (raw BE coords) |
 //!
 //! The trait-level [`HsmEcc::ecc_gen_keypair`] query mode reports
@@ -86,7 +86,7 @@ impl HsmEcc for StdHsmPal {
         };
 
         if priv_out.len() < priv_max || pub_out.len() < wire_pub_len {
-            return Err(HsmError::EccInvalidKeyLength);
+            return Err(HsmError::InvalidArg);
         }
 
         // Allocate the contiguous `priv || pub` scratch a real PKA
@@ -146,17 +146,17 @@ impl HsmEcc for StdHsmPal {
         hash: &DmaBuf,
         signature: &DmaBuf,
     ) -> HsmResult<bool> {
-        let pub_key_len = curve.pub_key_len();
-        let sig_len = curve.sig_len();
-        if pub_key.len() < pub_key_len || signature.len() < sig_len {
+        let wire_pub_len = curve.wire_pub_key_len();
+        let wire_sig_len = curve.wire_sig_len();
+        if pub_key.len() < wire_pub_len || signature.len() < wire_sig_len {
             return Err(HsmError::InvalidArg);
         }
         self.ecc
             .ecc_verify_le(
                 to_ecc_curve(curve),
-                &pub_key[..pub_key_len],
+                &pub_key[..wire_pub_len],
                 hash,
-                &signature[..sig_len],
+                &signature[..wire_sig_len],
             )
             .await
     }
@@ -166,7 +166,8 @@ impl HsmEcc for StdHsmPal {
     /// Parses the local PKCS#8 DER private into an OpenSSL handle
     /// and delegates to the driver's wire-LE ECDH method which
     /// constructs the remote pub-key handle internally from the
-    /// wire-LE coordinates.
+    /// wire-LE coordinates (stripping per-coordinate padding for
+    /// P-521).
     async fn ecdh_derive(
         &self,
         _io: &impl HsmIo,
@@ -175,8 +176,8 @@ impl HsmEcc for StdHsmPal {
         pub_key: &DmaBuf,
         secret: &mut DmaBuf,
     ) -> HsmResult<()> {
-        let pub_key_len = curve.pub_key_len();
-        if pub_key.len() < pub_key_len {
+        let wire_pub_len = curve.wire_pub_key_len();
+        if pub_key.len() < wire_pub_len || secret.len() < curve.secret_len() {
             return Err(HsmError::InvalidArg);
         }
         let pk = EccPrivateKey::from_bytes(priv_key).map_err(|_| HsmError::InvalidArg)?;
@@ -184,7 +185,7 @@ impl HsmEcc for StdHsmPal {
             .ecdh_derive_le(
                 &pk,
                 to_ecc_curve(curve),
-                &pub_key[..pub_key_len],
+                &pub_key[..wire_pub_len],
                 &mut secret[..],
             )
             .await

--- a/fw/plat/std/pal/src/hash.rs
+++ b/fw/plat/std/pal/src/hash.rs
@@ -41,9 +41,16 @@ impl HsmHash for StdHsmPal {
         algo: HsmHashAlgo,
         data: &DmaBuf,
         digest: &mut DmaBuf,
-        _big_endian: bool,
+        big_endian: bool,
     ) -> HsmResult<()> {
-        self.hash.hash(to_hash_algo(algo), data, digest).await
+        self.hash.hash(to_hash_algo(algo), data, digest).await?;
+        if !big_endian {
+            // SHA primitive is BE-native; reverse to the wire-LE
+            // layout used at the PAL boundary for hashes that feed
+            // directly into PKA-style operations (e.g. `ecc_sign`).
+            digest[..algo.digest_len()].reverse();
+        }
+        Ok(())
     }
 
     fn hash_begin<'a>(

--- a/fw/plat/std/pal/src/hash.rs
+++ b/fw/plat/std/pal/src/hash.rs
@@ -43,12 +43,18 @@ impl HsmHash for StdHsmPal {
         digest: &mut DmaBuf,
         big_endian: bool,
     ) -> HsmResult<()> {
-        self.hash.hash(to_hash_algo(algo), data, digest).await?;
+        let digest_len = algo.digest_len();
+        if digest.len() < digest_len {
+            return Err(HsmError::InvalidArg);
+        }
+        self.hash
+            .hash(to_hash_algo(algo), data, &mut digest[..digest_len])
+            .await?;
         if !big_endian {
             // SHA primitive is BE-native; reverse to the wire-LE
             // layout used at the PAL boundary for hashes that feed
             // directly into PKA-style operations (e.g. `ecc_sign`).
-            digest[..algo.digest_len()].reverse();
+            digest[..digest_len].reverse();
         }
         Ok(())
     }

--- a/fw/plat/std/pal/src/part.rs
+++ b/fw/plat/std/pal/src/part.rs
@@ -1124,9 +1124,10 @@ impl StdHsmPal {
     /// into `pub_key_out`.
     ///
     /// Bypasses [`HsmEcc::ecc_gen_keypair`] (which now requires an
-    /// `HsmIo`) and drives the [`StdEcc`](crate::drivers::ecc::StdEcc)
-    /// driver directly — this helper runs from the partition lifecycle
-    /// task where no IO context exists.
+    /// `HsmIo` and a scoped allocator) and drives the
+    /// [`StdEcc`](crate::drivers::ecc::StdEcc) driver directly — this
+    /// helper runs from the partition lifecycle task where neither
+    /// an IO context nor a scoped allocator exists.
     ///
     /// Returns the vault key ID.
     async fn create_internal_ecc384_key(


### PR DESCRIPTION
Add the firmware-side handlers for the two ECC DDI commands, the PAL trait surface that supports them, and matching std-PAL impls.

* DDI handlers:
  * `ecc_generate_key_pair`: validates session + curve, builds vault attrs from `key_metadata` (with `wrap` folded into usage_count so a sign+verify+wrap request fails fast instead of silently being treated as plain sign+verify), generates the keypair via the new PAL query-alloc-use flow inside a single scoped allocator, stores the private key in the partition vault (session-scoped iff requested), and emits the wire-format public key in the response.
  * `ecc_sign`: looks up a vault ECC key, validates the `sign` usage bit, and produces a raw `r || s` signature into the response slot. The handler now hands the wire-LE digest sub-slice directly to the PAL — endianness conversion lives entirely in the std PAL.

* PAL trait surface (`HsmEcc::ecc_gen_keypair`): switched to the query-alloc-use shape — takes a scoped allocator + an `Option<(&mut DmaBuf, &mut DmaBuf)>` for the two output buffers, returns `(usize, usize)` (query: per-curve upper bounds; use: actual bytes written, always `\u{2264}` the query bounds).  For real-HW PALs query == use; for std PAL DER private keys can be shorter than the max.  `ecc_sign` doc pins the wire-LE digest contract.

* std PAL (`fw/plat/std/pal/src/ecc.rs`):
  * `ecc_gen_keypair` implements the new shape: query returns `(priv_key_der_max, wire_pub_key_len)`; use allocates a contiguous `priv_max || pub_max` scratch (mirroring what real PKA emits as a single block), writes PKCS#8 DER + wire-LE coordinates, then copies into the caller's two output slots and returns the actual DER length.
  * `ecc_sign` now reverses the wire-LE digest to OpenSSL-BE internally so the trait stays wire-format consistent with `pub_key` / `signature`.

* Misc:
  * Tests: 6 new smoke tests (ecc_generate / ecc_sign).
  * All 30 emu smoke + 27/28 ECC-targeted tests pass; only the pre-existing unimplemented `attest_ecc_signing_key` still fails.
  * Mock full suite: 580/580.