### PR TITLE
Reverse part cert chain to leaf -> root sequence

### DIFF
--- a/api/lib/src/ddi/partition.rs
+++ b/api/lib/src/ddi/partition.rs
@@ -59,7 +59,7 @@ pub(crate) fn get_part_pub_key(dev: &HsmDev, rev: HsmApiRev) -> HsmResult<Vec<u8
 }
 
 /// Fetches the certificate chain and extracts the public key from the
-/// last certificate.
+/// leaf certificate.
 ///
 /// This combines the work of [`get_part_pub_key`] and [`get_cert_chain`]
 /// into one function, avoiding redundant `GetCertChainInfo` and
@@ -75,8 +75,8 @@ pub(crate) fn get_part_pub_key(dev: &HsmDev, rev: HsmApiRev) -> HsmResult<Vec<u8
 ///
 /// # Returns
 ///
-/// Returns a tuple of (PEM cert chain, DER-encoded public key from the
-/// last certificate).
+/// Returns a tuple of (PEM cert chain ordered leaf->root, DER-encoded
+/// public key from the leaf certificate).
 fn get_cert_chain_and_pub_key(
     dev: &HsmDev,
     rev: HsmApiRev,

--- a/api/lib/src/ddi/partition.rs
+++ b/api/lib/src/ddi/partition.rs
@@ -82,9 +82,9 @@ fn get_cert_chain_and_pub_key(
     rev: HsmApiRev,
     slot_id: u8,
 ) -> HsmResult<(String, Vec<u8>)> {
-    let (cert_chain, last_cert_der) = fetch_cert_chain_checked(dev, rev, slot_id)?;
+    let (cert_chain, leaf_cert_der) = fetch_cert_chain_checked(dev, rev, slot_id)?;
 
-    let cert = X509Certificate::from_der(&last_cert_der).map_hsm_err(HsmError::InternalError)?;
+    let cert = X509Certificate::from_der(&leaf_cert_der).map_hsm_err(HsmError::InternalError)?;
     let pub_key_der = cert
         .get_public_key_der()
         .map_hsm_err(HsmError::InternalError)?;
@@ -718,8 +718,10 @@ fn get_cert_chain_raw_no_res(dev: &HsmDev, rev: HsmApiRev, slot_id: u8) -> HsmRe
 /// Returns `InternalError` if the certificate count is zero (a partition
 /// must always have a provisioned cert chain).
 ///
-/// Also returns the DER bytes of the last certificate so callers can
-/// extract the public key.
+/// The returned PEM chain is ordered leaf->root (the firmware returns
+/// it root->leaf; this function reverses it to match the documented
+/// contract). Also returns the DER bytes of the leaf certificate so
+/// callers can extract the partition public key.
 fn fetch_cert_chain_checked(
     dev: &HsmDev,
     rev: HsmApiRev,
@@ -731,13 +733,15 @@ fn fetch_cert_chain_checked(
     }
 
     let mut cert_chain = String::new();
-    let mut last_cert_der = Vec::new();
-    for cert_id in 0..count {
+    let mut leaf_cert_der = Vec::new();
+
+    // Firmware returns chain in order root->leaf, but we want leaf->root, so reverse the chain before returning
+    for cert_id in (0..count).rev() {
         let der = get_cert(dev, rev, slot_id, cert_id)?;
         let pem = crypto::der_to_pem(&der).map_hsm_err(HsmError::InternalError)?;
         cert_chain.push_str(&pem);
         if cert_id == count - 1 {
-            last_cert_der = der;
+            leaf_cert_der = der;
         }
     }
 
@@ -746,7 +750,7 @@ fn fetch_cert_chain_checked(
         return Err(HsmError::CertChainChanged);
     }
 
-    Ok((cert_chain, last_cert_der))
+    Ok((cert_chain, leaf_cert_der))
 }
 
 /// Retrieves certificate chain information from the HSM device.

--- a/api/tests/Cargo.toml
+++ b/api/tests/Cargo.toml
@@ -28,6 +28,7 @@ libtest-mimic.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
 tracing-tree.workspace = true
+x509.workspace = true
 
 [features]
 default = []

--- a/api/tests/src/partition_tests.rs
+++ b/api/tests/src/partition_tests.rs
@@ -2,11 +2,12 @@
 // Licensed under the MIT License.
 
 use azihsm_crypto::pem_to_der;
+use x509::X509Certificate;
+use x509::X509CertificateOp;
 
 use super::*;
 use crate::utils::partition::*;
 use crate::utils::resiliency::*;
-
 /// No-op POTA callback for validation tests that need `pota_callback = Some`
 /// without exercising the actual signing flow.
 struct DummyPotaCallback;
@@ -260,6 +261,47 @@ fn test_cert_chain() {
         for block in blocks {
             pem_to_der(block.as_bytes()).expect("Failed to parse certificate PEM");
         }
+    }
+}
+
+/// Validates that the certificate chain returned by `cert_chain` is in leaf-to-root order
+#[api_test]
+fn test_cert_chain_leaf_to_root_order() {
+    let part_mgr = HsmPartitionManager::partition_info_list();
+    assert!(!part_mgr.is_empty(), "No partitions found.");
+    for part_info in part_mgr.iter() {
+        let part = HsmPartitionManager::open_partition(&part_info.path, test_api_rev())
+            .expect("Failed to open the partition");
+
+        let cert_chain = part.cert_chain(0).expect("Failed to retrieve cert chain");
+        assert!(!cert_chain.is_empty(), "Cert chain is empty");
+
+        // Parse the PEM chain into individual certificates, preserving order.
+        let certs = X509Certificate::from_pem_stack(cert_chain.as_bytes())
+            .expect("Failed to parse cert chain PEM stack");
+        assert!(!certs.is_empty(), "Parsed cert chain is empty");
+
+        // The sim layer returns a single (self-signed) certificate, so there is
+        // no leaf -> root ordering to validate. Only chains with more than one
+        // certificate carry an ordering that can be verified.
+        if certs.len() < 2 {
+            continue;
+        }
+
+        // The chain must be ordered leaf -> ... -> root. `validate_chain`
+        // treats the receiver as the leaf and the slice as the remaining
+        // certificates ending with the root, cryptographically verifying that
+        // each certificate is issued by the next one. This only succeeds when
+        // the chain is in leaf-to-root order; a reversed (root-to-leaf) chain
+        // would fail verification.
+        let (leaf, rest) = certs.split_first().expect("Cert chain is empty");
+        let valid = leaf
+            .validate_chain(rest)
+            .expect("Failed to validate cert chain order");
+        assert!(
+            valid,
+            "Cert chain is not in leaf -> root order or failed chain validation"
+        );
     }
 }
 

--- a/api/tests/src/partition_tests.rs
+++ b/api/tests/src/partition_tests.rs
@@ -242,17 +242,6 @@ fn test_cert_chain() {
             "Cert chain missing PEM header"
         );
 
-        // Save the retrieved PEM chain to a file for manual inspection /
-        // validation (e.g. `openssl crl2pkcs7 ... | openssl pkcs7 -print_certs`).
-        let out_path = std::env::temp_dir().join("azihsm_cert_chain.pem");
-        std::fs::write(&out_path, cert_chain.as_bytes())
-            .unwrap_or_else(|e| panic!("Failed to write cert chain to {out_path:?}: {e}"));
-        eprintln!(
-            "Saved cert chain ({} bytes) to {}",
-            cert_chain.len(),
-            out_path.display()
-        );
-
         let blocks: Vec<String> = cert_chain
             .split("-----BEGIN CERTIFICATE-----")
             .filter(|part| part.contains("-----END CERTIFICATE-----"))

--- a/api/tests/src/partition_tests.rs
+++ b/api/tests/src/partition_tests.rs
@@ -242,6 +242,17 @@ fn test_cert_chain() {
             "Cert chain missing PEM header"
         );
 
+        // Save the retrieved PEM chain to a file for manual inspection /
+        // validation (e.g. `openssl crl2pkcs7 ... | openssl pkcs7 -print_certs`).
+        let out_path = std::env::temp_dir().join("azihsm_cert_chain.pem");
+        std::fs::write(&out_path, cert_chain.as_bytes())
+            .unwrap_or_else(|e| panic!("Failed to write cert chain to {out_path:?}: {e}"));
+        eprintln!(
+            "Saved cert chain ({} bytes) to {}",
+            cert_chain.len(),
+            out_path.display()
+        );
+
         let blocks: Vec<String> = cert_chain
             .split("-----BEGIN CERTIFICATE-----")
             .filter(|part| part.contains("-----END CERTIFICATE-----"))


### PR DESCRIPTION
This pull request updates the handling and documentation of certificate chains in the HSM partition API to clarify and enforce the correct order of certificates (leaf-to-root) and to improve the clarity of variable naming. It also adds a test utility for easier manual inspection of the certificate chain.

**Certificate chain handling and documentation:**

* Updated the documentation and implementation of `fetch_cert_chain_checked` in `partition.rs` to clarify that the returned PEM chain is now ordered leaf-to-root (matching the documented contract), and that the DER bytes returned correspond to the leaf certificate (not the last/root certificate). Variable names were updated from `last_cert_der` to `leaf_cert_der` throughout for clarity. 
