### PR TITLE
feat(fw): implement DDI EcdhKeyExchange handler + shared helpers

### DIFF
--- a/ddi/mbor/types/tests/azihsm_ddi_tests.rs
+++ b/ddi/mbor/types/tests/azihsm_ddi_tests.rs
@@ -28,6 +28,7 @@ mod integration {
     pub mod ecdh_256_key_exchange;
     pub mod ecdh_384_key_exchange;
     pub mod ecdh_521_key_exchange;
+    pub mod ecdh_smoke;
     pub mod establish_credential;
     pub mod establish_credential_smoke;
     pub mod extension_support;

--- a/ddi/mbor/types/tests/integration/ecdh_smoke.rs
+++ b/ddi/mbor/types/tests/integration/ecdh_smoke.rs
@@ -41,8 +41,6 @@ fn test_ecdh_key_exchange_smoke() {
                     None,
                 );
 
-            let key_props = helper_key_properties(DdiKeyUsage::Derive, DdiKeyAvailability::App);
-
             // Side A: derive Secret256 from (priv1, pub2).
             let resp1 = helper_ecdh_key_exchange(
                 dev,
@@ -52,7 +50,7 @@ fn test_ecdh_key_exchange_smoke() {
                 MborByteArray::new(pub_key2, pub_key2_len).expect("failed to create byte array"),
                 None,
                 DdiKeyType::Secret256,
-                key_props,
+                helper_key_properties(DdiKeyUsage::Derive, DdiKeyAvailability::App),
             )
             .unwrap();
             assert_eq!(resp1.hdr.op, DdiOp::EcdhKeyExchange);
@@ -72,7 +70,7 @@ fn test_ecdh_key_exchange_smoke() {
                 MborByteArray::new(pub_key1, pub_key1_len).expect("failed to create byte array"),
                 None,
                 DdiKeyType::Secret256,
-                key_props,
+                helper_key_properties(DdiKeyUsage::Derive, DdiKeyAvailability::App),
             )
             .unwrap();
             assert_eq!(resp2.hdr.status, DdiStatus::Success);

--- a/ddi/mbor/types/tests/integration/ecdh_smoke.rs
+++ b/ddi/mbor/types/tests/integration/ecdh_smoke.rs
@@ -1,0 +1,168 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! EcdhKeyExchange smoke tests for the emu backend.
+//!
+//! - Happy path: generate two P-256 ECC keypairs in the open
+//!   session, derive a shared secret from each side, and assert both
+//!   ECDH calls succeed (so the derived `Secret256` vault entry is
+//!   created).
+//! - Reject ECDH against an unknown private key id: the backend
+//!   returns `KeyNotFound` (emu) or `InvalidKeyNumber` (mock); both
+//!   are acceptable.
+//! - Reject ECDH where the requested target `key_type` does not
+//!   match the private key's curve.
+
+#![cfg(test)]
+
+use azihsm_ddi::*;
+use azihsm_ddi_mbor_codec::MborByteArray;
+use azihsm_ddi_mbor_test_helpers::*;
+use azihsm_ddi_mbor_types::*;
+use test_with_tracing::test;
+
+use super::common::*;
+
+#[test]
+fn test_ecdh_key_exchange_smoke() {
+    ddi_dev_test(
+        common_setup,
+        common_cleanup,
+        |dev, _ddi, _path, session_id| {
+            // Generate two P-256 derive-capable keypairs in the open
+            // session.  Each side holds its own private key and
+            // receives the peer's public key.
+            let (priv_key_id1, pub_key1, pub_key1_len, priv_key_id2, pub_key2, pub_key2_len) =
+                helper_create_ecc_key_pairs(
+                    dev,
+                    Some(session_id),
+                    Some(DdiApiRev { major: 1, minor: 0 }),
+                    DdiEccCurve::P256,
+                    None,
+                );
+
+            let key_props = helper_key_properties(DdiKeyUsage::Derive, DdiKeyAvailability::App);
+
+            // Side A: derive Secret256 from (priv1, pub2).
+            let resp1 = helper_ecdh_key_exchange(
+                dev,
+                Some(session_id),
+                Some(DdiApiRev { major: 1, minor: 0 }),
+                priv_key_id1,
+                MborByteArray::new(pub_key2, pub_key2_len).expect("failed to create byte array"),
+                None,
+                DdiKeyType::Secret256,
+                key_props,
+            )
+            .unwrap();
+            assert_eq!(resp1.hdr.op, DdiOp::EcdhKeyExchange);
+            assert_eq!(resp1.hdr.status, DdiStatus::Success);
+            assert_ne!(resp1.data.key_id, 0);
+
+            // Side B: derive Secret256 from (priv2, pub1).  Both sides
+            // must succeed; the fact that both ECDH operations produce
+            // a vault entry is the firmware-side smoke contract — the
+            // bit-level equality of the two secrets is exercised by
+            // the full `ecdh_256_key_exchange` integration test.
+            let resp2 = helper_ecdh_key_exchange(
+                dev,
+                Some(session_id),
+                Some(DdiApiRev { major: 1, minor: 0 }),
+                priv_key_id2,
+                MborByteArray::new(pub_key1, pub_key1_len).expect("failed to create byte array"),
+                None,
+                DdiKeyType::Secret256,
+                key_props,
+            )
+            .unwrap();
+            assert_eq!(resp2.hdr.status, DdiStatus::Success);
+            assert_ne!(resp2.data.key_id, 0);
+            assert_ne!(resp1.data.key_id, resp2.data.key_id);
+        },
+    );
+}
+
+#[test]
+fn test_ecdh_key_exchange_unknown_key_smoke() {
+    ddi_dev_test(
+        common_setup,
+        common_cleanup,
+        |dev, _ddi, _path, session_id| {
+            // Borrow only the peer's public key from the helper; the
+            // private key we attempt ECDH against is an unknown id.
+            let (_, _, _, _, pub_key2, pub_key2_len) = helper_create_ecc_key_pairs(
+                dev,
+                Some(session_id),
+                Some(DdiApiRev { major: 1, minor: 0 }),
+                DdiEccCurve::P256,
+                None,
+            );
+
+            let key_props = helper_key_properties(DdiKeyUsage::Derive, DdiKeyAvailability::App);
+            let err = helper_ecdh_key_exchange(
+                dev,
+                Some(session_id),
+                Some(DdiApiRev { major: 1, minor: 0 }),
+                0xFFFF, /* unknown priv key id */
+                MborByteArray::new(pub_key2, pub_key2_len).expect("failed to create byte array"),
+                None,
+                DdiKeyType::Secret256,
+                key_props,
+            )
+            .expect_err("EcdhKeyExchange must reject an unknown priv_key_id");
+
+            // The exact error code differs across backends — emu's
+            // vault returns `KeyNotFound`, the mock returns
+            // `InvalidKeyNumber`.
+            assert!(
+                matches!(
+                    err,
+                    DdiError::DdiStatus(DdiStatus::KeyNotFound)
+                        | DdiError::DdiStatus(DdiStatus::InvalidKeyNumber)
+                ),
+                "expected KeyNotFound or InvalidKeyNumber, got {:?}",
+                err
+            );
+        },
+    );
+}
+
+#[test]
+fn test_ecdh_key_exchange_curve_mismatch_smoke() {
+    ddi_dev_test(
+        common_setup,
+        common_cleanup,
+        |dev, _ddi, _path, session_id| {
+            // Generate a P-256 keypair, then request a Secret384
+            // target.  The handler must reject the mismatched curve
+            // / target-key-type pair without doing any ECDH work.
+            let (priv_key_id1, _pub_key1, _pub_key1_len, _priv_key_id2, pub_key2, pub_key2_len) =
+                helper_create_ecc_key_pairs(
+                    dev,
+                    Some(session_id),
+                    Some(DdiApiRev { major: 1, minor: 0 }),
+                    DdiEccCurve::P256,
+                    None,
+                );
+
+            let key_props = helper_key_properties(DdiKeyUsage::Derive, DdiKeyAvailability::App);
+            let err = helper_ecdh_key_exchange(
+                dev,
+                Some(session_id),
+                Some(DdiApiRev { major: 1, minor: 0 }),
+                priv_key_id1,
+                MborByteArray::new(pub_key2, pub_key2_len).expect("failed to create byte array"),
+                None,
+                DdiKeyType::Secret384, /* mismatched target — priv is P-256 */
+                key_props,
+            )
+            .expect_err("EcdhKeyExchange must reject a curve / target-key-type mismatch");
+
+            assert!(
+                matches!(err, DdiError::DdiStatus(DdiStatus::InvalidKeyType)),
+                "expected InvalidKeyType, got {:?}",
+                err
+            );
+        },
+    );
+}

--- a/fw/core/lib/src/ddi/mbor/aes_encrypt_decrypt.rs
+++ b/fw/core/lib/src/ddi/mbor/aes_encrypt_decrypt.rs
@@ -50,7 +50,7 @@ pub(crate) async fn aes_encrypt_decrypt<'p, P: HsmPal>(
     // direction (Encrypt needs `encrypt`, Decrypt needs `decrypt`).
     let key_id = HsmKeyId::from(body.key_id);
     let vault_kind = pal.vault_key_kind(io, key_id)?;
-    assert_aes_kind(vault_kind)?;
+    super::from_pal::assert_aes(vault_kind)?;
     let vault_attrs = pal.vault_key_attrs(io, key_id)?;
     let required_attr = match op {
         AesOp::Encrypt => vault_attrs.encrypt(),
@@ -93,16 +93,5 @@ fn ddi_to_pal_aes_op(op: DdiAesOp) -> HsmResult<AesOp> {
         DdiAesOp::Encrypt => Ok(AesOp::Encrypt),
         DdiAesOp::Decrypt => Ok(AesOp::Decrypt),
         _ => Err(HsmError::InvalidArg),
-    }
-}
-
-/// Reject vault key kinds that are not a non-bulk AES key.
-///
-/// Bulk AES kinds (XTS / GCM) are excluded because they are used by
-/// dedicated bulk handlers, not the generic AES-CBC path here.
-fn assert_aes_kind(kind: HsmVaultKeyKind) -> HsmResult<()> {
-    match kind {
-        HsmVaultKeyKind::Aes128 | HsmVaultKeyKind::Aes192 | HsmVaultKeyKind::Aes256 => Ok(()),
-        _ => Err(HsmError::InvalidKeyType),
     }
 }

--- a/fw/core/lib/src/ddi/mbor/aes_generate_key.rs
+++ b/fw/core/lib/src/ddi/mbor/aes_generate_key.rs
@@ -15,7 +15,6 @@
 
 use azihsm_fw_ddi_mbor_types::aes_generate_key::DdiAesGenerateKeyReq;
 use azihsm_fw_ddi_mbor_types::aes_generate_key::DdiAesGenerateKeyResp;
-use azihsm_fw_ddi_mbor_types::DdiAesKeySize;
 
 use super::*;
 
@@ -34,14 +33,12 @@ pub(crate) async fn aes_generate_key<'p, P: HsmPal>(
 
     let sess_id = hdr.sess_id.ok_or(HsmError::SessionExpected)?;
 
-    let (key_len, vault_kind) = aes_key_size_to_kind(body.key_size)?;
-    let attrs = build_attrs_for_aes(&body.key_properties.key_metadata)?;
+    let (key_len, vault_kind) = super::from_ddi::aes(body.key_size)?;
+    let attrs = super::key_attrs::for_aes(&body.key_properties.key_metadata)?;
 
     // Session-only keys are anonymous — disallow a host-supplied
     // `key_tag` because the key cannot be looked up across sessions.
-    if attrs.session() && body.key_tag.is_some() {
-        return Err(HsmError::InvalidArg);
-    }
+    super::key_attrs::check_session_key_tag(attrs, body.key_tag)?;
 
     // Generate the random AES key bytes into a scratch buffer.  The
     // PAL's `aes_gen_key` wraps the CSPRNG and validates the buffer
@@ -85,61 +82,4 @@ pub(crate) async fn aes_generate_key<'p, P: HsmPal>(
     let _ = guard.dismiss();
 
     Ok(resp)
-}
-
-/// Map a `DdiAesKeySize` to its raw key byte length + private
-/// [`HsmVaultKeyKind`].  Bulk AES key kinds (XTS / GCM) are rejected
-/// — handled by separate future handlers.
-fn aes_key_size_to_kind(size: DdiAesKeySize) -> HsmResult<(usize, HsmVaultKeyKind)> {
-    match size {
-        DdiAesKeySize::Aes128 => Ok((16, HsmVaultKeyKind::Aes128)),
-        DdiAesKeySize::Aes192 => Ok((24, HsmVaultKeyKind::Aes192)),
-        DdiAesKeySize::Aes256 => Ok((32, HsmVaultKeyKind::Aes256)),
-        _ => Err(HsmError::InvalidArg),
-    }
-}
-
-/// Translate the requested `key_metadata` bitflags into a vault
-/// attribute set for a non-bulk AES key.
-///
-/// AES (non-bulk) keys can only carry the `EncryptDecrypt` usage.
-/// Any other usage flag — sign, verify, derive, wrap, or unwrap —
-/// is rejected with `InvalidPermissions`, mirroring the reference
-/// firmware's `Kind::allows_usage` check.
-///
-/// Internally-generated keys always carry `local = true`.
-fn build_attrs_for_aes(
-    metadata: &azihsm_fw_ddi_mbor_types::DdiTargetKeyMetadata,
-) -> HsmResult<HsmVaultKeyAttrs> {
-    let mut attrs = HsmVaultKeyAttrs::new().with_local(true);
-
-    let sign_verify = metadata.sign() && metadata.verify();
-    let encrypt_decrypt = metadata.encrypt() && metadata.decrypt();
-    let derive = metadata.derive();
-    let wrap = metadata.wrap();
-    let unwrap = metadata.unwrap();
-
-    // Exactly one usage — all five mutually-exclusive usage flags are
-    // counted so a host that piles on extras (e.g.
-    // encrypt+decrypt+wrap) is rejected instead of silently dropping
-    // the unsupported bits.
-    let usage_count = (sign_verify as u8)
-        + (encrypt_decrypt as u8)
-        + (derive as u8)
-        + (wrap as u8)
-        + (unwrap as u8);
-    if usage_count != 1 {
-        return Err(HsmError::InvalidPermissions);
-    }
-
-    if !encrypt_decrypt {
-        return Err(HsmError::InvalidPermissions);
-    }
-    attrs = attrs.with_encrypt(true).with_decrypt(true);
-
-    if metadata.session() {
-        attrs = attrs.with_session(true);
-    }
-
-    Ok(attrs)
 }

--- a/fw/core/lib/src/ddi/mbor/ecc_generate_key_pair.rs
+++ b/fw/core/lib/src/ddi/mbor/ecc_generate_key_pair.rs
@@ -12,7 +12,6 @@
 
 use azihsm_fw_ddi_mbor_types::ecc_generate_key_pair::DdiEccGenerateKeyPairReq;
 use azihsm_fw_ddi_mbor_types::ecc_generate_key_pair::DdiEccGenerateKeyPairResp;
-use azihsm_fw_ddi_mbor_types::DdiKeyType;
 
 use super::*;
 
@@ -34,38 +33,41 @@ pub(crate) async fn ecc_generate_key_pair<'p, P: HsmPal>(
 
     let sess_id = hdr.sess_id.ok_or(HsmError::SessionExpected)?;
     let pal_curve = super::from_ddi::curve(body.curve)?;
-    let vault_kind = curve_to_vault_kind(pal_curve);
-    let attrs = build_attrs_for_curve(pal_curve, &body.key_properties.key_metadata)?;
+    let vault_kind = super::from_pal::ecc_private(pal_curve);
+    let attrs = super::key_attrs::for_ecc(pal_curve, &body.key_properties.key_metadata)?;
 
     // Session-only keys are anonymous — disallow a host-supplied
     // `key_tag` because the key cannot be looked up across sessions.
     // Matches `test_ecc_generate_session_only_key_with_key_tag`.
-    if attrs.session() && body.key_tag.is_some() {
-        return Err(HsmError::InvalidArg);
-    }
+    super::key_attrs::check_session_key_tag(attrs, body.key_tag)?;
 
-    // ECC key generation follows the trait's query-alloc-use flow,
-    // wrapped in a single scoped allocator: query reports the PAL's
-    // per-curve deterministic sizes (raw HSM scalar for the private
-    // key; wire-format LE public-key length), we allocate the
-    // IO-lifetime output buffers, then use returns the same lengths.
-    let (priv_key, pub_key, priv_len, pub_len) = pal
+    // ECC key generation follows the trait's query-alloc-use flow.
+    // The IO-lifetime priv/pub buffers must outlive the scoped
+    // allocator block — `StdScopedAlloc::Drop` resets the DMA
+    // bump-mark on scope exit, including any `pal.dma_alloc(io, _)`
+    // bumps made inside, so an IO-scoped allocation done within the
+    // scope would silently overlap the next post-scope allocation
+    // (e.g. the response buffer).  Keep the `dma_alloc(io, _)`
+    // bufs outside any scope; reserve the scope only for the
+    // keygen's internal PKA-style scratch.
+    let (priv_size, pub_size) = pal
+        .alloc_scoped_async(io, async |a| {
+            pal.ecc_gen_keypair(io, a, pal_curve, None, HsmEccPct::SignVerify)
+                .await
+        })
+        .await?;
+    let priv_key = pal.dma_alloc(io, priv_size)?;
+    let pub_key = pal.dma_alloc(io, pub_size)?;
+    let (priv_len, pub_len) = pal
         .alloc_scoped_async(io, async |a| -> HsmResult<_> {
-            let (priv_size, pub_size) = pal
-                .ecc_gen_keypair(io, a, pal_curve, None, HsmEccPct::SignVerify)
-                .await?;
-            let priv_key = pal.dma_alloc(io, priv_size)?;
-            let pub_key = pal.dma_alloc(io, pub_size)?;
-            let (priv_len, pub_len) = pal
-                .ecc_gen_keypair(
-                    io,
-                    a,
-                    pal_curve,
-                    Some((&mut *priv_key, &mut *pub_key)),
-                    HsmEccPct::SignVerify,
-                )
-                .await?;
-            Ok((priv_key, pub_key, priv_len, pub_len))
+            pal.ecc_gen_keypair(
+                io,
+                a,
+                pal_curve,
+                Some((&mut *priv_key, &mut *pub_key)),
+                HsmEccPct::SignVerify,
+            )
+            .await
         })
         .await?;
 
@@ -101,7 +103,7 @@ pub(crate) async fn ecc_generate_key_pair<'p, P: HsmPal>(
             private_key_id,
             DdiPublicKeyFrameParams {
                 raw_len: pub_len,
-                key_kind: curve_to_pub_key_kind(pal_curve),
+                key_kind: super::from_pal::ecc_public_ddi(pal_curve),
             },
             0, /* masked_key length — empty placeholder */
         )?;
