### PR TITLE
feat(fw): implement DDI DeleteKey handler

### DIFF
--- a/ddi/mbor/types/tests/azihsm_ddi_tests.rs
+++ b/ddi/mbor/types/tests/azihsm_ddi_tests.rs
@@ -18,6 +18,7 @@ mod integration {
     pub mod common;
     pub mod ddi_dev_info;
     pub mod delete_key;
+    pub mod delete_key_smoke;
     pub mod device_handle_session;
     pub mod ecc_generate;
     pub mod ecc_generate_smoke;

--- a/ddi/mbor/types/tests/integration/delete_key_smoke.rs
+++ b/ddi/mbor/types/tests/integration/delete_key_smoke.rs
@@ -1,0 +1,125 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! DeleteKey smoke tests.
+//!
+//! Exercises the `DeleteKey` firmware handler end-to-end on both
+//! backends using an app AES key (the only key class creatable
+//! without the not-yet-available unwrapping/masking ops):
+//!
+//! - **Delete + reuse:** generate an AES-128 key, delete it
+//!   successfully, then confirm the freed id no longer resolves
+//!   (`KeyNotFound` on a subsequent use).
+//! - **Unknown key:** deleting a never-allocated id is rejected with
+//!   `KeyNotFound`.
+//! - **Idempotency:** a second delete of the same id is rejected with
+//!   `KeyNotFound`.
+
+#![cfg(test)]
+
+use azihsm_ddi::*;
+use azihsm_ddi_mbor_codec::MborByteArray;
+use azihsm_ddi_mbor_types::*;
+use test_with_tracing::test;
+
+use super::common::*;
+
+/// Generate an app AES-128 key and return its id.
+fn create_aes_key(dev: &mut <DdiTest as Ddi>::Dev, session_id: u16) -> u16 {
+    let key_props = helper_key_properties(DdiKeyUsage::EncryptDecrypt, DdiKeyAvailability::App);
+    helper_aes_generate(
+        dev,
+        Some(session_id),
+        Some(DdiApiRev { major: 1, minor: 0 }),
+        DdiAesKeySize::Aes128,
+        None,
+        key_props,
+    )
+    .expect("aes_generate should succeed")
+    .data
+    .key_id
+}
+
+fn delete(dev: &mut <DdiTest as Ddi>::Dev, session_id: u16, key_id: u16) -> Result<(), DdiError> {
+    helper_delete_key(
+        dev,
+        Some(session_id),
+        Some(DdiApiRev { major: 1, minor: 0 }),
+        key_id,
+    )
+    .map(|_| ())
+}
+
+#[test]
+fn test_delete_key_then_reuse_smoke() {
+    ddi_dev_test(
+        common_setup,
+        common_cleanup,
+        |dev, _ddi, _path, session_id| {
+            let key_id = create_aes_key(dev, session_id);
+
+            let resp = helper_delete_key(
+                dev,
+                Some(session_id),
+                Some(DdiApiRev { major: 1, minor: 0 }),
+                key_id,
+            )
+            .expect("DeleteKey should succeed for an app key");
+            assert_eq!(resp.hdr.op, DdiOp::DeleteKey);
+            assert_eq!(resp.hdr.status, DdiStatus::Success);
+
+            // The deleted key id must no longer resolve.
+            let err = helper_aes_encrypt_decrypt(
+                dev,
+                Some(session_id),
+                Some(DdiApiRev { major: 1, minor: 0 }),
+                key_id,
+                DdiAesOp::Encrypt,
+                MborByteArray::from_slice(&[0u8; 16]).unwrap(),
+                MborByteArray::new([0u8; 16], 16).unwrap(),
+            )
+            .expect_err("using a deleted key must fail");
+            assert!(
+                matches!(err, DdiError::DdiStatus(DdiStatus::KeyNotFound)),
+                "expected KeyNotFound after delete, got {err:?}"
+            );
+        },
+    );
+}
+
+#[test]
+fn test_delete_key_unknown_smoke() {
+    ddi_dev_test(
+        common_setup,
+        common_cleanup,
+        |dev, _ddi, _path, session_id| {
+            // Id 0x0020 is an in-range but unallocated slot.
+            let err =
+                delete(dev, session_id, 0x0020).expect_err("deleting an unknown key must fail");
+            assert!(
+                matches!(err, DdiError::DdiStatus(DdiStatus::KeyNotFound)),
+                "expected KeyNotFound, got {err:?}"
+            );
+        },
+    );
+}
+
+#[test]
+fn test_delete_key_idempotent_smoke() {
+    ddi_dev_test(
+        common_setup,
+        common_cleanup,
+        |dev, _ddi, _path, session_id| {
+            let key_id = create_aes_key(dev, session_id);
+
+            delete(dev, session_id, key_id).expect("first delete should succeed");
+
+            let err = delete(dev, session_id, key_id)
+                .expect_err("second delete of the same id must fail");
+            assert!(
+                matches!(err, DdiError::DdiStatus(DdiStatus::KeyNotFound)),
+                "expected KeyNotFound on double-delete, got {err:?}"
+            );
+        },
+    );
+}

--- a/fw/core/lib/src/ddi/mbor/delete_key.rs
+++ b/fw/core/lib/src/ddi/mbor/delete_key.rs
@@ -1,0 +1,51 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! DDI DeleteKey command handler.
+//!
+//! Within an open session, delete a vault-resident key by id.
+//!
+//! Internal device keys (the partition's unwrapping key, session and
+//! credential keys, etc. — anything carrying the `internal` attribute)
+//! cannot be destroyed by the host and are rejected with
+//! `CannotDeleteInternalKeys`.  An unknown `key_id` is rejected with
+//! `KeyNotFound`.
+
+use azihsm_fw_ddi_mbor_types::delete_key::DdiDeleteKeyReq;
+use azihsm_fw_ddi_mbor_types::delete_key::DdiDeleteKeyResp;
+
+use super::*;
+
+/// Handle `DdiDeleteKeyCmd`.
+///
+/// No `partition_lock` is needed: the `internal`-attribute check and
+/// the [`HsmVault::vault_key_delete`] mutation are both synchronous
+/// with no yield point between them, so there is no read-then-mutate
+/// window that could race against a concurrent handler on the same
+/// partition.
+pub(crate) fn delete_key<'p, P: HsmPal>(
+    pal: &'p P,
+    io: &impl HsmIo,
+    decoder: &mut DdiDecoder<'_>,
+    hdr: &DdiReqHdr,
+) -> HsmResult<&'p DmaBuf> {
+    let body: DdiDeleteKeyReq = decoder.decode_data()?;
+    let sess_id = hdr.sess_id.ok_or(HsmError::SessionExpected)?;
+    let key_id = HsmKeyId::from(body.key_id);
+
+    // Resolve the key's attributes first — an unknown id surfaces as
+    // `KeyNotFound`.  Internal device keys are never host-destroyable.
+    if pal.vault_key_attrs(io, key_id)?.internal() {
+        return Err(HsmError::CannotDeleteInternalKeys);
+    }
+    pal.vault_key_delete(io, key_id)?;
+
+    let resp = pal.dma_alloc_var(io, |buf| {
+        super::encode_resp(
+            &super::success_hdr_sess(hdr, DdiOp::DeleteKey, sess_id),
+            &DdiDeleteKeyResp {},
+            buf,
+        )
+    })?;
+    Ok(resp)
+}

