### PR TITLE
[ci] enable Rust and CodeQL workflows on tbor-hsm staging branch

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,9 +2,9 @@ name: "CodeQL Advanced"
 
 on:
   push:
-    branches: [ main, dev, fw ]
+    branches: [ main, dev, fw, tbor-hsm ]
   pull_request:
-    branches: [ main, dev, fw ]
+    branches: [ main, dev, fw, tbor-hsm ]
   schedule:
     - cron: '0 8 * * *'  # Daily at midnight PST (8 AM UTC)
 env:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,11 +2,11 @@ name: Rust
 
 on:
   push:
-    branches: [ main, dev, fw ]
+    branches: [ main, dev, fw, tbor-hsm ]
   pull_request:
-    branches: [ main, dev, fw ]
+    branches: [ main, dev, fw, tbor-hsm ]
   merge_group:
-    branches: [ main, dev, fw ]
+    branches: [ main, dev, fw, tbor-hsm ]
   schedule:
     - cron: '0 8 * * *'  # Daily at midnight PST (8 AM UTC)
 env:


### PR DESCRIPTION
tbor-hsm is the local + remote staging branch where PartInit-related PRs (HPKE fix, session_ctrl refactor, new crypto crates, PartInit end-to-end) are collected before the final integration PR to main.

Add tbor-hsm to push, pull_request, and merge_group triggers so CI runs on PRs targeting the staging branch and on commits landing there.