@@ -117,83 +119,4 @@ pub(crate) async fn ecc_generate_key_pair<'p, P: HsmPal>(
     let _ = guard.dismiss();
 
     Ok(resp)
-}
-
-/// Map a `HsmEccCurve` to its private [`HsmVaultKeyKind`].
-fn curve_to_vault_kind(curve: HsmEccCurve) -> HsmVaultKeyKind {
-    match curve {
-        HsmEccCurve::P256 => HsmVaultKeyKind::Ecc256Private,
-        HsmEccCurve::P384 => HsmVaultKeyKind::Ecc384Private,
-        HsmEccCurve::P521 => HsmVaultKeyKind::Ecc521Private,
-    }
-}
-
-/// Map a `HsmEccCurve` to the corresponding public-key DDI type.
-fn curve_to_pub_key_kind(curve: HsmEccCurve) -> DdiKeyType {
-    match curve {
-        HsmEccCurve::P256 => DdiKeyType::Ecc256Public,
-        HsmEccCurve::P384 => DdiKeyType::Ecc384Public,
-        HsmEccCurve::P521 => DdiKeyType::Ecc521Public,
-    }
-}
-
-/// Translate the requested `key_metadata` bitflags into a vault
-/// attribute set.
-///
-/// Mirrors the host-side `DdiKeyProperties -> DdiTargetKeyProperties`
-/// conversion: at most one logical usage is encoded in the metadata
-/// (sign+verify, encrypt+decrypt, derive, or unwrap), and the session
-/// flag is independent.  We re-derive the usage by inspecting the
-/// individual bit flags so an inconsistent/empty metadata fails fast
-/// with `InvalidPermissions`.
-///
-/// Internally-generated keys always carry `local = true` (mirrors
-/// PKCS#11 `CKA_LOCAL`).
-fn build_attrs_for_curve(
-    curve: HsmEccCurve,
-    metadata: &azihsm_fw_ddi_mbor_types::DdiTargetKeyMetadata,
-) -> HsmResult<HsmVaultKeyAttrs> {
-    let mut attrs = HsmVaultKeyAttrs::new().with_local(true);
-
-    let sign_verify = metadata.sign() && metadata.verify();
-    let encrypt_decrypt = metadata.encrypt() && metadata.decrypt();
-    let derive = metadata.derive();
-    let unwrap = metadata.unwrap();
-    let wrap = metadata.wrap();
-
-    // Exactly one usage; the host-side helper ensures this, so a
-    // multi-usage request is malformed.  `wrap` is folded into the
-    // usage count even though no curve currently allows it, so that
-    // `sign+verify+wrap` is rejected as multi-usage rather than
-    // silently treated as plain sign+verify.
-    let usage_count = (sign_verify as u8)
-        + (encrypt_decrypt as u8)
-        + (derive as u8)
-        + (unwrap as u8)
-        + (wrap as u8);
-    if usage_count != 1 {
-        return Err(HsmError::InvalidPermissions);
-    }
-
-    // ECC keys can sign / verify / derive (ECDH).  EncryptDecrypt,
-    // Unwrap, and Wrap are not valid usages for an ECC key — let
-    // the curve dictate which usage flags are accepted, matching
-    // the reference firmware's `Kind::allows_usage` check.
-    let _ = curve; // all three NIST curves currently allow the same usages
-    if encrypt_decrypt || unwrap || wrap {
-        return Err(HsmError::InvalidPermissions);
-    }
-
-    if sign_verify {
-        attrs = attrs.with_sign(true).with_verify(true);
-    }
-    if derive {
-        attrs = attrs.with_derive(true);
-    }
-
-    if metadata.session() {
-        attrs = attrs.with_session(true);
-    }
-
-    Ok(attrs)
 }

