### PR TITLE
aead-envelope: simplify ops surface (drop inspect, DmaBuf-typed views)

### DIFF
--- a/fw/core/crypto/aead-envelope/src/alg.rs
+++ b/fw/core/crypto/aead-envelope/src/alg.rs
@@ -79,7 +79,7 @@ impl AeadAlg {
 
     /// AAD-length granularity in bytes. `aad_len` must be `0` or a
     /// multiple of this value at [`seal`](crate::seal) /
-    /// [`open`](crate::open) / [`inspect`](crate::inspect).
+    /// [`open`](crate::open).
     ///
     /// AES-256-GCM uses `32` — the ocelot BCP `[padded_AAD | text]`
     /// hardware layout requires AAD padding to a 32-byte boundary,

--- a/fw/core/crypto/aead-envelope/src/envelope.rs
+++ b/fw/core/crypto/aead-envelope/src/envelope.rs
@@ -3,14 +3,13 @@
 
 //! Borrowed view of a parsed envelope.
 //!
-//! Returned by both [`inspect`](crate::inspect) and
-//! [`open`](crate::open). The semantics of
-//! [`AeadEnvelope::payload`] depend on which call produced the view:
-//!
-//! | Producer  | `payload` contents |
-//! |-----------|---------------------|
-//! | [`inspect`](crate::inspect) | Ciphertext — header is parsed, no decryption. |
-//! | [`open`](crate::open)       | Plaintext — PAL has decrypted in place. |
+//! Returned by [`open`](crate::open) after the PAL has decrypted
+//! the envelope in place.  All fields are sub-views (`&DmaBuf`)
+//! of the same source buffer so the parsed regions retain their
+//! DMA provenance and can flow into further PAL crypto primitives
+//! without a re-allocation.
+
+use azihsm_fw_hsm_pal_traits::DmaBuf;
 
 use crate::alg::AeadAlg;
 use crate::error::Error;
@@ -19,25 +18,24 @@ use crate::format::Header;
 use crate::format::HEADER_LEN;
 
 /// Borrowed view over the regions of an envelope sitting in a
-/// caller-owned buffer.
+/// caller-owned [`DmaBuf`].
 ///
-/// All fields are sub-slices of the input buffer; constructing an
+/// All fields are sub-views of the input buffer; constructing an
 /// `AeadEnvelope` performs no copies. The `'a` lifetime ties every
 /// field back to the source buffer.
-#[derive(Clone, Copy, Debug)]
+#[derive(Debug)]
 pub struct AeadEnvelope<'a> {
     /// AEAD algorithm read from the envelope header.
     pub alg: AeadAlg,
     /// The 12-byte GCM nonce.
-    pub iv: &'a [u8],
+    pub iv: &'a DmaBuf,
     /// Additional authenticated data (may be empty).
-    pub aad: &'a [u8],
-    /// Ciphertext (after [`inspect`](crate::inspect)) or plaintext
-    /// (after [`open`](crate::open)). Length always equals
-    /// `envelope_total - header - iv - aad - tag`.
-    pub payload: &'a [u8],
+    pub aad: &'a DmaBuf,
+    /// Plaintext payload (decrypted in place by [`open`](crate::open)).
+    /// Length always equals `envelope_total - header - iv - aad - tag`.
+    pub payload: &'a DmaBuf,
     /// The 16-byte GCM authentication tag.
-    pub tag: &'a [u8],
+    pub tag: &'a DmaBuf,
 }
 
 /// Compute the byte offsets of the IV, AAD, payload, and tag

--- a/fw/core/crypto/aead-envelope/src/error.rs
+++ b/fw/core/crypto/aead-envelope/src/error.rs
@@ -7,8 +7,7 @@
 
 use azihsm_fw_hsm_pal_traits::HsmError;
 
-/// Errors produced by [`seal`](crate::seal), [`open`](crate::open),
-/// and [`inspect`](crate::inspect).
+/// Errors produced by [`seal`](crate::seal) and [`open`](crate::open).
 ///
 /// `Error` exists so the per-call validation logic can be unit-tested
 /// without dragging in the full [`HsmError`] surface. It is converted
