### PR TITLE
[refactor] tbor: explicit per-request session_ctrl + local SessionCon…

### DIFF
--- a/ddi/emu/src/dev.rs
+++ b/ddi/emu/src/dev.rs
@@ -284,7 +284,7 @@ impl DdiDev for DdiEmuDev {
             .dst_prp1(dst.as_mut_slice().as_mut_ptr() as u64)
             .session_flags(
                 SessionFlags::new()
-                    .with_ctrl(0) // NoSession — TBOR has no sessioned commands yet.
+                    .with_ctrl(u8::from(req.session_ctrl()))
                     .with_id_valid(req_session_id.is_some()),
             )
             .session_id(req_session_id.unwrap_or(0))

--- a/ddi/tbor/derive/src/lib.rs
+++ b/ddi/tbor/derive/src/lib.rs
@@ -26,10 +26,16 @@
 //!
 //! | Form | Meaning |
 //! |---|---|
-//! | `#[tbor]` | request; opcode pulled from the FW schema's `TborRequest::OPCODE` impl; `OpResp` defaults to `Req → Resp` name swap |
-//! | `#[tbor(resp = TborFooResp)]` | request with explicit response type |
-//! | `#[tbor(schema = path::Type)]` | request/response with explicit FW schema path |
-//! | `#[tbor(response)]` | response |
+//! | `#[tbor(session_ctrl = <v>)]` | **request — required.** Sets the SQE `session_flags.ctrl` byte; one of `no_session`, `open`, `close`, `in_session` |
+//! | `#[tbor(session_ctrl = <v>, resp = TborFooResp)]` | request with explicit response type |
+//! | `#[tbor(session_ctrl = <v>, schema = path::Type)]` | request with explicit FW schema path |
+//! | `#[tbor(response)]` | response (no `session_ctrl`) |
+//! | `#[tbor(response, schema = path::Type)]` | response with explicit FW schema path |
+//!
+//! Opcode is pulled from the FW schema's `TborRequest::OPCODE` impl;
+//! `OpResp` defaults to a `Req → Resp` name swap when `resp` is
+//! omitted.  A request struct without `session_ctrl` is a compile
+//! error.
 //!
 //! ## Field-level attributes
 //!
@@ -180,8 +186,9 @@ fn gen_request(
     let ctrl_variant = attrs.session_ctrl.as_ref().ok_or_else(|| {
         syn::Error::new(
             name.span(),
-            "missing required `session_ctrl` attribute on request struct — \
-             add `#[tbor(session_ctrl = <no_session|open|close|in_session>)]`",
+            "missing required `session_ctrl` attribute on request struct.\n\
+             example: #[tbor(session_ctrl = no_session)]\n\
+             allowed variants: no_session, open, close, in_session",
         )
     })?;
     let session_ctrl_impl = quote! {

--- a/ddi/tbor/derive/src/lib.rs
+++ b/ddi/tbor/derive/src/lib.rs
@@ -161,10 +161,42 @@ fn gen_request(
         .map(gen_encode_call)
         .collect::<syn::Result<TokenStream2>>()?;
 
+    // ── `get_session_id` derived from struct shape; `session_ctrl` ──
+    // ── required explicit attribute (no struct-shape guessing) ──
+    let session_id_field = fields
+        .iter()
+        .find(|f| matches!(f.shape, crate::parse::FieldShape::SessionId))
+        .map(|f| f.name.clone());
+
+    let get_session_id_impl = match &session_id_field {
+        Some(name) => quote! {
+            fn get_session_id(&self) -> ::core::option::Option<u16> {
+                ::core::option::Option::Some(self.#name)
+            }
+        },
+        None => quote! {},
+    };
+
+    let ctrl_variant = attrs.session_ctrl.as_ref().ok_or_else(|| {
+        syn::Error::new(
+            name.span(),
+            "missing required `session_ctrl` attribute on request struct — \
+             add `#[tbor(session_ctrl = <no_session|open|close|in_session>)]`",
+        )
+    })?;
+    let session_ctrl_impl = quote! {
+        fn session_ctrl(&self) -> ::azihsm_ddi_tbor_types::SessionControlKind {
+            ::azihsm_ddi_tbor_types::SessionControlKind::#ctrl_variant
+        }
+    };
+
     Ok(quote! {
         impl ::azihsm_ddi_tbor_types::TborOpReq for #name {
             const OPCODE: u8 = <#schema as ::azihsm_ddi_tbor_codec::TborRequest>::OPCODE;
             type OpResp = #resp_ty;
+
+            #get_session_id_impl
+            #session_ctrl_impl
 
             fn encode_request<'__b>(
                 &self,

--- a/ddi/tbor/derive/src/parse.rs
+++ b/ddi/tbor/derive/src/parse.rs
@@ -28,6 +28,12 @@ pub struct StructAttrs {
     /// Explicit FW schema path (`#[tbor(schema = path::T)]`).  Defaults
     /// to `::azihsm_fw_ddi_tbor_types::<SameStructName>` when omitted.
     pub schema: Option<Path>,
+    /// Required `session_ctrl()` value.  Mandatory on request
+    /// structs (no default — explicit only).  Accepts the
+    /// lower-case identifier of a [`SessionControlKind`] variant:
+    /// `no_session`, `open`, `close`, or `in_session`.  Stored as
+    /// the matching CamelCase ident for code generation.
+    pub session_ctrl: Option<Ident>,
 }
 
 impl StructAttrs {
@@ -35,9 +41,11 @@ impl StructAttrs {
         let mut kind = StructKind::Request;
         let mut resp: Option<Path> = None;
         let mut schema: Option<Path> = None;
+        let mut session_ctrl: Option<Ident> = None;
         let mut saw_response = false;
         let mut saw_resp = false;
         let mut saw_schema = false;
+        let mut saw_session_ctrl = false;
 
         if !attr.is_empty() {
             let parser = syn::meta::parser(|m| {
@@ -62,10 +70,31 @@ impl StructAttrs {
                     saw_schema = true;
                     schema = Some(m.value()?.parse()?);
                     Ok(())
+                } else if m.path.is_ident("session_ctrl") {
+                    if saw_session_ctrl {
+                        return Err(m.error("duplicate `session_ctrl`"));
+                    }
+                    saw_session_ctrl = true;
+                    let ident: Ident = m.value()?.parse()?;
+                    let camel = match ident.to_string().as_str() {
+                        "no_session" => "NoSession",
+                        "open" => "Open",
+                        "close" => "Close",
+                        "in_session" => "InSession",
+                        _ => {
+                            return Err(m.error(
+                                "session_ctrl must be one of: \
+                                 no_session, open, close, in_session",
+                            ));
+                        }
+                    };
+                    session_ctrl = Some(Ident::new(camel, ident.span()));
+                    Ok(())
                 } else {
                     Err(m.error(format!(
                         "unknown #[tbor] option `{}` — expected one of: \
-                         `response`, `resp = T`, `schema = path::T`",
+                         `response`, `resp = T`, `schema = path::T`, \
+                         `session_ctrl = variant`",
                         m.path
                             .get_ident()
                             .map(|i| i.to_string())
@@ -83,7 +112,12 @@ impl StructAttrs {
             ));
         }
 
-        Ok(Self { kind, resp, schema })
+        Ok(Self {
+            kind,
+            resp,
+            schema,
+            session_ctrl,
+        })
     }
 }
 

--- a/ddi/tbor/types/src/change_psk.rs
+++ b/ddi/tbor/types/src/change_psk.rs
@@ -25,7 +25,7 @@ use crate::tbor;
 /// The target PSK slot is derived HSM-side from the session role
 /// (CO session → CO slot, CU session → CU slot); the request does
 /// not carry a slot-selection field.
-#[tbor]
+#[tbor(session_ctrl = in_session)]
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
 pub struct TborChangePskReq {
     /// Logical session id the request is bound to.  Same value must

--- a/ddi/tbor/types/src/close_session.rs
+++ b/ddi/tbor/types/src/close_session.rs
@@ -9,7 +9,7 @@ use crate::tbor;
 pub const TBOR_OP_CLOSE_SESSION: u8 = 0x12;
 
 /// Host-facing TBOR `CloseSession` request.
-#[tbor]
+#[tbor(session_ctrl = close)]
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
 pub struct TborCloseSessionReq {
     /// Session identifier to tear down.

--- a/ddi/tbor/types/src/get_api_rev.rs
+++ b/ddi/tbor/types/src/get_api_rev.rs
@@ -17,7 +17,7 @@ pub use azihsm_fw_ddi_tbor_types::TBOR_OP_GET_API_REV;
 use crate::tbor;
 
 /// Host-facing TBOR `GetApiRev` request. Carries no per-call data.
-#[tbor]
+#[tbor(session_ctrl = no_session)]
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
 pub struct TborGetApiRevReq;
 

--- a/ddi/tbor/types/src/lib.rs
+++ b/ddi/tbor/types/src/lib.rs
@@ -28,6 +28,37 @@ extern crate self as azihsm_ddi_tbor_types;
 pub use azihsm_ddi_tbor_codec as codec;
 pub use azihsm_ddi_tbor_derive::*;
 
+/// Session-control kind carried in the SQE `session_flags.ctrl` byte
+/// for a TBOR request.  The four variants encode as `u8` 0-3.
+///
+/// Defined locally in this crate (rather than re-using the MBOR
+/// equivalent) so the host TBOR surface has no transport-layer
+/// dependency on MBOR types.  The on-the-wire `u8` encoding matches
+/// the MBOR enum, so both transports populate the same SQE field
+/// with the same byte values.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum SessionControlKind {
+    /// Sessionless request (e.g. bootstrap commands).
+    NoSession,
+    /// Request that opens a new session.
+    Open,
+    /// Request that closes the bound session.
+    Close,
+    /// Request that operates within an already-open session.
+    InSession,
+}
+
+impl From<SessionControlKind> for u8 {
+    fn from(kind: SessionControlKind) -> u8 {
+        match kind {
+            SessionControlKind::NoSession => 0,
+            SessionControlKind::Open => 1,
+            SessionControlKind::Close => 2,
+            SessionControlKind::InSession => 3,
+        }
+    }
+}
+
 mod change_psk;
 mod close_session;
 mod get_api_rev;
@@ -57,6 +88,15 @@ pub trait TborOpReq: Sized {
     /// sessionless.
     fn get_session_id(&self) -> Option<u16> {
         None
+    }
+
+    /// SQE session-control kind for this request.  Mirrors the MBOR
+    /// pattern (`From<DdiOp> for SessionControlKind`): each request
+    /// type declares its own kind so the transport layer doesn't
+    /// need a central opcode→ctrl table.  Default is `NoSession`
+    /// to match the sessionless bootstrap commands.
+    fn session_ctrl(&self) -> SessionControlKind {
+        SessionControlKind::NoSession
     }
 
     /// Encode this request into `buf` and return the encoded message

--- a/ddi/tbor/types/src/open_session_finish.rs
+++ b/ddi/tbor/types/src/open_session_finish.rs
@@ -26,7 +26,7 @@ pub const SEED_LEN: usize = 32;
 pub const SEED_ENVELOPE_LEN: usize = 8 + 12 + SEED_LEN + 16;
 
 /// Host-facing TBOR `OpenSessionFinish` request.
-#[tbor]
+#[tbor(session_ctrl = in_session)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct TborOpenSessionFinishReq {
     /// Pending session identifier reserved in Phase 1.

--- a/ddi/tbor/types/src/open_session_init.rs
+++ b/ddi/tbor/types/src/open_session_init.rs
@@ -34,7 +34,7 @@ pub const SESSION_SUITE_P384_HKDF_SHA384_AES_GCM_256: u8 = 0x01;
 /// [`TborOpenSessionFinishReq`](crate::TborOpenSessionFinishReq) and
 /// shipped AEAD-encrypted in Phase 2.  Resume is handled by the MBOR
 /// `ReopenSession` command, not by this opcode.
-#[tbor]
+#[tbor(session_ctrl = open)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct TborOpenSessionInitReq {
     /// PSK identifier asserting the caller role.

--- a/fw/core/lib/src/op.rs
+++ b/fw/core/lib/src/op.rs
@@ -606,15 +606,17 @@ impl SessionCtrl {
 
     /// Map a TBOR opcode to its session control kind.
     ///
-    /// `GetApiRev` and `OpenSessionInit` are session-less (no SQE
-    /// session id; `OpenSessionInit` causes the server to allocate a
-    /// new pending slot whose id is returned in the response).
+    /// `GetApiRev` is session-less.
     ///
-    /// `OpenSessionFinish` and `ChangePsk` reference an existing
-    /// slot, so the SQE must carry the slot's `session_id`
-    /// (`InSession`).  `CloseSession` carries the slot id and is
-    /// classified as `Close` so the CQE flags signal the slot
-    /// transition to the host.
+    /// `OpenSessionInit` is classified as `Open` — it initiates the
+    /// session-open flow; the SQE carries no session id (the FW
+    /// allocates a pending slot and returns its id in the response).
+    ///
+    /// `OpenSessionFinish` and `ChangePsk` reference the
+    /// pending/active slot, so the SQE must carry the slot's
+    /// `session_id` (`InSession`).  `CloseSession` carries the slot
+    /// id and is classified as `Close` so the CQE flags signal the
+    /// slot transition to the host.
     ///
     /// Unknown opcodes default to `NoSession` so that dispatch can
     /// surface `HsmError::UnsupportedCmd` from the handler layer
@@ -622,7 +624,8 @@ impl SessionCtrl {
     pub fn from_tbor_opcode(opcode: u8) -> Self {
         use crate::ddi::tbor::opcode;
         match opcode {
-            opcode::GET_API_REV | opcode::OPEN_SESSION_INIT => Self::NoSession,
+            opcode::GET_API_REV => Self::NoSession,
+            opcode::OPEN_SESSION_INIT => Self::Open,
             opcode::OPEN_SESSION_FINISH | opcode::CHANGE_PSK => Self::InSession,
             opcode::CLOSE_SESSION => Self::Close,
             _ => Self::NoSession,


### PR DESCRIPTION
…trolKind

Replaces the previously hardcoded NoSession ctrl byte on every TBOR SQE with a per-request value declared at the type level.

Derive macro
============
* `#[tbor(session_ctrl = <variant>)]` is now a required attribute on every request struct.  Accepts the lower-case identifier of a `SessionControlKind` variant: `no_session`, `open`, `close`, or `in_session`.  The macro maps it to the matching CamelCase ident for code generation.
* No struct-shape guessing — explicit only.  Missing attribute is a compile error with a helpful diagnostic.
* The macro also generates `get_session_id()` automatically when the struct has a `#[tbor(session_id)]` field.

Host trait + enum
=================
* `azihsm_ddi_tbor_types::SessionControlKind` is now defined locally in the TBOR types crate (no dependency on `azihsm_ddi_mbor_types`). The 4-variant enum and its `From<Self> for u8` mirror the MBOR encoding so both transports populate the SQE ctrl byte with the same byte values, but the host TBOR surface has no transport-layer coupling to MBOR.
* `TborOpReq::session_ctrl(&self) -> SessionControlKind` is added with a `NoSession` default for backward compatibility with any out-of-tree manual impls; the derive macro overrides it.

Per-request classifications
===========================
* `TborGetApiRevReq`        → `no_session`
* `TborOpenSessionInitReq`  → `open`        (was wire-hardcoded `0`)
* `TborOpenSessionFinishReq`→ `in_session`  (was wire-hardcoded `0`)
* `TborChangePskReq`        → `in_session`  (was wire-hardcoded `0`)
* `TborCloseSessionReq`     → `close`       (was wire-hardcoded `0`)

Transport + dispatcher alignment
================================
* `ddi/emu/src/dev.rs` populates `SessionFlags::with_ctrl` from `req.session_ctrl()` instead of the hardcoded `0`.
* `SessionCtrl::from_tbor_opcode` updated to classify `OPEN_SESSION_INIT` as `Open` (was `NoSession`), matching the conceptual model and the host-side classification.  The FW's `validate_tbor_session_flags` already accepts `(Open, !id_valid)` for init, so this is purely a classification tightening.

Verification
============
* `cargo nextest run --features emu -p azihsm_ddi_tbor_types -p azihsm_fw_ddi_tbor_api -p azihsm_fw_ddi_tbor` — 146/146 green.
* clippy clean across all touched crates.