--- a/fw/core/lib/src/ddi/mbor/ecc_sign.rs
+++ b/fw/core/lib/src/ddi/mbor/ecc_sign.rs
@@ -41,7 +41,7 @@ pub(crate) async fn ecc_sign<'p, P: HsmPal>(
 
     let key_id = HsmKeyId::from(body.key_id);
     let vault_kind = pal.vault_key_kind(io, key_id)?;
-    let curve = vault_kind_to_curve(vault_kind)?;
+    let curve = super::from_pal::ecc_curve(vault_kind)?;
     let vault_attrs = pal.vault_key_attrs(io, key_id)?;
     if !vault_attrs.sign() {
         return Err(HsmError::InvalidPermissions);
@@ -69,17 +69,4 @@ pub(crate) async fn ecc_sign<'p, P: HsmPal>(
     .await?;
 
     Ok(resp)
-}
-
-/// Infer the ECC curve from a vault key kind.
-///
-/// Returns `InvalidKeyType` if the kind is not an ECC private key —
-/// matches the test that signs against a non-ECC key.
-fn vault_kind_to_curve(kind: HsmVaultKeyKind) -> HsmResult<HsmEccCurve> {
-    match kind {
-        HsmVaultKeyKind::Ecc256Private => Ok(HsmEccCurve::P256),
-        HsmVaultKeyKind::Ecc384Private => Ok(HsmEccCurve::P384),
-        HsmVaultKeyKind::Ecc521Private => Ok(HsmEccCurve::P521),
-        _ => Err(HsmError::InvalidKeyType),
-    }
 }