--- a/fw/core/lib/src/ddi/mbor/mod.rs
+++ b/fw/core/lib/src/ddi/mbor/mod.rs
@@ -4,6 +4,7 @@
 pub(crate) mod aes_encrypt_decrypt;
 pub(crate) mod aes_generate_key;
 pub(crate) mod close_session;
+pub(crate) mod delete_key;
 pub(crate) mod ecc_generate_key_pair;
 pub(crate) mod ecc_sign;
 pub(crate) mod ecdh_key_exchange;
@@ -31,6 +32,7 @@ use azihsm_fw_ddi_mbor_api::DdiEncoder;
 use azihsm_fw_ddi_mbor_types::error::DdiErrResp;
 use azihsm_fw_ddi_mbor_types::*;
 pub(crate) use close_session::*;
+pub(crate) use delete_key::*;
 pub(crate) use ecc_generate_key_pair::*;
 pub(crate) use ecc_sign::*;
 pub(crate) use ecdh_key_exchange::*;
@@ -121,6 +123,7 @@ pub(crate) async fn dispatch<'p, P: HsmPal>(
         DdiOp::EstablishCredential => establish_credential(pal, io, decoder, hdr).await,
         DdiOp::OpenSession => open_session(pal, io, decoder, hdr).await,
         DdiOp::CloseSession => close_session(pal, io, decoder, hdr),
+        DdiOp::DeleteKey => delete_key(pal, io, decoder, hdr),
         DdiOp::AesGenerateKey => aes_generate_key(pal, io, decoder, hdr).await,
         DdiOp::AesEncryptDecrypt => aes_encrypt_decrypt(pal, io, decoder, hdr).await,
         DdiOp::EccGenerateKeyPair => ecc_generate_key_pair(pal, io, decoder, hdr).await,


### PR DESCRIPTION
Wire up the previously-unimplemented DeleteKey (1014) DDI op in the firmware application layer: within an open session, delete a vault-resident key by id and return an empty success response.

- Internal device keys (anything carrying the `internal` attribute — the partition unwrapping key, session and credential keys) cannot be destroyed by the host and are rejected with CannotDeleteInternalKeys, matching the reference firmware.
- An unknown key_id is rejected with KeyNotFound.
- Session validation is framework-level (DeleteKey -> InSession), so a missing/mismatched session returns FileHandleSessionIdDoesNotMatch.

The handler is synchronous: the `internal`-attribute check and the vault deletion have no yield point between them, so no partition_lock is needed.

New: delete_key.rs handler; mod.rs dispatch wiring; delete_key_smoke.rs smoke tests (delete + reuse, unknown-key, and double-delete idempotency using an app AES key, so they run on both backends).

Validation:
- emu delete_key_smoke 3/3; mock 3/3.
- mock delete_key integration 8/8 (includes CannotDeleteInternalKeys for the unwrapping key). On emu the core delete_key integration tests pass (6/8); the unwrapping-key and bulk-import cases are setup-blocked by GetUnwrappingKey / RsaUnwrap, which are not yet implemented on main (a pre-existing limitation, not this handler) — the internal-key path is exercised on mock instead.
- emu smoke 33/33 (no regression).
- cargo xtask clippy clean; clippy --tests clean under emu and mock; fmt and copyright clean.