### PR TITLE
feat(fw): implement DDI Hmac handler

### DIFF
--- a/crates/crypto/src/kdf/kbkdf.rs
+++ b/crates/crypto/src/kdf/kbkdf.rs
@@ -80,7 +80,7 @@ impl KbkdfAlgo {
     /// # Arguments
     ///
     /// * `hash` - The hash algorithm to use for HMAC-based PRF
-    /// * `label` - Optional label for context binding (at least one of label or context required)
+    /// * `label` - Optional label for context binding
     /// * `context` - Optional additional context data
     ///
     /// # Returns
@@ -103,7 +103,7 @@ impl KbkdfAlgo {
     /// # Arguments
     ///
     /// * `hash` - The hash algorithm to use for HMAC-based PRF
-    /// * `label` - Optional label for context binding (at least one of label or context required)
+    /// * `label` - Optional label for context binding
     /// * `context` - Optional additional context data
     ///
     /// # Returns
@@ -150,7 +150,6 @@ impl DeriveOp for KbkdfAlgo {
     /// Returns an error if:
     /// - `CryptoError::KbkdfInvalidKdkLength` - Input key is empty (zero length)
     /// - `CryptoError::KbkdfInvalidDerivedKeyLength` - Requested output length is zero
-    /// - `CryptoError::KbkdfSetPropertyError` - Both label and context are None
     /// - `CryptoError::KbkdfDeriveError` - HMAC operation fails during derivation
     #[allow(unsafe_code)]
     fn derive(&self, key: &Self::Key, derive_len: usize) -> Result<Self::DerivedKey, CryptoError> {
@@ -161,10 +160,6 @@ impl DeriveOp for KbkdfAlgo {
         //check if derive_len is zero
         if derive_len == 0 {
             Err(CryptoError::KbkdfInvalidDerivedKeyLength)?
-        }
-        // check if label and context both are not set
-        if self.label.is_none() && self.context.is_none() {
-            Err(CryptoError::KbkdfSetPropertyError)?
         }
 
         // calculate number of rounds required

--- a/crates/crypto/src/kdf/tests/kbkdf_tests.rs
+++ b/crates/crypto/src/kdf/tests/kbkdf_tests.rs
@@ -179,7 +179,9 @@ fn test_kbkdf_empty_key() {
 
 /// Test KBKDF with neither label nor context provided.
 ///
-/// Expected: Should return KbkdfSetPropertyError.
+/// SP 800-108 permits an empty Label and Context, so derivation must
+/// succeed — the PRF input reduces to the counter (and the optional
+/// length field).
 #[test]
 fn test_kbkdf_no_label_no_context() {
     let key = GenericSecretKey::from_bytes(&[0x42; 32]).expect("Create key failed");
@@ -189,16 +191,11 @@ fn test_kbkdf_no_label_no_context() {
     let result = kbkdf.derive(&key, 16);
 
     assert!(
-        result.is_err(),
-        "Expected error when both label and context are None"
+        result.is_ok(),
+        "Derivation should succeed when both label and context are None"
     );
-    match result {
-        Err(CryptoError::KbkdfSetPropertyError) => {
-            // Expected error
-        }
-        Err(e) => panic!("Expected KbkdfSetPropertyError, got {:?}", e),
-        Ok(_) => panic!("Expected error but derivation succeeded"),
-    }
+    let derived = result.unwrap().to_vec().expect("extract derived bytes");
+    assert_eq!(derived.len(), 16);
 }
 
 /// Test KBKDF with only label (no context) - should succeed.

--- a/ddi/mbor/types/tests/azihsm_ddi_tests.rs
+++ b/ddi/mbor/types/tests/azihsm_ddi_tests.rs
@@ -44,6 +44,7 @@ mod integration {
     pub mod get_unwrapping_key;
     pub mod hkdf_smoke;
     pub mod hmac;
+    pub mod hmac_smoke;
     pub mod init_bk3_smoke;
     pub mod invalid_ecc_pub_key_vectors;
     pub mod kbkdf_smoke;

--- a/ddi/mbor/types/tests/integration/hmac_smoke.rs
+++ b/ddi/mbor/types/tests/integration/hmac_smoke.rs
@@ -1,0 +1,140 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! HMAC smoke tests.
+//!
+//! - **Fixed HMAC keys** (both backends): derive an `HmacSha256` /
+//!   `384` / `512` key (ECDH → HKDF) and compute a MAC, confirming the
+//!   tag length matches the key's hash (32 / 48 / 64 bytes).
+//! - **Variable-length HMAC keys** (emu only — the sim has no var-len
+//!   HMAC kind): same, deriving `VarHmac256` / `384` / `512`.
+//! - **Unknown key** (both backends): a MAC against a non-existent
+//!   `key_id` is rejected with `KeyNotFound`.
+//! - **Sign permission** (emu only): a `derive`-only HMAC key cannot
+//!   generate a MAC — rejected with `InvalidPermissions` (MAC
+//!   generation is a PKCS#11 `C_Sign` operation requiring `CKA_SIGN`).
+
+#![cfg(test)]
+
+use azihsm_ddi::*;
+use azihsm_ddi_mbor_codec::MborByteArray;
+use azihsm_ddi_mbor_types::*;
+use test_with_tracing::test;
+
+use super::common::*;
+
+/// Compute a MAC over a fixed message with `key_id`.
+fn hmac_msg(
+    dev: &mut <DdiTest as Ddi>::Dev,
+    session_id: u16,
+    key_id: u16,
+) -> Result<DdiHmacCmdResp, DdiError> {
+    helper_hmac(
+        dev,
+        Some(session_id),
+        Some(DdiApiRev { major: 1, minor: 0 }),
+        key_id,
+        MborByteArray::from_slice(&[0xA5u8; 64]).unwrap(),
+    )
+}
+
+#[test]
+fn test_hmac_fixed_key_sign_smoke() {
+    ddi_dev_test(
+        common_setup,
+        common_cleanup,
+        |dev, _ddi, _path, session_id| {
+            for (key_type, tag_len) in [
+                (DdiKeyType::HmacSha256, 32usize),
+                (DdiKeyType::HmacSha384, 48),
+                (DdiKeyType::HmacSha512, 64),
+            ] {
+                let key_id = create_hmac_key(session_id, key_type, dev, Default::default());
+                let resp = hmac_msg(dev, session_id, key_id)
+                    .unwrap_or_else(|e| panic!("HMAC with {key_type:?} should succeed: {e:?}"));
+                assert_eq!(resp.hdr.op, DdiOp::Hmac);
+                assert_eq!(resp.hdr.status, DdiStatus::Success);
+                assert_eq!(resp.data.tag.len(), tag_len, "tag length for {key_type:?}");
+            }
+        },
+    );
+}
+
+#[cfg(not(feature = "mock"))]
+#[test]
+fn test_hmac_var_hmac_key_sign_smoke() {
+    ddi_dev_test(
+        common_setup,
+        common_cleanup,
+        |dev, _ddi, _path, session_id| {
+            for (key_type, key_len, tag_len) in [
+                (DdiKeyType::VarHmac256, 48u8, 32usize),
+                (DdiKeyType::VarHmac384, 64, 48),
+                (DdiKeyType::VarHmac512, 96, 64),
+            ] {
+                let key_id = create_hmac_key(session_id, key_type, dev, Some(key_len));
+                let resp = hmac_msg(dev, session_id, key_id)
+                    .unwrap_or_else(|e| panic!("HMAC with {key_type:?} should succeed: {e:?}"));
+                assert_eq!(resp.hdr.status, DdiStatus::Success);
+                assert_eq!(resp.data.tag.len(), tag_len, "tag length for {key_type:?}");
+            }
+        },
+    );
+}
+
+#[test]
+fn test_hmac_unknown_key_smoke() {
+    ddi_dev_test(
+        common_setup,
+        common_cleanup,
+        |dev, _ddi, _path, session_id| {
+            // Id 20 is an in-range but unallocated slot (no app keys
+            // are created in this test), which both backends report as
+            // `KeyNotFound`.
+            let err = hmac_msg(dev, session_id, 20)
+                .expect_err("MAC against an unknown key must be rejected");
+            assert!(
+                matches!(err, DdiError::DdiStatus(DdiStatus::KeyNotFound)),
+                "expected KeyNotFound, got {err:?}"
+            );
+        },
+    );
+}
+
+#[cfg(not(feature = "mock"))]
+#[test]
+fn test_hmac_requires_sign_permission_smoke() {
+    ddi_dev_test(
+        common_setup,
+        common_cleanup,
+        |dev, _ddi, _path, session_id| {
+            // Derive a var-len HMAC key with `derive`-only usage, then
+            // try to generate a MAC with it.  MAC generation is a
+            // PKCS#11 `C_Sign` operation, so a key lacking `CKA_SIGN`
+            // must be rejected.
+            let (secret_id, _) = create_ecdh_secrets(session_id, dev, DdiKeyType::Secret256);
+            let key_props = helper_key_properties(DdiKeyUsage::Derive, DdiKeyAvailability::Session);
+            let derived = helper_hkdf_derive(
+                dev,
+                Some(session_id),
+                Some(DdiApiRev { major: 1, minor: 0 }),
+                secret_id,
+                DdiHashAlgorithm::Sha256,
+                None,
+                None,
+                DdiKeyType::VarHmac256,
+                None,
+                key_props,
+                Some(32),
+            )
+            .expect("derive-only var-HMAC key should be created");
+
+            let err = hmac_msg(dev, session_id, derived.data.key_id)
+                .expect_err("MAC with a derive-only key must be rejected");
+            assert!(
+                matches!(err, DdiError::DdiStatus(DdiStatus::InvalidPermissions)),
+                "expected InvalidPermissions, got {err:?}"
+            );
+        },
+    );
+}

--- a/fw/core/lib/src/ddi/mbor/from_pal.rs
+++ b/fw/core/lib/src/ddi/mbor/from_pal.rs
@@ -21,10 +21,27 @@
 use azihsm_fw_ddi_mbor_types::DdiKeyType;
 use azihsm_fw_hsm_pal_traits::HsmEccCurve;
 use azihsm_fw_hsm_pal_traits::HsmError;
+use azihsm_fw_hsm_pal_traits::HsmHashAlgo;
 use azihsm_fw_hsm_pal_traits::HsmResult;
 use azihsm_fw_hsm_pal_traits::HsmVaultKeyKind;
 
 // ── HsmVaultKeyKind → … ───────────────────────────────────────────
+
+/// Map an HMAC vault kind to the hash algorithm whose digest length
+/// is the MAC tag size.
+///
+/// Accepts both the fixed-length (`_HmacSha*`) and variable-length
+/// (`VarLenHmacSha*`) HMAC kinds — mirroring the reference firmware's
+/// `Hmac` handler.  Any non-HMAC kind returns
+/// [`HsmError::InvalidKeyType`].
+pub(crate) fn hmac_hash(kind: HsmVaultKeyKind) -> HsmResult<HsmHashAlgo> {
+    match kind {
+        HsmVaultKeyKind::_HmacSha256 | HsmVaultKeyKind::VarLenHmacSha256 => Ok(HsmHashAlgo::Sha256),
+        HsmVaultKeyKind::_HmacSha384 | HsmVaultKeyKind::VarLenHmacSha384 => Ok(HsmHashAlgo::Sha384),
+        HsmVaultKeyKind::_HmacSha512 | HsmVaultKeyKind::VarLenHmacSha512 => Ok(HsmHashAlgo::Sha512),
+        _ => Err(HsmError::InvalidKeyType),
+    }
+}
 
 /// Map an ECC private vault kind to its [`HsmEccCurve`].
 /// Non-ECC kinds return [`HsmError::InvalidKeyType`].

--- a/fw/core/lib/src/ddi/mbor/hmac.rs
+++ b/fw/core/lib/src/ddi/mbor/hmac.rs
@@ -1,0 +1,68 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! DDI Hmac command handler.
+//!
+//! Within an open session, compute an HMAC tag over a host-supplied
+//! message using a vault-resident HMAC key (referenced by `key_id`)
+//! and return the tag.
+//!
+//! The key must be an HMAC kind — either a fixed-length `_HmacSha*`
+//! or a variable-length `VarLenHmacSha*` entry (the latter is what
+//! HKDF / KBKDF derive in this firmware).  The key's hash variant
+//! selects the MAC algorithm and tag length (SHA-256 / 384 / 512 →
+//! 32 / 48 / 64 bytes).  A non-HMAC key is rejected with
+//! `InvalidKeyType`; an unknown `key_id` with `KeyNotFound`.
+
+use azihsm_fw_ddi_mbor_types::hmac::DdiHmacReq;
+use azihsm_fw_ddi_mbor_types::hmac::DdiHmacResp;
+
+use super::*;
+
+/// Handle `DdiHmacCmd`.
+///
+/// No `partition_lock` is needed: this handler only reads vault state
+/// (the HMAC key) and computes a tag — it performs no partition
+/// mutation.
+pub(crate) async fn hmac<'p, P: HsmPal>(
+    pal: &'p P,
+    io: &impl HsmIo,
+    decoder: &mut DdiDecoder<'_>,
+    hdr: &DdiReqHdr,
+) -> HsmResult<&'p DmaBuf> {
+    let body: DdiHmacReq = decoder.decode_data()?;
+    let sess_id = hdr.sess_id.ok_or(HsmError::SessionExpected)?;
+    let key_id = HsmKeyId::from(body.key_id);
+
+    // Resolve the key's hash variant — an unknown id surfaces as
+    // `KeyNotFound`, a non-HMAC kind as `InvalidKeyType`.
+    let algo = super::from_pal::hmac_hash(pal.vault_key_kind(io, key_id)?)?;
+    let tag_len = algo.digest_len();
+
+    // Generating a MAC is a PKCS#11 `C_Sign` operation, so the key
+    // must carry `CKA_SIGN`.  An HMAC key derived for `derive`-only
+    // use (a valid `for_var_hmac` outcome) is rejected here.
+    if !pal.vault_key_attrs(io, key_id)?.sign() {
+        return Err(HsmError::InvalidPermissions);
+    }
+
+    // Compute the tag into a DMA scratch slot, then encode it into the
+    // response.  The key borrow is scoped so it is released before the
+    // response allocation.
+    let tag = pal.dma_alloc(io, tag_len)?;
+    {
+        let key = pal.vault_key(io, key_id)?;
+        pal.hmac_sign(io, algo, key, body.msg, tag).await?;
+    }
+
+    let resp = pal.dma_alloc_var(io, |buf| {
+        super::encode_resp(
+            &super::success_hdr_sess(hdr, DdiOp::Hmac, sess_id),
+            &DdiHmacResp {
+                tag: &tag[..tag_len],
+            },
+            buf,
+        )
+    })?;
+    Ok(resp)
+}

--- a/fw/core/lib/src/ddi/mbor/hmac.rs
+++ b/fw/core/lib/src/ddi/mbor/hmac.rs
@@ -30,7 +30,7 @@ pub(crate) async fn hmac<'p, P: HsmPal>(
     decoder: &mut DdiDecoder<'_>,
     hdr: &DdiReqHdr,
 ) -> HsmResult<&'p DmaBuf> {
-    let body: DdiHmacReq = decoder.decode_data()?;
+    let body: DdiHmacReq<'_> = decoder.decode_data()?;
     let sess_id = hdr.sess_id.ok_or(HsmError::SessionExpected)?;
     let key_id = HsmKeyId::from(body.key_id);
 

--- a/fw/core/lib/src/ddi/mbor/mod.rs
+++ b/fw/core/lib/src/ddi/mbor/mod.rs
@@ -19,6 +19,7 @@ pub(crate) mod get_establish_cred_encryption_key;
 pub(crate) mod get_sealed_bk3;
 pub(crate) mod get_session_encryption_key;
 pub(crate) mod hkdf_derive;
+pub(crate) mod hmac;
 pub(crate) mod init_bk3;
 pub(crate) mod kbkdf_derive;
 pub(crate) mod kdf;
@@ -48,6 +49,7 @@ pub(crate) use get_establish_cred_encryption_key::*;
 pub(crate) use get_sealed_bk3::*;
 pub(crate) use get_session_encryption_key::*;
 pub(crate) use hkdf_derive::*;
+pub(crate) use hmac::*;
 pub(crate) use init_bk3::*;
 pub(crate) use kbkdf_derive::*;
 pub(crate) use open_session::*;
@@ -136,6 +138,7 @@ pub(crate) async fn dispatch<'p, P: HsmPal>(
         DdiOp::EcdhKeyExchange => ecdh_key_exchange(pal, io, decoder, hdr).await,
         DdiOp::HkdfDerive => hkdf_derive(pal, io, decoder, hdr).await,
         DdiOp::KbkdfCounterHmacDerive => kbkdf_counter_hmac_derive(pal, io, decoder, hdr).await,
+        DdiOp::Hmac => hmac(pal, io, decoder, hdr).await,
         _ => Err(HsmError::UnsupportedCmd),
     }
 }


### PR DESCRIPTION
Wire up the previously-unimplemented Hmac (1077) DDI op in the firmware application layer: compute an HMAC tag over a host-supplied message using a vault-resident HMAC key.

- The key may be any HMAC kind — fixed-length _HmacSha* or variable-length VarLenHmacSha* (the latter is what HKDF / KBKDF derive in this firmware). The key's hash variant selects the MAC algorithm and tag length (SHA-256/384/512 -> 32/48/64 bytes), matching the reference firmware's Hmac handler.
- An unknown key_id surfaces as KeyNotFound; a non-HMAC key as InvalidKeyType.
- Generating a MAC is a PKCS#11 C_Sign operation, so the key must carry CKA_SIGN; a derive-only HMAC key is rejected with InvalidPermissions.

Deriving an HMAC key via KBKDF with no label/context (as the hmac integration tests do) previously failed: azihsm_crypto's KbkdfAlgo rejected deriving with both Label and Context absent. SP 800-108 permits empty Label/Context (and the sim/reference allow it), so relax KbkdfAlgo to permit both-absent — the PRF input reduces to the counter (and optional length field), leaving all other cases byte-identical.

New: hmac.rs handler, from_pal::hmac_hash; mod.rs dispatch wiring; hmac_smoke.rs smoke tests (fixed-HMAC MAC + unknown-key on both backends; var-HMAC MAC and the derive-only sign-permission rejection gated to emu, since the sim has no var-len HMAC kind and only permits SignVerify on HMAC keys).

Validation:
- emu integration::hmac:: 17/17 and hmac_smoke 4/4; mock 10/10 and hmac_smoke 2/2.
- The Hmac op + KBKDF change advance secret_hkdf_derive and secret_kbkdf_derive from 15/29 to 19/29 each on emu (the *_aes*_sha* HMAC-roundtrip tests now pass; remaining failures are bulk AES and the unimplemented OpenKey op).
- azihsm_crypto 476/476; std PAL unit 128/128; emu smoke 50/50; hkdf_smoke / kbkdf_smoke pass on emu and mock (no regression).
- cargo xtask clippy clean; clippy --tests clean under emu and mock; fmt and copyright clean.