--- a/fw/core/lib/src/ddi/mbor/ecdh_key_exchange.rs
+++ b/fw/core/lib/src/ddi/mbor/ecdh_key_exchange.rs
@@ -54,8 +54,12 @@ pub(crate) async fn ecdh_key_exchange<'p, P: HsmPal>(
     // The on-wire `pub_key_der` field is named "der" for historical
     // reasons but already carries wire-LE `x || y` (P-521 padded to
     // 4-byte words) after the host's `pub_key_der_pre_encode`.
+    // The host emits a fixed-length frame for the selected curve,
+    // and the PAL trait requires exactly `wire_pub_key_len` bytes
+    // — reject any non-exact length so trailing junk isn't silently
+    // accepted.
     let wire_pub_key_len = curve.wire_pub_key_len();
-    if body.pub_key_der.len() < wire_pub_key_len {
+    if body.pub_key_der.len() != wire_pub_key_len {
         return Err(HsmError::InvalidArg);
     }
 

--- a/fw/core/lib/src/ddi/mbor/ecdh_key_exchange.rs
+++ b/fw/core/lib/src/ddi/mbor/ecdh_key_exchange.rs
@@ -1,0 +1,101 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! DDI EcdhKeyExchange command handler.
+//!
+//! Within an open session, look up an ECC private key by id, derive
+//! a shared secret against a host-supplied peer public key via ECDH,
+//! persist the secret in the partition vault — optionally
+//! session-scoped so it is torn down by
+//! [`CloseSession`](super::close_session) — and return the assigned
+//! `key_id` plus an opaque masked-key envelope the host may re-import
+//! on a future session.
+
+use azihsm_fw_ddi_mbor_types::ecdh_key_exchange::DdiEcdhKeyExchangeReq;
+use azihsm_fw_ddi_mbor_types::ecdh_key_exchange::DdiEcdhKeyExchangeResp;
+
+use super::*;
+
+/// Handle `DdiEcdhKeyExchangeCmd`.
+///
+/// No `partition_lock` is needed: this handler does not perform any
+/// multi-step read-then-mutate against partition state.  Its single
+/// state mutation — `vault_key_create` — is sync and atomic.  A
+/// concurrent `CloseSession` racing with our `ecdh_derive` await
+/// would just turn the subsequent vault create into a clean
+/// `SessionNotFound` error, never a partial commit.
+pub(crate) async fn ecdh_key_exchange<'p, P: HsmPal>(
+    pal: &'p P,
+    io: &impl HsmIo,
+    decoder: &mut DdiDecoder<'_>,
+    hdr: &DdiReqHdr,
+) -> HsmResult<&'p DmaBuf> {
+    let body: DdiEcdhKeyExchangeReq = decoder.decode_data()?;
+    let sess_id = hdr.sess_id.ok_or(HsmError::SessionExpected)?;
+    let priv_key_id = HsmKeyId::from(body.priv_key_id);
+
+    // Resolve the local private key's curve (non-ECC kinds map to
+    // `InvalidKeyType` — same precedent as `ecc_sign`) and require
+    // the `derive` perm on the vault entry.
+    let curve = super::from_pal::ecc_curve(pal.vault_key_kind(io, priv_key_id)?)?;
+    if !pal.vault_key_attrs(io, priv_key_id)?.derive() {
+        return Err(HsmError::InvalidPermissions);
+    }
+
+    // ECDH only produces a same-bit-size secret; reject any
+    // curve / target-key-type mismatch — same error as the sim.
+    if body.key_type != super::from_pal::ecdh_secret_ddi(curve) {
+        return Err(HsmError::InvalidKeyType);
+    }
+
+    let target_attrs = super::key_attrs::for_ecdh_secret(&body.key_properties.key_metadata)?;
+    super::key_attrs::check_session_key_tag(target_attrs, body.key_tag)?;
+
+    // The on-wire `pub_key_der` field is named "der" for historical
+    // reasons but already carries wire-LE `x || y` (P-521 padded to
+    // 4-byte words) after the host's `pub_key_der_pre_encode`.
+    let wire_pub_key_len = curve.wire_pub_key_len();
+    if body.pub_key_der.len() < wire_pub_key_len {
+        return Err(HsmError::InvalidArg);
+    }
+
+    // Derive into a DMA scratch slot; `vault_key_create` copies it
+    // into vault-owned storage so the scratch can drop after.
+    let secret = pal.dma_alloc(io, curve.secret_len())?;
+    let priv_key = pal.vault_key(io, priv_key_id)?;
+    pal.ecdh_derive(
+        io,
+        curve,
+        priv_key,
+        &body.pub_key_der[..wire_pub_key_len],
+        secret,
+    )
+    .await?;
+
+    // RAII vault entry — rolls back if response encoding below
+    // fails.  `masked_key` is the host's opaque re-import blob;
+    // firmware-side masking is pending the `UnmaskKey` handler, so
+    // we emit an empty placeholder for wire validity.
+    let guard = pal.vault_key_create(
+        io,
+        secret,
+        super::from_pal::ecdh_secret(curve),
+        target_attrs.session().then_some(HsmSessId::from(sess_id)),
+        target_attrs,
+        body.key_properties.key_label,
+    )?;
+    let key_id: u16 = guard.key_id().into();
+
+    let resp = pal.dma_alloc_var(io, |buf| {
+        super::encode_resp(
+            &super::success_hdr_sess(hdr, DdiOp::EcdhKeyExchange, sess_id),
+            &DdiEcdhKeyExchangeResp {
+                key_id,
+                masked_key: &[],
+            },
+            buf,
+        )
+    })?;
+    let _ = guard.dismiss();
+    Ok(resp)
+}

