### PR TITLE
pal: zero-copy session_param_key (return &DmaBuf instead of memcpy)

### DIFF
--- a/fw/core/lib/src/ddi/tbor/change_psk.rs
+++ b/fw/core/lib/src/ddi/tbor/change_psk.rs
@@ -37,7 +37,6 @@ use azihsm_fw_hsm_pal_traits::HsmScopedAlloc;
 use azihsm_fw_hsm_pal_traits::HsmSessId;
 use azihsm_fw_hsm_pal_traits::SessionRole;
 use azihsm_fw_hsm_pal_traits::PSK_LEN;
-use azihsm_fw_hsm_pal_traits::SESSION_PARAM_KEY_LEN;
 
 /// PSK slot id written when the active session is the Crypto Officer.
 const PSK_ID_CO: u8 = 0;
@@ -74,8 +73,7 @@ pub(crate) async fn handle<'p, P: HsmPal>(
     pal.alloc_scoped_async(io, async |alloc| {
         // Fetch the session's `param_key` schedule (the PAL hides the
         // session-blob layout from us).
-        let param_key = alloc.dma_alloc(SESSION_PARAM_KEY_LEN)?;
-        pal.session_param_key(io, sess_id, param_key)?;
+        let param_key = pal.session_param_key(io, sess_id)?;
 
         // AEAD-open the envelope in place.
         let env_buf = alloc.dma_alloc(envelope.len())?;

--- a/fw/core/lib/src/ddi/tbor/part_init.rs
+++ b/fw/core/lib/src/ddi/tbor/part_init.rs
@@ -76,7 +76,6 @@ use azihsm_fw_hsm_pal_traits::HsmVaultKeyKind;
 use azihsm_fw_hsm_pal_traits::SessionRole;
 use azihsm_fw_hsm_pal_traits::VaultKeyGuard;
 use azihsm_fw_hsm_pal_traits::PART_POLICY_LEN;
-use azihsm_fw_hsm_pal_traits::SESSION_PARAM_KEY_LEN;
 
 use super::*;
 
@@ -276,8 +275,7 @@ async fn open_mach_seed_envelope<'a, P: HsmPal>(
     sess_id: HsmSessId,
     envelope: &[u8],
 ) -> HsmResult<&'a mut DmaBuf> {
-    let param_key = alloc.dma_alloc(SESSION_PARAM_KEY_LEN)?;
-    pal.session_param_key(io, sess_id, param_key)?;
+    let param_key = pal.session_param_key(io, sess_id)?;
 
     let env_buf = alloc.dma_alloc(envelope.len())?;
     env_buf.copy_from_slice(envelope);

--- a/fw/pal/traits/src/session.rs
+++ b/fw/pal/traits/src/session.rs
@@ -514,31 +514,34 @@ pub trait HsmSessionManager {
         mac_rx_key: Option<&[u8]>,
     ) -> HsmResult<()>;
 
-    /// Copies the active session's `param_key` (a 32-byte AES-256
-    /// key used by [`azihsm_fw_core_crypto_aead_envelope`]) into
-    /// `out`.
+    /// Returns a borrowed view of the active session's `param_key`
+    /// (a 32-byte AES-256 key used by
+    /// [`azihsm_fw_core_crypto_aead_envelope`]).
     ///
+    /// Zero-copy: the returned `&DmaBuf` borrows directly from the
+    /// PAL's session-schedule storage, so callers can hand it to
+    /// PAL crypto primitives without an intermediate allocation.
     /// This hides the layout of the session schedule blob from
     /// in-session handlers — they no longer need to know that the
     /// schedule is stored as `api_rev ‖ param_key ‖ masking_key …`
-    /// behind a vault key.  If the schedule format changes, only the
-    /// PAL impl needs to update.
+    /// behind a vault key.  If the schedule format changes, only
+    /// the PAL impl needs to update.
     ///
     /// # Parameters
     ///
     /// - `io` — caller's I/O context (partition scope).
     /// - `id` — Active session slot.
-    /// - `out` — destination buffer; MUST be exactly
-    ///   [`SESSION_PARAM_KEY_LEN`] bytes.
     ///
     /// # Returns
     ///
-    /// - `Ok(())` on success; `out` is filled with the schedule.
-    /// - `Err(HsmError::InvalidArg)` — `out.len() != SESSION_PARAM_KEY_LEN`.
+    /// - `Ok(&DmaBuf)` — a sub-view of the schedule blob, exactly
+    ///   [`SESSION_PARAM_KEY_LEN`] bytes long.
     /// - `Err(HsmError::SessionNotFound)` — `id` does not refer to a
     ///   live Active session in the caller's partition (slot free,
     ///   destroyed, or still Pending).
-    fn session_param_key(&self, io: &impl HsmIo, id: HsmSessId, out: &mut [u8]) -> HsmResult<()>;
+    /// - `Err(HsmError::InternalError)` — schedule blob is shorter
+    ///   than expected (corruption indicator).
+    fn session_param_key(&self, io: &impl HsmIo, id: HsmSessId) -> HsmResult<&DmaBuf>;
 
     /// Atomically reserves the session's one-shot "PSK change"
     /// budget.  Each session may successfully consume this budget at

--- a/fw/plat/std/pal/src/session.rs
+++ b/fw/plat/std/pal/src/session.rs
@@ -313,20 +313,18 @@ impl HsmSessionManager for StdHsmPal {
         Ok(())
     }
 
-    fn session_param_key(&self, io: &impl HsmIo, id: HsmSessId, out: &mut [u8]) -> HsmResult<()> {
-        if out.len() != SESSION_PARAM_KEY_LEN {
-            return Err(HsmError::InvalidArg);
-        }
+    fn session_param_key(&self, io: &impl HsmIo, id: HsmSessId) -> HsmResult<&DmaBuf> {
         let entry = self.active_part(io.pid())?;
         let kid = entry.session_table.physical_id(id)?;
         let blob = entry.vault.key(kid)?;
         if blob.len() < SESSION_API_REV_SIZE + SESSION_PARAM_KEY_LEN {
             return Err(HsmError::InternalError);
         }
-        out.copy_from_slice(
-            &blob[SESSION_API_REV_SIZE..SESSION_API_REV_SIZE + SESSION_PARAM_KEY_LEN],
-        );
-        Ok(())
+        let key_bytes = &blob[SESSION_API_REV_SIZE..SESSION_API_REV_SIZE + SESSION_PARAM_KEY_LEN];
+        // SAFETY: same justification as `vault_key` — on the host,
+        // any heap byte is reachable; branding the sub-slice as
+        // `DmaBuf` only satisfies the type system.
+        Ok(unsafe { DmaBuf::from_raw(key_bytes) })
     }
 
     fn session_try_consume_psk_change(&self, io: &impl HsmIo, id: HsmSessId) -> HsmResult<()> {


### PR DESCRIPTION
Switch the `HsmSessionManager::session_param_key` trait from a copy-out signature (caller pre-allocates a 32-byte DmaBuf, PAL memcpy's into it) to a borrow-out signature (PAL returns a `&DmaBuf` sub-view of its internal session-schedule storage).

* `fw/pal/traits/src/session.rs` — trait signature and doc updated. Removes the `out: &mut [u8]` parameter and the `HsmError::InvalidArg` length-mismatch error.  Adds `HsmError::InternalError` when the schedule blob is shorter than expected (corruption indicator).

* `fw/plat/std/pal/src/session.rs` — std PAL impl drops the destination buffer + memcpy and returns `unsafe { DmaBuf::from_raw(&blob[off..off+len]) }`.  Same safety justification as `vault_key`: on the host, any heap byte is reachable; branding the sub-slice as `DmaBuf` only satisfies the type system.

* `fw/core/lib/src/ddi/tbor/{part_init,change_psk}.rs` — callers replace let param_key = alloc.dma_alloc(SESSION_PARAM_KEY_LEN)?; pal.session_param_key(io, sess_id, param_key)?; with let param_key = pal.session_param_key(io, sess_id)?; and drop the now-unused `SESSION_PARAM_KEY_LEN` import.

Removes one DmaBuf allocation and one 32-byte memcpy per PartInit and ChangePsk envelope-open call.

Verified: full workspace build green; `cargo xtask nextest --features mock --package azihsm_api_tests` 1788 passed / 3 skipped.