### PR TITLE
[build] re-enable default rerun behavior in azihsm_api_tests package

### DIFF
--- a/api/tests/build.rs
+++ b/api/tests/build.rs
@@ -17,8 +17,8 @@ const VS2026_GEN_NAME: &str = "Visual Studio 18 2026";
 const VS2022_GEN_NAME: &str = "Visual Studio 17 2022";
 
 fn main() {
-    // Instruct Cargo to re-run this build script if any project files changed
-    println!("cargo:rerun-if-changed=cpp");
+    // Scan the entire package directory for changes
+    println!("cargo:rerun-if-changed=.");
     // Instruct Cargo to re-run this build script if any of the following env
     // vars changed since they impact the CMake configuration.
     println!("cargo:rerun-if-env-changed=CARGO_FEATURE_MOCK");

--- a/api/tests/build.rs
+++ b/api/tests/build.rs
@@ -17,6 +17,8 @@ const VS2026_GEN_NAME: &str = "Visual Studio 18 2026";
 const VS2022_GEN_NAME: &str = "Visual Studio 17 2022";
 
 fn main() {
+    // Instruct Cargo to re-run this build script if any project files changed
+    println!("cargo:rerun-if-changed=cpp");
     // Instruct Cargo to re-run this build script if any of the following env
     // vars changed since they impact the CMake configuration.
     println!("cargo:rerun-if-env-changed=CARGO_FEATURE_MOCK");


### PR DESCRIPTION
#367 changed the cmake build to add cargo:: instructions to the Rust build script @ api\tests\build.rs. That change inadvertently overrode the default behavior to rerun the build if any files in the cargo package changed. This change updates the Rust build script to rerun the cmake build if any files changed in the package directory: api\tests\.

fixes #444