--- a/fw/core/lib/src/ddi/mbor/from_ddi.rs
+++ b/fw/core/lib/src/ddi/mbor/from_ddi.rs
@@ -14,12 +14,14 @@
 //! call sites read as `from_ddi::hash(algo)` / `from_ddi::curve(c)`,
 //! mirroring Rust's `From::from(value)` idiom.
 
+use azihsm_fw_ddi_mbor_types::DdiAesKeySize;
 use azihsm_fw_ddi_mbor_types::DdiEccCurve;
 use azihsm_fw_ddi_mbor_types::DdiHashAlgorithm;
 use azihsm_fw_hsm_pal_traits::HsmEccCurve;
 use azihsm_fw_hsm_pal_traits::HsmError;
 use azihsm_fw_hsm_pal_traits::HsmHashAlgo;
 use azihsm_fw_hsm_pal_traits::HsmResult;
+use azihsm_fw_hsm_pal_traits::HsmVaultKeyKind;
 
 /// Map a [`DdiHashAlgorithm`] to its [`HsmHashAlgo`] counterpart.
 /// Unsupported / unknown variants return [`HsmError::InvalidArg`].
@@ -40,6 +42,19 @@ pub(crate) fn curve(curve: DdiEccCurve) -> HsmResult<HsmEccCurve> {
         DdiEccCurve::P256 => Ok(HsmEccCurve::P256),
         DdiEccCurve::P384 => Ok(HsmEccCurve::P384),
         DdiEccCurve::P521 => Ok(HsmEccCurve::P521),
+        _ => Err(HsmError::InvalidArg),
+    }
+}
+
+/// Map a [`DdiAesKeySize`] to its raw byte length and the matching
+/// non-bulk AES vault kind.  Bulk AES variants (XTS / GCM) are
+/// rejected with [`HsmError::InvalidArg`] — handled by separate
+/// future handlers.
+pub(crate) fn aes(size: DdiAesKeySize) -> HsmResult<(usize, HsmVaultKeyKind)> {
+    match size {
+        DdiAesKeySize::Aes128 => Ok((16, HsmVaultKeyKind::Aes128)),
+        DdiAesKeySize::Aes192 => Ok((24, HsmVaultKeyKind::Aes192)),
+        DdiAesKeySize::Aes256 => Ok((32, HsmVaultKeyKind::Aes256)),
         _ => Err(HsmError::InvalidArg),
     }
 }