@@ -17,7 +16,7 @@ use azihsm_fw_hsm_pal_traits::HsmError;
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum Error {
     /// The output buffer (for [`seal`](crate::seal)) or input buffer
-    /// (for [`open`](crate::open) / [`inspect`](crate::inspect)) is
+    /// (for [`open`](crate::open)) is
     /// shorter than the envelope length implied by the inputs /
     /// header.
     BufferTooSmall {

--- a/fw/core/crypto/aead-envelope/src/gcm.rs
+++ b/fw/core/crypto/aead-envelope/src/gcm.rs
@@ -150,27 +150,15 @@ pub(crate) async fn open_gcm<'a>(
             other => Error::Backend(other),
         })?;
 
-    // Re-borrow `buf` immutably to construct the borrowed view.
+    // Re-borrow `buf` immutably to construct the DmaBuf sub-views.
+    // All ranges are validated by `region_offsets`; the indexed
+    // accesses below cannot panic.
     let view = &*buf;
-    let iv = view
-        .get(iv_off..aad_off)
-        .ok_or(Error::BufferTooSmall { needed: aad_off })?;
-    let aad = view
-        .get(aad_off..payload_off)
-        .ok_or(Error::BufferTooSmall {
-            needed: payload_off,
-        })?;
-    let payload = view
-        .get(payload_off..tag_off)
-        .ok_or(Error::BufferTooSmall { needed: tag_off })?;
-    let tag_view = view
-        .get(tag_off..total_len)
-        .ok_or(Error::BufferTooSmall { needed: total_len })?;
     Ok(AeadEnvelope {
         alg: header.alg,
-        iv,
-        aad,
-        payload,
-        tag: tag_view,
+        iv: &view[iv_off..aad_off],
+        aad: &view[aad_off..payload_off],
+        payload: &view[payload_off..tag_off],
+        tag: &view[tag_off..total_len],
     })
 }

--- a/fw/core/crypto/aead-envelope/src/lib.rs
+++ b/fw/core/crypto/aead-envelope/src/lib.rs
@@ -46,8 +46,8 @@
 //! hardware-DMA roles simultaneously.
 //!
 //! The constraint is enforced at [`seal`] (rejected with
-//! [`AeadError::InvalidAadLength`]) and at [`open`] / [`inspect`]
-//! (rejected with [`AeadError::InvalidAadLength`] when parsing).
+//! [`AeadError::InvalidAadLength`]) and at [`open`] (rejected with
+//! [`AeadError::InvalidAadLength`] when parsing).
 //!
 //! # Interop
 //!
@@ -86,7 +86,6 @@ mod format;
 mod gcm;
 mod ops;
 
-pub use ops::inspect;
 pub use ops::open;
 pub use ops::seal;
 pub use ops::AeadAlg;

--- a/fw/core/crypto/aead-envelope/src/ops.rs
+++ b/fw/core/crypto/aead-envelope/src/ops.rs
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-//! Public surface: [`seal`], [`open`], [`inspect`], and the types
-//! they hand to callers.
+//! Public surface: [`seal`], [`open`], and the types they hand to
+//! callers.
 //!
 //! This is the only module re-exported from the crate root. All
 //! other modules are `pub(crate)` implementation detail.
@@ -13,10 +13,6 @@
 //! means adding a new [`AeadAlg`] discriminant, a new `seal_xxx` /
 //! `open_xxx` private impl, and one new arm in each `match` below.
 //! The public signatures never change.
-//!
-//! [`inspect`] is algorithm-agnostic — every supported algorithm
-//! uses the same `[HEADER | IV | AAD | DATA | TAG]` wire layout —
-//! so it lives here for surface symmetry rather than dispatching.
 //!
 //! ```text
 //! seal(alg, ...) ──► match alg {
@@ -31,10 +27,6 @@
 //!                     AesGcm256 => open_gcm(...),
 //!                     // future arms ...
 //!                 }
-//!
-//! inspect(buf) ──► read_header(buf)
-//!               ──► region_offsets(...)
-//!               ──► AeadEnvelope { .. }   // no decrypt, no auth
 //! ```
 
 use azihsm_fw_hsm_pal_traits::DmaBuf;
@@ -43,11 +35,9 @@ use azihsm_fw_hsm_pal_traits::HsmIo;
 use azihsm_fw_hsm_pal_traits::HsmResult;
 
 pub use crate::alg::AeadAlg;
-use crate::envelope::region_offsets;
 pub use crate::envelope::AeadEnvelope;
 use crate::error::Error;
 pub use crate::error::Error as AeadError;
-use crate::error::Result;
 use crate::format::is_valid_aad_len;
 use crate::format::read_header;
 pub use crate::format::FORMAT_TAG;
