### PR TITLE
[tbor] FW TBOR stack: ViewMut codec, in-place AEAD-open, &DmaBuf field views

### DIFF
--- a/ddi/tbor/types/tests/commands/part_init/crypto_rejects.rs
+++ b/ddi/tbor/types/tests/commands/part_init/crypto_rejects.rs
@@ -99,9 +99,14 @@ fn part_init_envelope_from_other_session_emu() {
 /// AAD bytes of arbitrary but valid AEAD granularity (64 bytes —
 /// double the canonical [`PART_INIT_MACH_SEED_AAD_LEN`] of 32).
 /// AEAD-open succeeds (the FW recomputes the tag over these bytes),
-/// but the FW's `view.aad.len() != PART_INIT_MACH_SEED_AAD_LEN`
-/// length check rejects with [`TborStatus::InvalidArg`] before the
-/// AAD content compare runs. Mirrors `change_psk_wrong_aad_length_emu`.
+/// but the FW collapses any post-auth wire-shape mismatch (AAD
+/// length / layout / payload length) into
+/// [`TborStatus::AeadEnvelopeAuthFailed`] — see
+/// `open_mach_seed_envelope` in the FW part_init handler: once
+/// authentication has succeeded the only way the shape can diverge
+/// is a sender that constructed the envelope against a different
+/// protocol contract, which is operationally indistinguishable from
+/// a forgery attempt.
 #[test]
 fn part_init_wrong_aad_length_emu() {
     let ctx = TestCtx::new();
@@ -117,14 +122,15 @@ fn part_init_wrong_aad_length_emu() {
     req.part_policy.copy_from_slice(&known_good_part_policy());
     req.pota_thumbprint.copy_from_slice(&pota_thumbprint());
 
-    ctx.expect_fw_reject(&req, TborStatus::InvalidArg);
+    ctx.expect_fw_reject(&req, TborStatus::AeadEnvelopeAuthFailed);
 }
 
 /// `mach_seed` plaintext length ≠ [`MACH_SEED_LEN`] (32). AEAD-open
-/// succeeds, but the FW's plaintext-length check rejects with
-/// [`TborStatus::InvalidArg`] before any partition-state mutation.
-/// Loop over `MACH_SEED_LEN ± 1` to cover the shortest excursions on
-/// either side of the canonical length. Mirrors
+/// succeeds, but the FW collapses the post-auth length mismatch into
+/// [`TborStatus::AeadEnvelopeAuthFailed`] (see
+/// `part_init_wrong_aad_length_emu` for the rationale). Loop over
+/// `MACH_SEED_LEN ± 1` to cover the shortest excursions on either
+/// side of the canonical length. Mirrors
 /// `change_psk_wrong_plaintext_length_emu`.
 #[test]
 fn part_init_wrong_mach_seed_length_emu() {
@@ -150,7 +156,7 @@ fn part_init_wrong_mach_seed_length_emu() {
         let err = ctx.tbor(&req).expect_err(&format!(
             "mach_seed length {len} (\u{2260} MACH_SEED_LEN={MACH_SEED_LEN}) must be rejected",
         ));
-        crate::harness::assertions::assert_fw_rejects(&err, TborStatus::InvalidArg);
+        crate::harness::assertions::assert_fw_rejects(&err, TborStatus::AeadEnvelopeAuthFailed);
     }
 }
 

--- a/fw/core/ddi/tbor/api/Cargo.toml
+++ b/fw/core/ddi/tbor/api/Cargo.toml
@@ -17,6 +17,7 @@ azihsm_fw_ddi_tbor.workspace = true
 azihsm_fw_ddi_tbor_derive = { optional = true, workspace = true }
 
 [dev-dependencies]
+azihsm_fw_hsm_pal_traits.workspace = true
 trybuild.workspace = true
 
 [lints]

--- a/fw/core/ddi/tbor/api/examples/comprehensive.rs
+++ b/fw/core/ddi/tbor/api/examples/comprehensive.rs
@@ -4,6 +4,7 @@
 //! Comprehensive example of TBOR encode/decode with the #[tbor] derive macro.
 
 #![allow(clippy::unwrap_used)]
+#![allow(unsafe_code)]
 //!
 //! Demonstrates:
 //!   - Required and optional fields
@@ -17,6 +18,14 @@
 use std::println;
 
 use azihsm_fw_ddi_tbor_api::tbor;
+use azihsm_fw_hsm_pal_traits::DmaBuf;
+
+// SAFETY: example-only branding. Host-side examples have no real DMA
+// engine, so the DMA-reachability contract is moot.
+fn brand(b: &[u8]) -> &DmaBuf {
+    // SAFETY: see fn-level doc comment.
+    unsafe { DmaBuf::from_raw(b) }
+}
 
 // ═══════════════════════════════════════════════════════════════════════
 // 1. ENUM TYPES — used as field values
@@ -127,12 +136,12 @@ fn example_aes_gcm_full() {
     );
 
     // Decode: zero-copy, borrows the wire bytes.
-    let view = EncryptReq::decode(frame.as_bytes()).unwrap();
+    let view = EncryptReq::decode(brand(frame.as_bytes())).unwrap();
     assert_eq!(view.session_id(), azihsm_fw_ddi_tbor_api::SessionId(7));
     assert_eq!(view.key_id(), azihsm_fw_ddi_tbor_api::KeyId(42));
     assert_eq!(view.algorithm(), 3);
-    assert_eq!(view.iv(), Some(iv.as_slice()));
-    assert_eq!(view.aad(), Some(aad.as_slice()));
+    assert!(view.iv().is_some_and(|d| &**d == iv.as_slice()));
+    assert!(view.aad().is_some_and(|d| &**d == aad.as_slice()));
     assert_eq!(view.plaintext(), plaintext);
 
     // Pretty-print via generated Display impl.
@@ -162,7 +171,7 @@ fn example_aes_ecb_minimal() {
 
     println!("  Encoded: {} bytes (no IV/AAD overhead)", frame.len());
 
-    let view = EncryptReq::decode(frame.as_bytes()).unwrap();
+    let view = EncryptReq::decode(brand(frame.as_bytes())).unwrap();
     assert_eq!(view.iv(), None);
     assert_eq!(view.aad(), None);
     assert_eq!(view.plaintext(), b"ECB-data-here!!!");
@@ -198,8 +207,8 @@ fn example_skip_intermediate() {
         .unwrap()
         .finish();
 
-    let view = EncryptReq::decode(frame.as_bytes()).unwrap();
-    assert_eq!(view.iv(), Some(iv.as_slice()));
+    let view = EncryptReq::decode(brand(frame.as_bytes())).unwrap();
+    assert!(view.iv().is_some_and(|d| &**d == iv.as_slice()));
     assert_eq!(view.aad(), None); // auto-filled as None
     assert_eq!(view.plaintext(), b"CBC-block-data!!");
 
@@ -222,11 +231,11 @@ fn example_response() {
         .unwrap()
         .finish();
 
-    let view = EncryptResp::decode(frame.as_bytes()).unwrap();
+    let view = EncryptResp::decode(brand(frame.as_bytes())).unwrap();
     assert_eq!(view.status(), 0);
     assert!(view.fips_approved());
     assert_eq!(view.ciphertext(), b"<ciphertext-bytes>");
-    assert_eq!(view.tag(), Some(b"\xDE\xAD\xBE\xEF".as_slice()));
+    assert!(view.tag().is_some_and(|d| &**d == b"\xDE\xAD\xBE\xEF"));
     println!(
         "  GCM: status=0, FIPS=true, tag={:?}",
         view.tag().map(|t| t.len())
@@ -240,7 +249,7 @@ fn example_response() {
         .unwrap()
         .finish(); // tag is trailing optional → auto-filled as None
 
-    let view2 = EncryptResp::decode(frame2.as_bytes()).unwrap();
+    let view2 = EncryptResp::decode(brand(frame2.as_bytes())).unwrap();
     assert_eq!(view2.tag(), None);
     println!("  ECB: status=0, FIPS=false, tag=None\n");
 }
@@ -268,7 +277,7 @@ fn example_raw_decode() {
     println!("  Wire bytes: {} bytes", wire_bytes.len());
 
     // Decode — this is zero-copy: the view borrows wire_bytes.
-    let view = EncryptReq::decode(wire_bytes).unwrap();
+    let view = EncryptReq::decode(brand(wire_bytes)).unwrap();
     println!("  Decoded successfully:");
     println!("    session = {}", view.session_id());
     println!("    key     = {}", view.key_id());
@@ -281,7 +290,7 @@ fn example_raw_decode() {
     );
 
     // You can also use the generic core decoder for untyped access:
-    let raw = azihsm_fw_ddi_tbor::RequestView::parse(wire_bytes).unwrap();
+    let raw = azihsm_fw_ddi_tbor::RequestView::parse(brand(wire_bytes)).unwrap();
     println!(
         "\n  Raw view: opcode=0x{:02X}, {} TOC entries",
         raw.opcode(),

--- a/fw/core/ddi/tbor/api/tests/compile_tests/pass/array_and_constraints.rs
+++ b/fw/core/ddi/tbor/api/tests/compile_tests/pass/array_and_constraints.rs
@@ -1,7 +1,13 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 // Valid: fixed-size array and length constraints.
+#![allow(unsafe_code)]
 use azihsm_fw_ddi_tbor_api::tbor;
+use azihsm_fw_hsm_pal_traits::DmaBuf;
+
+fn brand(b: &[u8]) -> &DmaBuf {
+    unsafe { DmaBuf::from_raw(b) }
+}
 
 #[tbor(opcode = 0x03)]
 pub struct ArrayReq<'a> {
@@ -15,12 +21,16 @@ pub struct ArrayReq<'a> {
 fn main() {
     let nonce = [0u8; 16];
     let mut buf = [0u8; 256];
-    let frame = ArrayReq::encode(&mut buf).unwrap()
-        .nonce(&nonce).unwrap()
-        .tag(b"hello").unwrap()
-        .payload(b"data").unwrap()
+    let frame = ArrayReq::encode(&mut buf)
+        .unwrap()
+        .nonce(&nonce)
+        .unwrap()
+        .tag(b"hello")
+        .unwrap()
+        .payload(b"data")
+        .unwrap()
         .finish();
 
-    let view = ArrayReq::decode(frame.as_bytes()).unwrap();
-    let _n: &[u8; 16] = view.nonce(); // type is &[u8; 16]
+    let view = ArrayReq::decode(brand(frame.as_bytes())).unwrap();
+    let _n: &DmaBuf = view.nonce(); // accessor returns &DmaBuf uniformly
 }

--- a/fw/core/ddi/tbor/api/tests/compile_tests/pass/basic_request.rs
+++ b/fw/core/ddi/tbor/api/tests/compile_tests/pass/basic_request.rs
@@ -1,7 +1,13 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 // Valid: basic request with scalar fields.
+#![allow(unsafe_code)]
 use azihsm_fw_ddi_tbor_api::tbor;
+use azihsm_fw_hsm_pal_traits::DmaBuf;
+
+fn brand(b: &[u8]) -> &DmaBuf {
+    unsafe { DmaBuf::from_raw(b) }
+}
 
 #[tbor(opcode = 0x01)]
 pub struct BasicReq {
@@ -11,9 +17,12 @@ pub struct BasicReq {
 
 fn main() {
     let mut buf = [0u8; 64];
-    let frame = BasicReq::encode(&mut buf).unwrap()
-        .a(1).unwrap()
-        .b(2).unwrap()
+    let frame = BasicReq::encode(&mut buf)
+        .unwrap()
+        .a(1)
+        .unwrap()
+        .b(2)
+        .unwrap()
         .finish();
-    let _ = BasicReq::decode(frame.as_bytes()).unwrap();
+    let _ = BasicReq::decode(brand(frame.as_bytes())).unwrap();
 }

--- a/fw/core/ddi/tbor/api/tests/compile_tests/pass/empty_struct.rs
+++ b/fw/core/ddi/tbor/api/tests/compile_tests/pass/empty_struct.rs
@@ -3,7 +3,13 @@
 // Pass: #[tbor] on a struct with no fields. The body wire-encodes as a
 // single synthetic `None` TOC placeholder, and the generated decoder
 // validates that placeholder is present.
+#![allow(unsafe_code)]
 use azihsm_fw_ddi_tbor_api::tbor;
+use azihsm_fw_hsm_pal_traits::DmaBuf;
+
+fn brand(b: &[u8]) -> &DmaBuf {
+    unsafe { DmaBuf::from_raw(b) }
+}
 
 #[tbor(opcode = 0x01)]
 pub struct EmptyReq {}
@@ -14,5 +20,5 @@ fn main() {
     let bytes = frame.as_bytes();
     // 4-byte header + 1 TOC entry (4 bytes) = 8 bytes total.
     assert_eq!(bytes.len(), 8);
-    EmptyReq::decode(bytes).expect("decode");
+    EmptyReq::decode(brand(bytes)).expect("decode");
 }

--- a/fw/core/ddi/tbor/api/tests/derive_tests.rs
+++ b/fw/core/ddi/tbor/api/tests/derive_tests.rs
@@ -4,8 +4,18 @@
 //! Integration tests for the #[tbor] derive macro.
 
 #![allow(clippy::unwrap_used)]
+#![allow(unsafe_code)]
 
 use azihsm_fw_ddi_tbor_api::tbor;
+use azihsm_fw_hsm_pal_traits::DmaBuf;
+
+// SAFETY: test-only branding. Host-side tests have no real DMA engine,
+// so the DMA-reachability contract is moot; the brand is needed purely
+// to satisfy the parse/decode signatures.
+fn brand(b: &[u8]) -> &DmaBuf {
+    // SAFETY: see fn-level doc comment.
+    unsafe { DmaBuf::from_raw(b) }
+}
 
 // ── Request with scalar fields ─────────────────────────────────────────
 
@@ -30,7 +40,7 @@ fn request_scalar_encode_decode() {
     assert_eq!(frame.slot_id(), 3);
     assert_eq!(frame.cert_id(), 1);
 
-    let view = GetCertificateReq::decode(frame.as_bytes()).unwrap();
+    let view = GetCertificateReq::decode(brand(frame.as_bytes())).unwrap();
     assert_eq!(view.slot_id(), 3);
     assert_eq!(view.cert_id(), 1);
     assert_eq!(view.len(), 12);
@@ -58,7 +68,7 @@ fn response_buffer_encode_decode() {
     assert_eq!(frame.len(), 33);
     assert_eq!(frame.certificate(), cert_data);
 
-    let view = GetCertificateResp::decode(frame.as_bytes()).unwrap();
+    let view = GetCertificateResp::decode(brand(frame.as_bytes())).unwrap();
     assert_eq!(view.status(), 0);
     assert!(!view.fips_approved());
     assert_eq!(view.certificate(), cert_data);
@@ -99,7 +109,7 @@ fn request_mixed_types_round_trip() {
         .unwrap()
         .finish();
 
-    let view = AesEncryptReq::decode(frame.as_bytes()).unwrap();
+    let view = AesEncryptReq::decode(brand(frame.as_bytes())).unwrap();
     assert_eq!(view.sess_id(), azihsm_fw_ddi_tbor_api::SessionId(43));
     assert_eq!(view.key_id(), azihsm_fw_ddi_tbor_api::KeyId(16));
     assert_eq!(view.op(), 1);
@@ -129,7 +139,7 @@ fn request_u32_u64_round_trip() {
         .unwrap()
         .finish();
 
-    let view = BigFieldReq::decode(frame.as_bytes()).unwrap();
+    let view = BigFieldReq::decode(brand(frame.as_bytes())).unwrap();
     assert_eq!(view.count(), 0xDEADBEEF);
     assert_eq!(view.timestamp(), 0x0123456789ABCDEF);
     assert_eq!(view.flags(), 0x42);
@@ -154,7 +164,7 @@ fn response_fips_flag() {
         .unwrap()
         .finish();
 
-    let view = DeviceInfoResp::decode(frame.as_bytes()).unwrap();
+    let view = DeviceInfoResp::decode(brand(frame.as_bytes())).unwrap();
     assert_eq!(view.status(), 0);
     assert!(view.fips_approved());
     assert_eq!(view.kind(), 2);
@@ -194,7 +204,7 @@ fn view_display() {
         .unwrap()
         .finish();
 
-    let view = GetCertificateReq::decode(frame.as_bytes()).unwrap();
+    let view = GetCertificateReq::decode(brand(frame.as_bytes())).unwrap();
     let output = format!("{}", view);
     assert!(output.contains("GetCertificateReq"));
     assert!(output.contains("slot_id"));
@@ -214,7 +224,7 @@ fn decode_wrong_opcode() {
         .finish()
         .unwrap();
 
-    let err = GetCertificateReq::decode(msg).unwrap_err();
+    let err = GetCertificateReq::decode(brand(msg)).unwrap_err();
     assert!(matches!(
         err,
         azihsm_fw_ddi_tbor::DecodeError::OpcodeMismatch {
@@ -237,7 +247,7 @@ fn decode_wrong_toc_count() {
         .finish()
         .unwrap();
 
-    let err = GetCertificateReq::decode(msg).unwrap_err();
+    let err = GetCertificateReq::decode(brand(msg)).unwrap_err();
     assert!(matches!(
         err,
         azihsm_fw_ddi_tbor::DecodeError::MessageTruncated { .. }
@@ -255,7 +265,7 @@ fn decode_wrong_toc_type() {
         .finish()
         .unwrap();
 
-    let err = GetCertificateReq::decode(msg).unwrap_err();
+    let err = GetCertificateReq::decode(brand(msg)).unwrap_err();
     assert!(matches!(
         err,
         azihsm_fw_ddi_tbor::DecodeError::UnexpectedTocType {
@@ -292,7 +302,7 @@ fn optional_scalar_all_present() {
     assert_eq!(frame.opt_value(), Some(1000));
     assert_eq!(frame.opt_flags(), Some(0xFF));
 
-    let view = OptionalScalarReq::decode(frame.as_bytes()).unwrap();
+    let view = OptionalScalarReq::decode(brand(frame.as_bytes())).unwrap();
     assert_eq!(view.required_id(), 5);
     assert_eq!(view.opt_value(), Some(1000));
     assert_eq!(view.opt_flags(), Some(0xFF));
@@ -315,7 +325,7 @@ fn optional_scalar_some_absent() {
     assert_eq!(frame.opt_value(), None);
     assert_eq!(frame.opt_flags(), Some(42));
 
-    let view = OptionalScalarReq::decode(frame.as_bytes()).unwrap();
+    let view = OptionalScalarReq::decode(brand(frame.as_bytes())).unwrap();
     assert_eq!(view.required_id(), 3);
     assert_eq!(view.opt_value(), None);
     assert_eq!(view.opt_flags(), Some(42));
@@ -335,7 +345,7 @@ fn optional_scalar_all_absent_early_finish() {
     assert_eq!(frame.opt_value(), None);
     assert_eq!(frame.opt_flags(), None);
 
-    let view = OptionalScalarReq::decode(frame.as_bytes()).unwrap();
+    let view = OptionalScalarReq::decode(brand(frame.as_bytes())).unwrap();
     assert_eq!(view.required_id(), 1);
     assert_eq!(view.opt_value(), None);
     assert_eq!(view.opt_flags(), None);
@@ -387,10 +397,10 @@ fn optional_buffer_present() {
     assert_eq!(frame.data(), b"hello");
     assert_eq!(frame.opt_extra(), Some(b"world".as_slice()));
 
-    let view = OptionalBufferReq::decode(frame.as_bytes()).unwrap();
+    let view = OptionalBufferReq::decode(brand(frame.as_bytes())).unwrap();
     assert_eq!(view.sess(), azihsm_fw_ddi_tbor_api::SessionId(10));
     assert_eq!(view.data(), b"hello");
-    assert_eq!(view.opt_extra(), Some(b"world".as_slice()));
+    assert!(view.opt_extra().is_some_and(|d| &**d == b"world"));
 }
 
 #[test]
@@ -407,7 +417,7 @@ fn optional_buffer_absent_early_finish() {
     assert_eq!(frame.data(), b"hello");
     assert_eq!(frame.opt_extra(), None);
 
-    let view = OptionalBufferReq::decode(frame.as_bytes()).unwrap();
+    let view = OptionalBufferReq::decode(brand(frame.as_bytes())).unwrap();
     assert_eq!(view.data(), b"hello");
     assert_eq!(view.opt_extra(), None);
 
@@ -446,7 +456,7 @@ fn some_none_some_offset_compression() {
     // Total: 4 header + 3*4 TOC + 8 data = 24
     assert_eq!(frame.len(), 24);
 
-    let view = SomeNoneSomeReq::decode(frame.as_bytes()).unwrap();
+    let view = SomeNoneSomeReq::decode(brand(frame.as_bytes())).unwrap();
     assert_eq!(view.first(), b"AAAA");
     assert_eq!(view.middle(), None);
     assert_eq!(view.last(), b"BBBB");
@@ -492,11 +502,11 @@ fn optional_response_round_trip() {
         .unwrap()
         .finish();
 
-    let view = OptionalResp::decode(frame.as_bytes()).unwrap();
+    let view = OptionalResp::decode(brand(frame.as_bytes())).unwrap();
     assert_eq!(view.status(), 0);
     assert!(view.fips_approved());
     assert_eq!(view.result_code(), 1);
-    assert_eq!(view.opt_data(), Some(b"payload".as_slice()));
+    assert!(view.opt_data().is_some_and(|d| &**d == b"payload"));
 
     // Without data — early finish
     let mut buf2 = [0u8; 256];
@@ -506,7 +516,7 @@ fn optional_response_round_trip() {
         .unwrap()
         .finish();
 
-    let view2 = OptionalResp::decode(frame2.as_bytes()).unwrap();
+    let view2 = OptionalResp::decode(brand(frame2.as_bytes())).unwrap();
     assert_eq!(view2.status(), 0x05);
     assert_eq!(view2.result_code(), 0);
     assert_eq!(view2.opt_data(), None);
@@ -525,7 +535,7 @@ fn optional_display() {
         .unwrap()
         .finish();
 
-    let view = OptionalScalarReq::decode(frame.as_bytes()).unwrap();
+    let view = OptionalScalarReq::decode(brand(frame.as_bytes())).unwrap();
     let output = format!("{}", view);
     assert!(output.contains("OptionalScalarReq"));
     assert!(output.contains("required_id"));
@@ -558,7 +568,7 @@ fn aligned_field_with_padding_needed() {
     assert_eq!(frame.header(), b"ABCDE");
     assert_eq!(frame.value(), 0xDEADBEEF);
 
-    let view = AlignedReq::decode(frame.as_bytes()).unwrap();
+    let view = AlignedReq::decode(brand(frame.as_bytes())).unwrap();
     assert_eq!(view.header(), b"ABCDE");
     assert_eq!(view.value(), 0xDEADBEEF);
 }
@@ -577,7 +587,7 @@ fn aligned_field_already_aligned() {
     assert_eq!(frame.header(), b"ABCD");
     assert_eq!(frame.value(), 0x12345678);
 
-    let view = AlignedReq::decode(frame.as_bytes()).unwrap();
+    let view = AlignedReq::decode(brand(frame.as_bytes())).unwrap();
     assert_eq!(view.header(), b"ABCD");
     assert_eq!(view.value(), 0x12345678);
 }
@@ -606,7 +616,7 @@ fn align_8_with_padding() {
     assert_eq!(frame.prefix(), b"ABC");
     assert_eq!(frame.timestamp(), 0x0123456789ABCDEF);
 
-    let view = Aligned8Req::decode(frame.as_bytes()).unwrap();
+    let view = Aligned8Req::decode(brand(frame.as_bytes())).unwrap();
     assert_eq!(view.prefix(), b"ABC");
     assert_eq!(view.timestamp(), 0x0123456789ABCDEF);
 }
@@ -645,7 +655,7 @@ fn multiple_aligned_fields() {
     assert_eq!(frame.extra(), b"hello");
     assert_eq!(frame.checksum(), 0xABCD1234);
 
-    let view = MultiAlignReq::decode(frame.as_bytes()).unwrap();
+    let view = MultiAlignReq::decode(brand(frame.as_bytes())).unwrap();
     assert_eq!(view.tag(), b"XYZ");
     assert_eq!(view.count(), 100);
     assert_eq!(view.extra(), b"hello");
@@ -681,7 +691,7 @@ fn optional_aligned_present() {
     assert_eq!(frame.opt_value(), Some(42));
     assert_eq!(frame.suffix(), b"end");
 
-    let view = OptAlignReq::decode(frame.as_bytes()).unwrap();
+    let view = OptAlignReq::decode(brand(frame.as_bytes())).unwrap();
     assert_eq!(view.prefix(), b"AB");
     assert_eq!(view.opt_value(), Some(42));
     assert_eq!(view.suffix(), b"end");
@@ -703,7 +713,7 @@ fn optional_aligned_absent_skip_ahead() {
     assert_eq!(frame.opt_value(), None);
     assert_eq!(frame.suffix(), b"end");
 
-    let view = OptAlignReq::decode(frame.as_bytes()).unwrap();
+    let view = OptAlignReq::decode(brand(frame.as_bytes())).unwrap();
     assert_eq!(view.prefix(), b"AB");
     assert_eq!(view.opt_value(), None);
     assert_eq!(view.suffix(), b"end");
@@ -749,7 +759,7 @@ fn fixed_array_round_trip() {
     assert_eq!(frame.payload(), b"test data");
 
     // Decode
-    let view = FixedArrayReq::decode(frame.as_bytes()).unwrap();
+    let view = FixedArrayReq::decode(brand(frame.as_bytes())).unwrap();
     assert_eq!(view.nonce(), &nonce);
     assert_eq!(view.payload(), b"test data");
 }
@@ -766,7 +776,7 @@ fn fixed_array_wrong_length_rejected() {
         .finish()
         .unwrap();
 
-    let err = FixedArrayReq::decode(msg).unwrap_err();
+    let err = FixedArrayReq::decode(brand(msg)).unwrap_err();
     assert!(matches!(
         err,
         azihsm_fw_ddi_tbor::DecodeError::InvalidFixedLength { .. }
@@ -797,7 +807,7 @@ fn len_constraint_valid() {
     assert_eq!(frame.tag(), b"hello");
     assert_eq!(frame.data(), b"world");
 
-    let view = ConstrainedReq::decode(frame.as_bytes()).unwrap();
+    let view = ConstrainedReq::decode(brand(frame.as_bytes())).unwrap();
     assert_eq!(view.tag(), b"hello");
     assert_eq!(view.data(), b"world");
 }
@@ -836,7 +846,7 @@ fn len_constraint_decode_too_short() {
         .finish()
         .unwrap();
 
-    let err = ConstrainedReq::decode(msg).unwrap_err();
+    let err = ConstrainedReq::decode(brand(msg)).unwrap_err();
     assert!(matches!(
         err,
         azihsm_fw_ddi_tbor::DecodeError::InvalidFixedLength { .. }
@@ -859,7 +869,7 @@ fn all_optional_immediate_finish() {
     assert_eq!(frame.opt_a(), None);
     assert_eq!(frame.opt_b(), None);
 
-    let view = AllOptReq::decode(frame.as_bytes()).unwrap();
+    let view = AllOptReq::decode(brand(frame.as_bytes())).unwrap();
     assert_eq!(view.opt_a(), None);
     assert_eq!(view.opt_b(), None);
 }
@@ -902,7 +912,7 @@ fn derive_sealed_key_round_trip() {
     assert_eq!(frame.session(), azihsm_fw_ddi_tbor_api::SessionId(5));
     assert_eq!(frame.key_blob(), blob);
 
-    let view = SealedKeyReq::decode(frame.as_bytes()).unwrap();
+    let view = SealedKeyReq::decode(brand(frame.as_bytes())).unwrap();
     assert_eq!(view.session(), azihsm_fw_ddi_tbor_api::SessionId(5));
     assert_eq!(view.key_blob(), blob);
 }
@@ -929,8 +939,8 @@ fn optional_fixed_array_present() {
 
     assert_eq!(frame.opt_nonce(), Some(&nonce));
 
-    let view = OptFixedArrayReq::decode(frame.as_bytes()).unwrap();
-    assert_eq!(view.opt_nonce(), Some(&nonce));
+    let view = OptFixedArrayReq::decode(brand(frame.as_bytes())).unwrap();
+    assert!(view.opt_nonce().is_some_and(|d| **d == nonce));
 }
 
 #[test]
@@ -944,7 +954,7 @@ fn optional_fixed_array_absent() {
 
     assert_eq!(frame.opt_nonce(), None);
 
-    let view = OptFixedArrayReq::decode(frame.as_bytes()).unwrap();
+    let view = OptFixedArrayReq::decode(brand(frame.as_bytes())).unwrap();
     assert_eq!(view.opt_nonce(), None);
 }
 
@@ -1028,7 +1038,7 @@ fn derive_response_wrong_toc_count() {
         .unwrap();
 
     // DeviceInfoResp expects 2 TOC entries, not 3.
-    let err = DeviceInfoResp::decode(msg).unwrap_err();
+    let err = DeviceInfoResp::decode(brand(msg)).unwrap_err();
     assert!(matches!(
         err,
         azihsm_fw_ddi_tbor::DecodeError::MessageTruncated { .. }
@@ -1070,7 +1080,7 @@ fn include_group_encode_decode() {
         .finish();
 
     // Verify via raw core decoder.
-    let raw = azihsm_fw_ddi_tbor::RequestView::parse(frame.as_bytes()).unwrap();
+    let raw = azihsm_fw_ddi_tbor::RequestView::parse(brand(frame.as_bytes())).unwrap();
     assert_eq!(raw.opcode(), 0x70);
     assert_eq!(raw.toc_count(), 4);
     assert!(matches!(
@@ -1141,7 +1151,7 @@ fn nested_include_encode_decode() {
         .finish();
 
     // Wire: flat 5 TOC entries + 7 bytes data
-    let raw = azihsm_fw_ddi_tbor::RequestView::parse(frame.as_bytes()).unwrap();
+    let raw = azihsm_fw_ddi_tbor::RequestView::parse(brand(frame.as_bytes())).unwrap();
     assert_eq!(raw.opcode(), 0x71);
     assert_eq!(raw.toc_count(), 5);
     assert!(matches!(
@@ -1197,7 +1207,7 @@ fn tbor_request_trait_decode() {
         .unwrap()
         .finish();
 
-    let view = <GetCertificateReq as TborRequest>::decode(frame.as_bytes()).unwrap();
+    let view = <GetCertificateReq as TborRequest>::decode(brand(frame.as_bytes())).unwrap();
     assert_eq!(view.slot_id(), 3);
     assert_eq!(view.cert_id(), 1);
 }
@@ -1215,11 +1225,11 @@ fn trait_based_dispatch() {
         .finish();
 
     let wire = frame.as_bytes();
-    let raw = azihsm_fw_ddi_tbor::RequestView::parse(wire).unwrap();
+    let raw = azihsm_fw_ddi_tbor::RequestView::parse(brand(wire)).unwrap();
 
     let result = match raw.opcode() {
         GetCertificateReq::OPCODE => {
-            let view = GetCertificateReq::decode(wire).unwrap();
+            let view = GetCertificateReq::decode(brand(wire)).unwrap();
             assert_eq!(view.slot_id(), 5);
             Ok("get_cert")
         }

--- a/fw/core/ddi/tbor/api/tests/derive_tests.rs
+++ b/fw/core/ddi/tbor/api/tests/derive_tests.rs
@@ -1238,3 +1238,41 @@ fn trait_based_dispatch() {
     };
     assert_eq!(result, Ok("get_cert"));
 }
+
+// ── ViewMut with mixed scalar + mutable-buffer fields ──────────────────
+//
+// Regression guard for codegen_view_mut: `Uint32`/`Uint64` are
+// data-section types and participate in the `split_at_mut` chain, but
+// the destructured `ViewMut` field type is `u32`/`u64`. The codegen
+// must convert the split slice to the numeric value at struct-init
+// time, not pass the slice through (which would not type-check).
+#[tbor(opcode = 0x42)]
+pub struct MixedMutableReq<'a> {
+    pub epoch: u32,
+    pub serial: u64,
+    #[tbor(max_len = 32, mutable)]
+    pub payload: &'a [u8],
+}
+
+#[test]
+fn decode_mut_with_uint32_uint64_siblings() {
+    let mut buf = [0u8; 256];
+    let frame = MixedMutableReq::encode(&mut buf)
+        .unwrap()
+        .epoch(0xCAFEBABE)
+        .unwrap()
+        .serial(0x0011_2233_4455_6677)
+        .unwrap()
+        .payload(b"hello-payload")
+        .unwrap()
+        .finish();
+
+    let frame_len = frame.len();
+    // SAFETY: test-only branding of a heap-resident buffer; see
+    // module-level brand() helper.
+    let wire_mut: &mut DmaBuf = unsafe { DmaBuf::from_raw_mut(&mut buf[..frame_len]) };
+    let view = MixedMutableReq::decode_mut(wire_mut).unwrap();
+    assert_eq!(view.epoch, 0xCAFEBABE);
+    assert_eq!(view.serial, 0x0011_2233_4455_6677);
+    assert_eq!(&**view.payload, b"hello-payload");
+}

--- a/fw/core/ddi/tbor/codec/src/decode.rs
+++ b/fw/core/ddi/tbor/codec/src/decode.rs
@@ -6,10 +6,12 @@
 //! `RequestView` and `ResponseView` borrow the input buffer and provide
 //! infallible accessor methods after a single upfront validation pass.
 
+use azihsm_fw_hsm_pal_traits::DmaBuf;
+
 use crate::error::DecodeError;
 use crate::toc::*;
 
-// ── RequestView ────────────────────────────────────────────────────────
+// ── RequestView ───────────────────────────────────────────────────────
 
 /// Zero-copy view over a TBOR request message.
 ///
@@ -17,7 +19,7 @@ use crate::toc::*;
 /// The view borrows the input buffer for the lifetime `'a`.
 #[derive(Debug)]
 pub struct RequestView<'a> {
-    buf: &'a [u8],
+    buf: &'a DmaBuf,
 }
 
 impl<'a> RequestView<'a> {
@@ -31,7 +33,7 @@ impl<'a> RequestView<'a> {
     /// - Fixed-size types have correct lengths (uint32=4, uint64=8)
     ///
     /// Reserved bits are silently ignored per spec.
-    pub fn parse(buf: &'a [u8]) -> Result<Self, DecodeError> {
+    pub fn parse(buf: &'a DmaBuf) -> Result<Self, DecodeError> {
         // Minimum: 4-byte header + 1 TOC entry = 8 bytes.
         if buf.len() < REQ_HEADER_LEN + 4 {
             return Err(DecodeError::BufferTooShort {
@@ -60,10 +62,7 @@ impl<'a> RequestView<'a> {
         // Validate all known offset/length TOC entries.
         validate_toc_entries(buf, REQ_HEADER_LEN, toc_count, data_size)?;
 
-        // Pre-slice to exact message bounds.
-        Ok(Self {
-            buf: &buf[..buf.len()],
-        })
+        Ok(Self { buf })
     }
 
     /// Protocol version.
@@ -110,7 +109,7 @@ impl<'a> RequestView<'a> {
 
     /// The raw message bytes.
     #[inline]
-    pub fn as_bytes(&self) -> &'a [u8] {
+    pub fn as_bytes(&self) -> &'a DmaBuf {
         self.buf
     }
 
@@ -135,7 +134,7 @@ impl<'a> RequestView<'a> {
 
     /// The raw variable-length data section.
     #[inline]
-    pub fn data_section(&self) -> &'a [u8] {
+    pub fn data_section(&self) -> &'a DmaBuf {
         &self.buf[self.data_start()..]
     }
 }
@@ -147,7 +146,7 @@ impl<'a> RequestView<'a> {
 /// After [`parse()`](Self::parse) succeeds, all accessors are infallible.
 #[derive(Debug)]
 pub struct ResponseView<'a> {
-    buf: &'a [u8],
+    buf: &'a DmaBuf,
 }
 
 impl<'a> ResponseView<'a> {
@@ -161,7 +160,7 @@ impl<'a> ResponseView<'a> {
     /// - Fixed-size types have correct lengths (uint32=4, uint64=8)
     ///
     /// Reserved bits are silently ignored per spec.
-    pub fn parse(buf: &'a [u8]) -> Result<Self, DecodeError> {
+    pub fn parse(buf: &'a DmaBuf) -> Result<Self, DecodeError> {
         // Minimum: 8-byte header + 1 TOC entry = 12 bytes.
         if buf.len() < RESP_HEADER_LEN + 4 {
             return Err(DecodeError::BufferTooShort {
@@ -189,9 +188,7 @@ impl<'a> ResponseView<'a> {
 
         validate_toc_entries(buf, RESP_HEADER_LEN, toc_count, data_size)?;
 
-        Ok(Self {
-            buf: &buf[..buf.len()],
-        })
+        Ok(Self { buf })
     }
 
     /// Protocol version.
@@ -250,7 +247,7 @@ impl<'a> ResponseView<'a> {
 
     /// The raw message bytes.
     #[inline]
-    pub fn as_bytes(&self) -> &'a [u8] {
+    pub fn as_bytes(&self) -> &'a DmaBuf {
         self.buf
     }
 
@@ -275,7 +272,7 @@ impl<'a> ResponseView<'a> {
 
     /// The raw variable-length data section.
     #[inline]
-    pub fn data_section(&self) -> &'a [u8] {
+    pub fn data_section(&self) -> &'a DmaBuf {
         &self.buf[self.data_start()..]
     }
 }

--- a/fw/core/ddi/tbor/codec/src/error.rs
+++ b/fw/core/ddi/tbor/codec/src/error.rs
@@ -49,6 +49,15 @@ pub enum DecodeError {
     /// specific FW error instead of silently accepting the placeholder
     /// error envelope or failing with a generic `UnexpectedTocType`.
     FwError(u32),
+    /// Data-section TOC offsets are not monotonically non-decreasing
+    /// across consecutive fields. Raised only by the `decode_mut`
+    /// fast path, which performs a single forward `split_at_mut`
+    /// pass and therefore requires field regions to be ordered by
+    /// offset (the canonical encoder always produces this layout).
+    NonMonotonicTocOffsets {
+        prev_entry: usize,
+        curr_entry: usize,
+    },
 }
 
 /// Wire-level encode errors.
@@ -159,6 +168,16 @@ impl core::fmt::Display for DecodeError {
             }
             Self::FwError(status) => {
                 write!(f, "firmware returned error status 0x{:08X}", status)
+            }
+            Self::NonMonotonicTocOffsets {
+                prev_entry,
+                curr_entry,
+            } => {
+                write!(
+                    f,
+                    "non-monotonic TOC offsets between entries {} and {}",
+                    prev_entry, curr_entry
+                )
             }
         }
     }

--- a/fw/core/ddi/tbor/codec/src/lib.rs
+++ b/fw/core/ddi/tbor/codec/src/lib.rs
@@ -32,6 +32,8 @@
 
 #![no_std]
 
+use azihsm_fw_hsm_pal_traits::DmaBuf;
+
 /// Zero-copy decoders for request and response messages.
 pub mod decode;
 /// Fluent encoders for request and response messages.
@@ -79,7 +81,7 @@ pub trait TborRequest {
     ///
     /// Returns `Err` if the buffer is malformed, the opcode doesn't match,
     /// or the TOC structure doesn't match the schema.
-    fn decode(buf: &[u8]) -> Result<Self::View<'_>, DecodeError>;
+    fn decode(buf: &DmaBuf) -> Result<Self::View<'_>, DecodeError>;
 }
 
 /// Trait implemented by all `#[tbor(response)]` response types.
@@ -90,5 +92,5 @@ pub trait TborResponse {
     type View<'a>;
 
     /// Decode and validate a wire buffer into a typed view.
-    fn decode(buf: &[u8]) -> Result<Self::View<'_>, DecodeError>;
+    fn decode(buf: &DmaBuf) -> Result<Self::View<'_>, DecodeError>;
 }

--- a/fw/core/ddi/tbor/codec/src/toc.rs
+++ b/fw/core/ddi/tbor/codec/src/toc.rs
@@ -6,6 +6,8 @@
 //! Each TOC entry is a 32-bit little-endian word. The top 6 bits identify
 //! the entry type; the remaining 26 bits carry a type-specific encoding.
 
+use azihsm_fw_hsm_pal_traits::DmaBuf;
+
 /// Maximum number of TOC entries per message.
 pub const MAX_TOC_ENTRIES: usize = 32;
 
@@ -79,7 +81,7 @@ pub enum TocEntry<'a> {
     /// Key identifier (type 1, inline 16-bit).
     KeyId(u16),
     /// Sealed key blob (type 2, offset/length).
-    SealedKey(&'a [u8]),
+    SealedKey(&'a DmaBuf),
     /// 8-bit unsigned integer (type 3, inline 8-bit).
     Uint8(u8),
     /// 16-bit unsigned integer (type 4, inline 16-bit).
@@ -89,11 +91,11 @@ pub enum TocEntry<'a> {
     /// 64-bit unsigned integer (type 6, offset/length, len must be 8).
     Uint64(u64),
     /// Variable-length byte buffer (type 7, offset/length).
-    Buffer(&'a [u8]),
+    Buffer(&'a DmaBuf),
     /// Absent value (type 8). Used as a placeholder for optional fields.
     None,
     /// Alignment padding (type 9, offset/length). Data bytes are ignored.
-    Padding(&'a [u8]),
+    Padding(&'a DmaBuf),
     /// Unrecognized entry type (10–63). Preserved for forward compatibility.
     Unknown { entry_type: u8, raw_bits: u32 },
 }
@@ -160,14 +162,17 @@ pub fn read_toc_inline_u16(buf: &[u8], header_len: usize, toc_index: usize) -> u
     raw_toc_inline_u16(read_toc_word(buf, header_len, toc_index))
 }
 
-/// Read a buffer slice from the data section via an offset/length TOC entry.
+/// Read a DMA-branded buffer slice from the data section via an
+/// offset/length TOC entry.  Sub-slicing a `&DmaBuf` preserves the
+/// brand so handlers can hand the result directly to PAL crypto
+/// primitives without copying.
 #[inline(always)]
 pub fn read_toc_buffer(
-    buf: &[u8],
+    buf: &DmaBuf,
     header_len: usize,
     toc_index: usize,
     data_start: usize,
-) -> &[u8] {
+) -> &DmaBuf {
     let word = read_toc_word(buf, header_len, toc_index);
     let length = raw_toc_length(word);
     let offset = raw_toc_offset(word);
@@ -177,16 +182,27 @@ pub fn read_toc_buffer(
 /// Read a uint32 from the data section via an offset/length TOC entry.
 #[inline(always)]
 pub fn read_toc_uint32(buf: &[u8], header_len: usize, toc_index: usize, data_start: usize) -> u32 {
-    let slice = read_toc_buffer(buf, header_len, toc_index, data_start);
-    u32::from_le_bytes([slice[0], slice[1], slice[2], slice[3]])
+    let word = read_toc_word(buf, header_len, toc_index);
+    let offset = raw_toc_offset(word);
+    let base = data_start + offset;
+    u32::from_le_bytes([buf[base], buf[base + 1], buf[base + 2], buf[base + 3]])
 }
 
 /// Read a uint64 from the data section via an offset/length TOC entry.
 #[inline(always)]
 pub fn read_toc_uint64(buf: &[u8], header_len: usize, toc_index: usize, data_start: usize) -> u64 {
-    let slice = read_toc_buffer(buf, header_len, toc_index, data_start);
+    let word = read_toc_word(buf, header_len, toc_index);
+    let offset = raw_toc_offset(word);
+    let base = data_start + offset;
     u64::from_le_bytes([
-        slice[0], slice[1], slice[2], slice[3], slice[4], slice[5], slice[6], slice[7],
+        buf[base],
+        buf[base + 1],
+        buf[base + 2],
+        buf[base + 3],
+        buf[base + 4],
+        buf[base + 5],
+        buf[base + 6],
+        buf[base + 7],
     ])
 }
 
@@ -234,7 +250,7 @@ pub fn write_toc_word(buf: &mut [u8], header_len: usize, toc_index: usize, word:
 /// (header, TOC count, offset/length bounds). It is used by `RequestView`
 /// and `ResponseView` iterators.
 pub fn decode_toc_entry<'a>(
-    buf: &'a [u8],
+    buf: &'a DmaBuf,
     header_len: usize,
     toc_index: usize,
     data_start: usize,

--- a/fw/core/ddi/tbor/codec/tests/core_tests.rs
+++ b/fw/core/ddi/tbor/codec/tests/core_tests.rs
@@ -5,10 +5,20 @@
 //! edge cases, and error handling.
 
 #![allow(clippy::unwrap_used)]
+#![allow(unsafe_code)]
 
 use std::vec::Vec;
 
 use azihsm_fw_ddi_tbor::*;
+use azihsm_fw_hsm_pal_traits::DmaBuf;
+
+// SAFETY: test-only branding. Host-side tests have no real DMA engine,
+// so the DMA-reachability contract is moot; the brand is needed purely
+// to satisfy the `RequestView::parse` / `ResponseView::parse` signatures.
+fn brand(b: &[u8]) -> &DmaBuf {
+    // SAFETY: see fn-level doc comment.
+    unsafe { DmaBuf::from_raw(b) }
+}
 
 // ── Spec Worked Example 1: Simple Request ──────────────────────────────
 
@@ -25,7 +35,7 @@ fn spec_example1_request_decode() {
         0x48, 0x65, 0x6C, 0x6C, 0x6F, // data: "Hello"
     ];
 
-    let view = RequestView::parse(wire).unwrap();
+    let view = RequestView::parse(brand(wire)).unwrap();
     assert_eq!(view.version(), 0x01);
     assert_eq!(view.opcode(), 0x0A);
     assert_eq!(view.toc_count(), 2);
@@ -55,7 +65,7 @@ fn spec_example1_request_encode() {
 
     assert_eq!(msg.len(), 17);
 
-    let view = RequestView::parse(msg).unwrap();
+    let view = RequestView::parse(brand(msg)).unwrap();
     assert_eq!(view.opcode(), 0x0A);
     assert_eq!(view.toc_count(), 2);
 
@@ -83,7 +93,7 @@ fn spec_example2_response_decode() {
         0x4F, 0x4B, 0x21, // data: "OK!"
     ];
 
-    let view = ResponseView::parse(wire).unwrap();
+    let view = ResponseView::parse(brand(wire)).unwrap();
     assert_eq!(view.version(), 0x01);
     assert!(view.fips_approved());
     assert_eq!(view.status(), 0);
@@ -107,7 +117,7 @@ fn spec_example2_response_encode() {
 
     assert_eq!(msg.len(), 15);
 
-    let view = ResponseView::parse(msg).unwrap();
+    let view = ResponseView::parse(brand(msg)).unwrap();
     assert!(view.fips_approved());
     assert_eq!(view.status(), 0);
     match view.toc_entry(0) {
@@ -127,7 +137,7 @@ fn round_trip_session_id() {
         .finish()
         .unwrap();
 
-    let view = RequestView::parse(msg).unwrap();
+    let view = RequestView::parse(brand(msg)).unwrap();
     match view.toc_entry(0) {
         TocEntry::SessionId(v) => assert_eq!(v, 0x1234),
         other => panic!("expected SessionId, got {:?}", other),
@@ -143,7 +153,7 @@ fn round_trip_key_id() {
         .finish()
         .unwrap();
 
-    let view = RequestView::parse(msg).unwrap();
+    let view = RequestView::parse(brand(msg)).unwrap();
     match view.toc_entry(0) {
         TocEntry::KeyId(v) => assert_eq!(v, 0xABCD),
         other => panic!("expected KeyId, got {:?}", other),
@@ -159,7 +169,7 @@ fn round_trip_uint8() {
         .finish()
         .unwrap();
 
-    let view = RequestView::parse(msg).unwrap();
+    let view = RequestView::parse(brand(msg)).unwrap();
     match view.toc_entry(0) {
         TocEntry::Uint8(v) => assert_eq!(v, 0xFF),
         other => panic!("expected Uint8, got {:?}", other),
@@ -175,7 +185,7 @@ fn round_trip_uint16() {
         .finish()
         .unwrap();
 
-    let view = RequestView::parse(msg).unwrap();
+    let view = RequestView::parse(brand(msg)).unwrap();
     match view.toc_entry(0) {
         TocEntry::Uint16(v) => assert_eq!(v, 0xBEEF),
         other => panic!("expected Uint16, got {:?}", other),
@@ -191,7 +201,7 @@ fn round_trip_uint32() {
         .finish()
         .unwrap();
 
-    let view = RequestView::parse(msg).unwrap();
+    let view = RequestView::parse(brand(msg)).unwrap();
     match view.toc_entry(0) {
         TocEntry::Uint32(v) => assert_eq!(v, 0xDEADBEEF),
         other => panic!("expected Uint32, got {:?}", other),
@@ -207,7 +217,7 @@ fn round_trip_uint64() {
         .finish()
         .unwrap();
 
-    let view = RequestView::parse(msg).unwrap();
+    let view = RequestView::parse(brand(msg)).unwrap();
     match view.toc_entry(0) {
         TocEntry::Uint64(v) => assert_eq!(v, 0x0123456789ABCDEF),
         other => panic!("expected Uint64, got {:?}", other),
@@ -224,7 +234,7 @@ fn round_trip_sealed_key() {
         .finish()
         .unwrap();
 
-    let view = RequestView::parse(msg).unwrap();
+    let view = RequestView::parse(brand(msg)).unwrap();
     match view.toc_entry(0) {
         TocEntry::SealedKey(data) => assert_eq!(data, key_data),
         other => panic!("expected SealedKey, got {:?}", other),
@@ -248,7 +258,7 @@ fn round_trip_multiple_entries() {
         .finish()
         .unwrap();
 
-    let view = RequestView::parse(msg).unwrap();
+    let view = RequestView::parse(brand(msg)).unwrap();
     assert_eq!(view.toc_count(), 5);
 
     match view.toc_entry(0) {
@@ -286,7 +296,7 @@ fn round_trip_response_with_status_and_data() {
         .finish()
         .unwrap();
 
-    let view = ResponseView::parse(msg).unwrap();
+    let view = ResponseView::parse(brand(msg)).unwrap();
     assert_eq!(view.status(), 0x00000005);
     assert!(!view.fips_approved());
     assert_eq!(view.toc_count(), 2);
@@ -313,7 +323,7 @@ fn decode_minimum_request() {
         .unwrap();
 
     assert_eq!(msg.len(), 8);
-    let view = RequestView::parse(msg).unwrap();
+    let view = RequestView::parse(brand(msg)).unwrap();
     assert_eq!(view.toc_count(), 1);
     assert_eq!(view.data_size(), 0);
 }
@@ -328,7 +338,7 @@ fn decode_minimum_response() {
         .unwrap();
 
     assert_eq!(msg.len(), 12);
-    let view = ResponseView::parse(msg).unwrap();
+    let view = ResponseView::parse(brand(msg)).unwrap();
     assert_eq!(view.toc_count(), 1);
     assert_eq!(view.data_size(), 0);
 }
@@ -342,7 +352,7 @@ fn empty_buffer_field() {
         .finish()
         .unwrap();
 
-    let view = RequestView::parse(msg).unwrap();
+    let view = RequestView::parse(brand(msg)).unwrap();
     match view.toc_entry(0) {
         TocEntry::Buffer(data) => assert_eq!(data.len(), 0),
         other => panic!("expected Buffer, got {:?}", other),
@@ -358,7 +368,7 @@ fn max_toc_entries() {
     }
     let msg = enc.finish().unwrap();
 
-    let view = RequestView::parse(msg).unwrap();
+    let view = RequestView::parse(brand(msg)).unwrap();
     assert_eq!(view.toc_count(), 32);
     for i in 0..32 {
         match view.toc_entry(i) {
@@ -373,14 +383,14 @@ fn max_toc_entries() {
 #[test]
 fn decode_buffer_too_short() {
     let wire = [0x01, 0x00];
-    let err = RequestView::parse(&wire).unwrap_err();
+    let err = RequestView::parse(brand(&wire)).unwrap_err();
     assert!(matches!(err, DecodeError::BufferTooShort { .. }));
 }
 
 #[test]
 fn decode_unsupported_version() {
     let wire = [0x02, 0x00, 0x00, 0x0A, 0x0C, 0x00, 0x00, 0x00];
-    let err = RequestView::parse(&wire).unwrap_err();
+    let err = RequestView::parse(brand(&wire)).unwrap_err();
     assert!(matches!(err, DecodeError::UnsupportedVersion(0x02)));
 }
 
@@ -390,7 +400,7 @@ fn decode_message_truncated() {
         0x01, 0x00, 0x01, 0x0A, // 2 TOC entries expected
         0x00, 0x00, 0x00, 0x2B, // only 1 present
     ];
-    let err = RequestView::parse(&wire).unwrap_err();
+    let err = RequestView::parse(brand(&wire)).unwrap_err();
     assert!(matches!(err, DecodeError::MessageTruncated { .. }));
 }
 
@@ -400,7 +410,7 @@ fn decode_offset_out_of_bounds() {
     let word = toc::build_toc_offset_len(TocType::Buffer as u8, 127, 0);
     let wb = word.to_be_bytes();
     let wire = [0x01, 0x00, 0x00, 0x0A, wb[0], wb[1], wb[2], wb[3]];
-    let err = RequestView::parse(&wire).unwrap_err();
+    let err = RequestView::parse(brand(&wire)).unwrap_err();
     assert!(matches!(err, DecodeError::OffsetLengthOutOfBounds { .. }));
 }
 
@@ -413,7 +423,7 @@ fn decode_invalid_uint32_length() {
         0x01, 0x00, 0x00, 0x0A, wb[0], wb[1], wb[2], wb[3], 0x00, 0x00,
         0x00, // 3 bytes of data
     ];
-    let err = RequestView::parse(&wire).unwrap_err();
+    let err = RequestView::parse(brand(&wire)).unwrap_err();
     assert!(matches!(
         err,
         DecodeError::InvalidFixedLength {
@@ -458,7 +468,7 @@ fn decode_unknown_toc_type_preserved() {
         0x01, 0x00, 0x01, 0x0A, uw[0], uw[1], uw[2], uw[3], kw[0], kw[1], kw[2], kw[3],
     ];
 
-    let view = RequestView::parse(&wire).unwrap();
+    let view = RequestView::parse(brand(&wire)).unwrap();
     assert_eq!(view.toc_count(), 2);
 
     match view.toc_entry(0) {
@@ -486,7 +496,7 @@ fn decode_nonzero_reserved_bits_accepted() {
     wire[1] = 0xFF; // reserved byte
     wire[2] |= 0xE0; // upper 3 reserved bits of byte 2
 
-    let view = RequestView::parse(&wire).unwrap();
+    let view = RequestView::parse(brand(&wire)).unwrap();
     assert_eq!(view.toc_count(), 1);
     match view.toc_entry(0) {
         TocEntry::Uint8(v) => assert_eq!(v, 1),
@@ -509,7 +519,7 @@ fn toc_iter_yields_all_entries() {
         .finish()
         .unwrap();
 
-    let view = RequestView::parse(msg).unwrap();
+    let view = RequestView::parse(brand(msg)).unwrap();
     let entries: Vec<_> = view.toc_iter().collect();
     assert_eq!(entries.len(), 3);
     assert!(matches!(entries[0], TocEntry::SessionId(1)));
@@ -530,7 +540,7 @@ fn display_request_view() {
         .finish()
         .unwrap();
 
-    let view = RequestView::parse(msg).unwrap();
+    let view = RequestView::parse(brand(msg)).unwrap();
     let output = std::format!("{}", view);
     assert!(output.contains("Request v1"));
     assert!(output.contains("opcode=0x0A"));
@@ -547,7 +557,7 @@ fn display_response_view() {
         .finish()
         .unwrap();
 
-    let view = ResponseView::parse(msg).unwrap();
+    let view = ResponseView::parse(brand(msg)).unwrap();
     let output = std::format!("{}", view);
     assert!(output.contains("Response v1"));
     assert!(output.contains("Success"));
@@ -564,7 +574,7 @@ fn hex_dump_format() {
         .finish()
         .unwrap();
 
-    let view = RequestView::parse(msg).unwrap();
+    let view = RequestView::parse(brand(msg)).unwrap();
     let output = std::format!("{:#}", view);
     assert!(output.contains("0000"));
 }
@@ -580,7 +590,7 @@ fn round_trip_none_entry() {
         .finish()
         .unwrap();
 
-    let view = RequestView::parse(msg).unwrap();
+    let view = RequestView::parse(brand(msg)).unwrap();
     assert_eq!(view.toc_count(), 1);
     assert!(matches!(view.toc_entry(0), TocEntry::None));
 }
@@ -598,7 +608,7 @@ fn none_mixed_with_other_entries() {
         .finish()
         .unwrap();
 
-    let view = RequestView::parse(msg).unwrap();
+    let view = RequestView::parse(brand(msg)).unwrap();
     assert_eq!(view.toc_count(), 3);
     assert!(matches!(view.toc_entry(0), TocEntry::SessionId(42)));
     assert!(matches!(view.toc_entry(1), TocEntry::None));
@@ -619,7 +629,7 @@ fn none_response_round_trip() {
         .finish()
         .unwrap();
 
-    let view = ResponseView::parse(msg).unwrap();
+    let view = ResponseView::parse(brand(msg)).unwrap();
     assert_eq!(view.toc_count(), 2);
     assert!(matches!(view.toc_entry(0), TocEntry::None));
     assert!(matches!(view.toc_entry(1), TocEntry::Uint8(7)));
@@ -638,7 +648,7 @@ fn all_none_entries() {
         .finish()
         .unwrap();
 
-    let view = RequestView::parse(msg).unwrap();
+    let view = RequestView::parse(brand(msg)).unwrap();
     assert_eq!(view.toc_count(), 3);
     assert_eq!(view.data_size(), 0);
     for i in 0..3 {
@@ -655,7 +665,7 @@ fn none_entry_nonzero_payload_rejected() {
         0x01, 0x00, 0x00, 0x0A, // header
         bw[0], bw[1], bw[2], bw[3],
     ];
-    let err = RequestView::parse(&wire).unwrap_err();
+    let err = RequestView::parse(brand(&wire)).unwrap_err();
     assert!(matches!(
         err,
         DecodeError::InvalidNonePayload { entry_index: 0, .. }
@@ -673,7 +683,7 @@ fn none_display() {
         .finish()
         .unwrap();
 
-    let view = RequestView::parse(msg).unwrap();
+    let view = RequestView::parse(brand(msg)).unwrap();
     let output = std::format!("{}", view);
     assert!(output.contains("none"));
 }
@@ -693,7 +703,7 @@ fn round_trip_padding_entry() {
         .finish()
         .unwrap();
 
-    let view = RequestView::parse(msg).unwrap();
+    let view = RequestView::parse(brand(msg)).unwrap();
     assert_eq!(view.toc_count(), 3);
     match view.toc_entry(1) {
         TocEntry::Padding(p) => assert_eq!(p.len(), 2),
@@ -712,7 +722,7 @@ fn zero_length_padding_round_trip() {
         .finish()
         .unwrap();
 
-    let view = RequestView::parse(msg).unwrap();
+    let view = RequestView::parse(brand(msg)).unwrap();
     match view.toc_entry(0) {
         TocEntry::Padding(p) => assert_eq!(p.len(), 0),
         other => panic!("expected Padding, got {:?}", other),
@@ -741,7 +751,7 @@ fn request_exact_max_data_succeeds() {
         .finish()
         .unwrap();
 
-    let view = RequestView::parse(msg).unwrap();
+    let view = RequestView::parse(brand(msg)).unwrap();
     match view.toc_entry(0) {
         TocEntry::Buffer(b) => assert_eq!(b.len(), 8191),
         other => panic!("expected Buffer, got {:?}", other),
@@ -763,7 +773,7 @@ fn response_reserved_bits_accepted() {
     wire[2] = 0xFF; // reserved byte
     wire[3] |= 0xE0; // upper 3 reserved bits of toc_count byte
 
-    let view = ResponseView::parse(&wire).unwrap();
+    let view = ResponseView::parse(brand(&wire)).unwrap();
     assert_eq!(view.toc_count(), 1);
 }
 
@@ -778,7 +788,7 @@ fn response_toc_iter() {
         .finish()
         .unwrap();
 
-    let view = ResponseView::parse(msg).unwrap();
+    let view = ResponseView::parse(brand(msg)).unwrap();
     let entries: Vec<_> = view.toc_iter().collect();
     assert_eq!(entries.len(), 2);
     assert!(matches!(entries[0], TocEntry::SessionId(10)));
@@ -798,7 +808,7 @@ fn display_padding_and_sealed_key() {
         .finish()
         .unwrap();
 
-    let view = RequestView::parse(msg).unwrap();
+    let view = RequestView::parse(brand(msg)).unwrap();
     let output = std::format!("{}", view);
     assert!(output.contains("sealed_key"));
     assert!(output.contains("padding"));
@@ -813,7 +823,7 @@ fn empty_sealed_key_round_trip() {
         .finish()
         .unwrap();
 
-    let view = RequestView::parse(msg).unwrap();
+    let view = RequestView::parse(brand(msg)).unwrap();
     match view.toc_entry(0) {
         TocEntry::SealedKey(data) => assert_eq!(data.len(), 0),
         other => panic!("expected SealedKey, got {:?}", other),
@@ -827,7 +837,7 @@ fn decode_invalid_uint64_length() {
     let wire = [
         0x01, 0x00, 0x00, 0x0A, wb[0], wb[1], wb[2], wb[3], 0x00, 0x00, 0x00, 0x00,
     ];
-    let err = RequestView::parse(&wire).unwrap_err();
+    let err = RequestView::parse(brand(&wire)).unwrap_err();
     assert!(matches!(
         err,
         DecodeError::InvalidFixedLength {

--- a/fw/core/ddi/tbor/derive/src/codegen_enc.rs
+++ b/fw/core/ddi/tbor/derive/src/codegen_enc.rs
@@ -822,7 +822,19 @@ fn gen_frame_accessor(field: &SchemaField, toc_index: usize, schema: &Schema) ->
                     quote! { azihsm_fw_ddi_tbor::toc::read_toc_uint64(self.buf, #header_len, #toc_index, #ds) }
                 }
                 _ => {
-                    quote! { azihsm_fw_ddi_tbor::toc::read_toc_buffer(self.buf, #header_len, #toc_index, #ds) }
+                    // Frame.buf is `&[u8]` (the encoder's raw backing
+                    // buffer is not DMA-branded), so inline the slice
+                    // extraction rather than calling the codec's
+                    // `&DmaBuf`-typed `read_toc_buffer`.
+                    quote! {
+                        {
+                            let word = azihsm_fw_ddi_tbor::toc::read_toc_word(self.buf, #header_len, #toc_index);
+                            let length = azihsm_fw_ddi_tbor::toc::raw_toc_length(word);
+                            let offset = azihsm_fw_ddi_tbor::toc::raw_toc_offset(word);
+                            let ds = #ds;
+                            &self.buf[ds + offset..ds + offset + length]
+                        }
+                    }
                 }
             }
         }

--- a/fw/core/ddi/tbor/derive/src/codegen_view.rs
+++ b/fw/core/ddi/tbor/derive/src/codegen_view.rs
@@ -65,13 +65,13 @@ pub fn gen_view(schema: &Schema) -> TokenStream {
         #[doc = concat!("[`", stringify!(#name), "::decode()`].")]
         #[derive(Debug)]
         #vis struct #view_name #view_lifetime {
-            buf: &'a [u8],
+            buf: &'a azihsm_fw_hsm_pal_traits::DmaBuf,
         }
 
         impl<'a> #view_name<'a> {
             /// Construct from a validated buffer. Not public — use
             #[doc = concat!("[`", stringify!(#name), "::decode()`] instead.")]
-            fn from_validated(buf: &'a [u8]) -> Self {
+            fn from_validated(buf: &'a azihsm_fw_hsm_pal_traits::DmaBuf) -> Self {
                 Self { buf }
             }
 
@@ -85,7 +85,7 @@ pub fn gen_view(schema: &Schema) -> TokenStream {
 
             /// The raw message bytes.
             #[inline]
-            pub fn as_bytes(&self) -> &'a [u8] { self.buf }
+            pub fn as_bytes(&self) -> &'a azihsm_fw_hsm_pal_traits::DmaBuf { self.buf }
 
             #response_accessors
 
@@ -140,32 +140,8 @@ fn gen_accessor(
         WireType::SessionId => quote! { azihsm_fw_ddi_tbor_api::SessionId },
         WireType::KeyId => quote! { azihsm_fw_ddi_tbor_api::KeyId },
         WireType::Buffer | WireType::SealedKey => {
-            if let Some(n) = field.fixed_len {
-                quote! { &'a [u8; #n] }
-            } else {
-                quote! { &'a [u8] }
-            }
+            quote! { &'a azihsm_fw_hsm_pal_traits::DmaBuf }
         }
-    };
-
-    // For fixed arrays, convert the slice to an array ref.
-    let body = if let Some(n) = field.fixed_len {
-        let base_body = body;
-        quote! {
-            {
-                let slice = #base_body;
-                // Length was validated during decode; this branch is unreachable.
-                match <&[u8; #n]>::try_from(slice) {
-                    Ok(arr) => arr,
-                    Err(_) => {
-                        static ZERO: [u8; #n] = [0u8; #n];
-                        &ZERO
-                    }
-                }
-            }
-        }
-    } else {
-        body
     };
 
     if field.optional {

--- a/fw/core/ddi/tbor/derive/src/codegen_view_mut.rs
+++ b/fw/core/ddi/tbor/derive/src/codegen_view_mut.rs
@@ -1,0 +1,294 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Code generation for the `ViewMut` type (zero-copy mutable view).
+//!
+//! Emitted only when the schema has at least one `#[tbor(mutable)]`
+//! field. Unlike `View` (a wrapper that hands out borrows lazily via
+//! methods), `ViewMut` is a **destructured** struct: at construction
+//! time `decode_mut` performs a pipelined `split_at_mut` of the
+//! parent buffer and exposes each field as a directly-accessible
+//! public field at the parent buffer's lifetime `'a`.
+//!
+//! * Mutable-marked buffer/sealed_key fields: `&'a mut DmaBuf`.
+//! * Non-mutable buffer/sealed_key fields: `&'a DmaBuf` (reborrowed
+//!   from a split-off mutable region; all field borrows are disjoint).
+//! * Scalar fields (`u8`/`u16`/`u32`/`u64`/`SessionId`/`KeyId`): owned
+//!   by value, copied out of the TOC during construction.
+//!
+//! ## Layout invariants
+//!
+//! The destructured construction performs a single forward
+//! `split_at_mut` chain over the data section. This requires
+//! data-section field offsets to be monotonically non-decreasing in
+//! schema (TOC) order. The canonical encoder always produces this
+//! layout; any wire message that violates the invariant is rejected
+//! with [`azihsm_fw_ddi_tbor::DecodeError::NonMonotonicTocOffsets`].
+//!
+//! Schemas using `#[tbor(align = N)]` (which inject Padding TOC
+//! entries between fields) are currently unsupported in combination
+//! with `#[tbor(mutable)]`. None of the current targets need both.
+
+use proc_macro2::TokenStream;
+use quote::format_ident;
+use quote::quote;
+
+use crate::schema::*;
+
+/// Generate the `FooViewMut<'a>` struct definition.
+///
+/// Returns an empty `TokenStream` for schemas with no
+/// `#[tbor(mutable)]` fields; the caller skips emission in that case.
+pub fn gen_view_mut(schema: &Schema) -> TokenStream {
+    if !schema.has_mutable_fields() {
+        return TokenStream::new();
+    }
+
+    let vis = &schema.vis;
+    let view_mut_name = format_ident!("{}ViewMut", schema.name);
+    let name = &schema.name;
+
+    let struct_fields = schema.fields.iter().map(|field| {
+        let fname = &field.name;
+        let ty = field_type_tokens(field);
+        quote! { pub #fname: #ty, }
+    });
+
+    quote! {
+        /// Destructured zero-copy view over an encoded message. All
+        /// fields are pre-split from the parent `&mut DmaBuf` during
+        #[doc = concat!("[`", stringify!(#name), "::decode_mut()`],")]
+        /// so mutable-marked and shared-marked fields can be held
+        /// simultaneously without borrow conflicts.
+        #[derive(Debug)]
+        #vis struct #view_mut_name<'a> {
+            #(#struct_fields)*
+        }
+    }
+}
+
+/// Generate the body of the `decode_mut` function for the given
+/// schema, or `None` when the schema has no `#[tbor(mutable)]` field.
+///
+/// The body validates the wire message via the standard validation
+/// pass (using a shared reborrow of the input `&mut DmaBuf`), then
+/// drops that borrow, performs a pipelined `split_at_mut` of the
+/// data section, and constructs the `ViewMut` struct with all
+/// per-field borrows pre-split.
+pub fn gen_decode_mut_body(schema: &Schema) -> Option<TokenStream> {
+    if !schema.has_mutable_fields() {
+        return None;
+    }
+
+    let view_mut_name = format_ident!("{}ViewMut", schema.name);
+    let header_len = match schema.kind {
+        MessageKind::Request { .. } => quote! { azihsm_fw_ddi_tbor::REQ_HEADER_LEN },
+        MessageKind::Response => quote! { azihsm_fw_ddi_tbor::RESP_HEADER_LEN },
+        MessageKind::Fields => unreachable!(),
+    };
+
+    let layout = TocLayout::compute(&schema.fields);
+
+    // Data-section fields (Buffer/SealedKey) in schema (TOC) order.
+    // Today only Buffer/SealedKey can be `mutable`; other
+    // data-section types (Uint32/Uint64) are admitted as shared
+    // fields if present, since they still occupy data-section space.
+    let data_fields: Vec<(usize, &SchemaField)> = schema
+        .fields
+        .iter()
+        .enumerate()
+        .filter(|(_, f)| f.wire_type.uses_data_section())
+        .map(|(i, f)| (layout.field_toc_indices[i], f))
+        .collect();
+
+    // Scalar (inline-encoded) field captures: read directly via a
+    // transient shared reborrow.
+    let scalar_captures: Vec<TokenStream> = schema
+        .fields
+        .iter()
+        .enumerate()
+        .filter_map(|(i, field)| {
+            let toc_idx = layout.field_toc_indices[i];
+            let var = format_ident!("__scalar_{}", field.name);
+            let body = match field.wire_type {
+                WireType::Uint8 => Some(quote! {
+                    azihsm_fw_ddi_tbor::toc::read_toc_inline_u8(&*buf, #header_len, #toc_idx)
+                }),
+                WireType::Uint16 => Some(quote! {
+                    azihsm_fw_ddi_tbor::toc::read_toc_inline_u16(&*buf, #header_len, #toc_idx)
+                }),
+                WireType::SessionId => Some(quote! {
+                    azihsm_fw_ddi_tbor_api::SessionId(
+                        azihsm_fw_ddi_tbor::toc::read_toc_inline_u16(&*buf, #header_len, #toc_idx)
+                    )
+                }),
+                WireType::KeyId => Some(quote! {
+                    azihsm_fw_ddi_tbor_api::KeyId(
+                        azihsm_fw_ddi_tbor::toc::read_toc_inline_u16(&*buf, #header_len, #toc_idx)
+                    )
+                }),
+                _ => None,
+            }?;
+            Some(quote! { let #var = #body; })
+        })
+        .collect();
+
+    // (offset, length) captures for each data-section field.
+    let offset_captures: Vec<TokenStream> = data_fields
+        .iter()
+        .map(|(toc_idx, field)| {
+            let off_var = format_ident!("__off_{}", field.name);
+            let len_var = format_ident!("__len_{}", field.name);
+            quote! {
+                let (#off_var, #len_var): (usize, usize) = {
+                    let __word = azihsm_fw_ddi_tbor::toc::read_toc_word(
+                        &*buf, #header_len, #toc_idx
+                    );
+                    (
+                        azihsm_fw_ddi_tbor::toc::raw_toc_offset(__word),
+                        azihsm_fw_ddi_tbor::toc::raw_toc_length(__word),
+                    )
+                };
+            }
+        })
+        .collect();
+
+    // Monotonic-offset check across consecutive data-section fields.
+    let monotonic_checks: Vec<TokenStream> = data_fields
+        .windows(2)
+        .map(|w| {
+            let prev_toc = w[0].0;
+            let curr_toc = w[1].0;
+            let prev_off = format_ident!("__off_{}", w[0].1.name);
+            let prev_len = format_ident!("__len_{}", w[0].1.name);
+            let curr_off = format_ident!("__off_{}", w[1].1.name);
+            quote! {
+                if #prev_off.checked_add(#prev_len).is_none_or(|end| end > #curr_off) {
+                    return Err(azihsm_fw_ddi_tbor::DecodeError::NonMonotonicTocOffsets {
+                        prev_entry: #prev_toc,
+                        curr_entry: #curr_toc,
+                    });
+                }
+            }
+        })
+        .collect();
+
+    // Pipelined `split_at_mut` over the data section.
+    let mut split_chain: Vec<TokenStream> = Vec::new();
+    let mut prev_off: Option<syn::Ident> = None;
+    let mut prev_len: Option<syn::Ident> = None;
+    for (_, field) in &data_fields {
+        let off_var = format_ident!("__off_{}", field.name);
+        let len_var = format_ident!("__len_{}", field.name);
+        let field_var = format_ident!("__field_{}", field.name);
+        let gap_expr = if let (Some(po), Some(pl)) = (&prev_off, &prev_len) {
+            quote! { #off_var - (#po + #pl) }
+        } else {
+            quote! { #off_var }
+        };
+        split_chain.push(quote! {
+            // Peel the inter-field gap and discard it, then peel the
+            // field's bytes. `__rest` is shadowed in each iteration.
+            let (__gap, __rest_next) = __rest.split_at_mut(#gap_expr);
+            let _ = __gap;
+            let (#field_var, __rest) = __rest_next.split_at_mut(#len_var);
+        });
+        prev_off = Some(off_var);
+        prev_len = Some(len_var);
+    }
+    // The last `let __rest = ...` shadowed is unused; silence warnings.
+    split_chain.push(quote! { let _ = __rest; });
+
+    // Reborrow non-mutable data fields as shared.
+    let shared_reborrows: Vec<TokenStream> = data_fields
+        .iter()
+        .filter(|(_, f)| !f.mutable)
+        .map(|(_, field)| {
+            let field_var = format_ident!("__field_{}", field.name);
+            quote! {
+                let #field_var: &azihsm_fw_hsm_pal_traits::DmaBuf = &*#field_var;
+            }
+        })
+        .collect();
+
+    // Final struct construction.
+    let struct_init: Vec<TokenStream> = schema
+        .fields
+        .iter()
+        .map(|field| {
+            let fname = &field.name;
+            let value = match field.wire_type {
+                WireType::Buffer | WireType::SealedKey | WireType::Uint32 | WireType::Uint64 => {
+                    let v = format_ident!("__field_{}", field.name);
+                    // Uint32/Uint64 currently fall through to the
+                    // split-chain (they're data-section types). No
+                    // current schema with `mutable` uses them as
+                    // siblings, so emit a compile-time guard.
+                    quote! { #v }
+                }
+                _ => {
+                    let v = format_ident!("__scalar_{}", field.name);
+                    quote! { #v }
+                }
+            };
+            quote! { #fname: #value, }
+        })
+        .collect();
+
+    let validation = crate::codegen_view::gen_validation_standalone(schema);
+
+    let data_start_expr = quote! {
+        {
+            let toc_count_idx: usize = if #header_len == 4 { 2 } else { 3 };
+            let toc_count = ((&*buf)[toc_count_idx] & 0x1F) as usize + 1;
+            #header_len + toc_count * 4
+        }
+    };
+
+    Some(quote! {
+        // ── Phase 1a: validation pass (shared reborrow).
+        {
+            let buf: &azihsm_fw_hsm_pal_traits::DmaBuf = &*buf;
+            #validation
+        }
+
+        // ── Phase 1b: scalar reads, offset captures, monotonic check.
+        // Each helper uses a transient shared reborrow of `&*buf`;
+        // none outlive their statement, so the outer `&mut` borrow
+        // remains usable for Phase 2 below.
+        #(#scalar_captures)*
+        #(#offset_captures)*
+        #(#monotonic_checks)*
+        let __data_start: usize = #data_start_expr;
+
+        // ── Phase 2: pipelined split_at_mut over the parent buffer.
+        let (__prefix, __rest) = buf.split_at_mut(__data_start);
+        let _ = __prefix;
+        #(#split_chain)*
+
+        // ── Phase 3: reborrow shared data fields, then build struct.
+        #(#shared_reborrows)*
+        Ok(#view_mut_name {
+            #(#struct_init)*
+        })
+    })
+}
+
+/// Compute the field type for the `ViewMut` struct.
+fn field_type_tokens(field: &SchemaField) -> TokenStream {
+    match field.wire_type {
+        WireType::Uint8 => quote! { u8 },
+        WireType::Uint16 => quote! { u16 },
+        WireType::Uint32 => quote! { u32 },
+        WireType::Uint64 => quote! { u64 },
+        WireType::SessionId => quote! { azihsm_fw_ddi_tbor_api::SessionId },
+        WireType::KeyId => quote! { azihsm_fw_ddi_tbor_api::KeyId },
+        WireType::Buffer | WireType::SealedKey => {
+            if field.mutable {
+                quote! { &'a mut azihsm_fw_hsm_pal_traits::DmaBuf }
+            } else {
+                quote! { &'a azihsm_fw_hsm_pal_traits::DmaBuf }
+            }
+        }
+    }
+}

--- a/fw/core/ddi/tbor/derive/src/codegen_view_mut.rs
+++ b/fw/core/ddi/tbor/derive/src/codegen_view_mut.rs
@@ -218,13 +218,38 @@ pub fn gen_decode_mut_body(schema: &Schema) -> Option<TokenStream> {
         .map(|field| {
             let fname = &field.name;
             let value = match field.wire_type {
-                WireType::Buffer | WireType::SealedKey | WireType::Uint32 | WireType::Uint64 => {
+                WireType::Buffer | WireType::SealedKey => {
                     let v = format_ident!("__field_{}", field.name);
-                    // Uint32/Uint64 currently fall through to the
-                    // split-chain (they're data-section types). No
-                    // current schema with `mutable` uses them as
-                    // siblings, so emit a compile-time guard.
                     quote! { #v }
+                }
+                // Uint32/Uint64 occupy data-section bytes (so they
+                // participate in the split-chain) but the destructured
+                // `ViewMut` field type is `u32`/`u64`. Convert the
+                // split slice to the numeric value; length was already
+                // validated to be exactly 4/8 bytes during Phase 1a.
+                WireType::Uint32 => {
+                    let v = format_ident!("__field_{}", field.name);
+                    quote! {
+                        {
+                            let __bytes: &[u8] = &**#v;
+                            u32::from_le_bytes(
+                                <[u8; 4]>::try_from(&__bytes[..4])
+                                    .expect("validated length == 4"),
+                            )
+                        }
+                    }
+                }
+                WireType::Uint64 => {
+                    let v = format_ident!("__field_{}", field.name);
+                    quote! {
+                        {
+                            let __bytes: &[u8] = &**#v;
+                            u64::from_le_bytes(
+                                <[u8; 8]>::try_from(&__bytes[..8])
+                                    .expect("validated length == 8"),
+                            )
+                        }
+                    }
                 }
                 _ => {
                     let v = format_ident!("__scalar_{}", field.name);

--- a/fw/core/ddi/tbor/derive/src/lib.rs
+++ b/fw/core/ddi/tbor/derive/src/lib.rs
@@ -12,6 +12,7 @@ mod codegen_enc;
 mod codegen_enum;
 mod codegen_fields;
 mod codegen_view;
+mod codegen_view_mut;
 mod schema;
 
 use proc_macro::TokenStream;
@@ -59,21 +60,38 @@ fn on_struct(
     }
 
     let view_tokens = codegen_view::gen_view(&schema);
+    let view_mut_tokens = codegen_view_mut::gen_view_mut(&schema);
     let enc_tokens = codegen_enc::gen_encoder_and_frame(&schema);
 
     let name = &schema.name;
     let vis = &schema.vis;
     let view_name = format_ident!("{}View", schema.name);
+    let view_mut_name = format_ident!("{}ViewMut", schema.name);
     let enc_name = format_ident!("{}Enc", schema.name);
     let s0 = format_ident!("{}S0", schema.name);
 
     let validation = codegen_view::gen_validation_standalone(&schema);
 
     let decode_fn = quote! {
-        pub fn decode(buf: &[u8]) -> Result<#view_name<'_>, azihsm_fw_ddi_tbor::DecodeError> {
+        pub fn decode(buf: &azihsm_fw_hsm_pal_traits::DmaBuf) -> Result<#view_name<'_>, azihsm_fw_ddi_tbor::DecodeError> {
             #validation
             Ok(#view_name::from_validated(buf))
         }
+    };
+
+    // `decode_mut` is emitted only when the schema opts in via
+    // `#[tbor(mutable)]` on at least one field. The body is built by
+    // `codegen_view_mut`: a full validation pass via a shared
+    // reborrow, then a pipelined `split_at_mut` that hands out
+    // per-field borrows at the parent buffer's lifetime.
+    let decode_mut_fn = if let Some(body) = codegen_view_mut::gen_decode_mut_body(&schema) {
+        quote! {
+            pub fn decode_mut(buf: &mut azihsm_fw_hsm_pal_traits::DmaBuf) -> Result<#view_mut_name<'_>, azihsm_fw_ddi_tbor::DecodeError> {
+                #body
+            }
+        }
+    } else {
+        quote! {}
     };
 
     let encode_fn = match schema.kind {
@@ -99,7 +117,7 @@ fn on_struct(
                 const OPCODE: u8 = #opcode;
                 type View<'a> = #view_name<'a>;
 
-                fn decode(buf: &[u8]) -> Result<Self::View<'_>, azihsm_fw_ddi_tbor::DecodeError> {
+                fn decode(buf: &azihsm_fw_hsm_pal_traits::DmaBuf) -> Result<Self::View<'_>, azihsm_fw_ddi_tbor::DecodeError> {
                     #name::decode(buf)
                 }
             }
@@ -108,7 +126,7 @@ fn on_struct(
             impl azihsm_fw_ddi_tbor::TborResponse for #name {
                 type View<'a> = #view_name<'a>;
 
-                fn decode(buf: &[u8]) -> Result<Self::View<'_>, azihsm_fw_ddi_tbor::DecodeError> {
+                fn decode(buf: &azihsm_fw_hsm_pal_traits::DmaBuf) -> Result<Self::View<'_>, azihsm_fw_ddi_tbor::DecodeError> {
                     #name::decode(buf)
                 }
             }
@@ -123,12 +141,14 @@ fn on_struct(
             /// Maximum possible encoded message size for this type.
             pub const MAX_ENCODED_SIZE: usize = #max_encoded_size;
             #decode_fn
+            #decode_mut_fn
             #encode_fn
         }
 
         #trait_impl
 
         #view_tokens
+        #view_mut_tokens
         #enc_tokens
     })
 }

--- a/fw/core/ddi/tbor/derive/src/schema.rs
+++ b/fw/core/ddi/tbor/derive/src/schema.rs
@@ -34,6 +34,12 @@ pub struct SchemaField {
     pub max_len: usize,
     /// If this field is a `#[tbor(include)]`, the type name of the group.
     pub include_group: Option<syn::Ident>,
+    /// Field opts into the mutable view (`#[tbor(mutable)]`). Only
+    /// permitted on non-optional `Buffer` / `SealedKey` fields. When
+    /// any field in the schema is `mutable`, the codegen emits a
+    /// parallel `decode_mut` entry point and a `ViewMut` accessor
+    /// type whose mut-marked fields hand out `&mut DmaBuf`.
+    pub mutable: bool,
 }
 
 /// The wire encoding for a field.
@@ -178,6 +184,13 @@ impl Schema {
             }
         }
         size
+    }
+
+    /// Returns `true` iff any field opts into `#[tbor(mutable)]`.
+    /// When `true`, the derive emits a parallel `decode_mut` entry
+    /// point and a `ViewMut` accessor type.
+    pub fn has_mutable_fields(&self) -> bool {
+        self.fields.iter().any(|f| f.mutable)
     }
 
     /// Compute MAX_ENCODED_SIZE (header + TOC + worst-case data).
@@ -326,6 +339,7 @@ fn parse_single_field(field: &syn::Field) -> syn::Result<SchemaField> {
             min_len: 0,
             max_len: 0,
             include_group: Some(group_name),
+            mutable: false,
         });
     }
 
@@ -377,6 +391,27 @@ fn parse_single_field(field: &syn::Field) -> syn::Result<SchemaField> {
         ));
     }
 
+    // Parse `#[tbor(mutable)]`. Only allowed on non-optional
+    // Buffer/SealedKey fields: scalar accessors return-by-value (no
+    // mut surface needed) and optional fields would require
+    // generating a fallible mut accessor that has no current
+    // motivating handler.
+    let mutable = parse_mutable_attr(&field.attrs)?;
+    if mutable {
+        if !matches!(wire_type, WireType::Buffer | WireType::SealedKey) {
+            return Err(syn::Error::new(
+                field.ident.as_ref().unwrap().span(),
+                "#[tbor(mutable)] can only be applied to buffer or sealed_key fields",
+            ));
+        }
+        if optional {
+            return Err(syn::Error::new(
+                field.ident.as_ref().unwrap().span(),
+                "#[tbor(mutable)] cannot be applied to optional fields",
+            ));
+        }
+    }
+
     Ok(SchemaField {
         name,
         wire_type,
@@ -387,7 +422,31 @@ fn parse_single_field(field: &syn::Field) -> syn::Result<SchemaField> {
         min_len,
         max_len,
         include_group: None,
+        mutable,
     })
+}
+
+/// Returns `true` iff the field carries `#[tbor(mutable)]`.
+fn parse_mutable_attr(attrs: &[syn::Attribute]) -> syn::Result<bool> {
+    let mut found = false;
+    for attr in attrs {
+        if attr.path().is_ident("tbor") {
+            attr.parse_nested_meta(|meta| {
+                if meta.path.is_ident("mutable") {
+                    found = true;
+                } else if meta.path.is_ident("align")
+                    || meta.path.is_ident("min_len")
+                    || meta.path.is_ident("max_len")
+                    || meta.path.is_ident("len")
+                {
+                    let _value = meta.value()?;
+                    let _lit: syn::LitInt = _value.parse()?;
+                }
+                Ok(())
+            })?;
+        }
+    }
+    Ok(found)
 }
 
 /// Parse `opcode = 0x09`, `response`, or `fields` from the attribute token stream.
@@ -463,6 +522,8 @@ fn infer_wire_type(ty: &syn::Type, attrs: &[syn::Attribute]) -> syn::Result<Wire
                 {
                     let _value = meta.value()?;
                     let _lit: syn::LitInt = _value.parse()?;
+                } else if meta.path.is_ident("mutable") {
+                    // Consumed by `parse_mutable_attr`.
                 }
                 Ok(())
             })?;
@@ -552,6 +613,8 @@ fn is_include_field(attrs: &[syn::Attribute]) -> bool {
                     let _value = meta.value()?;
                     let _lit: syn::LitInt = _value.parse()?;
                 }
+                // `mutable` is a bare keyword; just consume.
+                let _ = meta.path.is_ident("mutable");
                 Ok(())
             });
             if found {
@@ -588,6 +651,8 @@ fn parse_align_attr(attrs: &[syn::Attribute]) -> syn::Result<usize> {
                 {
                     let _value = meta.value()?;
                     let _lit: syn::LitInt = _value.parse()?;
+                } else if meta.path.is_ident("mutable") {
+                    // Bare keyword; consumed by `parse_mutable_attr`.
                 }
                 Ok(())
             })?;
@@ -627,6 +692,8 @@ fn parse_len_constraints(attrs: &[syn::Attribute]) -> syn::Result<(usize, usize)
                 } else if meta.path.is_ident("align") {
                     let _value = meta.value()?;
                     let _lit: syn::LitInt = _value.parse()?;
+                } else if meta.path.is_ident("mutable") {
+                    // Bare keyword; consumed by `parse_mutable_attr`.
                 }
                 // Wire type idents (uint8, buffer, etc.) have no value — just consume.
                 Ok(())

--- a/fw/core/ddi/tbor/types/Cargo.toml
+++ b/fw/core/ddi/tbor/types/Cargo.toml
@@ -14,6 +14,7 @@ doctest = false
 [dependencies]
 azihsm_fw_ddi_tbor.workspace = true
 azihsm_fw_ddi_tbor_api.workspace = true
+azihsm_fw_hsm_pal_traits.workspace = true
 open-enum.workspace = true
 zerocopy.workspace = true
 

--- a/fw/core/ddi/tbor/types/src/change_psk.rs
+++ b/fw/core/ddi/tbor/types/src/change_psk.rs
@@ -91,7 +91,9 @@ pub struct TborChangePskReq<'a> {
     /// session's `param_key`.  See module docs for AAD layout.
     ///
     /// Marked `#[tbor(mutable)]` so the FW handler can AEAD-open the
-    /// envelope in place — see [`TborChangePskReqViewMut::psk_envelope_mut`].
+    /// envelope in place — the field is exposed as the
+    /// `psk_envelope` member of the generated
+    /// `TborChangePskReqViewMut` destructured view.
     #[tbor(max_len = 160, mutable)]
     pub psk_envelope: &'a [u8],
 }

--- a/fw/core/ddi/tbor/types/src/change_psk.rs
+++ b/fw/core/ddi/tbor/types/src/change_psk.rs
@@ -89,7 +89,10 @@ pub struct TborChangePskReq<'a> {
 
     /// AEAD envelope wrapping the 32-byte new PSK under the active
     /// session's `param_key`.  See module docs for AAD layout.
-    #[tbor(max_len = 160)]
+    ///
+    /// Marked `#[tbor(mutable)]` so the FW handler can AEAD-open the
+    /// envelope in place — see [`TborChangePskReqViewMut::psk_envelope_mut`].
+    #[tbor(max_len = 160, mutable)]
     pub psk_envelope: &'a [u8],
 }
 

--- a/fw/core/ddi/tbor/types/src/open_session_finish.rs
+++ b/fw/core/ddi/tbor/types/src/open_session_finish.rs
@@ -47,7 +47,10 @@ pub struct TborOpenSessionFinishReq<'a> {
     /// [`SEED_ENVELOPE_LEN`] for the exact layout.  The FW recovers
     /// the seed and uses it as the KBKDF context that produces
     /// `BK_SESSION` (the wrap key for the response `bmk_session`).
-    #[tbor(len = 68)]
+    ///
+    /// Marked `#[tbor(mutable)]` so the FW handler can AEAD-open the
+    /// envelope in place — see [`TborOpenSessionFinishReqViewMut::seed_envelope_mut`].
+    #[tbor(len = 68, mutable)]
     pub seed_envelope: &'a [u8],
 }
 

--- a/fw/core/ddi/tbor/types/src/open_session_finish.rs
+++ b/fw/core/ddi/tbor/types/src/open_session_finish.rs
@@ -49,7 +49,9 @@ pub struct TborOpenSessionFinishReq<'a> {
     /// `BK_SESSION` (the wrap key for the response `bmk_session`).
     ///
     /// Marked `#[tbor(mutable)]` so the FW handler can AEAD-open the
-    /// envelope in place — see [`TborOpenSessionFinishReqViewMut::seed_envelope_mut`].
+    /// envelope in place — the field is exposed as the
+    /// `seed_envelope` member of the generated
+    /// `TborOpenSessionFinishReqViewMut` destructured view.
     #[tbor(len = 68, mutable)]
     pub seed_envelope: &'a [u8],
 }

--- a/fw/core/ddi/tbor/types/src/part_init.rs
+++ b/fw/core/ddi/tbor/types/src/part_init.rs
@@ -111,9 +111,14 @@ pub struct TborPartInitReq<'a> {
     pub session_id: u16,
 
     /// AEAD-GCM envelope wrapping the 32-byte `mach_seed` plaintext
-    /// under the active session's `param_key`.  See
-    /// [`build_part_init_mach_seed_aad`] for the AAD layout.
-    #[tbor(max_len = 160)]
+    /// under the active session's `param_key`.  AAD layout is pinned
+    /// to `label(17) ‖ session_id(2 LE) ‖ rsv0(13)` —
+    /// see [`PART_INIT_MACH_SEED_AAD_LABEL`] and
+    /// [`PART_INIT_MACH_SEED_AAD_LEN`].
+    ///
+    /// Marked `#[tbor(mutable)]` so the FW handler can AEAD-open the
+    /// envelope in place — see [`TborPartInitReqViewMut::mach_seed_envelope_mut`].
+    #[tbor(max_len = 160, mutable)]
     pub mach_seed_envelope: &'a [u8],
 
     /// Caller-asserted [`PartPolicy`] blob bound into the partition's
@@ -146,24 +151,6 @@ pub struct TborPartInitResp<'a> {
     pub pta_report: &'a [u8],
 }
 
-/// Builds the 32-byte AEAD AAD bound into a `PartInit` `mach_seed`
-/// envelope.
-///
-/// Layout: [`PART_INIT_MACH_SEED_AAD_LABEL`] (17 B) `‖ session_id`
-/// (2 B LE) `‖ rsv0` (13 B).
-///
-/// This is the **single source of truth** for the AAD layout — both
-/// the firmware handler and the host wrapper construct envelopes via
-/// this helper to guarantee they stay byte-for-byte identical.
-#[must_use]
-pub fn build_part_init_mach_seed_aad(session_id: u16) -> [u8; PART_INIT_MACH_SEED_AAD_LEN] {
-    let mut aad = [0u8; PART_INIT_MACH_SEED_AAD_LEN];
-    aad[..PART_INIT_MACH_SEED_AAD_LABEL.len()].copy_from_slice(PART_INIT_MACH_SEED_AAD_LABEL);
-    aad[PART_INIT_MACH_SEED_AAD_LABEL.len()..PART_INIT_MACH_SEED_AAD_LABEL.len() + 2]
-        .copy_from_slice(&session_id.to_le_bytes());
-    aad
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -182,20 +169,5 @@ mod tests {
         // TBOR `MAX_DATA_SIZE` is 8191; our two response buffers must
         // sum to comfortably less than that.
         const { assert!(PTA_CSR_MAX_LEN + PTA_REPORT_MAX_LEN < 8191) };
-    }
-
-    #[test]
-    fn mach_seed_aad_layout() {
-        let aad = build_part_init_mach_seed_aad(0x1234);
-        assert_eq!(
-            &aad[..PART_INIT_MACH_SEED_AAD_LABEL.len()],
-            PART_INIT_MACH_SEED_AAD_LABEL
-        );
-        assert_eq!(
-            &aad[PART_INIT_MACH_SEED_AAD_LABEL.len()..PART_INIT_MACH_SEED_AAD_LABEL.len() + 2],
-            &[0x34, 0x12],
-        );
-        assert_eq!(aad.len(), PART_INIT_MACH_SEED_AAD_LEN);
-        assert_eq!(PART_INIT_MACH_SEED_AAD_LEN, 32);
     }
 }

--- a/fw/core/ddi/tbor/types/src/part_init.rs
+++ b/fw/core/ddi/tbor/types/src/part_init.rs
@@ -117,7 +117,9 @@ pub struct TborPartInitReq<'a> {
     /// [`PART_INIT_MACH_SEED_AAD_LEN`].
     ///
     /// Marked `#[tbor(mutable)]` so the FW handler can AEAD-open the
-    /// envelope in place — see [`TborPartInitReqViewMut::mach_seed_envelope_mut`].
+    /// envelope in place — the field is exposed as the
+    /// `mach_seed_envelope` member of the generated
+    /// `TborPartInitReqViewMut` destructured view.
     #[tbor(max_len = 160, mutable)]
     pub mach_seed_envelope: &'a [u8],
 

--- a/fw/core/lib/src/ddi/tbor/change_psk.rs
+++ b/fw/core/lib/src/ddi/tbor/change_psk.rs
@@ -22,7 +22,6 @@
 //! with `InvalidPermissions`.
 
 use azihsm_fw_core_crypto_aead_envelope::open as aead_open;
-use azihsm_fw_ddi_tbor::RequestView;
 use azihsm_fw_ddi_tbor_types::build_psk_change_aad;
 use azihsm_fw_ddi_tbor_types::TborChangePskReq;
 use azihsm_fw_ddi_tbor_types::TborChangePskResp;
@@ -33,7 +32,6 @@ use azihsm_fw_hsm_pal_traits::HsmError;
 use azihsm_fw_hsm_pal_traits::HsmIo;
 use azihsm_fw_hsm_pal_traits::HsmPal;
 use azihsm_fw_hsm_pal_traits::HsmResult;
-use azihsm_fw_hsm_pal_traits::HsmScopedAlloc;
 use azihsm_fw_hsm_pal_traits::HsmSessId;
 use azihsm_fw_hsm_pal_traits::SessionRole;
 use azihsm_fw_hsm_pal_traits::PSK_LEN;
@@ -47,17 +45,20 @@ const PSK_ID_CU: u8 = 1;
 pub(crate) async fn handle<'p, P: HsmPal>(
     pal: &'p P,
     io: &impl HsmIo,
-    view: &RequestView<'_>,
+    req_buf: &mut DmaBuf,
 ) -> HsmResult<&'p DmaBuf> {
-    let req = TborChangePskReq::decode(view.as_bytes())?;
-    let sess_id = HsmSessId::from(u16::from(req.session_id()));
-    let envelope = req.psk_envelope();
+    // `decode_mut` validates the wire frame and hands back a
+    // destructured view: scalar `session_id` by value, plus
+    // `psk_envelope` as `&mut DmaBuf` so `aead_open` can decrypt the
+    // envelope in place — no scratch copy.
+    let req = TborChangePskReq::decode_mut(req_buf)?;
+    let sess_id = HsmSessId::from(u16::from(req.session_id));
 
     // Target slot is implicit in the session role; no cross-role
     // rotation is permitted.
     let target_psk_id = target_psk_for_role(sess_id.role());
 
-    if envelope.is_empty() || envelope.len() > PSK_CHANGE_ENVELOPE_MAX_LEN {
+    if req.psk_envelope.is_empty() || req.psk_envelope.len() > PSK_CHANGE_ENVELOPE_MAX_LEN {
         return Err(HsmError::InvalidArg);
     }
 
@@ -70,15 +71,16 @@ pub(crate) async fn handle<'p, P: HsmPal>(
     // structurally impossible (HPKE-derived per-session `param_key`).
     pal.session_try_consume_psk_change(io, sess_id)?;
 
-    pal.alloc_scoped_async(io, async |alloc| {
+    pal.alloc_scoped_async(io, async |_alloc| {
         // Fetch the session's `param_key` schedule (the PAL hides the
         // session-blob layout from us).
         let param_key = pal.session_param_key(io, sess_id)?;
 
-        // AEAD-open the envelope in place.
-        let env_buf = alloc.dma_alloc(envelope.len())?;
-        env_buf.copy_from_slice(envelope);
-        let view = aead_open(pal, io, param_key, env_buf)
+        // AEAD-open the envelope **in place** on the inbound request
+        // buffer.  The destructured `req.psk_envelope` is a
+        // `&mut DmaBuf` carved by `decode_mut` from the same parent
+        // `req_buf`; no copy into a scratch buffer is needed.
+        let aead_view = aead_open(pal, io, param_key, req.psk_envelope)
             .await
             .map_err(|_| HsmError::AeadEnvelopeAuthFailed)?;
 
@@ -88,24 +90,23 @@ pub(crate) async fn handle<'p, P: HsmPal>(
         // `!=` is safe (no timing oracle on a secret).  A length
         // mismatch is a client encoding bug, not an auth failure, so
         // it surfaces as `InvalidArg`.
-        if view.aad.len() != PSK_CHANGE_AAD_LEN {
+        if aead_view.aad.len() != PSK_CHANGE_AAD_LEN {
             return Err(HsmError::InvalidArg);
         }
         let expected_aad = build_psk_change_aad(u16::from(sess_id));
-        let aad_bytes: &[u8] = view.aad;
+        let aad_bytes: &[u8] = aead_view.aad;
         if aad_bytes != expected_aad.as_slice() {
             return Err(HsmError::AeadEnvelopeAuthFailed);
         }
-        if view.payload.len() != PSK_LEN {
+        if aead_view.payload.len() != PSK_LEN {
             return Err(HsmError::InvalidArg);
         }
 
         // Persist the new PSK directly from the in-place envelope
         // view.  `part_psk_set` is synchronous and takes `&[u8]`, so
         // the borrow ends with the call — no need for a separate
-        // scratch buffer.  The envelope DmaBuf is zeroized by the
-        // scoped allocator on scope exit.
-        pal.part_psk_set(io, target_psk_id, view.payload)?;
+        // scratch buffer.
+        pal.part_psk_set(io, target_psk_id, aead_view.payload)?;
 
         encode_response(pal, io)
     })

--- a/fw/core/lib/src/ddi/tbor/close_session.rs
+++ b/fw/core/lib/src/ddi/tbor/close_session.rs
@@ -27,7 +27,6 @@
 //! in place** — track the gating issue in the PR description for
 //! #425.
 
-use azihsm_fw_ddi_tbor::RequestView;
 use azihsm_fw_ddi_tbor_types::TborCloseSessionReq;
 use azihsm_fw_ddi_tbor_types::TborCloseSessionResp;
 use azihsm_fw_hsm_pal_traits::DmaBuf;
@@ -43,9 +42,9 @@ use azihsm_fw_hsm_pal_traits::HsmSessId;
 pub(crate) async fn handle<'p, P: HsmPal>(
     pal: &'p P,
     io: &impl HsmIo,
-    view: &RequestView<'_>,
+    req_buf: &DmaBuf,
 ) -> HsmResult<&'p DmaBuf> {
-    let req = TborCloseSessionReq::decode(view.as_bytes())?;
+    let req = TborCloseSessionReq::decode(req_buf)?;
     let session_id: u16 = req.session_id().into();
     let id = HsmSessId::from(session_id);
     // SECURITY: This is a destructive operation gated only by

--- a/fw/core/lib/src/ddi/tbor/get_api_rev.rs
+++ b/fw/core/lib/src/ddi/tbor/get_api_rev.rs
@@ -9,7 +9,6 @@
 //! the request body is empty (the derive emits a synthetic `none`
 //! placeholder TOC entry), and the response carries `(min, max)`.
 
-use azihsm_fw_ddi_tbor::RequestView;
 use azihsm_fw_ddi_tbor_types::TborGetApiRevReq;
 use azihsm_fw_ddi_tbor_types::TborGetApiRevResp;
 use azihsm_fw_hsm_pal_traits::DmaBuf;
@@ -34,9 +33,9 @@ pub(crate) const MAX_PROTOCOL_VERSION: u8 = 1;
 pub(crate) fn handle<'p, P: HsmPal>(
     pal: &'p P,
     io: &impl HsmIo,
-    view: &RequestView<'_>,
+    req_buf: &DmaBuf,
 ) -> HsmResult<&'p DmaBuf> {
-    let _ = TborGetApiRevReq::decode(view.as_bytes())?;
+    let _ = TborGetApiRevReq::decode(req_buf)?;
     let resp = pal.dma_alloc_var(io, |buf| {
         let frame = TborGetApiRevResp::encode(buf, 0, false)?
             .min_protocol_version(MIN_PROTOCOL_VERSION)?

--- a/fw/core/lib/src/ddi/tbor/mod.rs
+++ b/fw/core/lib/src/ddi/tbor/mod.rs
@@ -104,7 +104,7 @@ pub(crate) mod opcode {
 pub(crate) async fn dispatch<'p, P: HsmPal>(
     pal: &'p P,
     io: &impl HsmIo,
-    view: &RequestView<'_>,
+    req_buf: &mut DmaBuf,
     opcode: u8,
     sqe_session_id: u16,
 ) -> HsmResult<&'p DmaBuf> {
@@ -115,49 +115,57 @@ pub(crate) async fn dispatch<'p, P: HsmPal>(
         return Err(HsmError::UnsupportedCmd);
     }
 
-    // SQE/body session-id cross-check: for every opcode whose
-    // `SessionCtrl` requires `id_valid = true` (close + in-session),
-    // the SQE-carried `session_id` MUST match the inline body
-    // `session_id` TOC entry.  Out-of-session opcodes do not carry a
-    // body session id, and `validate_tbor_session_flags` has already
-    // rejected the `id_valid = true` case for them upstream.
-    //
-    // This matches MBOR's `validate_session` (Rule 3): the audit
-    // trail / CQE always reflects the same slot the handler mutates.
-    if needs_session_id_cross_check(opcode) {
-        let body_sess_id = extract_session_id(view)?;
-        if u16::from(body_sess_id) != sqe_session_id {
-            return Err(HsmError::InvalidArg);
-        }
-    }
+    // Pre-dispatch gating work (session-id cross-check, default-PSK
+    // gate) runs against a short-lived shared reborrow of the parent
+    // mutable buffer. The reborrow drops at the end of this block,
+    // freeing `req_buf` for handlers that need `&mut DmaBuf`.
+    {
+        let view = RequestView::parse(&*req_buf)?;
 
-    // Default-PSK gate: applies only to in-session commands that are
-    // not on the allow-list.  Skipped for out-of-session opcodes.
-    //
-    // The role used for the gate is derived from the request's
-    // `session_id` TOC field (via [`HsmSessId::role`]).  This is the
-    // same source of truth each handler ultimately uses to fetch the
-    // session's `param_key`, so a client that forges a `session_id`
-    // they do not own gains nothing — the handler's crypto-layer
-    // authentication still rejects them.  When an outer
-    // authenticated-framing layer lands, the role source should
-    // switch to it; the gate's invariant ("the requested role's PSK
-    // must be rotated") remains the same.
-    if is_in_session(opcode) && !allowed_with_default_psk(opcode) {
-        let sess_id = extract_session_id(view)?;
-        let psk_id = psk_id_for_role(sess_id.role());
-        if pal.part_psk_is_default(io, psk_id)? {
-            return Err(HsmError::DefaultPskMustRotate);
+        // SQE/body session-id cross-check: for every opcode whose
+        // `SessionCtrl` requires `id_valid = true` (close + in-session),
+        // the SQE-carried `session_id` MUST match the inline body
+        // `session_id` TOC entry.  Out-of-session opcodes do not carry a
+        // body session id, and `validate_tbor_session_flags` has already
+        // rejected the `id_valid = true` case for them upstream.
+        //
+        // This matches MBOR's `validate_session` (Rule 3): the audit
+        // trail / CQE always reflects the same slot the handler mutates.
+        if needs_session_id_cross_check(opcode) {
+            let body_sess_id = extract_session_id(&view)?;
+            if u16::from(body_sess_id) != sqe_session_id {
+                return Err(HsmError::InvalidArg);
+            }
+        }
+
+        // Default-PSK gate: applies only to in-session commands that are
+        // not on the allow-list.  Skipped for out-of-session opcodes.
+        //
+        // The role used for the gate is derived from the request's
+        // `session_id` TOC field (via [`HsmSessId::role`]).  This is the
+        // same source of truth each handler ultimately uses to fetch the
+        // session's `param_key`, so a client that forges a `session_id`
+        // they do not own gains nothing — the handler's crypto-layer
+        // authentication still rejects them.  When an outer
+        // authenticated-framing layer lands, the role source should
+        // switch to it; the gate's invariant ("the requested role's PSK
+        // must be rotated") remains the same.
+        if is_in_session(opcode) && !allowed_with_default_psk(opcode) {
+            let sess_id = extract_session_id(&view)?;
+            let psk_id = psk_id_for_role(sess_id.role());
+            if pal.part_psk_is_default(io, psk_id)? {
+                return Err(HsmError::DefaultPskMustRotate);
+            }
         }
     }
 
     match opcode {
-        opcode::GET_API_REV => get_api_rev::handle(pal, io, view),
-        opcode::OPEN_SESSION_INIT => open_session_init::handle(pal, io, view).await,
-        opcode::OPEN_SESSION_FINISH => open_session_finish::handle(pal, io, view).await,
-        opcode::CLOSE_SESSION => close_session::handle(pal, io, view).await,
-        opcode::CHANGE_PSK => change_psk::handle(pal, io, view).await,
-        opcode::PART_INIT => part_init::handle(pal, io, view).await,
+        opcode::GET_API_REV => get_api_rev::handle(pal, io, req_buf),
+        opcode::OPEN_SESSION_INIT => open_session_init::handle(pal, io, req_buf).await,
+        opcode::OPEN_SESSION_FINISH => open_session_finish::handle(pal, io, req_buf).await,
+        opcode::CLOSE_SESSION => close_session::handle(pal, io, req_buf).await,
+        opcode::CHANGE_PSK => change_psk::handle(pal, io, req_buf).await,
+        opcode::PART_INIT => part_init::handle(pal, io, req_buf).await,
         _ => Err(HsmError::UnsupportedCmd),
     }
 }

--- a/fw/core/lib/src/ddi/tbor/open_session_finish.rs
+++ b/fw/core/lib/src/ddi/tbor/open_session_finish.rs
@@ -26,7 +26,6 @@ use azihsm_fw_core_crypto_aead_envelope::AeadAlg;
 use azihsm_fw_core_crypto_hpke::HpkeSuite;
 use azihsm_fw_core_crypto_key_masking::aead::mask as mask_key;
 use azihsm_fw_core_crypto_key_masking::aead::MaskParams;
-use azihsm_fw_ddi_tbor::RequestView;
 use azihsm_fw_ddi_tbor_types::*;
 use azihsm_fw_hsm_pal_traits::*;
 
@@ -71,13 +70,12 @@ const BMK_SESSION_KEY_LABEL: &[u8] = b"SESSION_BMK";
 struct ParsedRequest<'a> {
     /// Session Id
     sess_id: HsmSessId,
-    /// Borrowed directly from the request buffer; copied into a
-    /// scoped DmaBuf before being handed to the constant-time MAC
-    /// compare.
-    mac_fin: &'a [u8],
-    /// AEAD `seed_envelope` from the wire.  Copied into a scoped
-    /// mutable DmaBuf before [`aead_open`] (which decrypts in place).
-    seed_envelope: &'a [u8],
+    /// Codec-supplied `&DmaBuf` sub-view of the inbound request
+    /// buffer; flows straight into the constant-time MAC compare.
+    mac_fin: &'a DmaBuf,
+    /// Codec-supplied `&mut DmaBuf` sub-view of the inbound request
+    /// buffer.  Decrypted in place by [`aead_open`] — no scratch copy.
+    seed_envelope: &'a mut DmaBuf,
 }
 
 /// Per-session keys derived from the HPKE `exported` secret.
@@ -116,13 +114,13 @@ struct HandshakeState<'a> {
 pub(crate) async fn handle<'p, P: HsmPal>(
     pal: &'p P,
     io: &impl HsmIo,
-    view: &RequestView<'_>,
+    req_buf: &mut DmaBuf,
 ) -> HsmResult<&'p DmaBuf> {
     let ParsedRequest {
         sess_id,
         mac_fin,
         seed_envelope,
-    } = parse_request(view)?;
+    } = parse_request(req_buf)?;
     ensure_pending_blob_len(pal, io, sess_id)?;
 
     pal.alloc_scoped_async(io, async |alloc| {
@@ -162,7 +160,7 @@ pub(crate) async fn handle<'p, P: HsmPal>(
         )
         .await?;
 
-        let seed = open_seed_envelope(pal, io, alloc, sess_id, param_key, seed_envelope).await?;
+        let seed = open_seed_envelope(pal, io, sess_id, param_key, seed_envelope).await?;
 
         // ── Derive remaining per-session keys ─────────────────────
         let derived =
@@ -183,13 +181,13 @@ pub(crate) async fn handle<'p, P: HsmPal>(
 }
 
 /// Decode and validate the wire request.
-fn parse_request<'a>(view: &'a RequestView<'_>) -> HsmResult<ParsedRequest<'a>> {
-    let req = TborOpenSessionFinishReq::decode(view.as_bytes())?;
-    let id = HsmSessId::from(u16::from(req.session_id()));
+fn parse_request<'a>(req_buf: &'a mut DmaBuf) -> HsmResult<ParsedRequest<'a>> {
+    let req = TborOpenSessionFinishReq::decode_mut(req_buf)?;
+    let id = HsmSessId::from(u16::from(req.session_id));
     // `mac_fin` length is checked once the negotiated suite is known
     // (see [`handle`]); the schema already pins the wire field to 48 B.
-    let mac_fin: &[u8] = req.mac_fin();
-    let seed_envelope: &[u8] = req.seed_envelope();
+    let mac_fin: &DmaBuf = req.mac_fin;
+    let seed_envelope: &mut DmaBuf = req.seed_envelope;
     if seed_envelope.len() != SEED_ENVELOPE_LEN {
         return Err(HsmError::InvalidArg);
     }
@@ -276,7 +274,7 @@ async fn verify_mac<P: HsmPal>(
     io: &impl HsmIo,
     alloc: &impl HsmScopedAlloc,
     id: HsmSessId,
-    mac_fin: &[u8],
+    mac_fin: &DmaBuf,
     exported: &DmaBuf,
     pk_init: &DmaBuf,
     pk_hsm: &DmaBuf,
@@ -287,8 +285,6 @@ async fn verify_mac<P: HsmPal>(
     let label_sid = alloc.dma_alloc(SESSION_PHASE2_LABEL.len() + 2)?;
     label_sid[..SESSION_PHASE2_LABEL.len()].copy_from_slice(SESSION_PHASE2_LABEL);
     label_sid[SESSION_PHASE2_LABEL.len()..].copy_from_slice(&session_id_be);
-    let tag = alloc.dma_alloc(mac_fin.len())?;
-    tag.copy_from_slice(mac_fin);
 
     let mut hmac_ctx = pal
         .hmac_begin(io, HsmHashAlgo::Sha384, exported, alloc)
@@ -297,7 +293,7 @@ async fn verify_mac<P: HsmPal>(
     pal.hmac_continue(io, &mut hmac_ctx, pk_init).await?;
     pal.hmac_continue(io, &mut hmac_ctx, pk_hsm).await?;
     pal.hmac_continue(io, &mut hmac_ctx, pk_resp).await?;
-    let mac_verified = pal.hmac_finish_verify(io, hmac_ctx, tag).await?;
+    let mac_verified = pal.hmac_finish_verify(io, hmac_ctx, mac_fin).await?;
     if !mac_verified {
         let _ = pal.session_destroy(io, id);
         return Err(HsmError::SessionAuthFailure);
@@ -306,8 +302,8 @@ async fn verify_mac<P: HsmPal>(
 }
 
 /// AEAD-open the host's `seed_envelope` under the freshly-derived
-/// `param_key`.  Returns a scoped DMA buffer holding the 32-byte
-/// plaintext seed.
+/// `param_key`.  Returns the 32-byte plaintext seed as a `&DmaBuf`
+/// sub-view of the envelope buffer (which was decrypted in place).
 ///
 /// Any AEAD failure (bad magic, unsupported alg, tag mismatch) is
 /// treated as a session-establishment authentication failure: the
@@ -316,17 +312,15 @@ async fn verify_mac<P: HsmPal>(
 async fn open_seed_envelope<'a, P: HsmPal>(
     pal: &P,
     io: &impl HsmIo,
-    alloc: &'a impl HsmScopedAlloc,
     id: HsmSessId,
     param_key: &DmaBuf,
-    seed_envelope: &[u8],
-) -> HsmResult<&'a mut DmaBuf> {
-    // Stage the wire envelope into a scoped mutable DmaBuf so
-    // aead_open can decrypt in place.
-    let env_buf = alloc.dma_alloc(seed_envelope.len())?;
-    env_buf.copy_from_slice(seed_envelope);
-
-    let result = aead_open(pal, io, param_key, env_buf).await;
+    seed_envelope: &'a mut DmaBuf,
+) -> HsmResult<&'a DmaBuf> {
+    // Decrypt the envelope **in place** on the inbound request
+    // buffer; the destructured `seed_envelope` is a `&mut DmaBuf`
+    // sub-view of the parent `req_buf`, so no scratch copy is
+    // needed.
+    let result = aead_open(pal, io, param_key, seed_envelope).await;
     let view = match result {
         Ok(v) => v,
         Err(_) => {
@@ -341,10 +335,10 @@ async fn open_seed_envelope<'a, P: HsmPal>(
         let _ = pal.session_destroy(io, id);
         return Err(HsmError::SessionAuthFailure);
     }
-    // Copy plaintext out before env_buf goes out of scope below.
-    let seed = alloc.dma_alloc(SEED_LEN)?;
-    seed.copy_from_slice(view.payload);
-    Ok(seed)
+    // Hand the caller the AEAD plaintext view directly: it borrows
+    // from the envelope buffer (the parent `req_buf`), which lives
+    // until the enclosing scope exits.
+    Ok(view.payload)
 }
 
 /// HKDF-derive the remaining per-session keys: `masking_key` (always)

--- a/fw/core/lib/src/ddi/tbor/open_session_init.rs
+++ b/fw/core/lib/src/ddi/tbor/open_session_init.rs
@@ -21,7 +21,6 @@
 //! arrays on the async stack.
 
 use azihsm_fw_core_crypto_hpke::*;
-use azihsm_fw_ddi_tbor::RequestView;
 use azihsm_fw_ddi_tbor_types::*;
 use azihsm_fw_hsm_pal_traits::*;
 
@@ -39,10 +38,10 @@ struct ParsedRequest<'a> {
     /// Cryptographic suite negotiated by the caller.
     suite: SessionSuite,
 
-    /// Borrowed directly from the request buffer (managed by the
-    /// per-IO allocator) so it can flow through to HPKE without an
-    /// intermediate stack copy.
-    pk_init: &'a [u8],
+    /// Sub-view of the inbound request buffer (DMA-branded by the
+    /// codec), so it can flow straight into HPKE / HMAC inputs
+    /// without an intermediate copy.
+    pk_init: &'a DmaBuf,
 }
 
 /// Map a [`SessionSuite`] to the concrete [`HpkeSuite`] used by the
@@ -82,7 +81,7 @@ const _: () = assert!(PENDING_BLOB_LEN <= SESSION_PENDING_BLOB_MAX);
 pub(crate) async fn handle<'p, P: HsmPal>(
     pal: &'p P,
     io: &impl HsmIo,
-    view: &RequestView<'_>,
+    req_buf: &DmaBuf,
 ) -> HsmResult<&'p DmaBuf> {
     let ParsedRequest {
         role,
@@ -90,7 +89,7 @@ pub(crate) async fn handle<'p, P: HsmPal>(
         session_type,
         suite,
         pk_init,
-    } = parse_request(view)?;
+    } = parse_request(req_buf)?;
 
     let hpke_suite = hpke_suite_for(suite);
 
@@ -154,8 +153,8 @@ pub(crate) async fn handle<'p, P: HsmPal>(
 }
 
 /// Decode and validate the wire request.
-fn parse_request<'a>(view: &'a RequestView<'_>) -> HsmResult<ParsedRequest<'a>> {
-    let req = TborOpenSessionInitReq::decode(view.as_bytes())?;
+fn parse_request<'a>(req_buf: &'a DmaBuf) -> HsmResult<ParsedRequest<'a>> {
+    let req = TborOpenSessionInitReq::decode(req_buf)?;
     let psk_id = req.psk_id();
 
     if psk_id > 1 {
@@ -174,7 +173,7 @@ fn parse_request<'a>(view: &'a RequestView<'_>) -> HsmResult<ParsedRequest<'a>> 
     let suite = SessionSuite::from_u8(req.suite_id())?;
     let hpke_suite = hpke_suite_for(suite);
 
-    let pk_init: &[u8] = req.pk_init();
+    let pk_init: &DmaBuf = req.pk_init();
     if pk_init.len() != hpke_suite.npk() {
         return Err(HsmError::InvalidArg);
     }
@@ -259,7 +258,7 @@ async fn hpke_auth_psk_export<'a, P: HsmPal>(
     io: &impl HsmIo,
     alloc: &'a impl HsmScopedAlloc,
     suite: HpkeSuite,
-    pk_init: &[u8],
+    pk_init: &DmaBuf,
     sk_hsm: &DmaBuf,
     pk_hsm: &DmaBuf,
     psk: &DmaBuf,
@@ -306,7 +305,7 @@ fn create_pending_slot<P: HsmPal>(
     suite: SessionSuite,
     hpke_suite: HpkeSuite,
     exported: &DmaBuf,
-    pk_init: &[u8],
+    pk_init: &DmaBuf,
     pk_resp: &DmaBuf,
 ) -> HsmResult<HsmSessId> {
     let nh = hpke_suite.nh();
@@ -330,9 +329,9 @@ fn create_pending_slot<P: HsmPal>(
 ///
 /// The label and the 2-byte big-endian `session_id` share one DMA
 /// buffer so we don't pay for a separate small allocation just to
-/// satisfy the PAL `hmac_continue(&DmaBuf)` contract.  `pk_init`
-/// is copied into a scoped DmaBuf because the wire slice borrows
-/// from the request buffer rather than a DmaBuf.
+/// satisfy the PAL `hmac_continue(&DmaBuf)` contract.  `pk_init` is
+/// passed through as the codec-supplied `&DmaBuf` sub-view of the
+/// inbound request buffer.
 #[allow(clippy::too_many_arguments)]
 async fn compute_phase1_mac<'a, P: HsmPal>(
     pal: &P,
@@ -341,7 +340,7 @@ async fn compute_phase1_mac<'a, P: HsmPal>(
     suite: HpkeSuite,
     exported: &DmaBuf,
     session_id: u16,
-    pk_init: &[u8],
+    pk_init: &DmaBuf,
     pk_hsm: &DmaBuf,
     pk_resp: &DmaBuf,
 ) -> HsmResult<&'a mut DmaBuf> {
@@ -349,8 +348,6 @@ async fn compute_phase1_mac<'a, P: HsmPal>(
     let label_sid = alloc.dma_alloc(SESSION_PHASE1_LABEL.len() + 2)?;
     label_sid[..SESSION_PHASE1_LABEL.len()].copy_from_slice(SESSION_PHASE1_LABEL);
     label_sid[SESSION_PHASE1_LABEL.len()..].copy_from_slice(&session_id.to_be_bytes());
-    let pk_init_dma = alloc.dma_alloc(suite.npk())?;
-    pk_init_dma.copy_from_slice(pk_init);
 
     let mac_resp = alloc.dma_alloc(suite.nh())?;
     let mut hmac_ctx = pal
@@ -358,7 +355,7 @@ async fn compute_phase1_mac<'a, P: HsmPal>(
         .await?;
 
     pal.hmac_continue(io, &mut hmac_ctx, label_sid).await?;
-    pal.hmac_continue(io, &mut hmac_ctx, pk_init_dma).await?;
+    pal.hmac_continue(io, &mut hmac_ctx, pk_init).await?;
     pal.hmac_continue(io, &mut hmac_ctx, pk_hsm).await?;
     pal.hmac_continue(io, &mut hmac_ctx, pk_resp).await?;
     pal.hmac_finish_into(io, hmac_ctx, mac_resp).await?;

--- a/fw/core/lib/src/ddi/tbor/part_init.rs
+++ b/fw/core/lib/src/ddi/tbor/part_init.rs
@@ -58,12 +58,11 @@ use azihsm_fw_core_crypto_key_report::VM_LAUNCH_ID_LEN;
 use azihsm_fw_core_crypto_x509_builder::csr;
 use azihsm_fw_core_crypto_x509_builder::csr_builder;
 use azihsm_fw_core_crypto_x509_builder::padding;
-use azihsm_fw_ddi_tbor::RequestView;
-use azihsm_fw_ddi_tbor_types::build_part_init_mach_seed_aad;
 use azihsm_fw_ddi_tbor_types::TborPartInitReq;
 use azihsm_fw_ddi_tbor_types::TborPartInitResp;
 use azihsm_fw_ddi_tbor_types::MACH_SEED_ENVELOPE_MAX_LEN;
 use azihsm_fw_ddi_tbor_types::MACH_SEED_LEN;
+use azihsm_fw_ddi_tbor_types::PART_INIT_MACH_SEED_AAD_LABEL;
 use azihsm_fw_ddi_tbor_types::PART_INIT_MACH_SEED_AAD_LEN;
 use azihsm_fw_ddi_tbor_types::POTA_THUMBPRINT_LEN;
 use azihsm_fw_ddi_tbor_types::PTA_CSR_MAX_LEN;
@@ -138,20 +137,24 @@ const UMS_VAULT_ATTRS: HsmVaultKeyAttrs = HsmVaultKeyAttrs::new()
 pub(crate) async fn handle<'p, P: HsmPal>(
     pal: &'p P,
     io: &impl HsmIo,
-    view: &RequestView<'_>,
+    req_buf: &mut DmaBuf,
 ) -> HsmResult<&'p DmaBuf> {
-    let req = parse_request(view)?;
+    let req = parse_request(req_buf)?;
 
     pal.alloc_scoped_async(io, async |alloc| {
-        // Mirror request fields into DmaBufs so they can flow into
-        // PAL crypto primitives (which require DmaBuf inputs) and
-        // the write-once partition setters from a single, validated
-        // source.
-        let policy_dma = dma_copy(alloc, req.policy)?;
+        // `policy` and `pota_thumb` are read-only request fields; the
+        // codec already hands them out as `&DmaBuf` sub-views of the
+        // inbound request buffer, so they can flow directly into PAL
+        // crypto primitives and the write-once partition setters
+        // without an extra copy.  `mach_seed_envelope` is decrypted
+        // **in place** by `aead_open` on the same inbound buffer —
+        // the destructured `&mut DmaBuf` carved by `decode_mut`
+        // replaces the previous scratch-copy step.
+        let policy_dma = req.policy;
         let _ = super::policy::from_bytes(policy_dma)?;
         let mach_seed_dma =
-            open_mach_seed_envelope(pal, io, alloc, req.sess_id, req.mach_seed_envelope).await?;
-        let pota_thumb_dma = dma_copy(alloc, req.pota_thumb)?;
+            open_mach_seed_envelope(pal, io, req.sess_id, req.mach_seed_envelope).await?;
+        let pota_thumb_dma = req.pota_thumb;
 
         // Deterministic key derivation.
         let ums_dma = derive_ums(pal, io, alloc, mach_seed_dma, policy_dma, pota_thumb_dma).await?;
@@ -189,22 +192,23 @@ pub(crate) async fn handle<'p, P: HsmPal>(
 }
 
 /// Parsed-and-validated PartInit request fields, ready to flow into
-/// the cryptographic pipeline.  `mach_seed` is delivered AEAD-wrapped
-/// under the session's `param_key`; the raw bytes are recovered
-/// inside [`handle`] after `parse_request` has rejected obvious
-/// length/role errors.
+/// the cryptographic pipeline.  Variable-length fields are returned
+/// as sub-views of the inbound request buffer so they can be handed
+/// straight to PAL crypto primitives without copying.
+/// `mach_seed_envelope` is held as `&mut DmaBuf` so the FW handler
+/// can AEAD-open it in place; `policy` and `pota_thumb` are shared.
 struct ParsedRequest<'a> {
     sess_id: HsmSessId,
-    mach_seed_envelope: &'a [u8],
-    policy: &'a [u8],
-    pota_thumb: &'a [u8],
+    mach_seed_envelope: &'a mut DmaBuf,
+    policy: &'a DmaBuf,
+    pota_thumb: &'a DmaBuf,
 }
 
 /// Decode the wire request, enforce the CO-only role gate, and
 /// length-check the variable-length fields against the wire schema.
-fn parse_request<'a>(view: &'a RequestView<'_>) -> HsmResult<ParsedRequest<'a>> {
-    let req = TborPartInitReq::decode(view.as_bytes())?;
-    let sess_id = HsmSessId::from(u16::from(req.session_id()));
+fn parse_request<'a>(req_buf: &'a mut DmaBuf) -> HsmResult<ParsedRequest<'a>> {
+    let req = TborPartInitReq::decode_mut(req_buf)?;
+    let sess_id = HsmSessId::from(u16::from(req.session_id));
 
     // PartInit is CO-only.  The dispatcher's default-PSK gate uses
     // the same `psk_id_for_role` mapping but does not by itself
@@ -213,23 +217,19 @@ fn parse_request<'a>(view: &'a RequestView<'_>) -> HsmResult<ParsedRequest<'a>> 
         return Err(HsmError::InvalidPermissions);
     }
 
-    let mach_seed_envelope = req.mach_seed_envelope();
-    let policy = req.part_policy();
-    let pota_thumb = req.pota_thumbprint();
-
-    if mach_seed_envelope.is_empty()
-        || mach_seed_envelope.len() > MACH_SEED_ENVELOPE_MAX_LEN
-        || policy.len() != PART_POLICY_LEN
-        || pota_thumb.len() != POTA_THUMBPRINT_LEN
+    if req.mach_seed_envelope.is_empty()
+        || req.mach_seed_envelope.len() > MACH_SEED_ENVELOPE_MAX_LEN
+        || req.part_policy.len() != PART_POLICY_LEN
+        || req.pota_thumbprint.len() != POTA_THUMBPRINT_LEN
     {
         return Err(HsmError::InvalidArg);
     }
 
     Ok(ParsedRequest {
         sess_id,
-        mach_seed_envelope,
-        policy,
-        pota_thumb,
+        mach_seed_envelope: req.mach_seed_envelope,
+        policy: req.part_policy,
+        pota_thumb: req.pota_thumbprint,
     })
 }
 
@@ -249,55 +249,54 @@ struct CsrAssets {
 
 // ─── Pipeline stage helpers ──────────────────────────────────────────────────
 
-/// Copy `src` into a fresh scoped DmaBuf of equal length.
-fn dma_copy<'a>(alloc: &'a impl HsmScopedAlloc, src: &[u8]) -> HsmResult<&'a mut DmaBuf> {
-    let buf = alloc.dma_alloc(src.len())?;
-    buf.copy_from_slice(src);
-    Ok(buf)
-}
-
-/// AEAD-open the host-supplied `mach_seed` envelope and return the
-/// raw 32-byte plaintext in a fresh scoped DmaBuf.
+/// AEAD-open the host-supplied `mach_seed` envelope and return a
+/// zero-copy view of the 32-byte plaintext sub-region of the same
+/// envelope buffer.
 ///
 /// Cross-session replay is structurally impossible because
 /// `param_key` is HPKE-derived per session.  AAD binds the envelope
 /// to `(label, session_id)` so an envelope minted for session A
 /// fails authentication on session B even if their `param_key`s
-/// somehow collided.  An auth failure surfaces as
-/// [`HsmError::AeadEnvelopeAuthFailed`]; a wrong-AAD or wrong-payload-
-/// length condition (post-auth) surfaces as [`HsmError::InvalidArg`]
-/// because the bytes are by then trustworthy and the divergence is a
-/// client encoding bug, not an attack.
+/// somehow collided.  AEAD-auth failure and any post-auth wire-shape
+/// mismatch (AAD layout or payload length) both surface as
+/// [`HsmError::AeadEnvelopeAuthFailed`]: once authentication has
+/// succeeded the only way the shape can diverge is a sender that
+/// constructed the envelope against a different protocol contract,
+/// which is operationally indistinguishable from a forgery attempt.
 async fn open_mach_seed_envelope<'a, P: HsmPal>(
     pal: &P,
     io: &impl HsmIo,
-    alloc: &'a impl HsmScopedAlloc,
     sess_id: HsmSessId,
-    envelope: &[u8],
-) -> HsmResult<&'a mut DmaBuf> {
+    envelope: &'a mut DmaBuf,
+) -> HsmResult<&'a DmaBuf> {
     let param_key = pal.session_param_key(io, sess_id)?;
 
-    let env_buf = alloc.dma_alloc(envelope.len())?;
-    env_buf.copy_from_slice(envelope);
-    let view = aead_open(pal, io, param_key, env_buf)
+    let view = aead_open(pal, io, param_key, envelope)
         .await
         .map_err(|_| HsmError::AeadEnvelopeAuthFailed)?;
 
-    if view.aad.len() != PART_INIT_MACH_SEED_AAD_LEN {
-        return Err(HsmError::InvalidArg);
-    }
-    let expected_aad = build_part_init_mach_seed_aad(u16::from(sess_id));
-    let aad_bytes: &[u8] = view.aad;
-    if aad_bytes != expected_aad.as_slice() {
-        return Err(HsmError::AeadEnvelopeAuthFailed);
-    }
-    if view.payload.len() != MACH_SEED_LEN {
-        return Err(HsmError::InvalidArg);
+    // Wire-shape check: reconstruct the canonical 32-byte AAD and
+    // byte-compare.  See the function doc for why a post-auth shape
+    // mismatch surfaces as `AeadEnvelopeAuthFailed`.
+    let mut expected_aad = [0u8; PART_INIT_MACH_SEED_AAD_LEN];
+    {
+        fn push<'a>(rest: &'a mut [u8], bytes: &[u8]) -> &'a mut [u8] {
+            let (head, tail) = rest.split_at_mut(bytes.len());
+            head.copy_from_slice(bytes);
+            tail
+        }
+
+        let mut rest: &mut [u8] = &mut expected_aad;
+        rest = push(rest, PART_INIT_MACH_SEED_AAD_LABEL);
+        let _ = push(rest, &u16::from(sess_id).to_le_bytes());
     }
 
-    let mach_seed = alloc.dma_alloc(MACH_SEED_LEN)?;
-    mach_seed.copy_from_slice(view.payload);
-    Ok(mach_seed)
+    let aad: &[u8] = view.aad;
+    if view.payload.len() != MACH_SEED_LEN || aad != expected_aad {
+        return Err(HsmError::AeadEnvelopeAuthFailed);
+    }
+
+    Ok(view.payload)
 }
 
 /// Run the SP 800-108 / RFC 5869 UMS derivation with UDS plus the
@@ -448,7 +447,7 @@ async fn build_pta_report<'a, P: HsmPal>(
         pk_y: &pub_xy[P384_COORD_LEN..],
         flags,
         app_uuid: &app_uuid,
-        report_data: &report_data,
+        report_data: &report_data[..],
         vm_launch_id: &vm_launch_id,
     };
 
@@ -467,34 +466,41 @@ async fn build_pta_report<'a, P: HsmPal>(
 /// Build the 128-byte `report_data` field:
 /// `SHA-384(label || u16_be(|policy|) || policy || u16_be(|thumb|)
 /// || thumb) || zeros[..80]`.
-async fn build_report_data<P: HsmPal>(
+///
+/// The returned DmaBuf is zero-initialised and sized to
+/// [`REPORT_DATA_LEN`]; `pal.hash` only writes the leading
+/// [`SHA384_LEN`] bytes, leaving the trailing 80 bytes as the
+/// required zero pad.
+async fn build_report_data<'a, P: HsmPal>(
     pal: &P,
     io: &impl HsmIo,
-    alloc: &impl HsmScopedAlloc,
+    alloc: &'a impl HsmScopedAlloc,
     policy: &DmaBuf,
     thumb: &DmaBuf,
-) -> HsmResult<[u8; REPORT_DATA_LEN]> {
-    let policy_len = policy.len();
-    let thumb_len = thumb.len();
-    let input = alloc.dma_alloc(REPORT_DATA_LABEL.len() + 2 + policy_len + 2 + thumb_len)?;
-    let mut w = 0;
-    input[w..w + REPORT_DATA_LABEL.len()].copy_from_slice(REPORT_DATA_LABEL);
-    w += REPORT_DATA_LABEL.len();
-    input[w..w + 2].copy_from_slice(&(policy_len as u16).to_be_bytes());
-    w += 2;
-    input[w..w + policy_len].copy_from_slice(policy);
-    w += policy_len;
-    input[w..w + 2].copy_from_slice(&(thumb_len as u16).to_be_bytes());
-    w += 2;
-    input[w..w + thumb_len].copy_from_slice(thumb);
+) -> HsmResult<&'a mut DmaBuf> {
+    let input = alloc.dma_alloc(
+        REPORT_DATA_LABEL.len() + size_of::<u16>() + policy.len() + size_of::<u16>() + thumb.len(),
+    )?;
 
-    let digest = alloc.dma_alloc(SHA384_LEN)?;
-    pal.hash(io, HsmHashAlgo::Sha384, input, digest, true)
+    {
+        fn push<'a>(rest: &'a mut [u8], bytes: &[u8]) -> &'a mut [u8] {
+            let (head, tail) = rest.split_at_mut(bytes.len());
+            head.copy_from_slice(bytes);
+            tail
+        }
+
+        let mut rest: &mut [u8] = &mut input[..];
+        rest = push(rest, REPORT_DATA_LABEL);
+        rest = push(rest, &(policy.len() as u16).to_be_bytes());
+        rest = push(rest, policy);
+        rest = push(rest, &(thumb.len() as u16).to_be_bytes());
+        let _ = push(rest, thumb);
+    }
+
+    let report_data = alloc.dma_alloc_zeroed(REPORT_DATA_LEN)?;
+    pal.hash(io, HsmHashAlgo::Sha384, input, report_data, true)
         .await?;
-
-    let mut out = [0u8; REPORT_DATA_LEN];
-    out[..SHA384_LEN].copy_from_slice(digest);
-    Ok(out)
+    Ok(report_data)
 }
 
 /// Vault the PTA and UMS private keys, register the partition

--- a/fw/core/lib/src/io.rs
+++ b/fw/core/lib/src/io.rs
@@ -238,12 +238,20 @@ impl<P: HsmPal> Hsm<P> {
 
         // ── Phase 2: parse TBOR header, validate session, dispatch ─
         let (resp, session_ctrl) = {
-            let req_bytes = &req_buf[..params.src_len];
-            let req_view = TborRequestView::parse(req_bytes).op_err(
-                "core",
-                HsmError::DdiDecodeFailed,
-                HostStatus::REQ_HDR_DECODE_ERR,
-            )?;
+            // Capture `opcode` via a short-lived shared reborrow so
+            // the parsed `RequestView` is dropped before `dispatch`
+            // takes a mutable borrow of the same buffer.  AEAD-path
+            // handlers (`OpenSessionFinish` / `ChangePsk` / `PartInit`)
+            // open envelope sub-views in place via `decode_mut`,
+            // which requires `&mut DmaBuf` end-to-end.
+            let opcode = {
+                let req_view = TborRequestView::parse(&req_buf[..params.src_len]).op_err(
+                    "core",
+                    HsmError::DdiDecodeFailed,
+                    HostStatus::REQ_HDR_DECODE_ERR,
+                )?;
+                req_view.opcode()
+            };
 
             // Per-opcode session-flag validation: GetApiRev /
             // OpenSessionInit must be sessionless; OpenSessionFinish /
@@ -251,7 +259,6 @@ impl<P: HsmPal> Hsm<P> {
             // for the targeted slot.  Unknown opcodes are classified as
             // NoSession here so dispatch reaches the handler layer and
             // surfaces `UnsupportedCmd` via a typed TBOR response.
-            let opcode = req_view.opcode();
             let session_ctrl = SessionCtrl::from_tbor_opcode(opcode);
             if let Err(_e) = Self::validate_tbor_session_flags(session_ctrl, params.session_flags) {
                 let resp: &DmaBuf = self
@@ -262,9 +269,14 @@ impl<P: HsmPal> Hsm<P> {
                     .op_status(HostStatus::INTERNAL_ERROR)?;
                 (resp, session_ctrl)
             } else {
-                let dispatch_result =
-                    ddi::tbor::dispatch(self.pal(), io, &req_view, opcode, params.sqe_session_id)
-                        .await;
+                let dispatch_result = ddi::tbor::dispatch(
+                    self.pal(),
+                    io,
+                    &mut req_buf[..params.src_len],
+                    opcode,
+                    params.sqe_session_id,
+                )
+                .await;
                 let resp: &DmaBuf = dispatch_result.or_else(|err| {
                     self.pal()
                         .dma_alloc_var(io, |buf| ddi::tbor::encode_tbor_err(opcode, err, buf))

--- a/fw/pal/traits/src/alloc.rs
+++ b/fw/pal/traits/src/alloc.rs
@@ -161,6 +161,39 @@ impl core::ops::DerefMut for DmaBuf {
     }
 }
 
+// `DmaBuf` is a transparent newtype over `[u8]`, so byte-wise equality
+// matches caller expectations. This impl is required by the FW TBOR
+// codec's `TocEntry` enum (variants hold `&DmaBuf` and derive
+// `PartialEq`/`Eq` for test assertions and the wire round-trip).
+//
+// Note: comparing two byte buffers in constant time is the caller's
+// responsibility (use `subtle::ConstantTimeEq` for secrets); this
+// `PartialEq` is `[u8]::eq` and short-circuits.
+impl PartialEq for DmaBuf {
+    #[inline(always)]
+    fn eq(&self, other: &Self) -> bool {
+        self.inner == other.inner
+    }
+}
+
+impl Eq for DmaBuf {}
+
+// Cross-type byte equality used by tests and codec assertions that
+// compare a `&DmaBuf` to a `&[u8; N]` literal (e.g. `b"hello"`).
+impl PartialEq<[u8]> for DmaBuf {
+    #[inline(always)]
+    fn eq(&self, other: &[u8]) -> bool {
+        self.inner == *other
+    }
+}
+
+impl<const N: usize> PartialEq<[u8; N]> for DmaBuf {
+    #[inline(always)]
+    fn eq(&self, other: &[u8; N]) -> bool {
+        &self.inner == other.as_slice()
+    }
+}
+
 impl core::fmt::Debug for DmaBuf {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "DmaBuf({} bytes)", self.inner.len())

--- a/fw/pal/traits/src/alloc.rs
+++ b/fw/pal/traits/src/alloc.rs
@@ -183,7 +183,7 @@ impl Eq for DmaBuf {}
 impl PartialEq<[u8]> for DmaBuf {
     #[inline(always)]
     fn eq(&self, other: &[u8]) -> bool {
-        self.inner == *other
+        &self.inner == other
     }
 }
 


### PR DESCRIPTION
Companion to #440 (the host-side TBOR refactor). This PR ships the matching FW-side stack so that the FW handlers can take request fields as `&DmaBuf` / `&mut DmaBuf` sub-views of the inbound buffer and decrypt envelopes **in place**, eliminating the per-field DMA copies that previously trampolined every PartInit/ChangePsk field through a scoped allocator.

## Scope

### Core wire types
- `fw/core/ddi/tbor/codec/`
  - `TocEntry` variants for variable-length data switch from `(offset, len)` pairs to `&DmaBuf` sub-views, plus a new `Padding` variant for alignment slack and an `Unknown { entry_type, raw_bits }` forward-compat variant.
  - `read_toc_buffer` returns `&DmaBuf` directly; `&mut DmaBuf` variant added for the in-place decode path.
  - `EncodeError` gains `MissingTocEntries` (split out of the misleading `TooManyTocEntries` reuse) to mirror the host change in #440.
- `fw/core/ddi/tbor/derive/`
  - New `codegen_view_mut.rs`: generates `decode_mut(&mut DmaBuf) -> ViewMut<'_>` so handlers can carve `&mut DmaBuf` sub-buffers for in-place AEAD-open while keeping read-only fields as `&DmaBuf`.
  - Schema parser learns the bare `mutable` keyword and threads it through to `codegen_view_mut`.
- `fw/core/ddi/tbor/types/`
  - PartInit / ChangePsk / OpenSessionFinish request types regenerated with the new derive output (mutable on the AEAD envelope field, shared `&DmaBuf` on policy / thumbprint / etc.).

### FW PAL
- `fw/pal/traits/src/alloc.rs::DmaBuf` now implements `PartialEq + Eq` (required by `TocEntry`'s `&DmaBuf` variants which derive `PartialEq` for tests and round-trip assertions) plus the cross-impls `PartialEq<[u8]>` and `PartialEq<[u8; N]>` so existing test asserts of the form `assert_eq!(data, b"...")` (where `data: &DmaBuf`) keep compiling without ceremony.

  Constant-time comparison of secrets remains the caller's responsibility — these impls are byte-wise `[u8]::eq` and short-circuit (documented in a comment on the impl).

### Handlers (`fw/core/lib/src/ddi/tbor/`)
- `mod.rs`, `io.rs`: dispatcher hands handlers `&mut DmaBuf` rather than a parsed `RequestView`, so each handler can call its own `decode_mut`.
- `part_init.rs`:
  - Drops the per-field `dma_copy` ladder; `policy` and `pota_thumb` flow as `&DmaBuf` sub-views, `mach_seed_envelope` is opened in place on the inbound buffer.
  - **Semantics change**: post-auth wire-shape mismatches (AAD layout / AAD length / payload length) now surface as `AeadEnvelopeAuthFailed` rather than `InvalidArg`. Rationale: once AEAD authentication has succeeded the only way the shape can diverge is a sender that constructed the envelope against a different protocol contract — operationally indistinguishable from forgery. Test expectations updated accordingly in `commands/part_init/crypto_rejects.rs`.
- `change_psk.rs`, `open_session_finish.rs`, `open_session_init.rs`, `close_session.rs`, `get_api_rev.rs`: ported to the `decode_mut` / `&DmaBuf` field-view pattern.

## Validation

- `cargo clippy --workspace --all-targets --features emu -- -D warnings` ✓
- `cargo +nightly xtask fmt --fix` ✓
- `cargo xtask copyright --fix` ✓
- `cargo xtask nextest --features emu -p azihsm_ddi_tbor_types` → **52 / 52**
- `cargo xtask nextest -p azihsm_ddi_tbor_codec` → **42 / 42**
- `cargo xtask nextest -p azihsm_fw_ddi_tbor` → **45 / 45**
- `cargo xtask nextest -p azihsm_fw_ddi_tbor_api` → **51 / 51** (incl. trybuild compile_tests)

## Stack

Sits on top of #440 (merged into `tbor-hsm`). After this lands, PR-5 (`pr7-part-finalize`) brings the PartFinalize 0x31 opcode + std-pal multi-step SHA-384 driver per `files/part_finalize_plan.md`.