--- a/fw/core/lib/src/ddi/mbor/from_pal.rs
+++ b/fw/core/lib/src/ddi/mbor/from_pal.rs
@@ -1,0 +1,90 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! PAL trait type conversions shared by handlers.
+//!
+//! Sibling to [`from_ddi`](super::from_ddi): given a firmware-side
+//! PAL type ([`HsmVaultKeyKind`], [`HsmEccCurve`], …), produce a
+//! related firmware-side or on-wire DDI type that the handler needs
+//! to drive the response or validate caller input.  Centralizing
+//! these mappings keeps the per-curve / per-kind enum tables in
+//! sync across handlers and pins the error code used for
+//! non-matching variants in one place.
+//!
+//! Functions are intentionally bare-named (`ecc_curve`,
+//! `assert_aes`, `ecc_private`, …) so call sites read as
+//! `from_pal::ecc_curve(kind)` / `from_pal::ecc_private(curve)`.
+//! The first parameter's type pins the conversion direction; function
+//! names whose target type is a [`DdiKeyType`] (on-wire) carry a
+//! `_ddi` suffix to distinguish them from vault-kind targets.
+
+use azihsm_fw_ddi_mbor_types::DdiKeyType;
+use azihsm_fw_hsm_pal_traits::HsmEccCurve;
+use azihsm_fw_hsm_pal_traits::HsmError;
+use azihsm_fw_hsm_pal_traits::HsmResult;
+use azihsm_fw_hsm_pal_traits::HsmVaultKeyKind;
+
+// ── HsmVaultKeyKind → … ───────────────────────────────────────────
+
+/// Map an ECC private vault kind to its [`HsmEccCurve`].
+/// Non-ECC kinds return [`HsmError::InvalidKeyType`].
+pub(crate) fn ecc_curve(kind: HsmVaultKeyKind) -> HsmResult<HsmEccCurve> {
+    match kind {
+        HsmVaultKeyKind::Ecc256Private => Ok(HsmEccCurve::P256),
+        HsmVaultKeyKind::Ecc384Private => Ok(HsmEccCurve::P384),
+        HsmVaultKeyKind::Ecc521Private => Ok(HsmEccCurve::P521),
+        _ => Err(HsmError::InvalidKeyType),
+    }
+}
+
+/// Confirm a vault kind is a non-bulk AES key (128 / 192 / 256
+/// bits).  Bulk AES variants (XTS / GCM) and any non-AES kind
+/// return [`HsmError::InvalidKeyType`].
+pub(crate) fn assert_aes(kind: HsmVaultKeyKind) -> HsmResult<()> {
+    match kind {
+        HsmVaultKeyKind::Aes128 | HsmVaultKeyKind::Aes192 | HsmVaultKeyKind::Aes256 => Ok(()),
+        _ => Err(HsmError::InvalidKeyType),
+    }
+}
+
+// ── HsmEccCurve → … ───────────────────────────────────────────────
+
+/// Map a [`HsmEccCurve`] to its private ECC vault kind.
+pub(crate) fn ecc_private(curve: HsmEccCurve) -> HsmVaultKeyKind {
+    match curve {
+        HsmEccCurve::P256 => HsmVaultKeyKind::Ecc256Private,
+        HsmEccCurve::P384 => HsmVaultKeyKind::Ecc384Private,
+        HsmEccCurve::P521 => HsmVaultKeyKind::Ecc521Private,
+    }
+}
+
+/// Map a [`HsmEccCurve`] to the ECDH shared-secret vault kind for
+/// that curve's bit length.
+pub(crate) fn ecdh_secret(curve: HsmEccCurve) -> HsmVaultKeyKind {
+    match curve {
+        HsmEccCurve::P256 => HsmVaultKeyKind::Secret256,
+        HsmEccCurve::P384 => HsmVaultKeyKind::Secret384,
+        HsmEccCurve::P521 => HsmVaultKeyKind::Secret521,
+    }
+}
+
+/// Map a [`HsmEccCurve`] to the matching DDI public-key type tag
+/// the host expects in an ECC response (or in a target-key request
+/// field).
+pub(crate) fn ecc_public_ddi(curve: HsmEccCurve) -> DdiKeyType {
+    match curve {
+        HsmEccCurve::P256 => DdiKeyType::Ecc256Public,
+        HsmEccCurve::P384 => DdiKeyType::Ecc384Public,
+        HsmEccCurve::P521 => DdiKeyType::Ecc521Public,
+    }
+}
+
+/// Map a [`HsmEccCurve`] to the matching DDI shared-secret key type
+/// tag the host requests as the ECDH derive target.
+pub(crate) fn ecdh_secret_ddi(curve: HsmEccCurve) -> DdiKeyType {
+    match curve {
+        HsmEccCurve::P256 => DdiKeyType::Secret256,
+        HsmEccCurve::P384 => DdiKeyType::Secret384,
+        HsmEccCurve::P521 => DdiKeyType::Secret521,
+    }
+}