@@ -159,47 +149,4 @@ pub async fn open<'a>(
         AeadAlg::AesGcm256 => open_gcm(crypto, io, key, buf, header).await?,
     };
     Ok(env)
-}
-
-/// Parse an envelope header and return a borrowed [`AeadEnvelope`]
-/// view without decrypting or authenticating.
-///
-/// `payload` references the ciphertext bytes in `buf`. The tag is
-/// **not** verified; use [`open`] when authenticity matters.
-///
-/// Algorithm-agnostic: every supported algorithm shares the
-/// `[HEADER | IV | AAD | DATA | TAG]` wire layout.
-///
-/// # Errors
-/// * [`AeadError::BufferTooSmall`] — `buf.len()` is shorter than
-///   the minimum envelope length implied by the parsed header.
-/// * [`AeadError::InvalidFormat`] — bad magic byte.
-/// * [`AeadError::UnsupportedAlg`] — `alg` byte not supported in
-///   v1.
-/// * [`AeadError::InvalidAadLength`] — encoded `aad_len` violates
-///   the algorithm's AAD granularity.
-pub fn inspect(buf: &[u8]) -> Result<AeadEnvelope<'_>> {
-    let header = read_header(buf)?;
-    let (iv_off, aad_off, payload_off, tag_off) = region_offsets(header, buf.len())?;
-    // All ranges are validated by `region_offsets`; `get` keeps the
-    // accessors panic-free even if invariants are violated.
-    let iv = buf
-        .get(iv_off..aad_off)
-        .ok_or(Error::BufferTooSmall { needed: aad_off })?;
-    let aad = buf.get(aad_off..payload_off).ok_or(Error::BufferTooSmall {
-        needed: payload_off,
-    })?;
-    let payload = buf
-        .get(payload_off..tag_off)
-        .ok_or(Error::BufferTooSmall { needed: tag_off })?;
-    let tag = buf
-        .get(tag_off..)
-        .ok_or(Error::BufferTooSmall { needed: buf.len() })?;
-    Ok(AeadEnvelope {
-        alg: header.alg,
-        iv,
-        aad,
-        payload,
-        tag,
-    })
 }

--- a/fw/core/lib/src/ddi/tbor/change_psk.rs
+++ b/fw/core/lib/src/ddi/tbor/change_psk.rs
@@ -94,7 +94,8 @@ pub(crate) async fn handle<'p, P: HsmPal>(
             return Err(HsmError::InvalidArg);
         }
         let expected_aad = build_psk_change_aad(u16::from(sess_id));
-        if view.aad != expected_aad.as_slice() {
+        let aad_bytes: &[u8] = view.aad;
+        if aad_bytes != expected_aad.as_slice() {
             return Err(HsmError::AeadEnvelopeAuthFailed);
         }
         if view.payload.len() != PSK_LEN {

--- a/fw/core/lib/src/ddi/tbor/part_init.rs
+++ b/fw/core/lib/src/ddi/tbor/part_init.rs
@@ -289,7 +289,8 @@ async fn open_mach_seed_envelope<'a, P: HsmPal>(
         return Err(HsmError::InvalidArg);
     }
     let expected_aad = build_part_init_mach_seed_aad(u16::from(sess_id));
-    if view.aad != expected_aad.as_slice() {
+    let aad_bytes: &[u8] = view.aad;
+    if aad_bytes != expected_aad.as_slice() {
         return Err(HsmError::AeadEnvelopeAuthFailed);
     }
     if view.payload.len() != MACH_SEED_LEN {


### PR DESCRIPTION
* Drop the unused `inspect()` entrypoint — no in-tree consumer in the FW workspace; the only callers (host crypto unit tests) live in the parallel host crate `crates/crypto/src/aead_envelope`, which is independent.

* Switch `AeadEnvelope` field types from `&'a [u8]` to `&'a DmaBuf` so the parsed IV/AAD/payload/tag sub-views retain their DMA provenance and can flow directly into downstream PAL crypto primitives without re-allocating into a fresh DmaBuf.

* Clean up `gcm::open_gcm` to use direct indexing on the validated ranges (all offsets are pre-checked by `region_offsets`).

* Update two handler call-sites (`part_init`, `change_psk`) to bind `view.aad` to a `&[u8]` local before the slice comparison.

Verified: full workspace build green; `cargo xtask nextest --features mock --package azihsm_api_tests` 1788 passed / 3 skipped.