--- a/fw/core/lib/src/ddi/mbor/key_attrs.rs
+++ b/fw/core/lib/src/ddi/mbor/key_attrs.rs
@@ -41,6 +41,7 @@ pub(crate) fn for_ecc(
     metadata: &DdiTargetKeyMetadata,
 ) -> HsmResult<HsmVaultKeyAttrs> {
     let _ = curve;
+    validate_pairs(metadata)?;
     let mut attrs = HsmVaultKeyAttrs::new().with_local(true);
 
     let sign_verify = metadata.sign() && metadata.verify();
@@ -82,6 +83,7 @@ pub(crate) fn for_ecc(
 /// usage flag — sign, verify, derive, wrap, or unwrap — is rejected
 /// with [`HsmError::InvalidPermissions`].
 pub(crate) fn for_aes(metadata: &DdiTargetKeyMetadata) -> HsmResult<HsmVaultKeyAttrs> {
+    validate_pairs(metadata)?;
     let mut attrs = HsmVaultKeyAttrs::new().with_local(true);
 
     let sign_verify = metadata.sign() && metadata.verify();
@@ -117,6 +119,7 @@ pub(crate) fn for_aes(metadata: &DdiTargetKeyMetadata) -> HsmResult<HsmVaultKeyA
 /// is `derive` (PKCS#11 `CKA_DERIVE`).  Any other usage is rejected
 /// with [`HsmError::InvalidPermissions`].
 pub(crate) fn for_ecdh_secret(metadata: &DdiTargetKeyMetadata) -> HsmResult<HsmVaultKeyAttrs> {
+    validate_pairs(metadata)?;
     let mut attrs = HsmVaultKeyAttrs::new().with_local(true);
 
     let sign_verify = metadata.sign() && metadata.verify();
@@ -144,6 +147,23 @@ pub(crate) fn for_ecdh_secret(metadata: &DdiTargetKeyMetadata) -> HsmResult<HsmV
     }
 
     Ok(attrs)
+}
+
+/// Reject metadata where one half of a paired usage flag is set
+/// without the other (`sign` without `verify`, or `encrypt`
+/// without `decrypt`).  The host is supposed to encode these as
+/// matched pairs; a half-set pair is either a malformed request
+/// or an attempt to smuggle in a usage bit that would be silently
+/// dropped by the `sign && verify` / `encrypt && decrypt` grouping
+/// in the per-kind builders below.
+fn validate_pairs(metadata: &DdiTargetKeyMetadata) -> HsmResult<()> {
+    if metadata.sign() != metadata.verify() {
+        return Err(HsmError::InvalidPermissions);
+    }
+    if metadata.encrypt() != metadata.decrypt() {
+        return Err(HsmError::InvalidPermissions);
+    }
+    Ok(())
 }
 
 /// Reject a session-only key request that also carries a host-

--- a/fw/core/lib/src/ddi/mbor/key_attrs.rs
+++ b/fw/core/lib/src/ddi/mbor/key_attrs.rs
@@ -1,0 +1,160 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Shared [`HsmVaultKeyAttrs`] builders and request-validation
+//! helpers used by every key-creating handler.
+//!
+//! The per-handler `for_*` builders translate the requested DDI
+//! `key_metadata` bitflags into the firmware-side vault attribute
+//! set the corresponding key kind is allowed to carry.  All builders
+//! share the same skeleton — exactly one of the five usage flag
+//! groups must be set, `local` is always implied for internally
+//! created keys, and `session` is independent — but each one
+//! enforces a per-algorithm policy on which usage(s) are valid.
+//!
+//! [`check_session_key_tag`] folds in the cross-cutting consistency
+//! check that session-only keys cannot carry a host-supplied
+//! `key_tag` (those keys are anonymous and not looked up across
+//! sessions).
+
+use azihsm_fw_ddi_mbor_types::DdiTargetKeyMetadata;
+use azihsm_fw_hsm_pal_traits::HsmEccCurve;
+use azihsm_fw_hsm_pal_traits::HsmError;
+use azihsm_fw_hsm_pal_traits::HsmResult;
+use azihsm_fw_hsm_pal_traits::HsmVaultKeyAttrs;
+
+/// Build vault attrs for an internally-generated ECC private key.
+///
+/// ECC keys can sign / verify (matched pair) or derive (ECDH).
+/// `encrypt_decrypt`, `unwrap`, and `wrap` are rejected with
+/// [`HsmError::InvalidPermissions`].  `wrap` is folded into the
+/// usage-count even though no curve currently allows it, so that
+/// `sign+verify+wrap` is rejected as multi-usage rather than
+/// silently treated as plain `sign+verify`.
+///
+/// The `curve` parameter is currently unused — all three NIST
+/// curves accept the same usages — but kept in the signature so
+/// future curve-specific tightening lands without a call-site
+/// churn.
+pub(crate) fn for_ecc(
+    curve: HsmEccCurve,
+    metadata: &DdiTargetKeyMetadata,
+) -> HsmResult<HsmVaultKeyAttrs> {
+    let _ = curve;
+    let mut attrs = HsmVaultKeyAttrs::new().with_local(true);
+
+    let sign_verify = metadata.sign() && metadata.verify();
+    let encrypt_decrypt = metadata.encrypt() && metadata.decrypt();
+    let derive = metadata.derive();
+    let unwrap = metadata.unwrap();
+    let wrap = metadata.wrap();
+
+    let usage_count = (sign_verify as u8)
+        + (encrypt_decrypt as u8)
+        + (derive as u8)
+        + (unwrap as u8)
+        + (wrap as u8);
+    if usage_count != 1 {
+        return Err(HsmError::InvalidPermissions);
+    }
+
+    if encrypt_decrypt || unwrap || wrap {
+        return Err(HsmError::InvalidPermissions);
+    }
+
+    if sign_verify {
+        attrs = attrs.with_sign(true).with_verify(true);
+    }
+    if derive {
+        attrs = attrs.with_derive(true);
+    }
+
+    if metadata.session() {
+        attrs = attrs.with_session(true);
+    }
+
+    Ok(attrs)
+}
+
+/// Build vault attrs for an internally-generated non-bulk AES key.
+///
+/// AES (non-bulk) keys can only carry `EncryptDecrypt`.  Any other
+/// usage flag — sign, verify, derive, wrap, or unwrap — is rejected
+/// with [`HsmError::InvalidPermissions`].
+pub(crate) fn for_aes(metadata: &DdiTargetKeyMetadata) -> HsmResult<HsmVaultKeyAttrs> {
+    let mut attrs = HsmVaultKeyAttrs::new().with_local(true);
+
+    let sign_verify = metadata.sign() && metadata.verify();
+    let encrypt_decrypt = metadata.encrypt() && metadata.decrypt();
+    let derive = metadata.derive();
+    let wrap = metadata.wrap();
+    let unwrap = metadata.unwrap();
+
+    let usage_count = (sign_verify as u8)
+        + (encrypt_decrypt as u8)
+        + (derive as u8)
+        + (wrap as u8)
+        + (unwrap as u8);
+    if usage_count != 1 {
+        return Err(HsmError::InvalidPermissions);
+    }
+
+    if !encrypt_decrypt {
+        return Err(HsmError::InvalidPermissions);
+    }
+    attrs = attrs.with_encrypt(true).with_decrypt(true);
+
+    if metadata.session() {
+        attrs = attrs.with_session(true);
+    }
+
+    Ok(attrs)
+}
+
+/// Build vault attrs for an ECDH-derived shared secret.
+///
+/// Derived secrets are HKDF / KBKDF inputs, so the only valid usage
+/// is `derive` (PKCS#11 `CKA_DERIVE`).  Any other usage is rejected
+/// with [`HsmError::InvalidPermissions`].
+pub(crate) fn for_ecdh_secret(metadata: &DdiTargetKeyMetadata) -> HsmResult<HsmVaultKeyAttrs> {
+    let mut attrs = HsmVaultKeyAttrs::new().with_local(true);
+
+    let sign_verify = metadata.sign() && metadata.verify();
+    let encrypt_decrypt = metadata.encrypt() && metadata.decrypt();
+    let derive = metadata.derive();
+    let wrap = metadata.wrap();
+    let unwrap = metadata.unwrap();
+
+    let usage_count = (sign_verify as u8)
+        + (encrypt_decrypt as u8)
+        + (derive as u8)
+        + (wrap as u8)
+        + (unwrap as u8);
+    if usage_count != 1 {
+        return Err(HsmError::InvalidPermissions);
+    }
+
+    if !derive {
+        return Err(HsmError::InvalidPermissions);
+    }
+    attrs = attrs.with_derive(true);
+
+    if metadata.session() {
+        attrs = attrs.with_session(true);
+    }
+
+    Ok(attrs)
+}
+
+/// Reject a session-only key request that also carries a host-
+/// supplied `key_tag`.  Session-only keys are anonymous and cannot
+/// be looked up across sessions, so a tag is meaningless.
+pub(crate) fn check_session_key_tag(
+    attrs: HsmVaultKeyAttrs,
+    key_tag: Option<u16>,
+) -> HsmResult<()> {
+    if attrs.session() && key_tag.is_some() {
+        return Err(HsmError::InvalidArg);
+    }
+    Ok(())
+}

--- a/fw/core/lib/src/ddi/mbor/mod.rs
+++ b/fw/core/lib/src/ddi/mbor/mod.rs
@@ -6,8 +6,10 @@ pub(crate) mod aes_generate_key;
 pub(crate) mod close_session;
 pub(crate) mod ecc_generate_key_pair;
 pub(crate) mod ecc_sign;
+pub(crate) mod ecdh_key_exchange;
 pub(crate) mod establish_credential;
 pub(crate) mod from_ddi;
+pub(crate) mod from_pal;
 pub(crate) mod get_api_rev;
 pub(crate) mod get_cert_chain_info;
 pub(crate) mod get_certificate;
@@ -16,6 +18,7 @@ pub(crate) mod get_establish_cred_encryption_key;
 pub(crate) mod get_sealed_bk3;
 pub(crate) mod get_session_encryption_key;
 pub(crate) mod init_bk3;
+pub(crate) mod key_attrs;
 pub(crate) mod open_session;
 pub(crate) mod set_sealed_bk3;
 pub(crate) mod sha_digest;
@@ -30,6 +33,7 @@ use azihsm_fw_ddi_mbor_types::*;
 pub(crate) use close_session::*;
 pub(crate) use ecc_generate_key_pair::*;
 pub(crate) use ecc_sign::*;
+pub(crate) use ecdh_key_exchange::*;
 pub(crate) use establish_credential::*;
 pub(crate) use get_api_rev::*;
 pub(crate) use get_cert_chain_info::*;
@@ -121,6 +125,7 @@ pub(crate) async fn dispatch<'p, P: HsmPal>(
         DdiOp::AesEncryptDecrypt => aes_encrypt_decrypt(pal, io, decoder, hdr).await,
         DdiOp::EccGenerateKeyPair => ecc_generate_key_pair(pal, io, decoder, hdr).await,
         DdiOp::EccSign => ecc_sign(pal, io, decoder, hdr).await,
+        DdiOp::EcdhKeyExchange => ecdh_key_exchange(pal, io, decoder, hdr).await,
         _ => Err(HsmError::UnsupportedCmd),
     }
 }

--- a/fw/pal/traits/src/crypto/ecc.rs
+++ b/fw/pal/traits/src/crypto/ecc.rs
@@ -296,8 +296,10 @@ pub trait HsmEcc {
     ///
     /// - `Ok(true)` — signature is valid.
     /// - `Ok(false)` — signature is invalid (not an error).
-    /// - `Err(HsmError::InvalidArg)` — buffer-size mismatch or
-    ///   malformed public key.
+    /// - `Err(HsmError::InvalidArg)` — buffer-size mismatch.
+    /// - `Err(HsmError::EccPublicKeyValidationFailed)` — `pub_key`
+    ///   does not parse as a valid point on `curve` (out-of-range
+    ///   coordinate, malformed encoding, etc.).
     /// - `Err(HsmError)` — propagated from the PKA driver.
     async fn ecc_verify(
         &self,
@@ -333,8 +335,10 @@ pub trait HsmEcc {
     /// # Returns
     ///
     /// - `Ok(())` — `secret[..secret_len]` populated.
-    /// - `Err(HsmError::InvalidArg)` — buffer mismatch or invalid
-    ///   public-key point.
+    /// - `Err(HsmError::InvalidArg)` — buffer mismatch.
+    /// - `Err(HsmError::EccPublicKeyValidationFailed)` — `pub_key`
+    ///   does not parse as a valid point on `curve` (out-of-range
+    ///   coordinate, malformed encoding, etc.).
     /// - `Err(HsmError)` — PKA driver failure.
     async fn ecdh_derive(
         &self,

--- a/fw/plat/std/pal/src/drivers/ecc.rs
+++ b/fw/plat/std/pal/src/drivers/ecc.rs
@@ -260,7 +260,7 @@ impl StdEcc {
         reverse_copy(&mut x_be[..coord_len], &x_wire[..coord_len]);
         reverse_copy(&mut y_be[..coord_len], &y_wire[..coord_len]);
         let key = EccPublicKey::from_coordinates(curve, &x_be[..coord_len], &y_be[..coord_len])
-            .map_err(|_| HsmError::InvalidArg)?;
+            .map_err(|_| HsmError::EccPublicKeyValidationFailed)?;
 
         let (r_wire, s_wire) = sig_le[..wire_len].split_at(wire_coord);
         let sig_len = coord_len * 2;
@@ -344,7 +344,7 @@ impl StdEcc {
         reverse_copy(&mut x_be[..coord_len], &x_wire[..coord_len]);
         reverse_copy(&mut y_be[..coord_len], &y_wire[..coord_len]);
         let pubk = EccPublicKey::from_coordinates(curve, &x_be[..coord_len], &y_be[..coord_len])
-            .map_err(|_| HsmError::InvalidArg)?;
+            .map_err(|_| HsmError::EccPublicKeyValidationFailed)?;
 
         self.ecdh_derive(priv_key, &pubk, secret_out).await
     }


### PR DESCRIPTION
Add the firmware-side handler for the ECDH DDI command, refactor shared per-handler helpers into a small set of `from_*` / `key_attrs` modules so future ECC / AES / RSA handlers don't keep copy-pasting the same enum mapping + attr-policy code.

* DDI handler `ecdh_key_exchange`:
  * Validates session + looks up the local ECC private key, derives its curve, requires the `derive` perm on the vault entry.
  * Validates the requested target `key_type` matches the curve (ECDH only produces a same-bit-size shared secret).
  * Disallows a host-supplied `key_tag` on session-only target keys (anonymous keys cannot be looked up across sessions).
  * The on-wire `pub_key_der` field is wire-LE `x || y` after the host's `pub_key_der_pre_encode` (the "der" name is historical); handler validates length against `curve.wire_pub_key_len()` and forwards the validated prefix to `pal.ecdh_derive`.
  * Stores the derived secret as `Secret256/384/521` in the vault (session-scoped iff requested) via the standard RAII guard so a failed response encode rolls back the vault entry.
  * Returns the new `key_id` + empty placeholder `masked_key` pending the `UnmaskKey` handler.

* Std PAL `ecc_verify_le` / `ecdh_derive_le` now map an `EccPublicKey::from_coordinates` failure to `HsmError::EccPublicKeyValidationFailed` (was `InvalidArg`), matching the host-side test expectations and the precedent set by the sim.

* New shared modules (under `fw/core/lib/src/ddi/mbor/`):
  * `from_pal.rs` — PAL-type ↔ vault/DDI tag conversions.  Pulls the duplicated `vault_kind_to_curve` (was in both `ecc_sign` and the new `ecdh_key_exchange`) plus the singletons `curve_to_vault_kind`, `curve_to_pub_key_kind`, `curve_to_secret_kind`, and `assert_aes_kind` out of handler files.  Mirrors the `from_ddi` naming convention.
  * `key_attrs.rs` — `HsmVaultKeyAttrs` builders (`for_ecc`, `for_aes`, `for_ecdh_secret`) and the shared session-only / `key_tag` consistency check used by every key-creating handler.  Three previous one-off `build_attrs_for_*` helpers fold into the new module.
  * Extended `from_ddi.rs` with `aes(size)` (was `aes_key_size_to_kind` in the AES generate handler) so DDI-sourced size → vault-kind lives next to the existing `hash` and `curve` mappings.

* Tests:
  * 3 new `ecdh_smoke` tests (happy path P-256 both sides, unknown priv key id, curve / target-key-type mismatch).
  * 43/52 pre-existing `ecdh_*_key_exchange` integration tests now pass on emu (was 0/52); the 9 remaining failures are pre-existing limitations — 3 `key_tag` tests need the `OpenKey` handler, 3 `masked_key_ecdh` tests need `MaskKey`/`UnmaskKey`, and 3 `not_on_curve` tests need a finer crypto-crate error variant to distinguish `EccPointValidationFailed` from `EccPublicKeyValidationFailed`.
  * 33/33 emu smoke, 583/583 mock, 38/38 echo, clippy + format + copyright clean.