### PR TITLE
refactor(pal): property-based partition API with typed wrappers

### DIFF
--- a/fw/core/lib/src/ddi/mbor/establish_credential.rs
+++ b/fw/core/lib/src/ddi/mbor/establish_credential.rs
@@ -107,12 +107,16 @@ pub(crate) async fn establish_credential<'p, P: HsmPal>(
     // Reset the partition nonce *before* decrypting / committing the
     // credential so the nonce that authenticated this request cannot
     // be replayed if a later step fails partway through.
-    pal.part_nonce_refresh(io)?;
+    {
+        let nonce = pal.dma_alloc(io, crate::part_state::NONCE_LEN)?;
+        pal.rng_fill_bytes(io, nonce)?;
+        crate::part_state::part_set_nonce(pal, io, nonce)?;
+    }
     decrypt_credential(pal, io, &mut body.encrypted_credential, aes_key).await?;
 
     // Fail-fast on null id or pin before doing the rest of the
-    // provisioning work.  `part_set_credential` (called at the final
-    // commit) also rejects null credentials; this early check
+    // provisioning work.  The CREDENTIAL prop setter (called at the
+    // final commit) also rejects null halves; this early check
     // preserves the historical error ordering and avoids wasting
     // BK3 / MK / BMK derivation effort on requests we know will be
     // rejected.
@@ -122,7 +126,7 @@ pub(crate) async fn establish_credential<'p, P: HsmPal>(
         return Err(HsmError::InvalidAppCredentials);
     }
 
-    // Credential commit (`part_set_credential` / `part_clear_establish_cred_key`)
+    // Credential commit (CREDENTIAL prop write / `part_clear_establish_cred_key`)
     // and BK3 session commit (`part_set_bk3_session`) are intentionally
     // deferred to the final atomic-commit block at the end of this
     // handler.  Deferring lets a failure in steps 8-13 (e.g. tampered
@@ -143,8 +147,8 @@ pub(crate) async fn establish_credential<'p, P: HsmPal>(
     // `bk3_session_set` flag unchanged.
 
     // ── Step 10: Derive partition BK ─────────────────────────────────
-    let svn = pal.part_svn(io)?;
-    let bks2_id = pal.part_bks2_id(io)?;
+    let svn = crate::part_state::part_svn(pal, io)?;
+    let bks2_id = crate::part_state::part_bks2_id(pal, io)?;
     let bk = pal.dma_alloc(io, BK_LEN)?;
     derive_partition_bk(pal, io, bk3, body.pota_pub_key.raw, svn, bks2_id, bk).await?;
 
@@ -173,23 +177,31 @@ pub(crate) async fn establish_credential<'p, P: HsmPal>(
     //
     // Under the partition lock, every call below is effectively
     // infallible:
-    // - `part_set_credential` validates length and non-zero id/pin;
-    //   both are pre-checked above so this cannot fail here.
+    // - CREDENTIAL prop write validates length, write-once, and
+    //   non-zero id/pin; both halves are pre-checked above so this
+    //   cannot fail here.
     // - `part_set_bk3_session` validates length (48 B); `bk3_session`
     //   is allocated with `BK3_LEN = 48`.
     // - `part_clear_establish_cred_key` and `part_set_mk_key_id` only
     //   fail if the partition is disabled, which is prevented by the
     //   partition-enabled check at the start of `handle_io`.
     //
-    // `part_set_credential` is committed first so a (theoretical)
+    // The CREDENTIAL prop write is committed first so a (theoretical)
     // failure here triggers `mk_guard`'s Drop, which removes the
     // provisional MK vault entry. The establish-cred encryption key
     // is cleared only after the credential commit succeeds, so the
     // host can always retry on failure.
-    pal.part_set_credential(io, id, pin)?;
-    pal.part_set_bk3_session(io, bk3_session)?;
-    pal.part_clear_establish_cred_key(io)?;
-    pal.part_set_mk_key_id(io, mk_key_id)?;
+    // Compose `id ‖ pin` into a 32 B DmaBuf for the property setter.
+    // The CREDENTIAL prop setter enforces the write-once invariant and
+    // the all-zero half rejection (the latter is also pre-checked
+    // above to preserve the historical error ordering).
+    let cred = pal.dma_alloc(io, 2 * CRED_FIELD_LEN)?;
+    cred[..CRED_FIELD_LEN].copy_from_slice(id);
+    cred[CRED_FIELD_LEN..].copy_from_slice(pin);
+    crate::part_state::part_set_credential(pal, io, cred)?;
+    crate::part_state::part_set_bk3_session(pal, io, bk3_session)?;
+    crate::part_state::part_clear_establish_cred_key(pal, io)?;
+    crate::part_state::part_set_mk_key_id(pal, io, mk_key_id)?;
     mk_guard.dismiss();
 
     Ok(resp)
@@ -220,12 +232,12 @@ fn check_fail_fast<P: HsmPal>(
     io: &impl HsmIo,
     body: &DdiEstablishCredentialReq<'_>,
 ) -> HsmResult<()> {
-    pal.part_verify_nonce(io, body.encrypted_credential.nonce)?;
+    crate::part_state::part_verify_nonce(pal, io, body.encrypted_credential.nonce)?;
 
-    if pal.part_is_credential_set(io)? {
+    if crate::part_state::part_is_credential_set(pal, io)? {
         return Err(HsmError::VaultAppLimitReached);
     }
-    if pal.part_is_provisioned(io)? {
+    if crate::part_state::part_is_provisioned(pal, io)? {
         return Err(HsmError::PartitionAlreadyProvisioned);
     }
 
@@ -265,10 +277,13 @@ async fn verify_pota_signature<P: HsmPal>(
 ) -> HsmResult<()> {
     // `part_id_pub_key` returns the raw `x ‖ y` form (96 B); prepend
     // the SEC1 `0x04` uncompressed-point tag in a fresh DMA buffer.
-    let id_pub_key_len = pal.part_id_pub_key(io, None)?;
+    let id_pub_key_len = crate::part_state::part_id_pub_key(pal, io)?.len();
     let id_uncompressed = pal.dma_alloc(io, id_pub_key_len + 1)?;
     id_uncompressed[0] = 0x04;
-    pal.part_id_pub_key(io, Some(&mut id_uncompressed[1..]))?;
+    {
+        let pk = crate::part_state::part_id_pub_key(pal, io)?;
+        id_uncompressed[1..].copy_from_slice(&pk[..id_pub_key_len]);
+    }
 
     let digest = pal.dma_alloc(io, HsmHashAlgo::Sha384.digest_len())?;
     pal.hash(io, HsmHashAlgo::Sha384, id_uncompressed, digest, true)
@@ -306,9 +321,11 @@ async fn derive_credential_keys<P: HsmPal>(
     nonce: &DmaBuf,
     okm_out: &mut DmaBuf,
 ) -> HsmResult<()> {
-    let est_cred_key_id = pal
-        .part_establish_cred_key_id(io)?
-        .ok_or(HsmError::KeyNotFound)?;
+    let est_cred_key_id = match crate::part_state::part_establish_cred_key_id(pal, io) {
+        Ok(id) => id,
+        Err(HsmError::PartPropNotFound) => return Err(HsmError::KeyNotFound),
+        Err(e) => return Err(e),
+    };
 
     let secret = pal.dma_alloc(io, HsmEccCurve::P384.secret_len())?;
     {
@@ -435,9 +452,12 @@ async fn unmask_partition_bk3<P: HsmPal>(
     masked_bk3: &mut DmaBuf,
     bk3_out: &mut DmaBuf,
 ) -> HsmResult<()> {
-    let bk_boot_len = pal.part_bk_boot(io, None)?;
+    let bk_boot_len = crate::part_state::part_bk_boot(pal, io)?.len();
     let bk_boot = pal.dma_alloc(io, bk_boot_len)?;
-    pal.part_bk_boot(io, Some(bk_boot))?;
+    {
+        let src = crate::part_state::part_bk_boot(pal, io)?;
+        bk_boot.copy_from_slice(&src[..bk_boot_len]);
+    }
 
     let layout = unmask(pal, io, bk_boot, masked_bk3).await?;
     if layout.plaintext_max_len < BK3_LEN {
@@ -478,12 +498,11 @@ async fn derive_bk3_session<P: HsmPal>(
 ///
 /// SP 800-108 KBKDF-HMAC-SHA-384 keyed on `bk3` with
 /// `label = "PARTITION_BK" ‖ signer_pub_key` and
-/// `context = BKS1 ‖ BKS2` (contributed by the PAL via
-/// [`HsmPart::derive_masking_key`]).
+/// `context = MFGR_SEED[svn] ‖ DEV_OWNER_SEED[bks2_id]` (read from
+/// the PAL via [`derive_masking_key`]).
 ///
-/// [`HsmPart::derive_masking_key`] takes `label: &[u8]` (not
-/// `&DmaBuf`), so the label is built on the stack — no DMA alloc
-/// needed for it.
+/// [`derive_masking_key`] takes `label: &[u8]` (not `&DmaBuf`), so
+/// the label is built on the stack — no DMA alloc needed for it.
 ///
 /// `signer_pub_key` must be exactly 96 bytes (P-384 raw `x ‖ y`).
 /// `bk_out` must be exactly [`BK_LEN`] (80) bytes.
@@ -500,8 +519,85 @@ async fn derive_partition_bk<P: HsmPal>(
     bk_label[..PARTITION_BK_LABEL.len()].copy_from_slice(PARTITION_BK_LABEL);
     bk_label[PARTITION_BK_LABEL.len()..].copy_from_slice(signer_pub_key);
 
-    pal.derive_masking_key(io, bk3, &bk_label, &[], svn, bks2_id, bk_out)
-        .await
+    derive_masking_key(pal, io, bk3, &bk_label, &[], svn, bks2_id, bk_out).await
+}
+
+/// Derives a masking key via SP 800-108 KBKDF-HMAC-SHA-384.
+///
+/// The effective KDF context is
+/// `MFGR_SEED[svn] ‖ DEV_OWNER_SEED[bks2_id] ‖ extra_context`.  The
+/// two seed rows are PAL-private root-of-trust material exposed
+/// through [`PartPropId::MFGR_SEED`] / [`PartPropId::DEV_OWNER_SEED`]
+/// (sensitive, indexed, read-only); the KDK is caller-supplied so the
+/// same primitive can derive multiple flavours of masking key:
+///
+/// | Derivation | KDK | `label` | `extra_context` |
+/// |---|---|---|---|
+/// | `BKx` for `Masked_BK_BOOT` | `fw_seed` | `b"BK_BOOT_MK_DEFAULT"` | `&[]` |
+/// | Partition `BK` | partition `BK3` | `b"PARTITION_BK" ‖ pota_pub_key` | `&[]` |
+///
+/// # Parameters
+///
+/// - `kdk` — KBKDF key-derivation key, already DMA-resident.
+/// - `label` — KBKDF purpose label; `&[]` permitted (no label).
+/// - `extra_context` — caller-supplied context suffix appended after
+///   the seed rows.  `&[]` permitted.
+/// - `svn` — selects the [`PartPropId::MFGR_SEED`] row (`0..64`).
+/// - `bks2_id` — selects the [`PartPropId::DEV_OWNER_SEED`] row
+///   (`0..64`).
+/// - `output` — DMA-accessible destination; `output.len()` bytes are
+///   written.
+///
+/// # Errors
+///
+/// - [`HsmError::InvalidArg`] — `svn` ≥ 64, or PAL-layer validation
+///   failure (e.g. partition not in a serving state).
+/// - [`HsmError::PartPropNotFound`] — PAL has not provisioned a row
+///   for the requested `(svn, bks2_id)`.
+/// - [`HsmError::NotEnoughSpace`] — DMA arena exhausted.
+/// - Errors propagated from the underlying SP 800-108 driver.
+#[allow(clippy::too_many_arguments)]
+pub(crate) async fn derive_masking_key<P: HsmPal>(
+    pal: &P,
+    io: &impl HsmIo,
+    kdk: &DmaBuf,
+    label: &[u8],
+    extra_context: &[u8],
+    svn: u64,
+    bks2_id: u16,
+    output: &mut DmaBuf,
+) -> HsmResult<()> {
+    let mfgr = crate::part_state::part_mfgr_seed(pal, io, svn)?;
+    let dev_owner = crate::part_state::part_dev_owner_seed(pal, io, bks2_id)?;
+
+    let mfgr_len = mfgr.len();
+    let dev_owner_len = dev_owner.len();
+    let ctx_len = mfgr_len + dev_owner_len + extra_context.len();
+    let ctx = pal.dma_alloc(io, ctx_len)?;
+    {
+        let (mfgr_slot, rest) = ctx.split_at_mut(mfgr_len);
+        let (dev_slot, extra_slot) = rest.split_at_mut(dev_owner_len);
+        mfgr_slot.copy_from_slice(mfgr);
+        dev_slot.copy_from_slice(dev_owner);
+        if !extra_context.is_empty() {
+            extra_slot.copy_from_slice(extra_context);
+        }
+    }
+
+    let label_dma = pal.dma_alloc(io, label.len())?;
+    if !label.is_empty() {
+        label_dma.copy_from_slice(label);
+    }
+
+    pal.sp800_108_kdf(
+        io,
+        HsmHashAlgo::Sha384,
+        kdk,
+        Some(label_dma),
+        Some(ctx),
+        output,
+    )
+    .await
 }
 
 /// Provisions the partition masking key (MK) in the vault.

--- a/fw/core/lib/src/ddi/mbor/get_device_info.rs
+++ b/fw/core/lib/src/ddi/mbor/get_device_info.rs
@@ -27,7 +27,7 @@ pub(crate) fn get_device_info<'p, P: HsmPal>(
 
     let resp_data = DdiGetDeviceInfoResp {
         kind: DdiDeviceKind::Physical,
-        tables: pal.part_res_count(io).unwrap_or(0),
+        tables: crate::part_state::part_res_count(pal, io).unwrap_or(0),
         fips_approved: false,
     };
 

--- a/fw/core/lib/src/ddi/mbor/get_establish_cred_encryption_key.rs
+++ b/fw/core/lib/src/ddi/mbor/get_establish_cred_encryption_key.rs
@@ -27,15 +27,18 @@ pub(crate) async fn get_establish_cred_encryption_key<'p, P: HsmPal>(
     let _body: DdiGetEstablishCredEncryptionKeyReq = decoder.decode_data()?;
 
     // Key must exist (not yet consumed by EstablishCredential).
-    pal.part_establish_cred_key_id(io)?
-        .ok_or(HsmError::KeyNotFound)?;
+    match crate::part_state::part_establish_cred_key_id(pal, io) {
+        Ok(_) => {}
+        Err(HsmError::PartPropNotFound) => return Err(HsmError::KeyNotFound),
+        Err(e) => return Err(e),
+    }
 
     // Query sizes, then encode header + frame with reserved slots.
-    let pub_key_len = pal.part_establish_cred_pub_key(io, None)?;
-    let nonce_len = pal.part_nonce(io, None)?;
+    let pub_key_len = crate::part_state::part_establish_cred_pub_key(pal, io)?.len();
+    let nonce_len = crate::part_state::part_nonce(pal, io)?.len();
 
     let digest = pal.dma_alloc(io, HsmHashAlgo::Sha384.digest_len())?;
-    let id_priv_key = pal.vault_key(io, pal.part_id_key_id(io)?)?;
+    let id_priv_key = pal.vault_key(io, crate::part_state::part_id_key_id(pal, io)?)?;
 
     let (resp, layout) = pal.dma_alloc_var_with(io, |buf| {
         let mut encoder = super::encode_resp_hdr(
@@ -56,8 +59,14 @@ pub(crate) async fn get_establish_cred_encryption_key<'p, P: HsmPal>(
     let frame = DdiGetEstablishCredEncryptionKeyResp::from_layout(resp, &layout);
 
     // Fill public key and nonce in-place.
-    pal.part_establish_cred_pub_key(io, Some(frame.pub_key.raw))?;
-    pal.part_nonce(io, Some(frame.nonce))?;
+    {
+        let pk = crate::part_state::part_establish_cred_pub_key(pal, io)?;
+        frame.pub_key.raw.copy_from_slice(&pk[..pub_key_len]);
+    }
+    {
+        let n = crate::part_state::part_nonce(pal, io)?;
+        frame.nonce.copy_from_slice(&n[..nonce_len]);
+    }
 
     // Hash pub key directly in wire-LE (PAL's `ecc_sign` digest
     // contract), then sign into the signature slot.

--- a/fw/core/lib/src/ddi/mbor/get_sealed_bk3.rs
+++ b/fw/core/lib/src/ddi/mbor/get_sealed_bk3.rs
@@ -30,17 +30,19 @@ pub(crate) fn get_sealed_bk3<'p, P: HsmPal>(
 ) -> HsmResult<&'p DmaBuf> {
     let _body: DdiGetSealedBk3Req = decoder.decode_data()?;
 
-    let sealed_len = pal.part_sealed_bk3(io, None)?;
-    if sealed_len == 0 {
-        return Err(HsmError::SealedBk3NotPresent);
-    }
+    let sealed_len = match crate::part_state::part_sealed_bk3(pal, io) {
+        Ok(bytes) => bytes.len(),
+        Err(HsmError::PartPropNotFound) => return Err(HsmError::SealedBk3NotPresent),
+        Err(e) => return Err(e),
+    };
 
     let resp = pal.dma_alloc_var(io, |buf| {
         let mut encoder =
             super::encode_resp_hdr(&super::success_hdr(hdr, DdiOp::GetSealedBk3), buf)?;
         let frame = DdiGetSealedBk3Resp::frame(&mut encoder, sealed_len)?;
         let total = encoder.position();
-        pal.part_sealed_bk3(io, Some(frame.sealed_bk3))?;
+        let bytes = crate::part_state::part_sealed_bk3(pal, io)?;
+        frame.sealed_bk3.copy_from_slice(&bytes[..sealed_len]);
         Ok(total)
     })?;
 

--- a/fw/core/lib/src/ddi/mbor/get_session_encryption_key.rs
+++ b/fw/core/lib/src/ddi/mbor/get_session_encryption_key.rs
@@ -38,16 +38,16 @@ pub(crate) async fn get_session_encryption_key<'p, P: HsmPal>(
 ) -> HsmResult<&'p DmaBuf> {
     let _body: DdiGetSessionEncryptionKeyReq = decoder.decode_data()?;
 
-    if !pal.part_is_credential_set(io)? {
+    if !crate::part_state::part_is_credential_set(pal, io)? {
         return Err(HsmError::CredentialsNotEstablished);
     }
 
     // Query sizes, then encode header + frame with reserved slots.
-    let pub_key_len = pal.part_session_enc_pub_key(io, None)?;
-    let nonce_len = pal.part_nonce(io, None)?;
+    let pub_key_len = crate::part_state::part_session_enc_pub_key(pal, io)?.len();
+    let nonce_len = crate::part_state::part_nonce(pal, io)?.len();
 
     let digest = pal.dma_alloc(io, HsmHashAlgo::Sha384.digest_len())?;
-    let id_priv_key = pal.vault_key(io, pal.part_id_key_id(io)?)?;
+    let id_priv_key = pal.vault_key(io, crate::part_state::part_id_key_id(pal, io)?)?;
 
     let (resp, layout) = pal.dma_alloc_var_with(io, |buf| {
         let mut encoder = super::encode_resp_hdr(
@@ -68,8 +68,14 @@ pub(crate) async fn get_session_encryption_key<'p, P: HsmPal>(
     let frame = DdiGetSessionEncryptionKeyResp::from_layout(resp, &layout);
 
     // Fill public key and nonce in-place.
-    pal.part_session_enc_pub_key(io, Some(frame.pub_key.raw))?;
-    pal.part_nonce(io, Some(frame.nonce))?;
+    {
+        let pk = crate::part_state::part_session_enc_pub_key(pal, io)?;
+        frame.pub_key.raw.copy_from_slice(&pk[..pub_key_len]);
+    }
+    {
+        let n = crate::part_state::part_nonce(pal, io)?;
+        frame.nonce.copy_from_slice(&n[..nonce_len]);
+    }
 
     // Hash pub key directly in wire-LE (PAL's `ecc_sign` digest
     // contract), then sign into the signature slot.

--- a/fw/core/lib/src/ddi/mbor/init_bk3.rs
+++ b/fw/core/lib/src/ddi/mbor/init_bk3.rs
@@ -141,12 +141,12 @@ pub(crate) async fn init_bk3<'p, P: HsmPal>(
     let _lock = pal.partition_lock(io).await?;
 
     // Fail-fast; the authoritative commit below re-checks atomically.
-    if pal.part_is_bk3_initialized(io)? {
+    if crate::part_state::part_is_bk3_initialized(pal, io)? {
         return Err(HsmError::Bk3AlreadyInitialized);
     }
 
-    let svn = pal.part_svn(io)?;
-    let bks2_id = pal.part_bks2_id(io)?;
+    let svn = crate::part_state::part_svn(pal, io)?;
+    let bks2_id = crate::part_state::part_bks2_id(pal, io)?;
     let metadata = DdiMaskedKeyMetadata {
         svn,
         key_type: DdiKeyType::AesCbc256Hmac384,
@@ -160,17 +160,19 @@ pub(crate) async fn init_bk3<'p, P: HsmPal>(
     };
 
     // Single combined alloc for BK_BOOT + BKx (both live simultaneously
-    // during the second mask call below).  `part_bk_boot(None)` queries
-    // the canonical BK_BOOT length without copying any bytes.
-    let bk_boot_len = pal.part_bk_boot(io, None)?;
+    // during the second mask call below).
+    let bk_boot_len = crate::part_state::part_bk_boot(pal, io)?.len();
     let keys_dma = pal.dma_alloc(io, 2 * bk_boot_len)?;
     let (bk_boot_dma, bkx_dma) = keys_dma.split_at_mut(bk_boot_len);
-    pal.part_bk_boot(io, Some(bk_boot_dma))?;
+    {
+        let bk = crate::part_state::part_bk_boot(pal, io)?;
+        bk_boot_dma.copy_from_slice(&bk[..bk_boot_len]);
+    }
 
     // Size-only query (no crypto).
     let masked_bk3_len = mask(pal, io, bk_boot_dma, body.bk3, &metadata, None).await?;
 
-    let vm_launch_guid_len = pal.part_vm_launch_guid(io, None)?;
+    let vm_launch_guid_len = crate::part_state::part_vm_launch_guid(pal, io)?.len();
 
     // Reserve the response buffer (encoder-frame-then-fill).  The async
     // mask call below operates on the buffer materialized via
@@ -211,10 +213,15 @@ pub(crate) async fn init_bk3<'p, P: HsmPal>(
 
     // Derive BKx per-call from the PAL's fw_seed bound to (svn,
     // bks2_id).  The key materializes only inside `bkx_dma`; no BKx
-    // value crosses the trait boundary.
-    pal.derive_masking_key(
+    // value crosses the trait boundary.  `derive_masking_key` lives
+    // in `super::establish_credential` because that handler is the
+    // primary user; it reads the MFGR_SEED / DEV_OWNER_SEED rows
+    // from the PAL via the property API.
+    let fw_seed = crate::part_state::part_fw_seed(pal, io)?;
+    super::derive_masking_key(
+        pal,
         io,
-        pal.fw_seed(),
+        fw_seed,
         BK_BOOT_MK_LABEL,
         &[],
         svn,
@@ -238,14 +245,19 @@ pub(crate) async fn init_bk3<'p, P: HsmPal>(
     )
     .await?;
 
-    pal.part_set_masked_bk_boot(io, masked_bk_boot_dma)?;
+    crate::part_state::part_set_masked_bk_boot(pal, io, masked_bk_boot_dma)?;
 
-    pal.part_vm_launch_guid(io, Some(frame.vm_launch_guid))?;
+    {
+        let guid = crate::part_state::part_vm_launch_guid(pal, io)?;
+        frame
+            .vm_launch_guid
+            .copy_from_slice(&guid[..vm_launch_guid_len]);
+    }
 
     // Authoritative one-shot commit; must be the last fallible op so a
     // failure here cannot leave the partition in `Initialized` state
     // without the host having received the masked BK3.
-    pal.part_mark_bk3_initialized(io)?;
+    crate::part_state::part_mark_bk3_initialized(pal, io)?;
 
     Ok(resp)
 }

--- a/fw/core/lib/src/ddi/mbor/open_session.rs
+++ b/fw/core/lib/src/ddi/mbor/open_session.rs
@@ -18,7 +18,7 @@
 //!    split into a 32-byte AES key and a 48-byte HMAC key.
 //! 4. HMAC-SHA-384 verify the encrypted credential tag over
 //!    `enc_id ‖ enc_pin ‖ enc_seed ‖ iv ‖ nonce`.
-//! 5. `part_nonce_refresh` — consume the nonce so a replayed request
+//! 5. `part_set_nonce` — consume the nonce so a replayed request
 //!    cannot survive any later failure.
 //! 6. AES-CBC-256 decrypt id (16 B) → pin (16 B) → seed (48 B) in
 //!    place, chaining IVs across blocks just like the host wrap.
@@ -94,7 +94,11 @@ pub(crate) async fn open_session<'p, P: HsmPal>(
     // Reset the partition nonce *before* decrypting / verifying the
     // credential so the nonce that authenticated this request cannot
     // be replayed if a later step fails partway through.
-    pal.part_nonce_refresh(io)?;
+    {
+        let nonce = pal.dma_alloc(io, crate::part_state::NONCE_LEN)?;
+        pal.rng_fill_bytes(io, nonce)?;
+        crate::part_state::part_set_nonce(pal, io, nonce)?;
+    }
     decrypt_session_credential(pal, io, &mut body.encrypted_credential, aes_key).await?;
 
     // ── Step 6: Verify decrypted credential matches persisted ────────
@@ -103,15 +107,18 @@ pub(crate) async fn open_session<'p, P: HsmPal>(
     if id == [0u8; CRED_FIELD_LEN] || pin == [0u8; CRED_FIELD_LEN] {
         return Err(HsmError::InvalidAppCredentials);
     }
-    pal.part_verify_credential(io, id, pin)?;
+    crate::part_state::part_verify_credential(pal, io, id, pin)?;
 
     // ── Step 7: Fresh MK_SESSION + derived BK_SESSION ────────────────
     let mk_session = pal.dma_alloc(io, BK_LEN)?;
     pal.rng_fill_bytes(io, mk_session)?;
 
-    let bk_boot_len = pal.part_bk_boot(io, None)?;
+    let bk_boot_len = crate::part_state::part_bk_boot(pal, io)?.len();
     let bk_boot = pal.dma_alloc(io, bk_boot_len)?;
-    pal.part_bk_boot(io, Some(bk_boot))?;
+    {
+        let src = crate::part_state::part_bk_boot(pal, io)?;
+        bk_boot.copy_from_slice(&src[..bk_boot_len]);
+    }
 
     let bk_session = pal.dma_alloc(io, BK_LEN)?;
     let session_bk_label = pal.dma_alloc(io, SESSION_BK_LABEL.len())?;
@@ -139,8 +146,8 @@ pub(crate) async fn open_session<'p, P: HsmPal>(
         sess_id,
         bk_session,
         mk_session,
-        pal.part_svn(io)?,
-        pal.part_bks2_id(io)?,
+        crate::part_state::part_svn(pal, io)?,
+        crate::part_state::part_bks2_id(pal, io)?,
     )
     .await?;
 
@@ -176,17 +183,17 @@ fn check_fail_fast<P: HsmPal>(
     // partition: NonceMismatch could be hit by any random replay,
     // whereas CredentialsNotEstablished tells the host it must
     // EstablishCredential first.
-    if !pal.part_is_credential_set(io)? {
+    if !crate::part_state::part_is_credential_set(pal, io)? {
         return Err(HsmError::CredentialsNotEstablished);
     }
-    if !pal.part_is_provisioned(io)? {
+    if !crate::part_state::part_is_provisioned(pal, io)? {
         return Err(HsmError::PartitionNotProvisioned);
     }
     if pal.session_limit_reached(io) {
         return Err(HsmError::VaultSessionLimitReached);
     }
 
-    pal.part_verify_nonce(io, body.encrypted_credential.nonce)?;
+    crate::part_state::part_verify_nonce(pal, io, body.encrypted_credential.nonce)?;
 
     if body.pub_key.key_kind != DdiKeyType::Ecc384Public {
         return Err(HsmError::InvalidKeyType);
@@ -213,7 +220,7 @@ async fn derive_session_credential_keys<P: HsmPal>(
     nonce: &DmaBuf,
     okm_out: &mut DmaBuf,
 ) -> HsmResult<()> {
-    let sess_enc_key_id = pal.part_session_enc_key_id(io)?;
+    let sess_enc_key_id = crate::part_state::part_session_enc_key_id(pal, io)?;
 
     let secret = pal.dma_alloc(io, HsmEccCurve::P384.secret_len())?;
     {

--- a/fw/core/lib/src/ddi/mbor/set_sealed_bk3.rs
+++ b/fw/core/lib/src/ddi/mbor/set_sealed_bk3.rs
@@ -5,22 +5,32 @@
 //!
 //! Stores the sealed BK3 blob on the partition. Returns
 //! `SealedBk3AlreadySet` if one has already been stored, or
-//! `SealedBk3TooLarge` if the blob exceeds 1024 bytes.
+//! `SealedBk3TooLarge` if the blob exceeds the PAL's
+//! [`SEALED_BK3_MAX_LEN`](azihsm_fw_pal_traits::SEALED_BK3_MAX_LEN)
+//! bound.
 
 use azihsm_fw_ddi_mbor_types::set_sealed_bk3::DdiSetSealedBk3Req;
 use azihsm_fw_ddi_mbor_types::set_sealed_bk3::DdiSetSealedBk3Resp;
+use azihsm_fw_hsm_pal_traits::SEALED_BK3_MAX_LEN;
 
 use super::*;
 
 /// Handle DdiSetSealedBk3Cmd.
 ///
-/// 1. **Already-set check** — `sealed_bk3 len != 0` → `SealedBk3AlreadySet`.
+/// 1. **Body decode** — Decodes `DdiSetSealedBk3Req` with the blob.
 ///
-/// 2. **Body decode** — Decodes `DdiSetSealedBk3Req` with the blob.
+/// 2. **Size check** — Rejects blobs larger than
+///    [`SEALED_BK3_MAX_LEN`] with `SealedBk3TooLarge` before the
+///    PAL property setter (which would otherwise surface the
+///    overflow as the generic `InvalidArg`).
 ///
-/// 3. **Store** — Writes the blob via the PAL (validates size internally).
+/// 3. **Already-set check** — `SetSealedBk3` is write-once per
+///    power cycle; the PAL setter returns `SealedBk3AlreadySet` if
+///    a blob is already stored.
 ///
-/// 4. **Response** — Encodes `DdiSetSealedBk3Resp` (empty) into a
+/// 4. **Store** — Writes the blob via the PAL.
+///
+/// 5. **Response** — Encodes `DdiSetSealedBk3Resp` (empty) into a
 ///    heap-allocated response buffer.
 pub(crate) fn set_sealed_bk3<'p, P: HsmPal>(
     pal: &'p P,
@@ -29,6 +39,11 @@ pub(crate) fn set_sealed_bk3<'p, P: HsmPal>(
     hdr: &DdiReqHdr,
 ) -> HsmResult<&'p DmaBuf> {
     let body: DdiSetSealedBk3Req<'_> = decoder.decode_data()?;
+
+    if body.sealed_bk3.len() > usize::from(SEALED_BK3_MAX_LEN) {
+        return Err(HsmError::SealedBk3TooLarge);
+    }
+
     crate::part_state::part_set_sealed_bk3(pal, io, body.sealed_bk3)?;
 
     let resp_hdr = super::success_hdr(hdr, DdiOp::SetSealedBk3);

--- a/fw/core/lib/src/ddi/mbor/set_sealed_bk3.rs
+++ b/fw/core/lib/src/ddi/mbor/set_sealed_bk3.rs
@@ -29,7 +29,7 @@ pub(crate) fn set_sealed_bk3<'p, P: HsmPal>(
     hdr: &DdiReqHdr,
 ) -> HsmResult<&'p DmaBuf> {
     let body: DdiSetSealedBk3Req<'_> = decoder.decode_data()?;
-    pal.part_set_sealed_bk3(io, body.sealed_bk3)?;
+    crate::part_state::part_set_sealed_bk3(pal, io, body.sealed_bk3)?;
 
     let resp_hdr = super::success_hdr(hdr, DdiOp::SetSealedBk3);
     let resp_data = DdiSetSealedBk3Resp {};

--- a/fw/core/lib/src/ddi/tbor/change_psk.rs
+++ b/fw/core/lib/src/ddi/tbor/change_psk.rs
@@ -106,7 +106,7 @@ pub(crate) async fn handle<'p, P: HsmPal>(
         // view.  `part_psk_set` is synchronous and takes `&[u8]`, so
         // the borrow ends with the call — no need for a separate
         // scratch buffer.
-        pal.part_psk_set(io, target_psk_id, aead_view.payload)?;
+        crate::part_state::part_set_psk(pal, io, target_psk_id, aead_view.payload)?;
 
         encode_response(pal, io)
     })

--- a/fw/core/lib/src/ddi/tbor/mod.rs
+++ b/fw/core/lib/src/ddi/tbor/mod.rs
@@ -153,7 +153,7 @@ pub(crate) async fn dispatch<'p, P: HsmPal>(
         if is_in_session(opcode) && !allowed_with_default_psk(opcode) {
             let sess_id = extract_session_id(&view)?;
             let psk_id = psk_id_for_role(sess_id.role());
-            if pal.part_psk_is_default(io, psk_id)? {
+            if crate::part_state::part_psk_is_default(pal, io, psk_id)? {
                 return Err(HsmError::DefaultPskMustRotate);
             }
         }

--- a/fw/core/lib/src/ddi/tbor/open_session_finish.rs
+++ b/fw/core/lib/src/ddi/tbor/open_session_finish.rs
@@ -256,10 +256,13 @@ fn load_pk_hsm<'a, P: HsmPal>(
     io: &impl HsmIo,
     alloc: &'a impl HsmScopedAlloc,
 ) -> HsmResult<&'a mut DmaBuf> {
-    let xy_len = pal.part_id_pub_key(io, None)?;
+    let xy_len = crate::part_state::part_id_pub_key(pal, io)?.len();
     let pk_hsm = alloc.dma_alloc(xy_len + 1)?;
     pk_hsm[0] = 0x04;
-    pal.part_id_pub_key(io, Some(&mut pk_hsm[1..1 + xy_len]))?;
+    {
+        let pk = crate::part_state::part_id_pub_key(pal, io)?;
+        pk_hsm[1..1 + xy_len].copy_from_slice(&pk[..xy_len]);
+    }
     Ok(pk_hsm)
 }
 
@@ -436,8 +439,8 @@ async fn build_bmk_session<'a, P: HsmPal>(
 ) -> HsmResult<&'a mut DmaBuf> {
     let bk_session = derive_bk_session(pal, io, alloc, seed).await?;
 
-    let svn = pal.part_svn(io)?;
-    let owner_seed_id = pal.part_bks2_id(io)?;
+    let svn = crate::part_state::part_svn(pal, io)?;
+    let owner_seed_id = crate::part_state::part_bks2_id(pal, io)?;
 
     // `key_label` must be a DmaBuf per the masking-lib API; stage
     // the constant label into one.
@@ -487,9 +490,12 @@ async fn derive_bk_session<'a, P: HsmPal>(
     alloc: &'a impl HsmScopedAlloc,
     seed: &DmaBuf,
 ) -> HsmResult<&'a mut DmaBuf> {
-    let bk_boot_len = pal.part_bk_boot(io, None)?;
+    let bk_boot_len = crate::part_state::part_bk_boot(pal, io)?.len();
     let bk_boot = alloc.dma_alloc(bk_boot_len)?;
-    pal.part_bk_boot(io, Some(&mut bk_boot[..]))?;
+    {
+        let src = crate::part_state::part_bk_boot(pal, io)?;
+        bk_boot.copy_from_slice(&src[..bk_boot_len]);
+    }
 
     let label = alloc.dma_alloc(SESSION_BK_LABEL.len())?;
     label.copy_from_slice(SESSION_BK_LABEL);

--- a/fw/core/lib/src/ddi/tbor/open_session_init.rs
+++ b/fw/core/lib/src/ddi/tbor/open_session_init.rs
@@ -96,7 +96,7 @@ pub(crate) async fn handle<'p, P: HsmPal>(
     pal.alloc_scoped_async(io, async |alloc| {
         // ── Identity + PSK material (all on the scoped allocator) ──
         let psk = load_psk(pal, io, alloc, psk_id)?;
-        let key_id = pal.part_id_key_id(io)?;
+        let key_id = crate::part_state::part_id_key_id(pal, io)?;
         let sk_hsm = pal.vault_key(io, key_id)?;
         let pk_hsm = load_pk_hsm_sec1(pal, io, alloc)?;
 
@@ -195,7 +195,8 @@ fn load_psk<'a, P: HsmPal>(
     psk_id: u8,
 ) -> HsmResult<&'a mut DmaBuf> {
     let psk = alloc.dma_alloc(PSK_LEN)?;
-    pal.part_psk(io, psk_id, Some(&mut psk[..]))?;
+    let src = crate::part_state::part_psk(pal, io, psk_id)?;
+    psk.copy_from_slice(&src[..PSK_LEN]);
     Ok(psk)
 }
 
@@ -217,10 +218,13 @@ fn load_pk_hsm_sec1<'a, P: HsmPal>(
     io: &impl HsmIo,
     alloc: &'a impl HsmScopedAlloc,
 ) -> HsmResult<&'a mut DmaBuf> {
-    let xy_len = pal.part_id_pub_key(io, None)?;
+    let xy_len = crate::part_state::part_id_pub_key(pal, io)?.len();
     let pk_hsm = alloc.dma_alloc(xy_len + 1)?;
     pk_hsm[0] = 0x04;
-    pal.part_id_pub_key(io, Some(&mut pk_hsm[1..1 + xy_len]))?;
+    {
+        let pk = crate::part_state::part_id_pub_key(pal, io)?;
+        pk_hsm[1..1 + xy_len].copy_from_slice(&pk[..xy_len]);
+    }
     Ok(pk_hsm)
 }
 

--- a/fw/core/lib/src/ddi/tbor/part_init.rs
+++ b/fw/core/lib/src/ddi/tbor/part_init.rs
@@ -72,6 +72,7 @@ use azihsm_fw_hsm_pal_traits::HsmHashAlgo;
 use azihsm_fw_hsm_pal_traits::HsmSessId;
 use azihsm_fw_hsm_pal_traits::HsmVaultKeyAttrs;
 use azihsm_fw_hsm_pal_traits::HsmVaultKeyKind;
+use azihsm_fw_hsm_pal_traits::PartState;
 use azihsm_fw_hsm_pal_traits::SessionRole;
 use azihsm_fw_hsm_pal_traits::VaultKeyGuard;
 use azihsm_fw_hsm_pal_traits::PART_POLICY_LEN;
@@ -311,9 +312,12 @@ async fn derive_ums<'a, P: HsmPal>(
     policy: &DmaBuf,
     pota_thumb: &DmaBuf,
 ) -> HsmResult<&'a mut DmaBuf> {
-    let uds_len = pal.part_uds(io, None)?;
+    let uds_len = crate::part_state::part_uds(pal, io)?.len();
     let uds = alloc.dma_alloc(uds_len)?;
-    pal.part_uds(io, Some(uds))?;
+    {
+        let src = crate::part_state::part_uds(pal, io)?;
+        uds.copy_from_slice(&src[..uds_len]);
+    }
 
     let ums = alloc.dma_alloc(kdf::UMS_LEN)?;
     let _ = kdf::derive_ums(
@@ -426,13 +430,16 @@ async fn build_pta_report<'a, P: HsmPal>(
     policy: &DmaBuf,
     pota_thumb: &DmaBuf,
 ) -> HsmResult<(&'a mut DmaBuf, usize)> {
-    let pid_priv = pal.vault_key(io, pal.part_id_key_id(io)?)?;
+    let pid_priv = pal.vault_key(io, crate::part_state::part_id_key_id(pal, io)?)?;
     let app_uuid = super::super::super::session::session_app_id(pal, io, sess_id)?;
 
     let mut vm_launch_id = [0u8; VM_LAUNCH_ID_LEN];
-    let vm_len = pal.part_vm_launch_guid(io, Some(&mut vm_launch_id))?;
-    if vm_len != VM_LAUNCH_ID_LEN {
-        return Err(HsmError::InternalError);
+    {
+        let guid = crate::part_state::part_vm_launch_guid(pal, io)?;
+        if guid.len() != VM_LAUNCH_ID_LEN {
+            return Err(HsmError::InternalError);
+        }
+        vm_launch_id.copy_from_slice(&guid[..VM_LAUNCH_ID_LEN]);
     }
 
     let report_data = build_report_data(pal, io, alloc, policy, pota_thumb).await?;
@@ -545,11 +552,11 @@ fn commit_partition_state<P: HsmPal>(
     )?;
     let pta_key_id = pta_guard.key_id();
 
-    pal.part_set_pta_key(io, pta_key_id, pta_pub_sec1)?;
-    pal.part_set_ums_key(io, ums_key_id)?;
-    pal.part_set_policy(io, policy)?;
-    pal.part_set_pota_thumbprint(io, pota_thumb)?;
-    pal.part_mark_initializing(io)?;
+    crate::part_state::part_set_pta_key(pal, io, pta_key_id, pta_pub_sec1)?;
+    crate::part_state::part_set_ups_key_id(pal, io, ums_key_id)?;
+    crate::part_state::part_set_policy(pal, io, policy)?;
+    crate::part_state::part_set_pota_thumbprint(pal, io, pota_thumb)?;
+    crate::part_state::part_set_state(pal, io, PartState::Initializing)?;
     let _ = pta_guard.dismiss();
     let _ = ums_guard.dismiss();
     Ok(())

--- a/fw/core/lib/src/io.rs
+++ b/fw/core/lib/src/io.rs
@@ -94,9 +94,9 @@ impl<P: HsmPal> Hsm<P> {
     /// Returns `true` if the partition for this IO can accept host traffic.
     #[inline]
     fn partition_enabled(&self, io: &P::Io) -> bool {
-        self.pal()
-            .part_state(io)
-            .is_ok_and(|s| matches!(s, PartState::Enabled | PartState::Initializing))
+        crate::part_state::part_state(self.pal(), io)
+            .map(|s| matches!(s, PartState::Enabled | PartState::Initializing))
+            .unwrap_or(false)
     }
 
     /// Parses the SQE once, populates the CQE header, and returns the

--- a/fw/core/lib/src/lib.rs
+++ b/fw/core/lib/src/lib.rs
@@ -14,6 +14,7 @@ mod error;
 mod hsm;
 mod io;
 mod op;
+pub mod part_state;
 mod session;
 
 use azihsm_fw_hsm_core_tracing::*;

--- a/fw/core/lib/src/part_state.rs
+++ b/fw/core/lib/src/part_state.rs
@@ -1,0 +1,1030 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Typed, property-routed partition state accessors.
+//!
+//! This module is the canonical core-side view of per-partition state.
+//! Every public function here is a thin, typed wrapper over the generic
+//! property API on [`HsmPartitionManager`]
+//! ([`part_prop_get_*`](HsmPartitionManager::part_prop_get_u8) /
+//! [`part_prop_set_*`](HsmPartitionManager::part_prop_set_u8) /
+//! [`part_prop_clear`](HsmPartitionManager::part_prop_clear)) and
+//! mirrors the legacy typed `part_*` methods on `HsmPartitionManager`
+//! one-for-one in name and behaviour.
+//!
+//! # Position in the stack
+//!
+//! ```text
+//!     core call site
+//!         │
+//!         ▼
+//!   crate::part_state::part_*   ← you are here
+//!         │
+//!         ▼
+//!   HsmPartitionManager::part_prop_get_* / set_* / clear   (PAL trait)
+//!         │
+//!         ▼
+//!     PAL impl backing storage (flat region + presence bitmap + undo log)
+//! ```
+//!
+//! Two views back the same storage in the PAL: the typed `part_*`
+//! methods on [`HsmPartitionManager`] and the generic `part_prop_*`
+//! methods.  Readers of one observe writes from the other.  Core
+//! logic uses *only* this module so that:
+//!
+//! - The full set of partition state read or written by the firmware
+//!   is enumerable from a single place (the [`PartPropId`] catalogue
+//!   in the PAL traits crate).  New partition state is added there
+//!   first; new accessors get added here second; existing call sites
+//!   do not move.
+//! - State-rollback / undo-log emission can hang off the property
+//!   layer in the PAL without core ever caring.  The PAL is free to
+//!   intercept `part_prop_set_*` / `part_prop_clear` and journal an
+//!   inverse operation; core call sites stay shape-stable.
+//! - Future PAL refactors that retire the typed `part_*` methods (or
+//!   rearrange the storage layout) touch zero core call sites — only
+//!   the bodies of the wrappers in this file move.
+//!
+//! # Conventions
+//!
+//! ## Arguments
+//!
+//! Every accessor takes `pal: &impl HsmPartitionManager` and
+//! `io: &impl HsmIo`, in that order.  The PAL resolves the target
+//! partition from `io.pid()`; this module never names a partition
+//! id directly.
+//!
+//! ## Cardinality
+//!
+//! All currently-catalogued properties are single-valued
+//! (`cardinality = 1` in their [`PartPropMeta`]).  The `idx` argument
+//! to the underlying property API is therefore hard-wired to `0` in
+//! every wrapper.  When the first indexed property is added the
+//! affected wrappers will grow an `idx: u16` parameter; the rest will
+//! not.
+//!
+//! ## Byte-valued properties use [`DmaBuf`]
+//!
+//! All byte-valued accessors take or return `&DmaBuf` instead of the
+//! legacy `Option<&mut [u8]>` query/copy pattern.  This keeps data
+//! flowing through PAL crypto primitives zero-copy and avoids the
+//! two-pass length/copy idiom at every caller.
+//!
+//! Setters accept any `&DmaBuf` whose length matches the property's
+//! [`PartPropKind`]; the PAL impl validates length and returns
+//! [`HsmError::InvalidArg`] on a mismatch.  Getters return a borrow
+//! tied to the PAL impl's storage; callers must not assume the
+//! lifetime extends past the next PAL mutation against the same
+//! partition.
+//!
+//! ## Presence semantics
+//!
+//! Property getters return [`HsmError::PartPropNotFound`] when the
+//! addressed slot has not yet been written (or was last cleared).
+//! Wrappers here propagate that error unchanged; callers that want
+//! to treat absence as a non-error condition must match on
+//! [`HsmError::PartPropNotFound`] explicitly.  **No `Option` wrapper
+//! is layered on top — the error variant *is* the presence signal.**
+//!
+//! For properties whose PAL meta marks them as
+//! [`PartPropDefault::RequiredPresent`] the error is unreachable in
+//! well-formed builds (the PAL guarantees the slot is initialised on
+//! partition allocation) and callers may treat the result as
+//! infallible w.r.t. presence — PAL transport / storage errors still
+//! propagate.  The doc comment on each accessor calls out which
+//! presence class applies.
+//!
+//! ## Sensitivity
+//!
+//! Properties whose PAL meta marks them as `sensitive` (PSKs,
+//! credentials, nonce, sealed / masked / unmasked BK_BOOT, UDS,
+//! firmware seed) are zeroised by the PAL when overwritten or
+//! cleared.  Callers in this module never log the value of those
+//! properties; downstream code that takes a `&DmaBuf` of sensitive
+//! material is expected to honour the same rule.
+//!
+//! ## Type-narrowed views over the property kind
+//!
+//! Two property categories store wider scalars than their typed view
+//! exposes:
+//!
+//! - **Lifecycle state** ([`PartPropId::STATE`]) is stored as `U8` but
+//!   exposed here as [`PartState`].  The mapping is the
+//!   `#[repr(u8)]` discriminant on the enum.  An unknown byte
+//!   coming back from storage is treated as PAL corruption and
+//!   surfaces as [`HsmError::InternalError`] from [`part_state`].
+//! - **Vault key references** (the `*_KEY_ID` ids) are stored as
+//!   `U16` and exposed here as [`HsmKeyId`] (a `u16` newtype) via the
+//!   `key_id_get` / `key_id_set` helpers below.  Conversion is
+//!   loss-less because vault key ids are always `u16`; a stored
+//!   value out of `u16` range is treated as PAL corruption and
+//!   surfaces as [`HsmError::InternalError`].
+//!
+//! ## Naming
+//!
+//! Every accessor uses the `part_` prefix so that, when re-exported
+//! through `super::*` into the rest of the crate, the names stay
+//! self-describing without a `part_state::` qualifier at the call site.
+//! Setters are `part_set_<name>`; clear operations are
+//! `part_clear_<name>`.
+
+use super::*;
+
+// ─── Identity, lifecycle, and platform state ──────────────────────────────
+//
+// Properties that name *what* this partition is and *where* it is in
+// its lifecycle.  These are the first things every DDI handler reads
+// to decide whether to accept a request.
+
+/// Lifecycle state of the calling partition.
+///
+/// Wraps [`PartPropId::STATE`] (`U8` decoded into [`PartState`]).  The
+/// slot is `RequiredPresent`, so this never returns
+/// [`HsmError::PartPropNotFound`].  A stored byte that does not name
+/// a known [`PartState`] is treated as PAL-side corruption and
+/// surfaces as [`HsmError::InternalError`].
+pub fn part_state(pal: &impl HsmPartitionManager, io: &impl HsmIo) -> HsmResult<PartState> {
+    let raw = pal.part_prop_get_u8(io, PartPropId::STATE, 0)?;
+    PartState::from_u8(raw).ok_or(HsmError::InternalError)
+}
+
+/// Set the partition lifecycle state.
+///
+/// Wraps [`PartPropId::STATE`].  The PAL impl is responsible for
+/// rejecting any state byte that violates the partition's allowed
+/// transition graph — this wrapper performs no validation of its
+/// own and serialises the discriminant directly.
+pub fn part_set_state(
+    pal: &impl HsmPartitionManager,
+    io: &impl HsmIo,
+    s: PartState,
+) -> HsmResult<()> {
+    pal.part_prop_set_u8(io, PartPropId::STATE, 0, s as u8)
+}
+
+/// [`PartPropId`] backing [`part_state`] / [`part_set_state`].
+#[inline]
+pub const fn part_state_prop_id() -> PartPropId {
+    PartPropId::STATE
+}
+
+/// Monotonic partition generation counter.
+///
+/// Wraps [`PartPropId::GEN`] (`U32`, `RequiredPresent`, **read-only**).
+/// Incremented by the PAL on every allocate/free cycle; used by
+/// lifetime guards (e.g. session handles) to detect partition reuse
+/// across a free/realloc and refuse to operate on a stale generation.
+pub fn part_gen(pal: &impl HsmPartitionManager, io: &impl HsmIo) -> HsmResult<u32> {
+    pal.part_prop_get_u32(io, PartPropId::GEN, 0)
+}
+
+/// [`PartPropId`] backing [`part_gen`].
+#[inline]
+pub const fn part_gen_prop_id() -> PartPropId {
+    PartPropId::GEN
+}
+
+/// Security version number bound into this partition's derivation
+/// lineage.
+///
+/// Wraps [`PartPropId::SVN`] (`U64`, `RequiredPresent`, read-only).
+/// Read-only from the caller's perspective; the PAL pins the value
+/// at partition allocation time from the firmware SVN baked into the
+/// image, and no setter is exposed here.  Used as a tweak input to
+/// partition-bound key derivations so that material derived under
+/// firmware version N is not reachable from firmware version N-1.
+pub fn part_svn(pal: &impl HsmPartitionManager, io: &impl HsmIo) -> HsmResult<u64> {
+    pal.part_prop_get_u64(io, PartPropId::SVN, 0)
+}
+
+/// [`PartPropId`] backing [`part_svn`].
+#[inline]
+pub const fn part_svn_prop_id() -> PartPropId {
+    PartPropId::SVN
+}
+
+/// Number of host-allocated SQ/CQ resource pairs.
+///
+/// Wraps [`PartPropId::RES_COUNT`] (`U8`, `RequiredPresent`,
+/// read-only).  Read-only from the caller's perspective; set by the
+/// PAL at partition allocation time from the resource grant.
+pub fn part_res_count(pal: &impl HsmPartitionManager, io: &impl HsmIo) -> HsmResult<u8> {
+    pal.part_prop_get_u8(io, PartPropId::RES_COUNT, 0)
+}
+
+/// [`PartPropId`] backing [`part_res_count`].
+#[inline]
+pub const fn part_res_count_prop_id() -> PartPropId {
+    PartPropId::RES_COUNT
+}
+
+/// Opaque 16-byte partition identity blob.
+///
+/// Wraps [`PartPropId::ID`] (`FixedBytes { len: 16 }`,
+/// `AbsentUntilSet`, **read-only**).  Returns
+/// [`HsmError::PartPropNotFound`] before the PAL has populated it
+/// for this partition.  The bytes are opaque to core; only the host
+/// management layer interprets them.
+pub fn part_id<'a>(pal: &'a impl HsmPartitionManager, io: &impl HsmIo) -> HsmResult<&'a DmaBuf> {
+    pal.part_prop_get_bytes(io, PartPropId::ID, 0)
+}
+
+/// [`PartPropId`] backing [`part_id`].
+#[inline]
+pub const fn part_id_prop_id() -> PartPropId {
+    PartPropId::ID
+}
+
+/// Unique Device Secret (32 B).  **Sensitive.**
+///
+/// Wraps [`PartPropId::UDS`] (`FixedBytes { len: 32 }`,
+/// `AbsentUntilSet`, sensitive, **read-only**).  Returns
+/// [`HsmError::PartPropNotFound`] before the PAL has provisioned it.
+/// The UDS is the root secret for partition-bound derivations; the
+/// returned borrow must not be logged or copied outside crypto
+/// primitives.
+pub fn part_uds<'a>(pal: &'a impl HsmPartitionManager, io: &impl HsmIo) -> HsmResult<&'a DmaBuf> {
+    pal.part_prop_get_bytes(io, PartPropId::UDS, 0)
+}
+
+/// [`PartPropId`] backing [`part_uds`].
+#[inline]
+pub const fn part_uds_prop_id() -> PartPropId {
+    PartPropId::UDS
+}
+
+/// Firmware-supplied per-partition seed (32 B).  **Sensitive.**
+///
+/// Wraps [`PartPropId::FW_SEED`] (`FixedBytes { len: 32 }`,
+/// `RequiredPresent`, read-only).  Owned by the PAL; never set
+/// from core.  Used as a PAL-controlled tweak input to partition-bound
+/// derivations so that material from a forged or replayed UDS cannot
+/// alone reconstruct partition keys.
+pub fn part_fw_seed<'a>(
+    pal: &'a impl HsmPartitionManager,
+    io: &impl HsmIo,
+) -> HsmResult<&'a DmaBuf> {
+    pal.part_prop_get_bytes(io, PartPropId::FW_SEED, 0)
+}
+
+/// [`PartPropId`] backing [`part_fw_seed`].
+#[inline]
+pub const fn part_fw_seed_prop_id() -> PartPropId {
+    PartPropId::FW_SEED
+}
+
+// ─── Vault references ─────────────────────────────────────────────────────
+//
+// All vault-ref properties are stored in the property table as `U32`
+// for forward compatibility with vault namespaces wider than `u16`,
+// but the typed core view here exposes them as [`HsmKeyId`] (a `u16`
+// newtype) because every currently-defined vault id fits in `u16`.
+// Conversion is loss-less in both directions; a stored value out of
+// `u16` range is treated as PAL-side corruption and surfaces as
+// [`HsmError::InternalError`].
+
+/// Read a vault key reference and narrow `U16 → HsmKeyId` (`u16`).
+///
+/// Returns [`HsmError::InternalError`] if the stored value does not
+/// fit in `u16` — that signals storage corruption or a PAL bug, not
+/// caller error.  Returns [`HsmError::PartPropNotFound`] if the slot
+/// is absent; callers handle the absence/error split per the
+/// presence semantics in the module docs.
+#[inline]
+fn key_id_get(
+    pal: &impl HsmPartitionManager,
+    io: &impl HsmIo,
+    id: PartPropId,
+) -> HsmResult<HsmKeyId> {
+    let raw = pal.part_prop_get_u16(io, id, 0)?;
+    Ok(HsmKeyId::from(raw))
+}
+
+/// Write a vault key reference (`HsmKeyId` is a `u16`).
+#[inline]
+fn key_id_set(
+    pal: &impl HsmPartitionManager,
+    io: &impl HsmIo,
+    id: PartPropId,
+    key_id: HsmKeyId,
+) -> HsmResult<()> {
+    pal.part_prop_set_u16(io, id, 0, u16::from(key_id))
+}
+
+/// Vault id of the partition identity (ECC-P384) key.
+///
+/// Wraps [`PartPropId::ID_KEY_ID`] (`U16 → HsmKeyId`,
+/// `AbsentUntilSet`, **read-only**).
+pub fn part_id_key_id(pal: &impl HsmPartitionManager, io: &impl HsmIo) -> HsmResult<HsmKeyId> {
+    key_id_get(pal, io, PartPropId::ID_KEY_ID)
+}
+
+/// [`PartPropId`] backing [`part_id_key_id`].
+#[inline]
+pub const fn part_id_key_id_prop_id() -> PartPropId {
+    PartPropId::ID_KEY_ID
+}
+
+/// Vault id of the partition masking key.
+///
+/// Wraps [`PartPropId::MK_KEY_ID`] (`U16 → HsmKeyId`,
+/// `AbsentUntilSet`).
+pub fn part_mk_key_id(pal: &impl HsmPartitionManager, io: &impl HsmIo) -> HsmResult<HsmKeyId> {
+    key_id_get(pal, io, PartPropId::MK_KEY_ID)
+}
+
+/// Set the partition masking key id.
+pub fn part_set_mk_key_id(
+    pal: &impl HsmPartitionManager,
+    io: &impl HsmIo,
+    key_id: HsmKeyId,
+) -> HsmResult<()> {
+    key_id_set(pal, io, PartPropId::MK_KEY_ID, key_id)
+}
+
+/// [`PartPropId`] backing [`part_mk_key_id`] / [`part_set_mk_key_id`].
+#[inline]
+pub const fn part_mk_key_id_prop_id() -> PartPropId {
+    PartPropId::MK_KEY_ID
+}
+
+/// Whether the partition has been fully provisioned.
+///
+/// A partition is provisioned once its masking key (MK) has been
+/// imported into the vault and recorded via
+/// [`part_set_mk_key_id`].  This is the gate
+/// `EstablishCredential` uses to prevent double-provisioning, and
+/// `OpenSession` uses to require provisioning before a session can
+/// be opened.  Derived from [`PartPropId::MK_KEY_ID`] presence
+/// (`AbsentUntilSet`).
+pub fn part_is_provisioned(pal: &impl HsmPartitionManager, io: &impl HsmIo) -> HsmResult<bool> {
+    match part_mk_key_id(pal, io) {
+        Ok(_) => Ok(true),
+        Err(HsmError::PartPropNotFound) => Ok(false),
+        Err(e) => Err(e),
+    }
+}
+
+/// Vault id of the partition Unique Machine Secret derived key.
+///
+/// Wraps [`PartPropId::UPS_KEY_ID`] (`U16 → HsmKeyId`,
+/// `AbsentUntilSet`).
+pub fn part_ups_key_id(pal: &impl HsmPartitionManager, io: &impl HsmIo) -> HsmResult<HsmKeyId> {
+    key_id_get(pal, io, PartPropId::UPS_KEY_ID)
+}
+
+/// Set the partition UPS-derived key id.
+pub fn part_set_ups_key_id(
+    pal: &impl HsmPartitionManager,
+    io: &impl HsmIo,
+    key_id: HsmKeyId,
+) -> HsmResult<()> {
+    key_id_set(pal, io, PartPropId::UPS_KEY_ID, key_id)
+}
+
+/// [`PartPropId`] backing [`part_ups_key_id`] / [`part_set_ups_key_id`].
+#[inline]
+pub const fn part_ups_key_id_prop_id() -> PartPropId {
+    PartPropId::UPS_KEY_ID
+}
+
+/// Vault id of the Partition Trust Anchor (PTA) key.
+///
+/// Wraps [`PartPropId::PTA_KEY_ID`] (`U16 → HsmKeyId`,
+/// `AbsentUntilSet`).  Bound by the TBOR `PartInit` handler.
+pub fn part_pta_key_id(pal: &impl HsmPartitionManager, io: &impl HsmIo) -> HsmResult<HsmKeyId> {
+    key_id_get(pal, io, PartPropId::PTA_KEY_ID)
+}
+
+/// Set the PTA key id.
+pub fn part_set_pta_key_id(
+    pal: &impl HsmPartitionManager,
+    io: &impl HsmIo,
+    key_id: HsmKeyId,
+) -> HsmResult<()> {
+    key_id_set(pal, io, PartPropId::PTA_KEY_ID, key_id)
+}
+
+/// [`PartPropId`] backing [`part_pta_key_id`] / [`part_set_pta_key_id`].
+#[inline]
+pub const fn part_pta_key_id_prop_id() -> PartPropId {
+    PartPropId::PTA_KEY_ID
+}
+
+/// Vault id of the partition's unwrapping key.
+///
+/// Wraps [`PartPropId::RSA_UNWRAPPING_KEY_ID`] (`U16 → HsmKeyId`,
+/// `AbsentUntilSet`, **read-only**).
+pub fn part_unwrapping_key_id(
+    pal: &impl HsmPartitionManager,
+    io: &impl HsmIo,
+) -> HsmResult<HsmKeyId> {
+    key_id_get(pal, io, PartPropId::RSA_UNWRAPPING_KEY_ID)
+}
+
+/// [`PartPropId`] backing [`part_unwrapping_key_id`].
+#[inline]
+pub const fn part_unwrapping_key_id_prop_id() -> PartPropId {
+    PartPropId::RSA_UNWRAPPING_KEY_ID
+}
+
+/// Vault id of the long-lived session-encryption (ECDH) key.
+///
+/// Wraps [`PartPropId::SESSION_ENC_KEY_ID`] (`U16 → HsmKeyId`,
+/// `AbsentUntilSet`).
+pub fn part_session_enc_key_id(
+    pal: &impl HsmPartitionManager,
+    io: &impl HsmIo,
+) -> HsmResult<HsmKeyId> {
+    key_id_get(pal, io, PartPropId::SESSION_ENC_KEY_ID)
+}
+
+/// Set the session-encryption key id.
+pub fn part_set_session_enc_key_id(
+    pal: &impl HsmPartitionManager,
+    io: &impl HsmIo,
+    key_id: HsmKeyId,
+) -> HsmResult<()> {
+    key_id_set(pal, io, PartPropId::SESSION_ENC_KEY_ID, key_id)
+}
+
+/// [`PartPropId`] backing [`part_session_enc_key_id`] /
+/// [`part_set_session_enc_key_id`].
+#[inline]
+pub const fn part_session_enc_key_id_prop_id() -> PartPropId {
+    PartPropId::SESSION_ENC_KEY_ID
+}
+
+/// Vault id of the one-shot establish-credential RSA-OAEP key.
+///
+/// Wraps [`PartPropId::ESTABLISH_CRED_KEY_ID`] (`U16 → HsmKeyId`,
+/// `AbsentUntilSet`).  This is a one-shot key: the establish-cred
+/// handler clears the slot with [`part_clear_establish_cred_key`] as
+/// soon as the credential has been unwrapped, so a successful return
+/// here means the key is still consumable.
+pub fn part_establish_cred_key_id(
+    pal: &impl HsmPartitionManager,
+    io: &impl HsmIo,
+) -> HsmResult<HsmKeyId> {
+    key_id_get(pal, io, PartPropId::ESTABLISH_CRED_KEY_ID)
+}
+
+/// Set the establish-credential key id.
+pub fn part_set_establish_cred_key_id(
+    pal: &impl HsmPartitionManager,
+    io: &impl HsmIo,
+    key_id: HsmKeyId,
+) -> HsmResult<()> {
+    key_id_set(pal, io, PartPropId::ESTABLISH_CRED_KEY_ID, key_id)
+}
+
+/// Clear the establish-credential key id (one-shot consumed).
+///
+/// Wraps [`HsmPartitionManager::part_prop_clear`] for
+/// [`PartPropId::ESTABLISH_CRED_KEY_ID`].  Idempotent on an already
+/// absent slot (returns `Ok(())`).  After this call,
+/// [`part_establish_cred_key_id`] returns
+/// [`HsmError::PartPropNotFound`].
+pub fn part_clear_establish_cred_key(
+    pal: &impl HsmPartitionManager,
+    io: &impl HsmIo,
+) -> HsmResult<()> {
+    pal.part_prop_clear(io, PartPropId::ESTABLISH_CRED_KEY_ID, 0)
+}
+
+/// [`PartPropId`] backing [`part_establish_cred_key_id`] /
+/// [`part_set_establish_cred_key_id`] /
+/// [`part_clear_establish_cred_key`].
+#[inline]
+pub const fn part_establish_cred_key_id_prop_id() -> PartPropId {
+    PartPropId::ESTABLISH_CRED_KEY_ID
+}
+
+// ─── Caller-presented secrets ─────────────────────────────────────────────
+//
+// Material that the host or the management plane hands the partition
+// to authenticate or key sessions.  All sensitive; the PAL zeroises
+// previous values on overwrite or clear.
+
+/// Read a pre-shared key.
+///
+/// `psk_id` selects between PSK slots, matching the legacy
+/// [`HsmPartitionManager::part_psk`] enumeration:
+///
+/// | `psk_id` | Slot               | Property                 |
+/// |----------|--------------------|--------------------------|
+/// | `0`      | Crypto Officer PSK | [`PartPropId::PSK_CO`]   |
+/// | `1`      | Crypto User PSK    | [`PartPropId::PSK_CU`]   |
+///
+/// Any other value returns [`HsmError::InvalidArg`].  Both slots are
+/// `RequiredPresent` (default-baked at allocation time from
+/// [`DEFAULT_PSK_CO`] / [`DEFAULT_PSK_CU`]) so a successful call
+/// always yields exactly [`PSK_LEN`] bytes.
+pub fn part_psk<'a>(
+    pal: &'a impl HsmPartitionManager,
+    io: &impl HsmIo,
+    psk_id: u8,
+) -> HsmResult<&'a DmaBuf> {
+    pal.part_prop_get_bytes(io, part_psk_prop_id(psk_id)?, 0)
+}
+
+/// Write a pre-shared key.
+///
+/// `data` must be exactly [`PSK_LEN`] bytes; see [`part_psk`] for the
+/// `psk_id → slot` mapping.  Rotating from the default PSK is required
+/// before exposing the partition to untrusted traffic.
+pub fn part_set_psk(
+    pal: &impl HsmPartitionManager,
+    io: &impl HsmIo,
+    psk_id: u8,
+    data: &DmaBuf,
+) -> HsmResult<()> {
+    pal.part_prop_set_bytes(io, part_psk_prop_id(psk_id)?, 0, data)
+}
+
+/// Translate the `0/1` PSK selector into the backing
+/// [`PartPropId`].  Returns [`HsmError::InvalidArg`] for any other
+/// selector.
+///
+/// Exposed so upper-layer undo-log emitters can name the slot they
+/// are about to mutate without re-encoding the selector mapping.
+#[inline]
+pub fn part_psk_prop_id(psk_id: u8) -> HsmResult<PartPropId> {
+    match psk_id {
+        0 => Ok(PartPropId::PSK_CO),
+        1 => Ok(PartPropId::PSK_CU),
+        _ => Err(HsmError::InvalidArg),
+    }
+}
+
+/// Caller-presented credential blob (32 B).  **Sensitive.**
+///
+/// Wraps [`PartPropId::CREDENTIAL`] (`FixedBytes { len: 32 }`,
+/// `AbsentUntilSet`, sensitive).  Returns
+/// [`HsmError::PartPropNotFound`] before [`part_set_credential`] has
+/// been called.  Verified by the upper layer via constant-time
+/// compare against the returned bytes — callers must not branch on
+/// the contents themselves.
+pub fn part_credential<'a>(
+    pal: &'a impl HsmPartitionManager,
+    io: &impl HsmIo,
+) -> HsmResult<&'a DmaBuf> {
+    pal.part_prop_get_bytes(io, PartPropId::CREDENTIAL, 0)
+}
+
+/// Write the caller-presented credential blob.  **Sensitive.**
+///
+/// `data` must be exactly 32 bytes (`id ‖ pin`, 16 + 16).  Write-once
+/// per credential lifecycle: re-setting without an intervening
+/// [`PartPropId::CREDENTIAL`] clear returns
+/// [`HsmError::VaultAppLimitReached`]; an all-zero `id` or `pin` half
+/// is rejected with [`HsmError::InvalidAppCredentials`].
+pub fn part_set_credential(
+    pal: &impl HsmPartitionManager,
+    io: &impl HsmIo,
+    data: &DmaBuf,
+) -> HsmResult<()> {
+    pal.part_prop_set_bytes(io, PartPropId::CREDENTIAL, 0, data)
+}
+
+/// Constant-time-compare the supplied `id` and `pin` (16 B each)
+/// against the partition's stored credential.
+///
+/// Returns `Ok(())` on match.  Returns
+/// [`HsmError::InvalidAppCredentials`] when the credential has not
+/// been set yet, the lengths do not match (16 each), or either half
+/// differs.  The comparison runs over the full 32-byte width so a
+/// timing side-channel cannot distinguish "wrong id" from "wrong
+/// pin".
+pub fn part_verify_credential(
+    pal: &impl HsmPartitionManager,
+    io: &impl HsmIo,
+    id: &[u8],
+    pin: &[u8],
+) -> HsmResult<()> {
+    if id.len() != 16 || pin.len() != 16 {
+        return Err(HsmError::InvalidAppCredentials);
+    }
+    let stored = match part_credential(pal, io) {
+        Ok(buf) => buf,
+        Err(HsmError::PartPropNotFound) => return Err(HsmError::InvalidAppCredentials),
+        Err(e) => return Err(e),
+    };
+    if stored.len() != 32 {
+        return Err(HsmError::InvalidAppCredentials);
+    }
+    let mut diff = 0u8;
+    for i in 0..16 {
+        diff |= stored[i] ^ id[i];
+        diff |= stored[16 + i] ^ pin[i];
+    }
+    if diff == 0 {
+        Ok(())
+    } else {
+        Err(HsmError::InvalidAppCredentials)
+    }
+}
+
+/// [`PartPropId`] backing [`part_credential`] / [`part_set_credential`].
+#[inline]
+pub const fn part_credential_prop_id() -> PartPropId {
+    PartPropId::CREDENTIAL
+}
+
+/// Wire length of [`PartPropId::NONCE`] (matches the catalogue
+/// `FixedBytes { len: 32 }`).
+pub const NONCE_LEN: usize = 32;
+
+/// 32-byte partition nonce, refreshed per credential / session event.
+/// **Sensitive.**
+///
+/// Wraps [`PartPropId::NONCE`] (`FixedBytes { len: 32 }`,
+/// `RequiredPresent`, sensitive).  Always present; the PAL
+/// initialises it on partition allocation.  Refresh by writing fresh
+/// PAL-RNG bytes via [`part_set_nonce`].
+pub fn part_nonce<'a>(pal: &'a impl HsmPartitionManager, io: &impl HsmIo) -> HsmResult<&'a DmaBuf> {
+    pal.part_prop_get_bytes(io, PartPropId::NONCE, 0)
+}
+
+/// Overwrite the partition nonce with the supplied 32-byte buffer.
+///
+/// Wraps [`PartPropId::NONCE`] setter.  Callers must source the
+/// bytes from the PAL RNG (e.g. [`HsmRng::rng_fill_bytes`]) so the
+/// new nonce is unpredictable to the host.
+pub fn part_set_nonce(
+    pal: &impl HsmPartitionManager,
+    io: &impl HsmIo,
+    nonce: &DmaBuf,
+) -> HsmResult<()> {
+    pal.part_prop_set_bytes(io, PartPropId::NONCE, 0, nonce)
+}
+
+/// [`PartPropId`] backing [`part_nonce`].
+#[inline]
+pub const fn part_nonce_prop_id() -> PartPropId {
+    PartPropId::NONCE
+}
+
+/// Constant-time-compare `nonce` against the partition's current
+/// stored nonce.
+///
+/// Returns `Ok(())` on match, [`HsmError::NonceMismatch`] otherwise.
+/// The comparison runs over the full 32-byte width regardless of
+/// where bytes first diverge, so a timing side-channel cannot
+/// localize the mismatch.  Length mismatch is also a mismatch.
+pub fn part_verify_nonce(
+    pal: &impl HsmPartitionManager,
+    io: &impl HsmIo,
+    nonce: &[u8],
+) -> HsmResult<()> {
+    let stored = part_nonce(pal, io)?;
+    if stored.len() != nonce.len() {
+        return Err(HsmError::NonceMismatch);
+    }
+    let mut diff = 0u8;
+    for (a, b) in stored.iter().zip(nonce.iter()) {
+        diff |= a ^ b;
+    }
+    if diff == 0 {
+        Ok(())
+    } else {
+        Err(HsmError::NonceMismatch)
+    }
+}
+
+// ─── PAL-private root-of-trust seed rows ──────────────────────────────────
+//
+// Indexed properties exposing the manufacturer-provisioned and
+// device-owner-provisioned seed tables that anchor the masking-key
+// derivation in `derive_masking_key` (see `ddi::mbor::establish_credential`).
+// Only rows actually provisioned by the current PAL are present;
+// unprovisioned rows return [`HsmError::PartPropNotFound`].
+
+/// Manufacturer-provisioned 32 B seed row indexed by SVN.
+/// **Sensitive** PAL-private root-of-trust material.
+///
+/// Wraps [`PartPropId::MFGR_SEED`] (`FixedBytes { len: 32 }`,
+/// cardinality 64, `AbsentUntilSet`, sensitive).  `svn` must be in
+/// `0..64`; otherwise [`HsmError::InvalidArg`].  Returns
+/// [`HsmError::PartPropNotFound`] when the PAL has not provisioned a
+/// row for that SVN.
+pub fn part_mfgr_seed<'a>(
+    pal: &'a impl HsmPartitionManager,
+    io: &impl HsmIo,
+    svn: u64,
+) -> HsmResult<&'a DmaBuf> {
+    let idx = u16::try_from(svn).map_err(|_| HsmError::InvalidArg)?;
+    pal.part_prop_get_bytes(io, PartPropId::MFGR_SEED, idx)
+}
+
+/// Device-owner-provisioned 32 B seed row indexed by `bks2_index`.
+/// **Sensitive** PAL-private root-of-trust material.
+///
+/// Wraps [`PartPropId::DEV_OWNER_SEED`] (`FixedBytes { len: 32 }`,
+/// cardinality 64, `AbsentUntilSet`, sensitive).  `bks2_index` must
+/// be in `0..64`; otherwise [`HsmError::InvalidArg`].  Returns
+/// [`HsmError::PartPropNotFound`] when the PAL has not provisioned a
+/// row for that index.
+pub fn part_dev_owner_seed<'a>(
+    pal: &'a impl HsmPartitionManager,
+    io: &impl HsmIo,
+    bks2_index: u16,
+) -> HsmResult<&'a DmaBuf> {
+    pal.part_prop_get_bytes(io, PartPropId::DEV_OWNER_SEED, bks2_index)
+}
+
+// ─── Boot / launch-time bound material ────────────────────────────────────
+//
+// Material bound to a single boot / VM-launch incarnation.  Set once
+// per power cycle (or once per VM launch) and either consumed by the
+// session-establishment flow or used as inputs into derivations whose
+// outputs are themselves boot-bound.
+
+/// Sealed BK3 blob.  **Sensitive.**
+///
+/// Wraps [`PartPropId::SEALED_BK3`] (`VarBytes { max: 96 }`,
+/// `AbsentUntilSet`, sensitive).  Returns
+/// [`HsmError::PartPropNotFound`] before the host has supplied it this
+/// power cycle.  Set at most once per power cycle.
+pub fn part_sealed_bk3<'a>(
+    pal: &'a impl HsmPartitionManager,
+    io: &impl HsmIo,
+) -> HsmResult<&'a DmaBuf> {
+    pal.part_prop_get_bytes(io, PartPropId::SEALED_BK3, 0)
+}
+
+/// Write the sealed BK3 blob.  **Sensitive.**
+///
+/// `data` must be ≤ 96 bytes.
+pub fn part_set_sealed_bk3(
+    pal: &impl HsmPartitionManager,
+    io: &impl HsmIo,
+    data: &DmaBuf,
+) -> HsmResult<()> {
+    pal.part_prop_set_bytes(io, PartPropId::SEALED_BK3, 0, data)
+}
+
+/// [`PartPropId`] backing [`part_sealed_bk3`] / [`part_set_sealed_bk3`].
+#[inline]
+pub const fn part_sealed_bk3_prop_id() -> PartPropId {
+    PartPropId::SEALED_BK3
+}
+
+/// Masked BK_BOOT blob (variable, ≤ [`MASKED_BK_BOOT_LEN`]).
+/// **Sensitive.**
+///
+/// Wraps [`PartPropId::MASKED_BK_BOOT`]
+/// (`VarBytes { max: MASKED_BK_BOOT_LEN }`, `AbsentUntilSet`,
+/// sensitive).
+pub fn part_masked_bk_boot<'a>(
+    pal: &'a impl HsmPartitionManager,
+    io: &impl HsmIo,
+) -> HsmResult<&'a DmaBuf> {
+    pal.part_prop_get_bytes(io, PartPropId::MASKED_BK_BOOT, 0)
+}
+
+/// Write the masked BK_BOOT blob.  **Sensitive.**
+///
+/// `data` must be ≤ [`MASKED_BK_BOOT_LEN`] bytes.
+pub fn part_set_masked_bk_boot(
+    pal: &impl HsmPartitionManager,
+    io: &impl HsmIo,
+    data: &DmaBuf,
+) -> HsmResult<()> {
+    pal.part_prop_set_bytes(io, PartPropId::MASKED_BK_BOOT, 0, data)
+}
+
+/// [`PartPropId`] backing [`part_masked_bk_boot`] /
+/// [`part_set_masked_bk_boot`].
+#[inline]
+pub const fn part_masked_bk_boot_prop_id() -> PartPropId {
+    PartPropId::MASKED_BK_BOOT
+}
+
+/// Unmasked BK_BOOT (exactly [`BK_BOOT_LEN`] bytes).  **Sensitive.**
+///
+/// Wraps [`PartPropId::BK_BOOT`]
+/// (`FixedBytes { len: BK_BOOT_LEN }`, `AbsentUntilSet`, sensitive,
+/// **read-only**).  The PAL derives the unmasked value from
+/// [`PartPropId::MASKED_BK_BOOT`]; callers only read it.
+pub fn part_bk_boot<'a>(
+    pal: &'a impl HsmPartitionManager,
+    io: &impl HsmIo,
+) -> HsmResult<&'a DmaBuf> {
+    pal.part_prop_get_bytes(io, PartPropId::BK_BOOT, 0)
+}
+
+/// [`PartPropId`] backing [`part_bk_boot`].
+#[inline]
+pub const fn part_bk_boot_prop_id() -> PartPropId {
+    PartPropId::BK_BOOT
+}
+
+/// VM-launch GUID (16 B), bound at session-establishment time.
+///
+/// Wraps [`PartPropId::VM_LAUNCH_GUID`] (`FixedBytes { len: 16 }`,
+/// `AbsentUntilSet`, **read-only**).  Returns
+/// [`HsmError::PartPropNotFound`] before session establishment has
+/// bound the value for the current launch.  Populated by the PAL.
+pub fn part_vm_launch_guid<'a>(
+    pal: &'a impl HsmPartitionManager,
+    io: &impl HsmIo,
+) -> HsmResult<&'a DmaBuf> {
+    pal.part_prop_get_bytes(io, PartPropId::VM_LAUNCH_GUID, 0)
+}
+
+/// [`PartPropId`] backing [`part_vm_launch_guid`].
+#[inline]
+pub const fn part_vm_launch_guid_prop_id() -> PartPropId {
+    PartPropId::VM_LAUNCH_GUID
+}
+
+/// Partition policy blob (exactly [`PART_POLICY_LEN`] bytes).
+///
+/// Wraps [`PartPropId::POLICY`]
+/// (`FixedBytes { len: PART_POLICY_LEN }`, `AbsentUntilSet`).  Set
+/// by the TBOR `PartInit` handler and consulted by every DDI handler
+/// that gates on policy.
+pub fn part_policy<'a>(
+    pal: &'a impl HsmPartitionManager,
+    io: &impl HsmIo,
+) -> HsmResult<&'a DmaBuf> {
+    pal.part_prop_get_bytes(io, PartPropId::POLICY, 0)
+}
+
+/// Write the partition policy blob.
+///
+/// `data` must be exactly [`PART_POLICY_LEN`] bytes.
+pub fn part_set_policy(
+    pal: &impl HsmPartitionManager,
+    io: &impl HsmIo,
+    data: &DmaBuf,
+) -> HsmResult<()> {
+    pal.part_prop_set_bytes(io, PartPropId::POLICY, 0, data)
+}
+
+/// [`PartPropId`] backing [`part_policy`] / [`part_set_policy`].
+#[inline]
+pub const fn part_policy_prop_id() -> PartPropId {
+    PartPropId::POLICY
+}
+
+/// POTA thumbprint (32 B).  Set by `PartInit`.
+///
+/// Wraps [`PartPropId::POTA_THUMBPRINT`] (`FixedBytes { len: 32 }`,
+/// `AbsentUntilSet`).
+pub fn part_pota_thumbprint<'a>(
+    pal: &'a impl HsmPartitionManager,
+    io: &impl HsmIo,
+) -> HsmResult<&'a DmaBuf> {
+    pal.part_prop_get_bytes(io, PartPropId::POTA_THUMBPRINT, 0)
+}
+
+/// Write the POTA thumbprint.
+///
+/// `data` must be exactly 32 bytes.
+pub fn part_set_pota_thumbprint(
+    pal: &impl HsmPartitionManager,
+    io: &impl HsmIo,
+    data: &DmaBuf,
+) -> HsmResult<()> {
+    pal.part_prop_set_bytes(io, PartPropId::POTA_THUMBPRINT, 0, data)
+}
+
+/// [`PartPropId`] backing [`part_pota_thumbprint`] /
+/// [`part_set_pota_thumbprint`].
+#[inline]
+pub const fn part_pota_thumbprint_prop_id() -> PartPropId {
+    PartPropId::POTA_THUMBPRINT
+}
+
+/// Whether the PSK selected by `psk_id` is still the well-known
+/// default value.
+///
+/// Reads the PSK via [`part_psk`] and compares against
+/// [`DEFAULT_PSK_CO`] / [`DEFAULT_PSK_CU`] in constant time.  Returns
+/// `Ok(true)` only when the stored bytes match the default.
+pub fn part_psk_is_default(
+    pal: &impl HsmPartitionManager,
+    io: &impl HsmIo,
+    psk_id: u8,
+) -> HsmResult<bool> {
+    let stored = part_psk(pal, io, psk_id)?;
+    let default = match psk_id {
+        0 => DEFAULT_PSK_CO.as_slice(),
+        1 => DEFAULT_PSK_CU.as_slice(),
+        _ => return Err(HsmError::InvalidArg),
+    };
+    if stored.len() != default.len() {
+        return Ok(false);
+    }
+    let mut diff = 0u8;
+    for (a, b) in stored.iter().zip(default.iter()) {
+        diff |= a ^ b;
+    }
+    Ok(diff == 0)
+}
+
+/// Whether the partition's caller-presented credential blob has been
+/// set for the current incarnation.
+///
+/// Wraps `part_prop_get_bytes(CREDENTIAL)` and maps
+/// [`HsmError::PartPropNotFound`] to `Ok(false)`; any other PAL error
+/// propagates.
+pub fn part_is_credential_set(pal: &impl HsmPartitionManager, io: &impl HsmIo) -> HsmResult<bool> {
+    match pal.part_prop_get_bytes(io, PartPropId::CREDENTIAL, 0) {
+        Ok(_) => Ok(true),
+        Err(HsmError::PartPropNotFound) => Ok(false),
+        Err(e) => Err(e),
+    }
+}
+
+// ─── Public keys, BKS2, BK3 session (Phase A property additions) ─────
+
+/// Raw ECC-P384 public key (x ∥ y, 96 B) for the partition identity key.
+pub fn part_id_pub_key<'a>(
+    pal: &'a impl HsmPartitionManager,
+    io: &impl HsmIo,
+) -> HsmResult<&'a DmaBuf> {
+    pal.part_prop_get_bytes(io, PartPropId::ID_PUB_KEY, 0)
+}
+
+/// Raw ECC-P384 public key (x ∥ y, 96 B) for the session encryption key.
+pub fn part_session_enc_pub_key<'a>(
+    pal: &'a impl HsmPartitionManager,
+    io: &impl HsmIo,
+) -> HsmResult<&'a DmaBuf> {
+    pal.part_prop_get_bytes(io, PartPropId::SESSION_ENC_PUB_KEY, 0)
+}
+
+/// Raw ECC-P384 public key (x ∥ y, 96 B) for the establish-credential key.
+pub fn part_establish_cred_pub_key<'a>(
+    pal: &'a impl HsmPartitionManager,
+    io: &impl HsmIo,
+) -> HsmResult<&'a DmaBuf> {
+    pal.part_prop_get_bytes(io, PartPropId::ESTABLISH_CRED_PUB_KEY, 0)
+}
+
+/// SEC1-uncompressed ECC-P384 public key (97 B) for the Partition Trust Anchor.
+pub fn part_pta_pub_sec1<'a>(
+    pal: &'a impl HsmPartitionManager,
+    io: &impl HsmIo,
+) -> HsmResult<&'a DmaBuf> {
+    pal.part_prop_get_bytes(io, PartPropId::PTA_PUB_SEC1, 0)
+}
+
+/// Set the PTA SEC1 public key bytes (97 B).
+pub fn part_set_pta_pub_sec1(
+    pal: &impl HsmPartitionManager,
+    io: &impl HsmIo,
+    data: &DmaBuf,
+) -> HsmResult<()> {
+    pal.part_prop_set_bytes(io, PartPropId::PTA_PUB_SEC1, 0, data)
+}
+
+/// Bind both halves of the Partition Trust Anchor — the vault key id
+/// and the SEC1 public key bytes — in a single composite write.
+pub fn part_set_pta_key(
+    pal: &impl HsmPartitionManager,
+    io: &impl HsmIo,
+    key_id: HsmKeyId,
+    pub_sec1: &DmaBuf,
+) -> HsmResult<()> {
+    key_id_set(pal, io, PartPropId::PTA_KEY_ID, key_id)?;
+    pal.part_prop_set_bytes(io, PartPropId::PTA_PUB_SEC1, 0, pub_sec1)
+}
+
+/// BK3 session key (48 B). **Sensitive.**
+pub fn part_bk3_session<'a>(
+    pal: &'a impl HsmPartitionManager,
+    io: &impl HsmIo,
+) -> HsmResult<&'a DmaBuf> {
+    pal.part_prop_get_bytes(io, PartPropId::BK3_SESSION, 0)
+}
+
+/// Set the BK3 session key (48 B).
+pub fn part_set_bk3_session(
+    pal: &impl HsmPartitionManager,
+    io: &impl HsmIo,
+    data: &DmaBuf,
+) -> HsmResult<()> {
+    pal.part_prop_set_bytes(io, PartPropId::BK3_SESSION, 0, data)
+}
+
+/// Whether the partition has completed one-shot BK3 initialization.
+pub fn part_is_bk3_initialized(pal: &impl HsmPartitionManager, io: &impl HsmIo) -> HsmResult<bool> {
+    pal.part_prop_get_bool(io, PartPropId::BK3_INITIALIZED, 0)
+}
+
+/// Atomically commit the partition's one-shot BK3 init state to
+/// `true`.  Returns [`HsmError::Bk3AlreadyInitialized`] if the flag
+/// was already set in the current partition incarnation.  This is the
+/// authoritative race-winner gate for `DdiInitBk3`.
+pub fn part_mark_bk3_initialized(pal: &impl HsmPartitionManager, io: &impl HsmIo) -> HsmResult<()> {
+    pal.part_prop_set_bool(io, PartPropId::BK3_INITIALIZED, 0, true)
+}
+
+/// Partition BKS2 lineage identifier (`u16`). Read-only.
+pub fn part_bks2_id(pal: &impl HsmPartitionManager, io: &impl HsmIo) -> HsmResult<u16> {
+    pal.part_prop_get_u16(io, PartPropId::BKS2_ID, 0)
+}

--- a/fw/core/lib/src/part_state.rs
+++ b/fw/core/lib/src/part_state.rs
@@ -56,12 +56,14 @@
 //!
 //! ## Cardinality
 //!
-//! All currently-catalogued properties are single-valued
-//! (`cardinality = 1` in their [`PartPropMeta`]).  The `idx` argument
-//! to the underlying property API is therefore hard-wired to `0` in
-//! every wrapper.  When the first indexed property is added the
-//! affected wrappers will grow an `idx: u16` parameter; the rest will
-//! not.
+//! Most catalogued properties are single-valued
+//! (`cardinality = 1` in their [`PartPropMeta`]); their wrappers
+//! hard-wire the underlying property API's `idx` argument to `0`.
+//! Indexed properties (currently [`PartPropId::MFGR_SEED`] and
+//! [`PartPropId::DEV_OWNER_SEED`], both `cardinality = 64`) expose
+//! the row index as an `idx: u16` parameter on their wrappers
+//! (see [`part_mfgr_seed`] / [`part_dev_owner_seed`]); the rest
+//! still take no index.
 //!
 //! ## Byte-valued properties use [`DmaBuf`]
 //!
@@ -116,9 +118,7 @@
 //! - **Vault key references** (the `*_KEY_ID` ids) are stored as
 //!   `U16` and exposed here as [`HsmKeyId`] (a `u16` newtype) via the
 //!   `key_id_get` / `key_id_set` helpers below.  Conversion is
-//!   loss-less because vault key ids are always `u16`; a stored
-//!   value out of `u16` range is treated as PAL corruption and
-//!   surfaces as [`HsmError::InternalError`].
+//!   loss-less because both representations are `u16`.
 //!
 //! ## Naming
 //!
@@ -253,9 +253,9 @@ pub const fn part_uds_prop_id() -> PartPropId {
     PartPropId::UDS
 }
 
-/// Firmware-supplied per-partition seed (32 B).  **Sensitive.**
+/// Firmware-supplied per-partition seed (48 B).  **Sensitive.**
 ///
-/// Wraps [`PartPropId::FW_SEED`] (`FixedBytes { len: 32 }`,
+/// Wraps [`PartPropId::FW_SEED`] (`FixedBytes { len: 48 }`,
 /// `RequiredPresent`, read-only).  Owned by the PAL; never set
 /// from core.  Used as a PAL-controlled tweak input to partition-bound
 /// derivations so that material from a forged or replayed UDS cannot
@@ -275,21 +275,19 @@ pub const fn part_fw_seed_prop_id() -> PartPropId {
 
 // ─── Vault references ─────────────────────────────────────────────────────
 //
-// All vault-ref properties are stored in the property table as `U32`
-// for forward compatibility with vault namespaces wider than `u16`,
-// but the typed core view here exposes them as [`HsmKeyId`] (a `u16`
-// newtype) because every currently-defined vault id fits in `u16`.
-// Conversion is loss-less in both directions; a stored value out of
-// `u16` range is treated as PAL-side corruption and surfaces as
-// [`HsmError::InternalError`].
+// All vault-ref properties are stored in the property table as `U16`
+// (matching today's [`HsmKeyId`] width).  The typed core view here
+// re-exposes them as [`HsmKeyId`] (a `u16` newtype) for call-site
+// ergonomics; conversion is loss-less.  If the catalogue ever grows
+// to a wider scalar kind, the `key_id_get` helper is the single
+// point at which narrowing happens, and an out-of-range stored value
+// will surface as [`HsmError::InternalError`].
 
-/// Read a vault key reference and narrow `U16 → HsmKeyId` (`u16`).
+/// Read a vault key reference as an [`HsmKeyId`] (`u16`).
 ///
-/// Returns [`HsmError::InternalError`] if the stored value does not
-/// fit in `u16` — that signals storage corruption or a PAL bug, not
-/// caller error.  Returns [`HsmError::PartPropNotFound`] if the slot
-/// is absent; callers handle the absence/error split per the
-/// presence semantics in the module docs.
+/// Returns [`HsmError::PartPropNotFound`] if the slot is absent;
+/// callers handle the absence/error split per the presence
+/// semantics in the module docs.
 #[inline]
 fn key_id_get(
     pal: &impl HsmPartitionManager,
@@ -516,7 +514,7 @@ pub const fn part_establish_cred_key_id_prop_id() -> PartPropId {
 /// | `0`      | Crypto Officer PSK | [`PartPropId::PSK_CO`]   |
 /// | `1`      | Crypto User PSK    | [`PartPropId::PSK_CU`]   |
 ///
-/// Any other value returns [`HsmError::InvalidArg`].  Both slots are
+/// Any other value returns [`HsmError::InvalidPskId`].  Both slots are
 /// `RequiredPresent` (default-baked at allocation time from
 /// [`DEFAULT_PSK_CO`] / [`DEFAULT_PSK_CU`]) so a successful call
 /// always yields exactly [`PSK_LEN`] bytes.
@@ -543,7 +541,7 @@ pub fn part_set_psk(
 }
 
 /// Translate the `0/1` PSK selector into the backing
-/// [`PartPropId`].  Returns [`HsmError::InvalidArg`] for any other
+/// [`PartPropId`].  Returns [`HsmError::InvalidPskId`] for any other
 /// selector.
 ///
 /// Exposed so upper-layer undo-log emitters can name the slot they
@@ -553,7 +551,7 @@ pub fn part_psk_prop_id(psk_id: u8) -> HsmResult<PartPropId> {
     match psk_id {
         0 => Ok(PartPropId::PSK_CO),
         1 => Ok(PartPropId::PSK_CU),
-        _ => Err(HsmError::InvalidArg),
+        _ => Err(HsmError::InvalidPskId),
     }
 }
 
@@ -590,12 +588,19 @@ pub fn part_set_credential(
 /// Constant-time-compare the supplied `id` and `pin` (16 B each)
 /// against the partition's stored credential.
 ///
-/// Returns `Ok(())` on match.  Returns
-/// [`HsmError::InvalidAppCredentials`] when the credential has not
-/// been set yet, the lengths do not match (16 each), or either half
-/// differs.  The comparison runs over the full 32-byte width so a
-/// timing side-channel cannot distinguish "wrong id" from "wrong
-/// pin".
+/// Returns `Ok(())` on match.  Returns:
+///
+/// - [`HsmError::InvalidArg`] if `id` or `pin` is not exactly 16 B
+///   (caller bug — the wire shape is fixed).
+/// - [`HsmError::InvalidAppCredentials`] when the credential has not
+///   been set yet, or when either half differs from the stored
+///   value.  The comparison runs over the full 32-byte width so a
+///   timing side-channel cannot distinguish "wrong id" from "wrong
+///   pin".
+/// - [`HsmError::InternalError`] if the stored credential blob has
+///   a length other than 32 bytes — that signals a property
+///   catalogue / PAL storage corruption bug, not an authentication
+///   failure, and must not be masked as one.
 pub fn part_verify_credential(
     pal: &impl HsmPartitionManager,
     io: &impl HsmIo,
@@ -603,7 +608,7 @@ pub fn part_verify_credential(
     pin: &[u8],
 ) -> HsmResult<()> {
     if id.len() != 16 || pin.len() != 16 {
-        return Err(HsmError::InvalidAppCredentials);
+        return Err(HsmError::InvalidArg);
     }
     let stored = match part_credential(pal, io) {
         Ok(buf) => buf,
@@ -611,7 +616,7 @@ pub fn part_verify_credential(
         Err(e) => return Err(e),
     };
     if stored.len() != 32 {
-        return Err(HsmError::InvalidAppCredentials);
+        return Err(HsmError::InternalError);
     }
     let mut diff = 0u8;
     for i in 0..16 {
@@ -742,10 +747,11 @@ pub fn part_dev_owner_seed<'a>(
 
 /// Sealed BK3 blob.  **Sensitive.**
 ///
-/// Wraps [`PartPropId::SEALED_BK3`] (`VarBytes { max: 96 }`,
-/// `AbsentUntilSet`, sensitive).  Returns
-/// [`HsmError::PartPropNotFound`] before the host has supplied it this
-/// power cycle.  Set at most once per power cycle.
+/// Wraps [`PartPropId::SEALED_BK3`]
+/// (`VarBytes { max: SEALED_BK3_MAX_LEN }`, `AbsentUntilSet`,
+/// sensitive).  Returns [`HsmError::PartPropNotFound`] before the
+/// host has supplied it this power cycle.  Set at most once per
+/// power cycle.
 pub fn part_sealed_bk3<'a>(
     pal: &'a impl HsmPartitionManager,
     io: &impl HsmIo,
@@ -755,7 +761,10 @@ pub fn part_sealed_bk3<'a>(
 
 /// Write the sealed BK3 blob.  **Sensitive.**
 ///
-/// `data` must be ≤ 96 bytes.
+/// `data` must be ≤ [`SEALED_BK3_MAX_LEN`] bytes; the PAL setter
+/// is write-once per power cycle and returns
+/// [`HsmError::SealedBk3AlreadySet`] if invoked a second time
+/// without an intervening clear (free / NSSR).
 pub fn part_set_sealed_bk3(
     pal: &impl HsmPartitionManager,
     io: &impl HsmIo,
@@ -869,9 +878,9 @@ pub const fn part_policy_prop_id() -> PartPropId {
     PartPropId::POLICY
 }
 
-/// POTA thumbprint (32 B).  Set by `PartInit`.
+/// POTA thumbprint (48 B).  Set by `PartInit`.
 ///
-/// Wraps [`PartPropId::POTA_THUMBPRINT`] (`FixedBytes { len: 32 }`,
+/// Wraps [`PartPropId::POTA_THUMBPRINT`] (`FixedBytes { len: 48 }`,
 /// `AbsentUntilSet`).
 pub fn part_pota_thumbprint<'a>(
     pal: &'a impl HsmPartitionManager,
@@ -882,7 +891,7 @@ pub fn part_pota_thumbprint<'a>(
 
 /// Write the POTA thumbprint.
 ///
-/// `data` must be exactly 32 bytes.
+/// `data` must be exactly 48 bytes.
 pub fn part_set_pota_thumbprint(
     pal: &impl HsmPartitionManager,
     io: &impl HsmIo,
@@ -913,7 +922,10 @@ pub fn part_psk_is_default(
     let default = match psk_id {
         0 => DEFAULT_PSK_CO.as_slice(),
         1 => DEFAULT_PSK_CU.as_slice(),
-        _ => return Err(HsmError::InvalidArg),
+        // Unreachable: `part_psk` above already rejected any other
+        // selector with `InvalidPskId`.  Returned here for defence in
+        // depth so the match stays exhaustive.
+        _ => return Err(HsmError::InvalidPskId),
     };
     if stored.len() != default.len() {
         return Ok(false);

--- a/fw/core/lib/src/session.rs
+++ b/fw/core/lib/src/session.rs
@@ -13,7 +13,6 @@ use azihsm_fw_hsm_pal_traits::HsmPal;
 use azihsm_fw_hsm_pal_traits::HsmResult;
 use azihsm_fw_hsm_pal_traits::HsmSessId;
 use azihsm_fw_hsm_pal_traits::APP_ID_LEN;
-use azihsm_fw_hsm_pal_traits::PSK_LEN;
 
 /// Returns the public AppId bound to `sess_id`'s partition PSK slot.
 ///
@@ -51,13 +50,10 @@ pub fn session_app_id<P: HsmPal>(
 ) -> HsmResult<[u8; APP_ID_LEN]> {
     let psk_id = u8::from(sess_id.role() == azihsm_fw_hsm_pal_traits::SessionRole::CryptoUser);
 
-    let mut psk = [0u8; PSK_LEN];
-    let res = pal.part_psk(io, psk_id, Some(&mut psk[..]));
-
     let mut app_id = [0u8; APP_ID_LEN];
-    if res.is_ok() {
-        app_id.copy_from_slice(&psk[..APP_ID_LEN]);
+    let res = crate::part_state::part_psk(pal, io, psk_id);
+    if let Ok(psk_buf) = res.as_ref() {
+        app_id.copy_from_slice(&psk_buf[..APP_ID_LEN]);
     }
-    psk.fill(0);
     res.map(|_| app_id)
 }

--- a/fw/pal/traits/src/error.rs
+++ b/fw/pal/traits/src/error.rs
@@ -307,7 +307,7 @@ pub enum HsmError {
     /// One-shot enforcement matching [`Self::PtaKeyAlreadySet`]: the
     /// only path to a fresh UMS binding is via a full partition
     /// free/realloc cycle.
-    UmsKeyAlreadySet = 0x087000FD,
+    UpsKeyAlreadySet = 0x087000FD,
 
     /// A partition operation required the Unique Machine Secret (UMS)
     /// vault key but `PartInit` has not yet successfully bound one
@@ -315,6 +315,16 @@ pub enum HsmError {
     /// [`HsmPartitionManager::part_ums_key_id`](crate::HsmPartitionManager::part_ums_key_id)
     /// when the slot is empty.
     UmsKeyNotSet = 0x087000FE,
+
+    /// Returned by the property-based getters on
+    /// [`HsmPartitionManager`](crate::HsmPartitionManager)
+    /// (`part_prop_get_*` / `part_prop_get_bytes`) when the addressed
+    /// `(PartPropId, idx)` slot is absent (i.e. has not been
+    /// populated, or was last
+    /// [`part_prop_clear`](crate::HsmPartitionManager::part_prop_clear)ed).
+    /// Distinct from [`HsmError::InvalidArg`], which signals a
+    /// caller bug (unknown id, out-of-range idx, kind mismatch, etc.).
+    PartPropNotFound = 0x087000FF,
 }
 
 impl core::fmt::Debug for HsmError {

--- a/fw/pal/traits/src/part.rs
+++ b/fw/pal/traits/src/part.rs
@@ -1,61 +1,120 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-//! Partition management types and traits.
+//! Partition management trait and property surface.
 //!
-//! Defines the [`HsmPartitionManager`] trait used by core to query
-//! and mutate per-partition state.  Each partition is a host-facing
-//! controller interface identified by [`HsmPartId`]; the firmware
-//! supports up to `HSM_NUM_PARTITIONS` of them, addressed implicitly
-//! through the [`HsmIo`] handle (`io.pid()`).
+//! This module defines:
 //!
-//! ## Per-partition state
+//! - [`HsmPartitionManager`] — the PAL trait core uses to read and
+//!   mutate per-partition state.
+//! - The **property surface** ([`PartPropId`], [`PartPropMeta`],
+//!   [`PartPropKind`], [`PartPropAccess`], [`PartPropDefault`]) —
+//!   a generic, kind-typed key-value view of that state, addressed
+//!   by `(PartPropId, idx: u16)` pairs whose wire shape is pinned
+//!   at compile time.
+//! - The [`PartState`] lifecycle enum and a small set of canonical
+//!   length constants ([`PART_POLICY_LEN`], [`BK_BOOT_LEN`],
+//!   [`SEALED_BK3_MAX_LEN`], [`MASKED_BK_BOOT_LEN`]) that pin the
+//!   byte sizes shared between core, the PAL, and host-side tools.
 //!
-//! Each partition slot owns:
+//! Each partition is a host-facing controller interface identified
+//! by [`HsmPartId`]; the firmware supports up to `HSM_NUM_PARTITIONS`
+//! of them.  Every trait method takes an [`HsmIo`] handle and
+//! operates on the partition resolved from `io.pid()` — partitions
+//! are never named explicitly at the trait boundary, which prevents
+//! accidental cross-partition queries.
 //!
-//! - A [`PartState`] lifecycle field.
-//! - A resource count (number of host-allocated SQ/CQ pairs).
-//! - An opaque identity blob ([`PartId`]) and an ECC-P384 identity
-//!   key pair.
-//! - A pair of crypto material slots used during credential
-//!   establishment and session setup:
-//!   - **establish-cred** — one-time RSA-OAEP keypair used to receive
-//!     the host's bootstrap credential. Cleared after use.
-//!   - **session-enc** — long-lived ECDH key used to derive
-//!     per-session encryption keys.
-//! - A 32-byte randomness nonce, refreshed per credential / session
-//!   event.
-//! - An optional sealed BK3 blob (set once, ≤ 1024 bytes).
+//! # Property surface at a glance
 //!
-//! ## Lifecycle
+//! All partition state is reached through one of seven methods on
+//! [`HsmPartitionManager`]:
+//!
+//! - One getter and one setter per scalar kind
+//!   (`U8` / `U16` / `U32` / `U64` / `Bool`).
+//! - [`part_prop_get_bytes`](HsmPartitionManager::part_prop_get_bytes) /
+//!   [`part_prop_set_bytes`](HsmPartitionManager::part_prop_set_bytes)
+//!   for `FixedBytes` / `VarBytes` slots, exchanging `&DmaBuf` so
+//!   the bytes flow into further PAL crypto without a copy.
+//! - [`part_prop_clear`](HsmPartitionManager::part_prop_clear) to
+//!   reset an absent-capable slot.
+//!
+//! The full set of slots backed by the PAL is enumerated by the
+//! `pub const` catalogue on [`PartPropId`]; each entry's
+//! [`PartPropMeta`] (returned by [`PartPropId::meta`]) pins its
+//! kind, cardinality, access mode ([`PartPropAccess::Rw`] /
+//! [`PartPropAccess::Ro`]), presence semantics
+//! ([`PartPropDefault::RequiredPresent`] /
+//! [`PartPropDefault::AbsentUntilSet`]), and whether the bytes are
+//! sensitive.
+//!
+//! # Lifecycle
 //!
 //! ```text
-//! Unallocated ── allocate resources + identity ──▶ Allocated
-//!                                                      │
-//!                          generate internal keys + nonce
-//!                                                      ▼
-//!                                                  Enabled ──▶ Disabled
-//!                                                                │
-//!                                              re-enable internal keys
-//!                                                                │
-//!                                                                ▼
-//!                                                            Enabled
+//!   Unallocated ── allocate resources + identity ──▶ Allocated
+//!                                                        │
+//!                       generate internal keys + nonce + provisioning
+//!                                                        │
+//!                                                        ▼
+//!                                                     Enabled ──▶ Disabled
+//!                                                        │           │
+//!                                                        │   re-enable internal keys
+//!                                                        │           │
+//!                                                        │           ▼
+//!                                                        │       Enabled
+//!                                                        ▼
+//!     PartInit binds PTA / policy / POTA thumbprint  Initializing
 //! ```
 //!
-//! ## Implicit partition addressing
+//! [`PartState::Initializing`] is a one-shot transient: once
+//! `PartInit` has bound the Partition Trust Anchor (PTA) key, the
+//! partition policy, and the POTA thumbprint, no further `PartInit`
+//! is permitted until the next alloc/free cycle.
 //!
-//! All trait methods take an [`HsmIo`] handle rather than an explicit
-//! [`HsmPartId`].  The partition is resolved via [`HsmIo::pid`].  This
-//! prevents accidental cross-partition queries and keeps the trait
-//! shape uniform with the rest of the PAL.
+//! # Cardinality and indexing
+//!
+//! Every getter/setter takes a `u16` `idx`.  Single-valued props
+//! (the common case) have `cardinality = 1` and accept only
+//! `idx = 0`; out-of-range indices yield [`HsmError::InvalidArg`].
+//! Indexed properties (`cardinality > 1`) address a flat array of
+//! homogeneous slots — both the storage backend and the undo log
+//! treat `(id, idx)` as an atomic addressing pair.  See
+//! [`PartPropMeta::fixed_indexed`].
+//!
+//! # Presence semantics
+//!
+//! Each slot is either *present* (has a value) or *absent*.  Getters
+//! return [`HsmError::PartPropNotFound`] for absent slots; whether
+//! absence is reachable is pinned by [`PartPropDefault`]:
+//!
+//! - **`RequiredPresent`** — populated by the PAL before the
+//!   partition is exposed to callers; `PartPropNotFound` is
+//!   unreachable, [`part_prop_clear`](HsmPartitionManager::part_prop_clear)
+//!   returns [`HsmError::InvalidArg`].
+//! - **`AbsentUntilSet`** — starts absent; first successful setter
+//!   makes it present; `part_prop_clear` resets it to absent (and
+//!   is idempotent on an already-absent slot).
+//!
+//! # Sensitivity
+//!
+//! Slots whose meta marks them `sensitive = true` (PSKs, credentials,
+//! nonce, sealed / masked / unmasked BK_BOOT, UDS, firmware seed,
+//! root-of-trust seeds, BK3 session) MUST be zeroised by the PAL
+//! on clear and on overwrite so plaintext secrets do not linger in
+//! shared storage (DMA pool, flat persistent region).
+//!
+//! # Pure-state surface
+//!
+//! The property API is **pure state**.  Cryptographic derivations
+//! (e.g. masking-key derivation), credential verification, nonce
+//! refresh, and similar behaviours live on dedicated PAL traits and
+//! consume the partition via this property surface where they need
+//! to read partition-owned bytes.
 
 use super::*;
 
 /// Opaque identity blob for a partition.
 ///
-/// Returned by [`HsmPartitionManager::part_id`].  The slice borrows
-/// directly from partition state and is valid for the duration of the
-/// `&self` borrow on the [`HsmPartitionManager`] implementation.  The
+/// Borrowed view of the bytes stored at [`PartPropId::ID`].  The
 /// content is treated as opaque by core; only the host knows how to
 /// interpret it.
 pub type PartId<'a> = &'a [u8];
@@ -69,978 +128,385 @@ pub const PART_POLICY_LEN: usize = 167;
 /// enum is the canonical observation point for downstream code (DDI
 /// dispatch, IO gating, vault/session scoping).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
 pub enum PartState {
     /// The partition slot is free.  No resources, no identity, no
     /// keys.  IO arriving for this partition is dropped.
-    Unallocated,
+    Unallocated = 0,
 
     /// Resources and the ECC-P384 identity key pair are present, but
     /// the establish-cred and session-enc keys plus the nonce have
     /// not been generated yet.  The host must complete provisioning
     /// before DDI traffic is accepted.
-    Allocated,
+    Allocated = 1,
 
     /// The partition is fully provisioned and ready for DDI
     /// operations.  All internal crypto material (identity,
     /// establish-cred, session-enc, nonce) is present.
-    Enabled,
+    Enabled = 2,
 
     /// The partition was previously [`Enabled`](Self::Enabled) and has
     /// been disabled by the host.  Internal crypto material, vault
     /// keys, and sessions are cleared, but the resource allocation
     /// and identity key pair are retained so the partition can be
     /// re-enabled without a full re-provision.
-    Disabled,
+    Disabled = 3,
 
     /// The TBOR `PartInit` handler has bound the Partition Trust
     /// Anchor (PTA) key, the partition policy, and the POTA
     /// thumbprint to this incarnation, but partition finalization
     /// has not yet run.  No further `PartInit` is permitted until
     /// the next alloc/free cycle (one-shot enforcement).
-    Initializing,
+    Initializing = 4,
+}
+
+impl PartState {
+    /// Decode a serialized `u8` discriminant back into a `PartState`.
+    ///
+    /// # Parameters
+    ///
+    /// - `raw` — the `#[repr(u8)]` discriminant byte, typically
+    ///   produced by an earlier read of [`PartPropId::STATE`] or by
+    ///   on-disk decoders.
+    ///
+    /// # Returns
+    ///
+    /// [`Option<Self>`] — `Some(state)` for a recognised byte, or
+    /// `None` for any byte that does not name a known lifecycle
+    /// state.  Callers that read state from persistent storage or
+    /// the property API treat `None` as storage corruption /
+    /// unsupported lifecycle byte and fail closed.
+    #[inline]
+    pub const fn from_u8(raw: u8) -> Option<Self> {
+        match raw {
+            0 => Some(Self::Unallocated),
+            1 => Some(Self::Allocated),
+            2 => Some(Self::Enabled),
+            3 => Some(Self::Disabled),
+            4 => Some(Self::Initializing),
+            _ => None,
+        }
+    }
 }
 
 /// Partition manager interface.
 ///
-/// All methods take an [`HsmIo`] handle and operate on the partition
-/// resolved from `io.pid()`.  The trait is `&self`; PAL
+/// PAL impls back per-partition state and expose it to core through
+/// the **property surface** documented in the module-level overview
+/// above.  Every method takes an [`HsmIo`] handle and operates on the
+/// partition resolved from `io.pid()`; the trait is `&self`, so PAL
 /// implementations are expected to use interior mutability.
 ///
-/// Methods returning `usize` follow a uniform query/copy pattern: pass
-/// `out = None` to obtain the required buffer size, then call again
-/// with `out = Some(&mut buf[..size])` to perform the copy.  Both
-/// calls return the same canonical size.
+/// # Error contract
+///
+/// Common to every `part_prop_*` method:
+///
+/// - [`HsmError::InvalidArg`] — unknown `id`,
+///   `idx >= cardinality`, kind/accessor mismatch (e.g. `get_u8`
+///   on a `U32` slot, or `set_bytes` on a `Bool` slot), bytes
+///   length violates the `FixedBytes` / `VarBytes` bound, or a
+///   write/clear targets an [`Access::Ro`](PartPropAccess::Ro) or
+///   [`RequiredPresent`](PartPropDefault::RequiredPresent) slot.
+/// - [`HsmError::PartPropNotFound`] — getter on an absent slot.
+///   Unreachable for `RequiredPresent` slots; reachable for
+///   `AbsentUntilSet` slots until the first successful setter or
+///   after the most recent [`Self::part_prop_clear`].
+/// - [`HsmError::UnsupportedCmd`] — the default body.  PAL impls
+///   override only the methods they back; existing impls compile
+///   unchanged until they opt in to additional kinds.
+/// - Other [`HsmError`] variants — PAL-level failures (for example
+///   [`HsmError::InternalError`] on backing-store corruption,
+///   [`HsmError::Bk3AlreadyInitialized`] on the one-shot
+///   [`PartPropId::BK3_INITIALIZED`] guard).
+///
+/// Partition scoping is implicit via `io.pid()`, as elsewhere on
+/// this trait.
 pub trait HsmPartitionManager {
-    /// Returns the lifecycle state of the calling partition.
-    ///
-    /// Cheap probe used by IO dispatch to drop traffic for
-    /// non-[`Enabled`](PartState::Enabled) partitions.
+    /// Read a [`PartPropKind::U8`] slot.
     ///
     /// # Parameters
     ///
-    /// - `io` — caller's I/O context (partition selected via
-    ///   [`HsmIo::pid`]).
+    /// - `io` — IO handle; the target partition is resolved from
+    ///   [`io.pid()`](HsmIo::pid).
+    /// - `id` — property identifier; its [`meta`](PartPropId::meta)
+    ///   `kind` must be [`PartPropKind::U8`].
+    /// - `idx` — row index within `0..id.meta().cardinality`.
     ///
     /// # Returns
     ///
-    /// - `Ok(state)` — the current [`PartState`].
-    /// - `Err(HsmError::InvalidArg)` — `io.pid()` is out of range
-    ///   for this build.
-    fn part_state(&self, io: &impl HsmIo) -> HsmResult<PartState>;
+    /// [`HsmResult<u8>`] — the stored byte on success.  See the
+    /// [`HsmPartitionManager`] doc-comment for the shared error
+    /// contract.
+    fn part_prop_get_u8(&self, io: &impl HsmIo, id: PartPropId, idx: u16) -> HsmResult<u8>;
 
-    /// Returns the number of host-allocated resources (SQ/CQ pairs)
-    /// bound to this partition.
+    /// Write a [`PartPropKind::U8`] slot.
     ///
     /// # Parameters
     ///
-    /// - `io` — caller's I/O context.
+    /// - `io` — IO handle; the target partition is resolved from
+    ///   [`io.pid()`](HsmIo::pid).
+    /// - `id` — property identifier; its [`meta`](PartPropId::meta)
+    ///   `kind` must be [`PartPropKind::U8`] and `access` must be
+    ///   [`PartPropAccess::Rw`].
+    /// - `idx` — row index within `0..id.meta().cardinality`.
+    /// - `value` — byte to store; replaces any previous value and
+    ///   transitions [`AbsentUntilSet`](PartPropDefault::AbsentUntilSet)
+    ///   slots to present.
     ///
     /// # Returns
     ///
-    /// - `Ok(count)` — number of resources, in the range `0..=u8::MAX`.
-    ///   `0` is valid for [`PartState::Unallocated`].
-    /// - `Err(HsmError::InvalidArg)` — `io.pid()` is out of range.
-    fn part_res_count(&self, io: &impl HsmIo) -> HsmResult<u8>;
-
-    /// Borrows the opaque identity blob for the calling partition.
-    ///
-    /// The returned slice points into partition storage and is valid
-    /// for the duration of the `&self` borrow.  Content is opaque to
-    /// core.
-    ///
-    /// # Parameters
-    ///
-    /// - `io` — caller's I/O context.
-    ///
-    /// # Returns
-    ///
-    /// - `Ok(id)` — borrowed [`PartId`] slice.
-    /// - `Err(HsmError::InvalidArg)` — `io.pid()` is out of range.
-    /// - `Err(HsmError::PartitionNotProvisioned)` — partition is
-    ///   [`Unallocated`](PartState::Unallocated).
-    fn part_id(&self, io: &impl HsmIo) -> HsmResult<PartId<'_>>;
-
-    /// Returns the vault key ID for the partition's ECC-P384
-    /// identity key pair.
-    ///
-    /// The private key is stored in the vault as
-    /// [`HsmVaultKeyKind::Ecc384Private`] with `sign + local +
-    /// internal` attributes set.  The corresponding public key is
-    /// served by [`part_id_pub_key`](Self::part_id_pub_key).
-    ///
-    /// # Parameters
-    ///
-    /// - `io` — caller's I/O context.
-    ///
-    /// # Returns
-    ///
-    /// - `Ok(key_id)` — vault [`HsmKeyId`] for the identity private
-    ///   key.
-    /// - `Err(HsmError::InvalidArg)` — `io.pid()` is out of range.
-    /// - `Err(HsmError::PartitionNotProvisioned)` — partition is
-    ///   [`Unallocated`](PartState::Unallocated) (no identity key yet).
-    fn part_id_key_id(&self, io: &impl HsmIo) -> HsmResult<HsmKeyId>;
-
-    /// Returns the DER-encoded SubjectPublicKeyInfo for the
-    /// partition's identity key, optionally copying it into a
-    /// caller-supplied buffer.
-    ///
-    /// # Parameters
-    ///
-    /// - `io` — caller's I/O context.
-    /// - `out` —
-    ///   - `None` — query mode; no copy is performed, just return the
-    ///     required size.
-    ///   - `Some(buf)` — copy mode; the encoded key is written to
-    ///     `buf[..size]`.  `buf.len()` must be ≥ size.
-    ///
-    /// # Returns
-    ///
-    /// - `Ok(size)` — number of bytes that were (or would be) written.
-    /// - `Err(HsmError::InvalidArg)` — `io.pid()` is out of range, or
-    ///   `out` is `Some(buf)` and `buf.len() < size`.
-    /// - `Err(HsmError::PartitionNotProvisioned)` — no identity key.
-    fn part_id_pub_key(&self, io: &impl HsmIo, out: Option<&mut [u8]>) -> HsmResult<usize>;
-
-    /// Returns the vault key ID of the establish-credential
-    /// encryption key, if present.
-    ///
-    /// The establish-cred key is a one-time-use RSA-OAEP keypair
-    /// generated when the partition transitions to
-    /// [`Enabled`](PartState::Enabled).  Core calls
-    /// [`part_clear_establish_cred_key`](Self::part_clear_establish_cred_key)
-    /// once the bootstrap credential has been received, after which
-    /// this method returns `Ok(None)`.
-    ///
-    /// # Parameters
-    ///
-    /// - `io` — caller's I/O context.
-    ///
-    /// # Returns
-    ///
-    /// - `Ok(Some(key_id))` — key is present in the vault.
-    /// - `Ok(None)` — key has been cleared (one-time-use complete).
-    /// - `Err(HsmError::InvalidArg)` — `io.pid()` is out of range.
-    /// - `Err(HsmError::PartitionNotEnabled)` — partition is not
-    ///   currently [`Enabled`](PartState::Enabled).
-    fn part_establish_cred_key_id(&self, io: &impl HsmIo) -> HsmResult<Option<HsmKeyId>>;
-
-    /// Returns the DER-encoded SubjectPublicKeyInfo for the
-    /// establish-credential encryption key, optionally copying it.
-    ///
-    /// Follows the same query/copy pattern as
-    /// [`part_id_pub_key`](Self::part_id_pub_key).  After the key has
-    /// been cleared, returns `Ok(0)` (no data, no error) so callers
-    /// can treat absence as a `len == 0` reply.
-    ///
-    /// # Parameters
-    ///
-    /// - `io` — caller's I/O context.
-    /// - `out` — `None` for size query, `Some(buf)` to copy.
-    ///
-    /// # Returns
-    ///
-    /// - `Ok(size)` — bytes that were (or would be) written; `0` if
-    ///   the key has been cleared.
-    /// - `Err(HsmError::InvalidArg)` — `io.pid()` is out of range, or
-    ///   `out = Some(buf)` and `buf.len() < size`.
-    /// - `Err(HsmError::PartitionNotEnabled)` — partition is not
-    ///   currently [`Enabled`](PartState::Enabled).
-    fn part_establish_cred_pub_key(
+    /// [`HsmResult<()>`] — `Ok(())` on success.  See the
+    /// [`HsmPartitionManager`] doc-comment for the shared error
+    /// contract.
+    fn part_prop_set_u8(
         &self,
         io: &impl HsmIo,
-        out: Option<&mut [u8]>,
-    ) -> HsmResult<usize>;
-
-    /// Removes the establish-credential encryption key from the
-    /// vault.
-    ///
-    /// Implements the one-time-use pattern: core calls this after
-    /// the bootstrap credential has been received.  Idempotent —
-    /// calling on an already-cleared key returns `Ok(())`.  After
-    /// this call,
-    /// [`part_establish_cred_key_id`](Self::part_establish_cred_key_id)
-    /// returns `Ok(None)` and
-    /// [`part_establish_cred_pub_key`](Self::part_establish_cred_pub_key)
-    /// returns `Ok(0)`.
-    ///
-    /// # Parameters
-    ///
-    /// - `io` — caller's I/O context.
-    ///
-    /// # Returns
-    ///
-    /// - `Ok(())` on success or if already cleared.
-    /// - `Err(HsmError::InvalidArg)` — `io.pid()` is out of range.
-    /// - `Err(HsmError::PartitionNotEnabled)` — partition is not
-    ///   currently [`Enabled`](PartState::Enabled).
-    fn part_clear_establish_cred_key(&self, io: &impl HsmIo) -> HsmResult<()>;
-
-    /// Returns the vault key ID of the session encryption key.
-    ///
-    /// Unlike the establish-cred key, this key is long-lived and is
-    /// reused for every session opened against this partition.  It
-    /// is regenerated only on disable→enable transitions.
-    ///
-    /// # Parameters
-    ///
-    /// - `io` — caller's I/O context.
-    ///
-    /// # Returns
-    ///
-    /// - `Ok(key_id)` — vault [`HsmKeyId`] for the session-enc
-    ///   private key.
-    /// - `Err(HsmError::InvalidArg)` — `io.pid()` is out of range.
-    /// - `Err(HsmError::PartitionNotEnabled)` — partition is not
-    ///   currently [`Enabled`](PartState::Enabled).
-    fn part_session_enc_key_id(&self, io: &impl HsmIo) -> HsmResult<HsmKeyId>;
-
-    /// Returns the DER-encoded SubjectPublicKeyInfo for the session
-    /// encryption key, optionally copying it.
-    ///
-    /// Follows the same query/copy pattern as
-    /// [`part_id_pub_key`](Self::part_id_pub_key).
-    ///
-    /// # Parameters
-    ///
-    /// - `io` — caller's I/O context.
-    /// - `out` — `None` for size query, `Some(buf)` to copy.
-    ///
-    /// # Returns
-    ///
-    /// - `Ok(size)` — bytes that were (or would be) written.
-    /// - `Err(HsmError::InvalidArg)` — `io.pid()` is out of range, or
-    ///   `out = Some(buf)` and `buf.len() < size`.
-    /// - `Err(HsmError::PartitionNotEnabled)` — partition is not
-    ///   currently [`Enabled`](PartState::Enabled).
-    fn part_session_enc_pub_key(&self, io: &impl HsmIo, out: Option<&mut [u8]>)
-    -> HsmResult<usize>;
-
-    /// Returns the partition's 32-byte random nonce, optionally
-    /// copying it.
-    ///
-    /// The nonce is freshened by
-    /// [`part_nonce_refresh`](Self::part_nonce_refresh) on credential
-    /// and session events; the size is therefore always 32.
-    ///
-    /// # Parameters
-    ///
-    /// - `io` — caller's I/O context.
-    /// - `out` — `None` for size query, `Some(buf)` to copy.
-    ///
-    /// # Returns
-    ///
-    /// - `Ok(32)` always (on success), with `buf[..32]` populated when
-    ///   `out = Some(buf)`.
-    /// - `Err(HsmError::InvalidArg)` — `io.pid()` is out of range, or
-    ///   `out = Some(buf)` and `buf.len() < 32`.
-    /// - `Err(HsmError::PartitionNotEnabled)` — partition is not
-    ///   currently [`Enabled`](PartState::Enabled).
-    fn part_nonce(&self, io: &impl HsmIo, out: Option<&mut [u8]>) -> HsmResult<usize>;
-
-    /// Regenerates the partition nonce from the hardware RNG.
-    ///
-    /// Called by core after credential establishment and session open
-    /// to ensure the nonce read by the host has not been observed in
-    /// a previous transaction.
-    ///
-    /// # Parameters
-    ///
-    /// - `io` — caller's I/O context.
-    ///
-    /// # Returns
-    ///
-    /// - `Ok(())` on success.
-    /// - `Err(HsmError::InvalidArg)` — `io.pid()` is out of range.
-    /// - `Err(HsmError::PartitionNotEnabled)` — partition is not
-    ///   currently [`Enabled`](PartState::Enabled).
-    /// - `Err(HsmError)` — propagated from the RNG driver.
-    fn part_nonce_refresh(&self, io: &impl HsmIo) -> HsmResult<()>;
-
-    /// Returns the sealed BK3 blob for the partition, optionally
-    /// copying it.
-    ///
-    /// The sealed BK3 is set once via
-    /// [`part_set_sealed_bk3`](Self::part_set_sealed_bk3); subsequent
-    /// reads return the same blob.  Before any write, returns
-    /// `Ok(0)`.
-    ///
-    /// # Parameters
-    ///
-    /// - `io` — caller's I/O context.
-    /// - `out` — `None` for size query, `Some(buf)` to copy.
-    ///
-    /// # Returns
-    ///
-    /// - `Ok(size)` — bytes that were (or would be) written; `0` if
-    ///   no sealed BK3 has been stored.
-    /// - `Err(HsmError::InvalidArg)` — `io.pid()` is out of range, or
-    ///   `out = Some(buf)` and `buf.len() < size`.
-    /// - `Err(HsmError::PartitionNotEnabled)` — partition is not
-    ///   currently [`Enabled`](PartState::Enabled).
-    fn part_sealed_bk3(&self, io: &impl HsmIo, out: Option<&mut [u8]>) -> HsmResult<usize>;
-
-    /// Stores the sealed BK3 blob for the partition.
-    ///
-    /// Write-once: a second call returns
-    /// [`HsmError::SealedBk3AlreadySet`].
-    ///
-    /// # Parameters
-    ///
-    /// - `io` — caller's I/O context.
-    /// - `data` — sealed BK3 bytes; must be ≤ 1024 bytes.
-    ///
-    /// # Returns
-    ///
-    /// - `Ok(())` on success.
-    /// - `Err(HsmError::InvalidArg)` — `io.pid()` is out of range.
-    /// - `Err(HsmError::PartitionNotEnabled)` — partition is not
-    ///   currently [`Enabled`](PartState::Enabled).
-    /// - `Err(HsmError::SealedBk3AlreadySet)` — a sealed BK3 has
-    ///   already been stored.
-    /// - `Err(HsmError::SealedBk3TooLarge)` — `data.len() > 1024`.
-    fn part_set_sealed_bk3(&self, io: &impl HsmIo, data: &[u8]) -> HsmResult<()>;
-
-    /// Returns the partition's 16-byte VM launch GUID.
-    ///
-    /// The VM launch GUID identifies the host VM that owns the
-    /// partition.  It is established during partition enable and is
-    /// always exactly 16 bytes.  Follows the same query/copy pattern
-    /// as [`part_id_pub_key`](Self::part_id_pub_key): pass
-    /// `out = None` to learn the canonical size, then `Some(buf)` to
-    /// copy.
-    ///
-    /// On the standard PAL this returns a hardcoded value; on real
-    /// hardware it returns the platform-supplied GUID.
-    ///
-    /// # Parameters
-    ///
-    /// - `io` — caller's I/O context.
-    /// - `out` — `None` for size query, `Some(buf)` to copy.
-    ///
-    /// # Returns
-    ///
-    /// - `Ok(16)` on success.
-    /// - `Err(HsmError::InvalidArg)` — `io.pid()` is out of range, or
-    ///   `out = Some(buf)` and `buf.len() < 16`.
-    /// - `Err(HsmError::PartitionNotEnabled)` — partition is not
-    ///   currently [`Enabled`](PartState::Enabled).
-    fn part_vm_launch_guid(&self, io: &impl HsmIo, out: Option<&mut [u8]>) -> HsmResult<usize>;
-
-    /// Returns the partition's current Security Version Number (SVN).
-    ///
-    /// Used as masked-key metadata by BK3 masking and other
-    /// platform-bound operations.  Application-layer code reads the
-    /// SVN through this method rather than touching the underlying
-    /// BKS tables, which remain hidden inside the PAL.
-    ///
-    /// # Parameters
-    ///
-    /// - `io` — caller's I/O context.
-    ///
-    /// # Returns
-    ///
-    /// - `Ok(svn)` — current SVN.
-    /// - `Err(HsmError::InvalidArg)` — `io.pid()` is out of range.
-    /// - `Err(HsmError::PartitionNotEnabled)` — partition is not
-    ///   currently [`Enabled`](PartState::Enabled).
-    fn part_svn(&self, io: &impl HsmIo) -> HsmResult<u64>;
-
-    /// Returns the partition's BKS2 ID.
-    ///
-    /// BKS2 is always available in firmware (every partition has an
-    /// assigned BKS2 seed slot), so this is non-optional.  The
-    /// returned identifier is recorded in masked-key metadata so the
-    /// blob can later be unmasked against the same BKS2 lineage.
-    /// `BKS1` / `BKS2` themselves are never exposed to
-    /// application-layer code.
-    ///
-    /// Note: the wire-format metadata field
-    /// [`bks2_index`](azihsm_fw_ddi_mbor_types::masked_key::DdiMaskedKeyMetadata::bks2_index)
-    /// is `Option<u16>` only for backward compatibility with legacy
-    /// blobs from the prior reference firmware that were masked with
-    /// `None`; firmware code that produces new masked keys must
-    /// always populate the value returned by this method.
-    ///
-    /// # Parameters
-    ///
-    /// - `io` — caller's I/O context.
-    ///
-    /// # Returns
-    ///
-    /// - `Ok(id)` — BKS2 identifier for the current partition.
-    /// - `Err(HsmError::InvalidArg)` — `io.pid()` is out of range.
-    /// - `Err(HsmError::PartitionNotEnabled)` — partition is not
-    ///   currently [`Enabled`](PartState::Enabled).
-    fn part_bks2_id(&self, io: &impl HsmIo) -> HsmResult<u16>;
-
-    /// Returns the partition's `BK_BOOT` boot-key material.
-    ///
-    /// `BK_BOOT` is a per-partition secret created during partition
-    /// enable (on real hardware derived from `BKS1`/`BKS2` via the
-    /// platform key engine; on the std PAL emulator it is opaque
-    /// random material).  It is the input to BK3 masking performed by
-    /// the `DdiInitBk3` handler.  `BK_BOOT` is treated as a secret;
-    /// the partition lifecycle clears it on every disable/free, and
-    /// the platform must not log it.
-    ///
-    /// Follows the same query/copy pattern as
-    /// [`part_id_pub_key`](Self::part_id_pub_key): pass `out = None`
-    /// to learn the canonical length, then `Some(buf)` to copy.
-    /// `buf.len()` must be `>=` the returned length or the call
-    /// returns [`HsmError::InvalidArg`].
-    ///
-    /// # Parameters
-    ///
-    /// - `io` — caller's I/O context.
-    /// - `out` — `None` for size query, `Some(buf)` to copy.
-    ///
-    /// # Returns
-    ///
-    /// - `Ok([`BK_BOOT_LEN`])` on success.
-    /// - `Err(HsmError::InvalidArg)` — `io.pid()` is out of range, or
-    ///   `out = Some(buf)` and `buf.len() < BK_BOOT_LEN`.
-    /// - `Err(HsmError::PartitionNotEnabled)` — partition is not
-    ///   currently [`Enabled`](PartState::Enabled).
-    fn part_bk_boot(&self, io: &impl HsmIo, out: Option<&mut [u8]>) -> HsmResult<usize>;
-
-    /// Returns whether BK3 has been initialized for the current
-    /// partition incarnation.
-    ///
-    /// Used by the `DdiInitBk3` handler as a fail-fast check before
-    /// performing masking work.  The authoritative one-shot commit is
-    /// [`part_mark_bk3_initialized`](Self::part_mark_bk3_initialized);
-    /// this read-only getter is intentionally lock-free.
-    ///
-    /// # Parameters
-    ///
-    /// - `io` — caller's I/O context.
-    ///
-    /// # Returns
-    ///
-    /// - `Ok(true)` — `InitBk3` has succeeded for the current
-    ///   partition incarnation.
-    /// - `Ok(false)` — `InitBk3` has not yet been issued for the
-    ///   current partition incarnation.
-    /// - `Err(HsmError::InvalidArg)` — `io.pid()` is out of range.
-    /// - `Err(HsmError::PartitionNotEnabled)` — partition is not
-    ///   currently [`Enabled`](PartState::Enabled).
-    fn part_is_bk3_initialized(&self, io: &impl HsmIo) -> HsmResult<bool>;
-
-    /// Atomically commits the BK3 init state to initialized.
-    ///
-    /// This is the authoritative one-shot gate for `DdiInitBk3`.
-    /// Concurrent or repeated callers race here: the first call
-    /// succeeds and subsequent calls return
-    /// [`HsmError::Bk3AlreadyInitialized`].  Handler-level partition
-    /// write-lock serialization is an optimization, not the
-    /// correctness barrier.
-    ///
-    /// Callers must perform any masking-or-encoding work that should
-    /// be visible to the host *before* calling this method, because
-    /// once the state has transitioned no further `InitBk3` will
-    /// succeed for the current partition incarnation.
-    ///
-    /// # Parameters
-    ///
-    /// - `io` — caller's I/O context.
-    ///
-    /// # Returns
-    ///
-    /// - `Ok(())` — state transitioned from not-initialized to
-    ///   initialized.
-    /// - `Err(HsmError::InvalidArg)` — `io.pid()` is out of range.
-    /// - `Err(HsmError::PartitionNotEnabled)` — partition is not
-    ///   currently [`Enabled`](PartState::Enabled).
-    /// - `Err(HsmError::Bk3AlreadyInitialized)` — BK3 has already
-    ///   been initialized for the current partition incarnation.
-    fn part_mark_bk3_initialized(&self, io: &impl HsmIo) -> HsmResult<()>;
-
-    /// Returns the partition's `Masked_BK_BOOT` envelope.
-    ///
-    /// `Masked_BK_BOOT` is the AES-CBC-256 + HMAC-SHA-384 envelope
-    /// of raw `BK_BOOT` under `BKx`, persisted by the `DdiInitBk3`
-    /// handler via
-    /// [`part_set_masked_bk_boot`](Self::part_set_masked_bk_boot).
-    /// Subsequent handlers (e.g. `DdiEstablishCredential`) read this
-    /// blob and recover raw `BK_BOOT` via
-    /// `key_masking::cbc::unmask` so plaintext `BK_BOOT` never needs to
-    /// be persisted across calls.
-    ///
-    /// Follows the same query/copy pattern as
-    /// [`part_sealed_bk3`](Self::part_sealed_bk3): pass `out = None`
-    /// to learn the encoded length, then `Some(buf)` to copy.  The
-    /// length is variable (≤ [`MASKED_BK_BOOT_LEN`]) because the
-    /// envelope's metadata size depends on the encoded labels and
-    /// fields.  Before any successful [`part_set_masked_bk_boot`]
-    /// call, returns `Ok(0)` — callers that require an initialised
-    /// blob (e.g. unmask paths) must treat a returned length of `0`
-    /// as "not yet initialised" and surface an appropriate error to
-    /// the host.
-    ///
-    /// # Parameters
-    ///
-    /// - `io` — caller's I/O context.
-    /// - `out` — `None` for size query, `Some(buf)` to copy.
-    ///
-    /// # Returns
-    ///
-    /// - `Ok(size)` — bytes that were (or would be) written; `0` if
-    ///   no `Masked_BK_BOOT` has been stored yet.
-    /// - `Err(HsmError::InvalidArg)` — `io.pid()` is out of range, or
-    ///   `out = Some(buf)` and `buf.len() < size`.
-    /// - `Err(HsmError::PartitionNotEnabled)` — partition is not
-    ///   currently [`Enabled`](PartState::Enabled).
-    fn part_masked_bk_boot(&self, io: &impl HsmIo, out: Option<&mut [u8]>) -> HsmResult<usize>;
-
-    /// Persists `Masked_BK_BOOT` for the partition.
-    ///
-    /// Called by the `DdiInitBk3` handler after producing the
-    /// AES-CBC-256 + HMAC-SHA-384 envelope of raw `BK_BOOT` under
-    /// `BKx` (derived per-call via
-    /// [`derive_masking_key`](Self::derive_masking_key)).  The blob
-    /// is stored alongside other partition state and cleared on
-    /// every disable/free.
-    ///
-    /// Overwrite-allowed: a retry of `DdiInitBk3` after a partial
-    /// failure will re-envelope the same `BK_BOOT` (with a fresh IV)
-    /// and write the new blob.  The handler-level one-shot gate
-    /// ([`part_mark_bk3_initialized`](Self::part_mark_bk3_initialized))
-    /// is the authoritative idempotency barrier.
-    ///
-    /// # Parameters
-    ///
-    /// - `io` — caller's I/O context.
-    /// - `data` — masked envelope bytes; must be
-    ///   `<= MASKED_BK_BOOT_LEN`.
-    ///
-    /// # Returns
-    ///
-    /// - `Ok(())` on success.
-    /// - `Err(HsmError::InvalidArg)` — `io.pid()` is out of range, or
-    ///   `data.len() > MASKED_BK_BOOT_LEN`.
-    /// - `Err(HsmError::PartitionNotEnabled)` — partition is not
-    ///   currently [`Enabled`](PartState::Enabled).
-    fn part_set_masked_bk_boot(&self, io: &impl HsmIo, data: &[u8]) -> HsmResult<()>;
-
-    /// Returns a borrow of the PAL-internal firmware boot seed
-    /// (`FBS` / `fw_seed`).
-    ///
-    /// The returned slice points into PAL-owned storage; the caller
-    /// must not retain it past the current request scope.  Typical
-    /// use is passing it straight to
-    /// [`derive_masking_key`](Self::derive_masking_key) as the KDK
-    /// for `BKx`-style derivations:
-    ///
-    /// ```ignore
-    /// pal.derive_masking_key(io, pal.fw_seed(), label, extra, svn, bks2, out).await?;
-    /// ```
-    ///
-    /// The returned slice is secret material; it must never be
-    /// logged, copied into non-secret state, or returned over the
-    /// wire.  The PAL is responsible for ensuring the underlying
-    /// storage is DMA-stageable (the implementation of
-    /// [`derive_masking_key`](Self::derive_masking_key) typically
-    /// copies it into a DMA scratch buffer before invoking the
-    /// SP 800-108 driver).
-    fn fw_seed(&self) -> &[u8];
-
-    /// Derives an 80-byte masking key for [`BK_BOOT_LEN`]-sized
-    /// `MaskedKey` envelopes using SP 800-108 Counter Mode KBKDF
-    /// with HMAC-SHA-384.
-    ///
-    /// The effective KDF context is
-    /// `BKS1[svn] || BKS2[bks2_index] || extra_context`, where
-    /// `BKS1`/`BKS2` are partition-binding seed tables held in the
-    /// PAL.  The `svn` and `bks2_index` arguments select rows from
-    /// those tables; they are *not* mixed into the context as raw
-    /// integers.  Only the BKS tables are PAL-internal; the KDK is
-    /// caller-supplied so the same primitive can derive multiple
-    /// flavours of masking key:
-    ///
-    /// | Derivation | KDK | `label` | `extra_context` |
-    /// |---|---|---|---|
-    /// | `BKx` for `Masked_BK_BOOT` | [`fw_seed`](Self::fw_seed) | `b"BK_BOOT_MK_DEFAULT"` | `&[]` |
-    /// | Partition `BK` | partition `BK3` | `b"PARTITION_BK"` ‖ `pota_pub_key` | `&[]` |
-    /// | Session `BK` | session `BK3` | `b"SESSION_BK"` | `session_seed` |
-    ///
-    /// ## Caller responsibilities
-    ///
-    /// - `InitBk3` (forward direction) passes the *current* partition
-    ///   values from [`part_svn`](Self::part_svn) and
-    ///   [`part_bks2_id`](Self::part_bks2_id), so the produced key
-    ///   binds the new `Masked_BK_BOOT` to today's firmware and
-    ///   partition.
-    /// - Recovery paths (e.g. `EstablishCredential` unwrapping a
-    ///   stored `Masked_BK_BOOT`) must pass the `svn` and
-    ///   `bks2_index` decoded from the masked-key metadata, not the
-    ///   "current" PAL values — otherwise post-rotation recovery will
-    ///   fail.
-    /// - The caller is responsible for selecting the appropriate KDK
-    ///   for the derivation flavour (typically a borrow of
-    ///   [`fw_seed`](Self::fw_seed) or an unmasked `BK3` already in
-    ///   DMA scratch).
-    ///
-    /// ## Memory contract
-    ///
-    /// `kdk`, `label`, and `extra_context` are plain byte slices; the
-    /// PAL implementation is responsible for staging them (along
-    /// with `BKS1` and `BKS2`) into DMA-capable memory before
-    /// invoking the underlying SP 800-108 driver.  `output` must
-    /// already be DMA-accessible (typically allocated via
-    /// [`HsmAlloc::dma_alloc`]); the implementation writes the
-    /// derived key directly into it without an intermediate copy.
-    ///
-    /// `output.len()` selects the output length; for `BK_BOOT`
-    /// masking this is always [`BK_BOOT_LEN`].  The derived key is
-    /// secret material and must never be logged or copied into
-    /// non-secret state.
-    ///
-    /// # Parameters
-    ///
-    /// - `io` — caller's I/O context.
-    /// - `kdk` — KBKDF key-derivation key (e.g.
-    ///   [`fw_seed`](Self::fw_seed) for `BKx`, or unmasked `BK3` for
-    ///   partition/session `BK` derivations).
-    /// - `label` — KBKDF purpose label; e.g. `b"BK_BOOT_MK_DEFAULT"`.
-    ///   `&[]` is permitted (no label).
-    /// - `extra_context` — caller-supplied context suffix appended
-    ///   after `BKS1 || BKS2`.  `&[]` is permitted (no suffix).
-    /// - `svn` — selects which row of the PAL-internal `BKS1` table
-    ///   to use.  Values out of range for this PAL must error with
-    ///   [`HsmError::InvalidArg`].
-    /// - `bks2_index` — selects which row of the PAL-internal `BKS2`
-    ///   table to use.  Values out of range must error with
-    ///   [`HsmError::InvalidArg`].
-    /// - `output` — DMA-accessible destination for the derived key.
-    ///   `output.len()` bytes are written.
-    ///
-    /// # Returns
-    ///
-    /// - `Ok(())` — `output` filled with the derived masking key.
-    /// - `Err(HsmError::InvalidArg)` — `io.pid()` is out of range,
-    ///   `svn` or `bks2_index` is out of range, or `output.len()`
-    ///   exceeds the KBKDF block-counter cap.
-    /// - `Err(HsmError::NotEnoughSpace)` — DMA arena cannot satisfy
-    ///   the internal staging allocations.
-    /// - `Err(HsmError::PartitionNotEnabled)` — partition is not
-    ///   currently [`Enabled`](PartState::Enabled).
-    /// - `Err(HsmError)` — propagated from the underlying KBKDF
-    ///   driver.
-    #[allow(clippy::too_many_arguments)]
-    async fn derive_masking_key(
-        &self,
-        io: &impl HsmIo,
-        kdk: &[u8],
-        label: &[u8],
-        extra_context: &[u8],
-        svn: u64,
-        bks2_index: u16,
-        output: &mut DmaBuf,
+        id: PartPropId,
+        idx: u16,
+        value: u8,
     ) -> HsmResult<()>;
 
-    // ------------------------------------------------------------------
-    // Establish-credential and provisioning state
-    // ------------------------------------------------------------------
-
-    /// Verifies that the provided nonce matches the partition's current
-    /// nonce.
-    ///
-    /// Returns `Ok(())` if the nonces match, or
-    /// `Err(HsmError::NonceMismatch)` if they differ.  The check is
-    /// constant-time where supported by the platform.
+    /// Read a [`PartPropKind::U16`] slot.
     ///
     /// # Parameters
     ///
-    /// - `io` — caller's I/O context.
-    /// - `nonce` — 32-byte nonce to compare against the partition's
-    ///   stored nonce.
-    fn part_verify_nonce(&self, io: &impl HsmIo, nonce: &[u8]) -> HsmResult<()>;
-
-    /// Stores the user credential (ID and PIN) for the partition.
-    ///
-    /// Write-once per credential lifecycle: if credentials are already
-    /// set, returns [`HsmError::VaultAppLimitReached`] (matching the
-    /// `verify_cred_is_not_set` behavior in real firmware).  The PAL is
-    /// responsible for storing the credential securely and clearing it
-    /// on partition disable/deprovision.
-    ///
-    /// Both `id` and `pin` are exactly 16 bytes (AES block size).  An
-    /// all-zero `id` or `pin` is rejected with
-    /// [`HsmError::InvalidAppCredentials`], matching the reference
-    /// firmware's `cred_mgr::change_user_cred` invariant.  The all-zero
-    /// value is also the sentinel that `part_is_credential_set` uses
-    /// for "unset", so accepting it would corrupt the lifecycle.
-    ///
-    /// # Parameters
-    ///
-    /// - `io` — caller's I/O context.
-    /// - `id` — 16-byte user credential identifier (non-zero).
-    /// - `pin` — 16-byte user credential PIN (non-zero).
-    fn part_set_credential(&self, io: &impl HsmIo, id: &[u8], pin: &[u8]) -> HsmResult<()>;
-
-    /// Returns whether the partition's user credential is already set.
-    fn part_is_credential_set(&self, io: &impl HsmIo) -> HsmResult<bool>;
-
-    /// Constant-time compares `id` and `pin` against the partition's
-    /// stored user credential.
-    ///
-    /// Used by `OpenSession` to authenticate the credential the host
-    /// just decrypted from the wrapped session-credential payload.
-    /// Both fields are compared even when the first mismatches so a
-    /// timing side-channel cannot distinguish "wrong id" from "wrong
-    /// pin" — both yield [`HsmError::InvalidAppCredentials`].
-    ///
-    /// # Parameters
-    ///
-    /// - `io` — caller's I/O context.
-    /// - `id` — 16-byte user credential identifier to compare.
-    /// - `pin` — 16-byte user credential PIN to compare.
+    /// - `io` — IO handle; the target partition is resolved from
+    ///   [`io.pid()`](HsmIo::pid).
+    /// - `id` — property identifier; its [`meta`](PartPropId::meta)
+    ///   `kind` must be [`PartPropKind::U16`].
+    /// - `idx` — row index within `0..id.meta().cardinality`.
     ///
     /// # Returns
     ///
-    /// - `Ok(())` — both `id` and `pin` match the stored credential.
-    /// - `Err(HsmError::InvalidAppCredentials)` — credential is not
-    ///   yet set, or either field does not match.
-    /// - `Err(HsmError::InvalidArg)` — `id` or `pin` length differs
-    ///   from 16 bytes.
-    fn part_verify_credential(&self, io: &impl HsmIo, id: &[u8], pin: &[u8]) -> HsmResult<()>;
+    /// [`HsmResult<u16>`] — the stored value on success.
+    fn part_prop_get_u16(&self, io: &impl HsmIo, id: PartPropId, idx: u16) -> HsmResult<u16>;
 
-    /// Returns whether the partition has been fully provisioned.
-    ///
-    /// A partition is provisioned when it has a masking key (MK)
-    /// imported into its vault.  This flag is the gate that
-    /// `EstablishCredential` uses to prevent double-provisioning.
-    fn part_is_provisioned(&self, io: &impl HsmIo) -> HsmResult<bool>;
-
-    /// Stores the BK3 session key (48 bytes) for the partition.
-    ///
-    /// The BK3 session key is derived from BK3 via SP 800-108 KDF
-    /// during `EstablishCredential` and used for subsequent session
-    /// operations.
+    /// Write a [`PartPropKind::U16`] slot.
     ///
     /// # Parameters
     ///
-    /// - `io` — caller's I/O context.
-    /// - `data` — 48-byte BK3 session key.
-    fn part_set_bk3_session(&self, io: &impl HsmIo, data: &[u8]) -> HsmResult<()>;
-
-    /// Returns the vault key ID of the partition's masking key (MK),
-    /// or `None` if no MK has been imported.
-    fn part_mk_key_id(&self, io: &impl HsmIo) -> HsmResult<Option<HsmKeyId>>;
-
-    /// Stores the vault key ID of the partition's masking key (MK).
-    ///
-    /// Set once during `EstablishCredential` provisioning.  After this
-    /// call, [`part_is_provisioned`](Self::part_is_provisioned) returns
-    /// `true` and [`part_mk_key_id`](Self::part_mk_key_id) returns the
-    /// stored ID.
-    fn part_set_mk_key_id(&self, io: &impl HsmIo, key_id: HsmKeyId) -> HsmResult<()>;
-
-    /// Returns the vault key ID of the partition's unwrapping key, or
-    /// `None` if no unwrapping key has been imported.
-    fn part_unwrapping_key_id(&self, io: &impl HsmIo) -> HsmResult<Option<HsmKeyId>>;
-
-    /// Stores the vault key ID of the partition's unwrapping key.
-    fn part_set_unwrapping_key_id(&self, io: &impl HsmIo, key_id: HsmKeyId) -> HsmResult<()>;
-
-    /// Returns the partition's pre-shared key (PSK) for the requested
-    /// role identifier.
-    ///
-    /// PSKs identify the caller role in the session-establishment
-    /// handshake: `psk_id = 0` is the Crypto Officer (CO) PSK,
-    /// `psk_id = 1` is the Crypto User (CU) PSK.  Any other identifier
-    /// returns [`HsmError::InvalidPskId`].
-    ///
-    /// If [`part_psk_set`](Self::part_psk_set) has not been called for
-    /// this `psk_id`, the well-known compiled-in default
-    /// ([`DEFAULT_PSK_CO`](crate::DEFAULT_PSK_CO) or
-    /// [`DEFAULT_PSK_CU`](crate::DEFAULT_PSK_CU)) is returned.  The
-    /// well-known defaults are public; production deployments MUST
-    /// rotate them via [`part_psk_set`](Self::part_psk_set) before
-    /// exposing the partition to untrusted traffic.
-    ///
-    /// Follows the standard query/copy pattern: pass `out = None` to
-    /// learn the size, then `Some(buf)` to copy.  All PSKs are
-    /// [`PSK_LEN`](crate::PSK_LEN) bytes.
-    ///
-    /// # Parameters
-    ///
-    /// - `io` — caller's I/O context.
-    /// - `psk_id` — `0` for CO PSK, `1` for CU PSK.
-    /// - `out` — `None` for size query, `Some(buf)` to copy.
+    /// - `io` — IO handle; the target partition is resolved from
+    ///   [`io.pid()`](HsmIo::pid).
+    /// - `id` — property identifier; its [`meta`](PartPropId::meta)
+    ///   `kind` must be [`PartPropKind::U16`] and `access` must be
+    ///   [`PartPropAccess::Rw`].
+    /// - `idx` — row index within `0..id.meta().cardinality`.
+    /// - `value` — value to store; replaces any previous value and
+    ///   transitions [`AbsentUntilSet`](PartPropDefault::AbsentUntilSet)
+    ///   slots to present.
     ///
     /// # Returns
     ///
-    /// - `Ok(PSK_LEN)` on success.
-    /// - `Err(HsmError::InvalidArg)` — `io.pid()` is out of range, or
-    ///   `out = Some(buf)` and `buf.len() < PSK_LEN`.
-    /// - `Err(HsmError::InvalidPskId)` — `psk_id` is not `0` or `1`.
-    /// - `Err(HsmError::PartitionNotEnabled)` — partition is not
-    ///   currently [`Enabled`](PartState::Enabled).
-    fn part_psk(&self, io: &impl HsmIo, psk_id: u8, out: Option<&mut [u8]>) -> HsmResult<usize>;
+    /// [`HsmResult<()>`] — `Ok(())` on success.
+    fn part_prop_set_u16(
+        &self,
+        io: &impl HsmIo,
+        id: PartPropId,
+        idx: u16,
+        value: u16,
+    ) -> HsmResult<()>;
 
-    /// Rotates the partition's pre-shared key (PSK) for the requested
-    /// role identifier, replacing the well-known default (or a prior
-    /// rotated value).
-    ///
-    /// Once called, [`part_psk`](Self::part_psk) returns `psk` for the
-    /// matching `psk_id` until the next rotation or partition
-    /// disable.  No wire command currently exposes this PAL method;
-    /// callers must drive it via privileged provisioning paths only.
+    /// Read a [`PartPropKind::U32`] slot.
     ///
     /// # Parameters
     ///
-    /// - `io` — caller's I/O context.
-    /// - `psk_id` — `0` for CO PSK, `1` for CU PSK.
-    /// - `psk` — replacement PSK; must be exactly
-    ///   [`PSK_LEN`](crate::PSK_LEN) bytes.
+    /// - `io` — IO handle; the target partition is resolved from
+    ///   [`io.pid()`](HsmIo::pid).
+    /// - `id` — property identifier; its [`meta`](PartPropId::meta)
+    ///   `kind` must be [`PartPropKind::U32`].
+    /// - `idx` — row index within `0..id.meta().cardinality`.
     ///
     /// # Returns
     ///
-    /// - `Ok(())` on success.
-    /// - `Err(HsmError::InvalidArg)` — `io.pid()` is out of range, or
-    ///   `psk.len() != PSK_LEN`.
-    /// - `Err(HsmError::InvalidPskId)` — `psk_id` is not `0` or `1`.
-    /// - `Err(HsmError::PartitionNotEnabled)` — partition is not
-    ///   currently [`Enabled`](PartState::Enabled).
-    fn part_psk_set(&self, io: &impl HsmIo, psk_id: u8, psk: &[u8]) -> HsmResult<()>;
+    /// [`HsmResult<u32>`] — the stored value on success.
+    fn part_prop_get_u32(&self, io: &impl HsmIo, id: PartPropId, idx: u16) -> HsmResult<u32>;
 
-    /// Reports whether the role's effective PSK still equals the
-    /// public, compiled-in default
-    /// ([`DEFAULT_PSK_CO`](crate::DEFAULT_PSK_CO) /
-    /// [`DEFAULT_PSK_CU`](crate::DEFAULT_PSK_CU)).
-    ///
-    /// **Authoritative byte-compare**, not a rotation-history flag:
-    /// even if [`part_psk_set`](Self::part_psk_set) was called with
-    /// the default bytes (e.g. via a malformed/malicious `ChangePsk`),
-    /// this method still reports `true` because the effective PSK is
-    /// still the public default.  This keeps the TBOR dispatcher's
-    /// default-PSK gate strictly tied to the bytes actually in use.
-    ///
-    /// The well-known defaults are public by design so partitions are
-    /// usable at bring-up, but they offer no authentication and MUST
-    /// be rotated before any sensitive operation is permitted.
+    /// Write a [`PartPropKind::U32`] slot.
     ///
     /// # Parameters
     ///
-    /// - `io` — caller's I/O context (partition scope).
-    /// - `psk_id` — role identifier; `0` = Crypto Officer, `1` =
-    ///   Crypto User.  Any other value returns
-    ///   [`HsmError::InvalidPskId`].
+    /// - `io` — IO handle; the target partition is resolved from
+    ///   [`io.pid()`](HsmIo::pid).
+    /// - `id` — property identifier; its [`meta`](PartPropId::meta)
+    ///   `kind` must be [`PartPropKind::U32`] and `access` must be
+    ///   [`PartPropAccess::Rw`].
+    /// - `idx` — row index within `0..id.meta().cardinality`.
+    /// - `value` — value to store.
     ///
     /// # Returns
     ///
-    /// - `Ok(true)` — the partition's effective PSK for this `psk_id`
-    ///   is byte-identical to the compiled-in default.
-    /// - `Ok(false)` — the effective PSK differs from the default.
-    /// - `Err(HsmError::InvalidPskId)` — `psk_id > 1`.
-    /// - `Err(HsmError::PartitionNotEnabled)` — partition is not
-    ///   currently [`Enabled`](PartState::Enabled).
-    fn part_psk_is_default(&self, io: &impl HsmIo, psk_id: u8) -> HsmResult<bool>;
+    /// [`HsmResult<()>`] — `Ok(())` on success.
+    fn part_prop_set_u32(
+        &self,
+        io: &impl HsmIo,
+        id: PartPropId,
+        idx: u16,
+        value: u32,
+    ) -> HsmResult<()>;
 
-    // ── PartInit surface ──────────────────────────────────────────
-
-    /// Returns the per-machine Unique Device Secret (UDS).
-    ///
-    /// On real hardware this is a fused per-device secret; on the std
-    /// PAL it is a fixed per-partition pseudo-random blob established
-    /// at allocation time.  Follows the standard query/copy pattern.
+    /// Read a [`PartPropKind::U64`] slot.
     ///
     /// # Parameters
     ///
-    /// - `io` — caller's I/O context.
-    /// - `out` — `None` for size query, `Some(buf)` to copy.
+    /// - `io` — IO handle; the target partition is resolved from
+    ///   [`io.pid()`](HsmIo::pid).
+    /// - `id` — property identifier; its [`meta`](PartPropId::meta)
+    ///   `kind` must be [`PartPropKind::U64`].
+    /// - `idx` — row index within `0..id.meta().cardinality`.
     ///
     /// # Returns
     ///
-    /// - `Ok(size)` — UDS byte length (`32` for the std PAL).
-    /// - `Err(HsmError::PartitionNotEnabled)` — partition is not
-    ///   currently [`Enabled`](PartState::Enabled) (and not
-    ///   [`Initializing`](PartState::Initializing)).
-    /// - `Err(HsmError::InvalidArg)` — `out` buffer too small.
-    fn part_uds(&self, io: &impl HsmIo, out: Option<&mut [u8]>) -> HsmResult<usize>;
+    /// [`HsmResult<u64>`] — the stored value on success.
+    fn part_prop_get_u64(&self, io: &impl HsmIo, id: PartPropId, idx: u16) -> HsmResult<u64>;
 
-    /// Binds the partition's PTA (Partition Trust Anchor) ECC-P384
-    /// key to this incarnation.
-    ///
-    /// One-shot: subsequent calls return
-    /// [`HsmError::PtaKeyAlreadySet`].  The PAL stores both the
-    /// vault key id of the private half and the raw 97-byte SEC1
-    /// uncompressed public key bytes for later attestation use.
+    /// Write a [`PartPropKind::U64`] slot.
     ///
     /// # Parameters
     ///
-    /// - `io` — caller's I/O context.
-    /// - `key_id` — vault id of the PTA private key (kind
-    ///   [`HsmVaultKeyKind::PartitionTrustAnchor`](crate::HsmVaultKeyKind::PartitionTrustAnchor)).
-    /// - `pub_sec1` — 97-byte SEC1 uncompressed encoding
-    ///   (`0x04 ‖ X_be ‖ Y_be`) of the PTA public key.
-    fn part_set_pta_key(&self, io: &impl HsmIo, key_id: HsmKeyId, pub_sec1: &[u8])
-    -> HsmResult<()>;
+    /// - `io` — IO handle; the target partition is resolved from
+    ///   [`io.pid()`](HsmIo::pid).
+    /// - `id` — property identifier; its [`meta`](PartPropId::meta)
+    ///   `kind` must be [`PartPropKind::U64`] and `access` must be
+    ///   [`PartPropAccess::Rw`].
+    /// - `idx` — row index within `0..id.meta().cardinality`.
+    /// - `value` — value to store.
+    ///
+    /// # Returns
+    ///
+    /// [`HsmResult<()>`] — `Ok(())` on success.
+    fn part_prop_set_u64(
+        &self,
+        io: &impl HsmIo,
+        id: PartPropId,
+        idx: u16,
+        value: u64,
+    ) -> HsmResult<()>;
 
-    /// Stores the validated `PartPolicy` blob for this incarnation.
-    ///
-    /// The bytes are stored verbatim (the caller is responsible for
-    /// pre-validation via `policy::from_bytes`).
-    ///
-    /// One-shot: subsequent calls return [`HsmError::InvalidArg`].
-    /// The slot is cleared on `part_disable`.
-    fn part_set_policy(&self, io: &impl HsmIo, policy: &[u8]) -> HsmResult<()>;
-
-    /// Stores the 48-byte POTA (Partition Owner Trust Anchor)
-    /// SHA-384 thumbprint for this incarnation.
-    ///
-    /// One-shot: subsequent calls return [`HsmError::InvalidArg`].
-    /// The slot is cleared on `part_disable`.
-    fn part_set_pota_thumbprint(&self, io: &impl HsmIo, thumb: &[u8]) -> HsmResult<()>;
-
-    /// Binds the partition's Unique Machine Secret (UMS) vault key id
-    /// to this incarnation.
-    ///
-    /// The UMS is a 48-byte HMAC-SHA-384-sized secret derived by
-    /// `PartInit` from `UDS` plus the request-side
-    /// (`MachineSeed`, `PartPolicy`, `POTAThumbprint`) inputs.  The
-    /// raw bytes live inside the partition key vault under `key_id`
-    /// (kind
-    /// [`HsmVaultKeyKind::PartitionUniqueMachineSecret`](crate::HsmVaultKeyKind::PartitionUniqueMachineSecret));
-    /// the PAL only stores the id so later phases can reach the
-    /// material through the normal vault read path.
-    ///
-    /// One-shot: subsequent calls return
-    /// [`HsmError::UmsKeyAlreadySet`].  The slot is cleared (and the
-    /// underlying vault entry deleted) on `part_disable`.
+    /// Read a [`PartPropKind::Bool`] slot.
     ///
     /// # Parameters
     ///
-    /// - `io` — caller's I/O context.
-    /// - `key_id` — vault id of the UMS secret (kind
-    ///   [`HsmVaultKeyKind::PartitionUniqueMachineSecret`](crate::HsmVaultKeyKind::PartitionUniqueMachineSecret)).
-    fn part_set_ums_key(&self, io: &impl HsmIo, key_id: HsmKeyId) -> HsmResult<()>;
+    /// - `io` — IO handle; the target partition is resolved from
+    ///   [`io.pid()`](HsmIo::pid).
+    /// - `id` — property identifier; its [`meta`](PartPropId::meta)
+    ///   `kind` must be [`PartPropKind::Bool`].
+    /// - `idx` — row index within `0..id.meta().cardinality`.
+    ///
+    /// # Returns
+    ///
+    /// [`HsmResult<bool>`] — the stored flag on success.
+    fn part_prop_get_bool(&self, io: &impl HsmIo, id: PartPropId, idx: u16) -> HsmResult<bool>;
 
-    /// Returns the vault key id of the partition's Unique Machine
-    /// Secret (UMS), set by a prior successful
-    /// [`part_set_ums_key`](Self::part_set_ums_key).
+    /// Write a [`PartPropKind::Bool`] slot.
     ///
-    /// # Errors
+    /// # Parameters
     ///
-    /// - `Err(HsmError::UmsKeyNotSet)` — `PartInit` has not yet
-    ///   successfully bound a UMS for this partition incarnation.
-    /// - `Err(HsmError::PartitionNotEnabled)` — partition is not
-    ///   currently [`Enabled`](PartState::Enabled) (or
-    ///   [`Initializing`](PartState::Initializing)).
-    fn part_ums_key_id(&self, io: &impl HsmIo) -> HsmResult<HsmKeyId>;
+    /// - `io` — IO handle; the target partition is resolved from
+    ///   [`io.pid()`](HsmIo::pid).
+    /// - `id` — property identifier; its [`meta`](PartPropId::meta)
+    ///   `kind` must be [`PartPropKind::Bool`] and `access` must be
+    ///   [`PartPropAccess::Rw`].  Per-slot semantics may further
+    ///   constrain the legal transitions (for example
+    ///   [`PartPropId::BK3_INITIALIZED`] permits only `false → true`).
+    /// - `idx` — row index within `0..id.meta().cardinality`.
+    /// - `value` — flag to store.
+    ///
+    /// # Returns
+    ///
+    /// [`HsmResult<()>`] — `Ok(())` on success.
+    fn part_prop_set_bool(
+        &self,
+        io: &impl HsmIo,
+        id: PartPropId,
+        idx: u16,
+        value: bool,
+    ) -> HsmResult<()>;
 
-    /// Transitions the partition from [`Enabled`](PartState::Enabled)
-    /// to [`Initializing`](PartState::Initializing).
+    /// Read a [`PartPropKind::FixedBytes`] or [`PartPropKind::VarBytes`]
+    /// slot.
     ///
-    /// All four of [`part_set_pta_key`](Self::part_set_pta_key),
-    /// [`part_set_ums_key`](Self::part_set_ums_key),
-    /// [`part_set_policy`](Self::part_set_policy), and
-    /// [`part_set_pota_thumbprint`](Self::part_set_pota_thumbprint)
-    /// must have succeeded for this call to succeed; otherwise the
-    /// PAL returns [`HsmError::InvalidArg`].
-    fn part_mark_initializing(&self, io: &impl HsmIo) -> HsmResult<()>;
+    /// # Parameters
+    ///
+    /// - `io` — IO handle; the target partition is resolved from
+    ///   [`io.pid()`](HsmIo::pid).
+    /// - `id` — property identifier; its [`meta`](PartPropId::meta)
+    ///   `kind` must be [`PartPropKind::FixedBytes`] or
+    ///   [`PartPropKind::VarBytes`].
+    /// - `idx` — row index within `0..id.meta().cardinality`.
+    ///
+    /// # Returns
+    ///
+    /// [`HsmResult<&DmaBuf>`] — on success, a borrowed sub-view of
+    /// the PAL's backing storage so the bytes can flow into further
+    /// PAL crypto primitives without a copy.  For `FixedBytes` the
+    /// length equals the slot's declared `len`; for `VarBytes` it is
+    /// the recorded value length (which may be `0` and is at most
+    /// `max`).
+    ///
+    /// The returned view is valid for the duration of the `&self`
+    /// borrow on the [`HsmPartitionManager`] implementation; PAL
+    /// impls must not invalidate it before the borrow ends.
+    fn part_prop_get_bytes<'a>(
+        &'a self,
+        io: &impl HsmIo,
+        id: PartPropId,
+        idx: u16,
+    ) -> HsmResult<&'a DmaBuf>;
+
+    /// Write a [`PartPropKind::FixedBytes`] or
+    /// [`PartPropKind::VarBytes`] slot.
+    ///
+    /// # Parameters
+    ///
+    /// - `io` — IO handle; the target partition is resolved from
+    ///   [`io.pid()`](HsmIo::pid).
+    /// - `id` — property identifier; its [`meta`](PartPropId::meta)
+    ///   `kind` must be [`PartPropKind::FixedBytes`] or
+    ///   [`PartPropKind::VarBytes`], and `access` must be
+    ///   [`PartPropAccess::Rw`].
+    /// - `idx` — row index within `0..id.meta().cardinality`.
+    /// - `data` — bytes to store.  For `FixedBytes`, `data.len()`
+    ///   must equal the declared `len`; for `VarBytes`, `data.len()`
+    ///   must be `≤` the declared `max`.  Any other length returns
+    ///   [`HsmError::InvalidArg`].  Writing replaces any previous
+    ///   value and transitions [`AbsentUntilSet`](PartPropDefault::AbsentUntilSet)
+    ///   slots to present; PAL impls zeroise the previous bytes of a
+    ///   `sensitive` slot before the overwrite.
+    ///
+    /// # Returns
+    ///
+    /// [`HsmResult<()>`] — `Ok(())` on success.
+    fn part_prop_set_bytes(
+        &self,
+        io: &impl HsmIo,
+        id: PartPropId,
+        idx: u16,
+        data: &DmaBuf,
+    ) -> HsmResult<()>;
+
+    /// Reset a property slot to its absent state.
+    ///
+    /// # Parameters
+    ///
+    /// - `io` — IO handle; the target partition is resolved from
+    ///   [`io.pid()`](HsmIo::pid).
+    /// - `id` — property identifier.  Its [`meta`](PartPropId::meta)
+    ///   `default` must be [`PartPropDefault::AbsentUntilSet`] and
+    ///   `access` must be [`PartPropAccess::Rw`];
+    ///   [`RequiredPresent`](PartPropDefault::RequiredPresent) slots
+    ///   have no "absent" state to reset to and return
+    ///   [`HsmError::InvalidArg`].
+    /// - `idx` — row index within `0..id.meta().cardinality`.
+    ///
+    /// PAL impls that back the store with reusable memory must
+    /// zeroise the underlying bytes of a `sensitive = true` slot on
+    /// clear so plaintext secrets do not linger in shared storage.
+    ///
+    /// # Returns
+    ///
+    /// [`HsmResult<()>`] — `Ok(())` on success.  Idempotent on an
+    /// already-absent slot (also returns `Ok(())`).
+    fn part_prop_clear(&self, io: &impl HsmIo, id: PartPropId, idx: u16) -> HsmResult<()>;
 }
 
 /// Length of the per-partition `BK_BOOT` boot-key material in bytes.
@@ -1053,6 +519,16 @@ pub trait HsmPartitionManager {
 /// hardware.
 pub const BK_BOOT_LEN: usize = 80;
 
+/// Maximum size of the `Sealed_BK3` blob in bytes.
+///
+/// `Sealed_BK3` is the host-supplied sealed envelope holding the
+/// per-power-cycle BK3 secret consumed by the `DdiInitBk3` handler.
+/// The upper bound mirrors the prior reference firmware's
+/// `SEALED_BK3_SIZE` so blobs stay bit-compatible with host-side
+/// tooling.  PAL implementations size their backing storage to at
+/// least this many bytes.
+pub const SEALED_BK3_MAX_LEN: u16 = 96;
+
 /// Maximum size of the `Masked_BK_BOOT` envelope in bytes.
 ///
 /// `Masked_BK_BOOT` is the AES-CBC-256 + HMAC-SHA-384 envelope of
@@ -1061,6 +537,623 @@ pub const BK_BOOT_LEN: usize = 80;
 /// bound is fixed to mirror the prior reference firmware's
 /// `MASKED_BK_BOOT_SIZE` (300 bytes) so blobs stay bit-compatible
 /// with host-side tooling and persistent stores sized by that
-/// firmware.  All PAL implementations size [`PartitionEntry`]-equivalent
-/// storage to at least this many bytes.
+/// firmware.  All PAL implementations size their backing storage
+/// for the [`PartPropId::MASKED_BK_BOOT`] slot to at least this
+/// many bytes.
 pub const MASKED_BK_BOOT_LEN: usize = 300;
+
+// ============================================================================
+// Property surface — types and the PartPropId catalogue.
+//
+// Crate-level concepts (presence, cardinality, sensitivity, pure-state)
+// are documented at the module level (see the //! block above);
+// the items below carry only item-specific documentation.
+// ============================================================================
+
+// ─── Access mode ──────────────────────────────────────────────────────────
+
+/// Access mode for a property.
+///
+/// Pinned per [`PartPropId`] by its meta; the PAL impl enforces it
+/// in the typed setters (`set_*`) and in [`HsmPartitionManager::part_prop_clear`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PartPropAccess {
+    /// Caller may read and write the property.  All typed setters
+    /// and [`HsmPartitionManager::part_prop_clear`] are permitted (subject to
+    /// [`PartPropDefault`] for `clear`).
+    Rw,
+
+    /// Caller may only read the property.  All typed setters and
+    /// [`HsmPartitionManager::part_prop_clear`] return [`HsmError::InvalidArg`].
+    /// Used for state owned by the PAL itself (e.g. firmware-supplied
+    /// seeds, resource counters) where the caller has no business
+    /// mutating the value.
+    Ro,
+}
+
+// ─── Default presence ─────────────────────────────────────────────────────
+
+/// Initial presence semantics for a property slot.
+///
+/// Pinned per [`PartPropId`] by its meta; the PAL impl uses it both
+/// at partition-allocation time (to populate `RequiredPresent` slots)
+/// and at [`HsmPartitionManager::part_prop_clear`] time (to reject clears on
+/// always-present slots).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PartPropDefault {
+    /// The slot is initialised by the PAL when the partition is
+    /// allocated (or earlier) and is never observed absent from the
+    /// caller's perspective.  Getters do not return
+    /// [`HsmError::PartPropNotFound`] for this slot; the PAL impl
+    /// must guarantee a value is materialised before the partition
+    /// is exposed to callers.  [`HsmPartitionManager::part_prop_clear`] on such a
+    /// slot returns [`HsmError::InvalidArg`].
+    RequiredPresent,
+
+    /// The slot starts absent and only becomes present after a
+    /// successful setter call.  Getters return
+    /// [`HsmError::PartPropNotFound`] until then.
+    /// [`HsmPartitionManager::part_prop_clear`] resets the slot back to absent and is
+    /// idempotent on an already-absent slot (returns `Ok(())`).
+    AbsentUntilSet,
+}
+
+// ─── Wire-shape ───────────────────────────────────────────────────────────
+
+/// Wire-shape ("kind") of a property's stored value.
+///
+/// Pins both the typed accessor that may be used and the storage
+/// footprint per slot.  Mismatched access (e.g. calling
+/// [`HsmPartitionManager::part_prop_get_u8`] on a `U32` slot) returns
+/// [`HsmError::InvalidArg`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PartPropKind {
+    /// Single unsigned byte.  Access: [`HsmPartitionManager::part_prop_get_u8`] /
+    /// [`HsmPartitionManager::part_prop_set_u8`].
+    U8,
+
+    /// 16-bit unsigned integer.  Access: [`HsmPartitionManager::part_prop_get_u16`] /
+    /// [`HsmPartitionManager::part_prop_set_u16`].
+    U16,
+
+    /// 32-bit unsigned integer.  Access: [`HsmPartitionManager::part_prop_get_u32`] /
+    /// [`HsmPartitionManager::part_prop_set_u32`].
+    U32,
+
+    /// 64-bit unsigned integer.  Access: [`HsmPartitionManager::part_prop_get_u64`] /
+    /// [`HsmPartitionManager::part_prop_set_u64`].
+    U64,
+
+    /// Boolean flag.  Access: [`HsmPartitionManager::part_prop_get_bool`] /
+    /// [`HsmPartitionManager::part_prop_set_bool`].
+    Bool,
+
+    /// Fixed-length byte buffer.  Every present slot holds exactly
+    /// `len` bytes.  Access: [`HsmPartitionManager::part_prop_get_bytes`] /
+    /// [`HsmPartitionManager::part_prop_set_bytes`]; setter writes that pass a
+    /// different length return [`HsmError::InvalidArg`].
+    FixedBytes {
+        /// Mandatory exact length, in bytes, of every present slot.
+        len: u16,
+    },
+
+    /// Variable-length byte buffer with an upper bound.  Present
+    /// slots hold between 0 and `max` bytes (inclusive); the actual
+    /// length is recorded with the value.  Access:
+    /// [`HsmPartitionManager::part_prop_get_bytes`] / [`HsmPartitionManager::part_prop_set_bytes`];
+    /// setter writes that exceed `max` return [`HsmError::InvalidArg`].
+    VarBytes {
+        /// Inclusive upper bound, in bytes, on any present slot.
+        max: u16,
+    },
+}
+
+// ─── Metadata ─────────────────────────────────────────────────────────────
+
+/// Compile-time metadata for a [`PartPropId`].
+///
+/// Returned by [`PartPropId::meta`].  Drives both:
+///
+/// - **Static layout** — PAL impls that use a flat storage backing
+///   (presence bitmap + value region) compute slot offsets from
+///   `(kind, cardinality)` at compile time.
+/// - **Runtime enforcement** — the PAL impl checks `kind` against the
+///   typed accessor, `cardinality` against the `idx` argument,
+///   `access` against any mutation, and `default` against `clear`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PartPropMeta {
+    /// Wire-shape of the slot's value.
+    pub kind: PartPropKind,
+
+    /// Number of slots addressable by `idx`.  Single-valued props
+    /// have `cardinality = 1` (only `idx = 0` is legal).
+    /// Indexed props have `cardinality > 1`; `idx` ranges over
+    /// `0..cardinality`.  Values exceeding this bound return
+    /// [`HsmError::InvalidArg`].
+    pub cardinality: u16,
+
+    /// Whether the caller may mutate the property; see
+    /// [`PartPropAccess`].
+    pub access: PartPropAccess,
+
+    /// Whether the slot starts present or absent; see
+    /// [`PartPropDefault`].
+    pub default: PartPropDefault,
+
+    /// Whether the slot's value is secret.  PAL impls that back the
+    /// store with reusable memory (DMA pool, flat persistent
+    /// storage) should zeroise the underlying bytes whenever a
+    /// `sensitive = true` slot is cleared or overwritten so plaintext
+    /// secrets do not linger in shared storage after they are no
+    /// longer needed.
+    pub sensitive: bool,
+}
+
+impl PartPropMeta {
+    /// Single-slot fixed-length byte buffer
+    /// ([`PartPropKind::FixedBytes`], `cardinality = 1`).
+    ///
+    /// Use for slots whose every present value is exactly `len`
+    /// bytes (identity blobs, raw public-key coordinates, fixed-size
+    /// keys).  Setter writes that pass a different length return
+    /// [`HsmError::InvalidArg`].
+    ///
+    /// # Parameters
+    ///
+    /// - `len` — exact byte length of every present value.
+    /// - `access` — caller mutability ([`Rw`](PartPropAccess::Rw) /
+    ///   [`Ro`](PartPropAccess::Ro)).
+    /// - `default` — initial presence semantics.
+    /// - `sensitive` — `true` if the slot's bytes are secret and
+    ///   must be zeroised on clear/overwrite by the PAL.
+    ///
+    /// # Returns
+    ///
+    /// [`Self`] — the assembled metadata.
+    pub const fn fixed(
+        len: u16,
+        access: PartPropAccess,
+        default: PartPropDefault,
+        sensitive: bool,
+    ) -> Self {
+        Self {
+            kind: PartPropKind::FixedBytes { len },
+            cardinality: 1,
+            access,
+            default,
+            sensitive,
+        }
+    }
+
+    /// Indexed fixed-length byte buffer (`cardinality` slots, each
+    /// `len` bytes).
+    ///
+    /// `idx` addresses the row in `0..cardinality`; rows out of range
+    /// return [`HsmError::InvalidArg`].  Use for homogeneous arrays
+    /// (e.g. per-SVN root-of-trust seed rows).  Per-row presence is
+    /// independent — unprovisioned rows return
+    /// [`HsmError::PartPropNotFound`] when `default` is
+    /// [`PartPropDefault::AbsentUntilSet`].
+    ///
+    /// # Parameters
+    ///
+    /// - `len` — exact byte length of every present row.
+    /// - `cardinality` — number of rows; getter/setter `idx`
+    ///   ranges over `0..cardinality`.
+    /// - `access`, `default`, `sensitive` — see [`Self::fixed`].
+    ///
+    /// # Returns
+    ///
+    /// [`Self`] — the assembled metadata.
+    pub const fn fixed_indexed(
+        len: u16,
+        cardinality: u16,
+        access: PartPropAccess,
+        default: PartPropDefault,
+        sensitive: bool,
+    ) -> Self {
+        Self {
+            kind: PartPropKind::FixedBytes { len },
+            cardinality,
+            access,
+            default,
+            sensitive,
+        }
+    }
+
+    /// Single-slot variable-length byte buffer with an inclusive
+    /// upper bound ([`PartPropKind::VarBytes`], `cardinality = 1`).
+    ///
+    /// Use for slots whose value length is data-dependent but
+    /// bounded (sealed envelopes, masked boot-key blobs).  The PAL
+    /// records the actual length alongside the bytes; setter writes
+    /// exceeding `max` return [`HsmError::InvalidArg`].
+    ///
+    /// # Parameters
+    ///
+    /// - `max` — inclusive upper bound on a present value's
+    ///   length, in bytes.  Present values may be any size in
+    ///   `0..=max`.
+    /// - `access`, `default`, `sensitive` — see [`Self::fixed`].
+    ///
+    /// # Returns
+    ///
+    /// [`Self`] — the assembled metadata.
+    pub const fn var(
+        max: u16,
+        access: PartPropAccess,
+        default: PartPropDefault,
+        sensitive: bool,
+    ) -> Self {
+        Self {
+            kind: PartPropKind::VarBytes { max },
+            cardinality: 1,
+            access,
+            default,
+            sensitive,
+        }
+    }
+
+    /// Single-slot scalar (`U8` / `U16` / `U32` / `U64` / `Bool`).
+    ///
+    /// Use for any non-byte-buffer kind.  The caller picks the
+    /// [`PartPropKind`] variant; calling a typed accessor of a
+    /// different kind (e.g. `get_u8` on a slot built with `U32`)
+    /// returns [`HsmError::InvalidArg`].
+    ///
+    /// # Parameters
+    ///
+    /// - `kind` — the scalar variant; must not be
+    ///   [`PartPropKind::FixedBytes`] or [`PartPropKind::VarBytes`]
+    ///   (use [`Self::fixed`] / [`Self::var`] for those).
+    /// - `access`, `default`, `sensitive` — see [`Self::fixed`].
+    ///
+    /// # Returns
+    ///
+    /// [`Self`] — the assembled metadata.
+    pub const fn scalar(
+        kind: PartPropKind,
+        access: PartPropAccess,
+        default: PartPropDefault,
+        sensitive: bool,
+    ) -> Self {
+        Self {
+            kind,
+            cardinality: 1,
+            access,
+            default,
+            sensitive,
+        }
+    }
+}
+
+// ─── PartPropId ───────────────────────────────────────────────────────────
+
+/// Stable wire identifier for a partition property.
+///
+/// `PartPropId` is a `#[repr(transparent)]` `u16` newtype: the raw
+/// value is part of the on-disk and undo-log encoding and MUST NOT
+/// be reassigned once shipped.  Adding new properties is allowed (
+/// pick the next free id in the appropriate range and add a match arm
+/// to [`PartPropId::meta`]); reassigning, repurposing, or shifting
+/// existing ids is a wire-breaking change.
+///
+/// # Id ranges
+///
+/// Ids are grouped into ranges by category to keep the on-disk and
+/// undo-log dumps readable, but the ranges are purely organisational
+/// — the PAL impl does not gate behaviour on the id range.
+///
+/// | Range            | Category                                |
+/// |------------------|-----------------------------------------|
+/// | `0x0001..0x000F` | Identity, lifecycle, and platform state |
+/// | `0x0010..0x0016` | Vault references (`HsmKeyId` scalars)   |
+/// | `0x0017..0x001F` | Raw public-key views (P-384 coordinates / SEC1) |
+/// | `0x0020..0x002F` | Caller-presented secrets                |
+/// | `0x0030..0x003F` | Boot / launch-time bound material       |
+///
+/// # Adding a property
+///
+/// 1. Pick the next free `u16` in the appropriate range and add a
+///    `pub const` here, with a doc comment that records the wire
+///    shape, who sets the slot, and who reads it.
+/// 2. Add a match arm to [`PartPropId::meta`] returning the
+///    [`PartPropMeta`] for the new id — prefer the
+///    [`PartPropMeta::fixed`] / [`PartPropMeta::var`] /
+///    [`PartPropMeta::scalar`] / [`PartPropMeta::fixed_indexed`]
+///    constructors over building the struct literal by hand.
+/// 3. Update the PAL implementation(s) to back the new slot in their
+///    storage layout (presence bit + value region, undo-log entry
+///    if applicable).
+#[repr(transparent)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct PartPropId(u16);
+
+impl PartPropId {
+    // ── Identity, lifecycle, and platform state (0x0001..) ────────
+
+    /// Opaque partition identity blob (16 B).  Read-only from caller
+    /// perspective; populated by the PAL during partition setup.
+    pub const ID: PartPropId = PartPropId(0x0001);
+
+    /// Unique Device Secret (32 B).  Sensitive; used as the root
+    /// secret for partition-bound derivations.  Read-only from
+    /// caller perspective; provisioned by the PAL.
+    pub const UDS: PartPropId = PartPropId(0x0002);
+
+    /// Lifecycle state.  Encoded as `u8` matching
+    /// [`PartState`](crate::PartState) discriminants.
+    pub const STATE: PartPropId = PartPropId(0x0003);
+
+    /// Monotonic partition generation counter, incremented on every
+    /// allocate/free cycle.  Used by lifetime guards to detect
+    /// partition reuse.  Read-only from caller perspective; managed
+    /// by the PAL.
+    pub const GEN: PartPropId = PartPropId(0x0004);
+
+    /// Security version number of the firmware bound into the
+    /// partition's derivation lineage.  Read-only from caller
+    /// perspective.
+    pub const SVN: PartPropId = PartPropId(0x0005);
+
+    /// Number of host-allocated SQ/CQ resource pairs.  Read-only
+    /// from caller perspective.
+    pub const RES_COUNT: PartPropId = PartPropId(0x0006);
+
+    /// Firmware-supplied per-partition seed (32 B).  Read-only;
+    /// PAL-owned input to partition-bound derivations.
+    pub const FW_SEED: PartPropId = PartPropId(0x0007);
+
+    /// One-shot BK3 initialization flag.  Bool, `RequiredPresent`,
+    /// `Rw` but **the only legal transition is `false → true`**;
+    /// the PAL setter rejects redundant `true` writes with
+    /// [`HsmError::Bk3AlreadyInitialized`] and rejects `* → false`
+    /// with [`HsmError::InvalidArg`].  Reset back to `false` happens
+    /// PAL-internally on partition free / NSSR.
+    pub const BK3_INITIALIZED: PartPropId = PartPropId(0x0008);
+
+    /// BKS2 lineage identifier (`u16`).  Read-only; selects which
+    /// `BKS2` seed row binds the partition's boot-key derivations.
+    pub const BKS2_ID: PartPropId = PartPropId(0x0009);
+
+    /// Manufacturer-provisioned 32-byte seed row, indexed by SVN
+    /// (`0..64`).  PAL-private root-of-trust material used as the
+    /// first half of the KBKDF context for masking-key derivations.
+    /// Sensitive, read-only.  Indexed properties — only rows that
+    /// have been provisioned for the current PAL are present;
+    /// unprovisioned rows return [`HsmError::PartPropNotFound`].
+    pub const MFGR_SEED: PartPropId = PartPropId(0x000A);
+
+    /// Device-owner-provisioned 32-byte seed row, indexed by
+    /// `bks2_index` (`0..64`).  PAL-private root-of-trust material
+    /// used as the second half of the KBKDF context for masking-key
+    /// derivations.  Sensitive, read-only.  Indexed properties —
+    /// only rows provisioned for the current PAL are present.
+    pub const DEV_OWNER_SEED: PartPropId = PartPropId(0x000B);
+
+    // ── Vault references (0x0010..) ───────────────────────────────
+
+    /// Vault [`HsmKeyId`](crate::HsmKeyId) for the partition identity
+    /// key (ECC-P384).  Read-only from caller perspective; assigned
+    /// by the PAL when the identity key is materialised.
+    pub const ID_KEY_ID: PartPropId = PartPropId(0x0010);
+
+    /// Vault [`HsmKeyId`](crate::HsmKeyId) for the partition masking
+    /// key.
+    pub const MK_KEY_ID: PartPropId = PartPropId(0x0011);
+
+    /// Vault [`HsmKeyId`](crate::HsmKeyId) for the partition Unique
+    /// Partition Secret derived key.
+    pub const UPS_KEY_ID: PartPropId = PartPropId(0x0012);
+
+    /// Vault [`HsmKeyId`](crate::HsmKeyId) for the Partition Trust
+    /// Anchor (PTA) key.
+    pub const PTA_KEY_ID: PartPropId = PartPropId(0x0013);
+
+    /// Vault [`HsmKeyId`](crate::HsmKeyId) for the partition's
+    /// unwrapping key.  Read-only from caller perspective; assigned
+    /// by the PAL when the key is materialised.
+    pub const RSA_UNWRAPPING_KEY_ID: PartPropId = PartPropId(0x0014);
+
+    /// Vault [`HsmKeyId`](crate::HsmKeyId) for the partition's
+    /// session encryption key (long-lived ECDH).
+    pub const SESSION_ENC_KEY_ID: PartPropId = PartPropId(0x0015);
+
+    /// Vault [`HsmKeyId`](crate::HsmKeyId) for the partition's
+    /// one-shot establish-credential RSA-OAEP key.
+    pub const ESTABLISH_CRED_KEY_ID: PartPropId = PartPropId(0x0016);
+
+    /// Raw ECC-P384 public-key coordinates (x ∥ y, 96 B) of the
+    /// partition identity key.  Read-only from caller perspective;
+    /// materialised by the PAL alongside [`ID_KEY_ID`](Self::ID_KEY_ID).
+    pub const ID_PUB_KEY: PartPropId = PartPropId(0x0017);
+
+    /// Raw ECC-P384 public-key coordinates (x ∥ y, 96 B) for the
+    /// session encryption key.  Read-only from caller perspective.
+    pub const SESSION_ENC_PUB_KEY: PartPropId = PartPropId(0x0018);
+
+    /// Raw ECC-P384 public-key coordinates (x ∥ y, 96 B) for the
+    /// one-shot establish-credential key.  Read-only from caller
+    /// perspective.
+    pub const ESTABLISH_CRED_PUB_KEY: PartPropId = PartPropId(0x0019);
+
+    /// SEC1-uncompressed ECC-P384 public key (97 B) for the
+    /// Partition Trust Anchor.  Set together with
+    /// [`PTA_KEY_ID`](Self::PTA_KEY_ID) by `PartInit`.
+    pub const PTA_PUB_SEC1: PartPropId = PartPropId(0x001A);
+
+    // ── Caller-presented secrets (0x0020..) ───────────────────────
+
+    /// Crypto Officer pre-shared key (32 B).  Sensitive.
+    /// Default-baked at allocation time
+    /// (see [`DEFAULT_PSK_CO`](crate::DEFAULT_PSK_CO)) so callers
+    /// can establish a CO session immediately; rotation through the
+    /// setter is required before exposing the partition to
+    /// untrusted traffic.
+    pub const PSK_CO: PartPropId = PartPropId(0x0020);
+
+    /// Crypto User pre-shared key (32 B).  Sensitive.  Default-baked
+    /// at allocation; see [`PSK_CO`](Self::PSK_CO).
+    pub const PSK_CU: PartPropId = PartPropId(0x0021);
+
+    /// Caller-presented credential blob (32 B).  Sensitive.
+    /// Absent-until-set; verified by the upper layer via
+    /// constant-time compare against the value returned by
+    /// [`HsmPartitionManager::part_prop_get_bytes`].
+    pub const CREDENTIAL: PartPropId = PartPropId(0x0022);
+
+    /// 32-byte partition nonce, refreshed per credential / session
+    /// event.  Sensitive.  Caller refreshes by writing a fresh
+    /// PAL-RNG buffer via [`HsmPartitionManager::part_prop_set_bytes`].
+    pub const NONCE: PartPropId = PartPropId(0x0023);
+
+    // ── Boot / launch-time bound material (0x0030..) ──────────────
+
+    /// Sealed BK3 blob (≤ 96 B).  Sensitive.  Absent-until-set;
+    /// set once per power cycle.
+    pub const SEALED_BK3: PartPropId = PartPropId(0x0030);
+
+    /// Masked BK_BOOT blob (variable, ≤ [`MASKED_BK_BOOT_LEN`](crate::MASKED_BK_BOOT_LEN)).
+    /// Sensitive.
+    pub const MASKED_BK_BOOT: PartPropId = PartPropId(0x0031);
+
+    /// Unmasked BK_BOOT (exactly [`BK_BOOT_LEN`](crate::BK_BOOT_LEN)).
+    /// Sensitive.  Read-only from caller perspective; derived by the
+    /// PAL from the masked form.
+    pub const BK_BOOT: PartPropId = PartPropId(0x0032);
+
+    /// VM-launch GUID (16 B), bound at session-establishment time.
+    /// Read-only from caller perspective; populated by the PAL.
+    pub const VM_LAUNCH_GUID: PartPropId = PartPropId(0x0033);
+
+    /// Partition policy blob (exactly [`PART_POLICY_LEN`](crate::PART_POLICY_LEN)).
+    /// Set by `PartInit`.
+    pub const POLICY: PartPropId = PartPropId(0x0034);
+
+    /// POTA thumbprint (32 B).  Set by `PartInit`.
+    pub const POTA_THUMBPRINT: PartPropId = PartPropId(0x0035);
+
+    /// BK3 session key (48 B).  Sensitive.  Set by EstablishCredential
+    /// once per session.
+    pub const BK3_SESSION: PartPropId = PartPropId(0x0036);
+
+    /// Wrap a raw `u16` as a [`PartPropId`].
+    ///
+    /// Used by undo-log replay and on-disk decoders that read raw
+    /// ids off the wire.  Callers obtain ids from the named
+    /// constants in normal code; this constructor exists for
+    /// generic dispatch.
+    ///
+    /// # Parameters
+    ///
+    /// - `v` — the raw 16-bit wire identifier.
+    ///
+    /// # Returns
+    ///
+    /// [`Self`] — the wrapped id.  Unknown ids are accepted here
+    /// and rejected later by the PAL impl (via [`Self::meta`]
+    /// returning `None`).
+    #[inline]
+    pub const fn from_raw(v: u16) -> Self {
+        Self(v)
+    }
+
+    /// Unwrap to the raw `u16` value.
+    ///
+    /// # Returns
+    ///
+    /// [`u16`] — the wire-stable identifier that may be journaled
+    /// to the undo log or written to persistent storage.
+    #[inline]
+    pub const fn raw(self) -> u16 {
+        self.0
+    }
+
+    /// Compile-time metadata for this id.
+    ///
+    /// # Returns
+    ///
+    /// [`Option<PartPropMeta>`] — `Some(meta)` describing the
+    /// slot's wire shape, cardinality, access mode, presence
+    /// semantics, and sensitivity for any id known to this build of
+    /// the PAL traits crate; `None` for any id not added to the
+    /// match below at compile time.  PAL impls surface unknown ids
+    /// as [`HsmError::InvalidArg`] in their getters and setters.
+    pub const fn meta(self) -> Option<PartPropMeta> {
+        use PartPropAccess::Ro;
+        use PartPropAccess::Rw;
+        use PartPropDefault::AbsentUntilSet as Abs;
+        use PartPropDefault::RequiredPresent as Req;
+        use PartPropKind::Bool;
+        use PartPropKind::U8;
+        use PartPropKind::U16;
+        use PartPropKind::U32;
+        use PartPropKind::U64;
+
+        // Writable vault-ref props share the same shape (u16 HsmKeyId, RW, absent).
+        const VAULT_REF_RW: PartPropMeta = PartPropMeta::scalar(U16, Rw, Abs, false);
+        // Read-only vault-ref props share the same shape (u16 HsmKeyId, RO, absent).
+        const VAULT_REF_RO: PartPropMeta = PartPropMeta::scalar(U16, Ro, Abs, false);
+
+        let meta = match self {
+            // ── Identity, lifecycle, platform ──
+            Self::ID => PartPropMeta::fixed(16, Ro, Abs, false),
+            Self::UDS => PartPropMeta::fixed(32, Ro, Abs, true),
+            Self::STATE => PartPropMeta::scalar(U8, Rw, Req, false),
+            Self::GEN => PartPropMeta::scalar(U32, Ro, Req, false),
+            Self::SVN => PartPropMeta::scalar(U64, Ro, Req, false),
+            Self::RES_COUNT => PartPropMeta::scalar(U8, Ro, Req, false),
+            Self::FW_SEED => PartPropMeta::fixed(48, Ro, Req, true),
+            Self::BK3_INITIALIZED => PartPropMeta::scalar(Bool, Rw, Req, false),
+            Self::BKS2_ID => PartPropMeta::scalar(U16, Ro, Req, false),
+            Self::MFGR_SEED | Self::DEV_OWNER_SEED => {
+                PartPropMeta::fixed_indexed(32, 64, Ro, Abs, true)
+            }
+
+            // ── Vault refs (HsmKeyId as u16) ──
+            Self::ID_KEY_ID | Self::RSA_UNWRAPPING_KEY_ID => VAULT_REF_RO,
+            Self::MK_KEY_ID
+            | Self::UPS_KEY_ID
+            | Self::PTA_KEY_ID
+            | Self::SESSION_ENC_KEY_ID
+            | Self::ESTABLISH_CRED_KEY_ID => VAULT_REF_RW,
+
+            // ── Public-key views (fixed P-384 sizes) ──
+            Self::ID_PUB_KEY | Self::SESSION_ENC_PUB_KEY | Self::ESTABLISH_CRED_PUB_KEY => {
+                PartPropMeta::fixed(96, Ro, Abs, false)
+            }
+            Self::PTA_PUB_SEC1 => PartPropMeta::fixed(97, Rw, Abs, false),
+
+            // ── Caller-presented secrets ──
+            Self::PSK_CO | Self::PSK_CU => PartPropMeta::fixed(PSK_LEN as u16, Rw, Req, true),
+            Self::CREDENTIAL => PartPropMeta::fixed(32, Rw, Abs, true),
+            Self::NONCE => PartPropMeta::fixed(32, Rw, Req, true),
+
+            // ── Boot / launch-time bound material ──
+            Self::SEALED_BK3 => PartPropMeta::var(SEALED_BK3_MAX_LEN, Rw, Abs, true),
+            Self::MASKED_BK_BOOT => PartPropMeta::var(MASKED_BK_BOOT_LEN as u16, Rw, Abs, true),
+            Self::BK_BOOT => PartPropMeta::fixed(BK_BOOT_LEN as u16, Ro, Abs, true),
+            Self::VM_LAUNCH_GUID => PartPropMeta::fixed(16, Ro, Abs, false),
+            Self::POLICY => PartPropMeta::fixed(PART_POLICY_LEN as u16, Rw, Abs, false),
+            Self::POTA_THUMBPRINT => PartPropMeta::fixed(48, Rw, Abs, false),
+            Self::BK3_SESSION => PartPropMeta::fixed(48, Rw, Abs, true),
+
+            _ => return None,
+        };
+        Some(meta)
+    }
+}
+
+impl From<u16> for PartPropId {
+    #[inline]
+    fn from(v: u16) -> Self {
+        Self(v)
+    }
+}
+
+impl From<PartPropId> for u16 {
+    #[inline]
+    fn from(id: PartPropId) -> Self {
+        id.0
+    }
+}

--- a/fw/pal/traits/src/part.rs
+++ b/fw/pal/traits/src/part.rs
@@ -211,9 +211,6 @@ impl PartState {
 ///   Unreachable for `RequiredPresent` slots; reachable for
 ///   `AbsentUntilSet` slots until the first successful setter or
 ///   after the most recent [`Self::part_prop_clear`].
-/// - [`HsmError::UnsupportedCmd`] — the default body.  PAL impls
-///   override only the methods they back; existing impls compile
-///   unchanged until they opt in to additional kinds.
 /// - Other [`HsmError`] variants — PAL-level failures (for example
 ///   [`HsmError::InternalError`] on backing-store corruption,
 ///   [`HsmError::Bk3AlreadyInitialized`] on the one-shot
@@ -527,7 +524,7 @@ pub const BK_BOOT_LEN: usize = 80;
 /// `SEALED_BK3_SIZE` so blobs stay bit-compatible with host-side
 /// tooling.  PAL implementations size their backing storage to at
 /// least this many bytes.
-pub const SEALED_BK3_MAX_LEN: u16 = 96;
+pub const SEALED_BK3_MAX_LEN: u16 = 512;
 
 /// Maximum size of the `Masked_BK_BOOT` envelope in bytes.
 ///
@@ -900,7 +897,7 @@ impl PartPropId {
     /// from caller perspective.
     pub const RES_COUNT: PartPropId = PartPropId(0x0006);
 
-    /// Firmware-supplied per-partition seed (32 B).  Read-only;
+    /// Firmware-supplied per-partition seed (48 B).  Read-only;
     /// PAL-owned input to partition-bound derivations.
     pub const FW_SEED: PartPropId = PartPropId(0x0007);
 
@@ -1009,8 +1006,8 @@ impl PartPropId {
 
     // ── Boot / launch-time bound material (0x0030..) ──────────────
 
-    /// Sealed BK3 blob (≤ 96 B).  Sensitive.  Absent-until-set;
-    /// set once per power cycle.
+    /// Sealed BK3 blob (≤ [`SEALED_BK3_MAX_LEN`](crate::SEALED_BK3_MAX_LEN) B).
+    /// Sensitive.  Absent-until-set; set once per power cycle.
     pub const SEALED_BK3: PartPropId = PartPropId(0x0030);
 
     /// Masked BK_BOOT blob (variable, ≤ [`MASKED_BK_BOOT_LEN`](crate::MASKED_BK_BOOT_LEN)).
@@ -1030,7 +1027,7 @@ impl PartPropId {
     /// Set by `PartInit`.
     pub const POLICY: PartPropId = PartPropId(0x0034);
 
-    /// POTA thumbprint (32 B).  Set by `PartInit`.
+    /// POTA thumbprint (48 B).  Set by `PartInit`.
     pub const POTA_THUMBPRINT: PartPropId = PartPropId(0x0035);
 
     /// BK3 session key (48 B).  Sensitive.  Set by EstablishCredential

--- a/fw/plat/std/pal/src/part.rs
+++ b/fw/plat/std/pal/src/part.rs
@@ -1414,6 +1414,13 @@ impl PartitionEntry {
                 Ok(())
             }
             PartPropId::SEALED_BK3 => {
+                // Write-once per power cycle: a second SetSealedBk3
+                // without an intervening clear (free / NSSR /
+                // explicit `prop_clear`) returns `SealedBk3AlreadySet`
+                // to preserve the wire-visible legacy behaviour.
+                if self.sealed_bk3_len != 0 {
+                    return Err(HsmError::SealedBk3AlreadySet);
+                }
                 self.sealed_bk3.fill(0);
                 self.sealed_bk3[..data.len()].copy_from_slice(data);
                 self.sealed_bk3_len = data.len() as u32;

--- a/fw/plat/std/pal/src/part.rs
+++ b/fw/plat/std/pal/src/part.rs
@@ -87,7 +87,7 @@ pub(crate) const P384_PUB_KEY_LEN: usize = P384_COORD_SIZE * 2;
 ///
 /// Matches the prior reference firmware's `VmLaunchGuid` size
 /// (16 bytes).
-pub(crate) const VM_LAUNCH_GUID_LEN: usize = 16;
+const VM_LAUNCH_GUID_LEN: usize = 16;
 
 /// Hardcoded std PAL VM launch GUID returned by
 /// [`HsmPartitionManager::part_vm_launch_guid`].
@@ -101,41 +101,32 @@ const STD_VM_LAUNCH_GUID: [u8; VM_LAUNCH_GUID_LEN] = [
 /// Hardcoded std PAL SVN returned by [`HsmPartitionManager::part_svn`].
 const STD_SVN: u64 = 0;
 
-/// Length of a single backup-key seed (`BKS1`, `BKS2`) row used by
-/// [`HsmPartitionManager::derive_masking_key`] in bytes.
+/// Length of a single backup-key seed (`MFGR_SEED`, `DEV_OWNER_SEED`)
+/// row in bytes.
 const BK_SEED_LEN: usize = 32;
 
-/// Hardcoded std PAL firmware boot seed used as the KDK input to
-/// [`HsmPartitionManager::derive_masking_key`].
+/// Hardcoded std PAL `MFGR_SEED` row 0 — manufacturer-provisioned
+/// 32 B seed exposed through [`PartPropId::MFGR_SEED`] at `idx = 0`.
 ///
-/// Real hardware reads this from a one-time-programmed, device-bound
-/// hardware register that is not visible outside the secure-world
-/// firmware.  The std PAL emulator uses a fixed pattern so tests are
-/// deterministic.  The seed never crosses the trait boundary; callers
-/// only see derived masking keys.
-const STD_FW_SEED: [u8; 48] = [0x42u8; 48];
-
-/// Hardcoded std PAL `BKS1` seed row used as the first half of the
-/// KDF context in [`HsmPartitionManager::derive_masking_key`].
-///
-/// Real hardware selects this row from a `BKS1` table indexed by SVN;
-/// the std PAL emulator has a single row because the simulator models
-/// a single SVN.  The bytes are taken from the prior reference
-/// firmware so derived masking keys are bit-compatible with persisted
+/// Real hardware exposes a 64-row table indexed by SVN; the std PAL
+/// emulator provisions only row 0 because the simulator models a
+/// single SVN.  The bytes are taken from the prior reference firmware
+/// so derived masking keys are bit-compatible with persisted
 /// `Masked_BK_BOOT` blobs across emulator and real hardware.
-const STD_BKS1: [u8; BK_SEED_LEN] = [
+const STD_MFGR_SEED_ROW0: [u8; BK_SEED_LEN] = [
     0x9b, 0x4e, 0x4e, 0xb7, 0xad, 0xab, 0xdc, 0xd6, 0xb4, 0xd5, 0x07, 0xeb, 0x68, 0xeb, 0x26, 0x99,
     0x2a, 0xbb, 0xca, 0xb5, 0x5c, 0xfb, 0x77, 0x3b, 0xc4, 0xd0, 0xa8, 0x8c, 0x21, 0x02, 0xb0, 0xac,
 ];
 
-/// Hardcoded std PAL `BKS2` seed row used as the second half of the
-/// KDF context in [`HsmPartitionManager::derive_masking_key`].
+/// Hardcoded std PAL `DEV_OWNER_SEED` row 0 — device-owner-provisioned
+/// 32 B seed exposed through [`PartPropId::DEV_OWNER_SEED`] at
+/// `idx = 0`.
 ///
-/// Real hardware selects this row from a `BKS2` table indexed by
-/// `bks2_index`; the std PAL emulator has a single row because the
-/// simulator models a single partition lineage.  The bytes are taken
-/// from the prior reference firmware for bit-compatibility.
-const STD_BKS2: [u8; BK_SEED_LEN] = [
+/// Real hardware exposes a 64-row table indexed by `bks2_index`; the
+/// std PAL emulator provisions only row 0 because the simulator
+/// models a single partition lineage.  The bytes are taken from the
+/// prior reference firmware for bit-compatibility.
+const STD_DEV_OWNER_SEED_ROW0: [u8; BK_SEED_LEN] = [
     0xad, 0x1a, 0x17, 0xe9, 0xed, 0x38, 0x27, 0x5e, 0x8b, 0x30, 0x5d, 0xb8, 0x19, 0x0f, 0x82, 0xb6,
     0x2d, 0xa2, 0x5a, 0xc6, 0xf0, 0x70, 0xa3, 0xe1, 0x75, 0x9c, 0x61, 0x92, 0xcc, 0xf4, 0x19, 0xa3,
 ];
@@ -212,20 +203,20 @@ pub(crate) struct PartitionEntry {
 
     /// Vault key ID for the establish-credential encryption ECC-384 key.
     /// `None` before enable or after one-time clear.
-    pub(crate) establish_cred_key_id: Option<HsmKeyId>,
+    establish_cred_key_id: Option<HsmKeyId>,
 
     /// DER-encoded public key for establish-credential encryption.
     establish_cred_pub_key: [u8; P384_PUB_KEY_LEN],
 
     /// Vault key ID for the session encryption ECC-384 key.
     /// `None` before enable.
-    pub(crate) session_enc_key_id: Option<HsmKeyId>,
+    session_enc_key_id: Option<HsmKeyId>,
 
     /// Raw public key coordinates (x ∥ y) for session encryption.
     session_enc_pub_key: [u8; P384_PUB_KEY_LEN],
 
     /// 32-byte random nonce, generated on enable and refreshable.
-    pub(crate) nonce: [u8; NONCE_LEN],
+    nonce: [u8; NONCE_LEN],
 
     /// Sealed BK3 blob — up to 512 bytes of opaque data.
     sealed_bk3: [u8; SEALED_BK3_SIZE],
@@ -273,13 +264,9 @@ pub(crate) struct PartitionEntry {
     /// one-shot gate for `InitBk3`.
     bk3_initialized: bool,
 
-    /// User credential ID (16 bytes).  Zeroed until set by
-    /// `part_set_credential`.
-    credential_id: [u8; 16],
-
-    /// User credential PIN (16 bytes).  Zeroed until set by
-    /// `part_set_credential`.
-    credential_pin: [u8; 16],
+    /// User credential blob (`id ‖ pin`, 16 + 16 = 32 bytes).  Zeroed
+    /// until set via the `CREDENTIAL` property.
+    credential: [u8; 32],
 
     /// Whether the user credential has been set for this incarnation.
     credential_set: bool,
@@ -312,7 +299,7 @@ pub(crate) struct PartitionEntry {
     /// bound by `PartInit`.  `None` until the one-shot
     /// [`HsmPartitionManager::part_set_ums_key`] succeeds; cleared on
     /// `part_disable`.
-    ums_key_id: Option<HsmKeyId>,
+    ups_key_id: Option<HsmKeyId>,
 
     /// SEC1 uncompressed P-384 public key for the Partition Trust Anchor.
     pta_pub_sec1: Option<[u8; P384_PUB_SEC1_LEN]>,
@@ -352,8 +339,7 @@ impl Default for PartitionEntry {
             masked_bk_boot_len: 0,
             vm_launch_guid: [0u8; VM_LAUNCH_GUID_LEN],
             bk3_initialized: false,
-            credential_id: [0u8; 16],
-            credential_pin: [0u8; 16],
+            credential: [0u8; 32],
             credential_set: false,
             bk3_session: [0u8; 48],
             bk3_session_set: false,
@@ -362,7 +348,7 @@ impl Default for PartitionEntry {
             psk_co: None,
             psk_cu: None,
             pta_key_id: None,
-            ums_key_id: None,
+            ups_key_id: None,
             pta_pub_sec1: None,
             part_policy_buf: None,
             pota_thumbprint: None,
@@ -454,498 +440,105 @@ pub enum PartCommand {
 // ---------------------------------------------------------------------------
 
 impl HsmPartitionManager for StdHsmPal {
-    /// Returns the current state of the calling partition (`io.pid()`).
-    fn part_state(&self, io: &impl HsmIo) -> HsmResult<PartState> {
-        // SAFETY: Embassy is single-threaded. This synchronous method
-        // completes without yielding, so no concurrent mutation occurs.
-        let table = unsafe { &*self.part_table.get() };
-        let idx = u8::from(io.pid()) as usize;
-        if idx >= NUM_PARTITIONS {
-            return Err(HsmError::InvalidArg);
-        }
-        Ok(table.entries[idx].state)
+    // ─── Property API ──────────────────────────────────────────────────
+    //
+    // Forwarding shims to the inherent `prop_*` implementations on
+    // [`StdHsmPal`] declared in [`crate::part_prop`].  All validation,
+    // lifecycle gating, and dispatch into [`PartitionEntry`] lives in
+    // that module; the methods below exist solely to attach the
+    // implementation to the trait.
+
+    fn part_prop_get_u8(&self, io: &impl HsmIo, id: PartPropId, idx: u16) -> HsmResult<u8> {
+        self.prop_get_u8(io, id, idx)
     }
 
-    /// Returns the resource count allocated to the calling partition.
-    fn part_res_count(&self, io: &impl HsmIo) -> HsmResult<u8> {
-        let table = unsafe { &*self.part_table.get() };
-        let idx = u8::from(io.pid()) as usize;
-        if idx >= NUM_PARTITIONS {
-            return Err(HsmError::InvalidArg);
-        }
-        let entry = &table.entries[idx];
-        if entry.state == PartState::Unallocated {
-            return Err(HsmError::InvalidArg);
-        }
-        Ok(entry.res_mask.count_ones() as u8)
-    }
-
-    /// Returns the 16-byte identity blob for the calling partition.
-    fn part_id(&self, io: &impl HsmIo) -> HsmResult<PartId<'_>> {
-        let table = unsafe { &*self.part_table.get() };
-        let idx = u8::from(io.pid()) as usize;
-        if idx >= NUM_PARTITIONS {
-            return Err(HsmError::InvalidArg);
-        }
-        let entry = &table.entries[idx];
-        if entry.state == PartState::Unallocated {
-            return Err(HsmError::InvalidArg);
-        }
-        Ok(&entry.id)
-    }
-
-    fn part_id_key_id(&self, io: &impl HsmIo) -> HsmResult<HsmKeyId> {
-        self.active_part(io.pid())?
-            .id_key_id
-            .ok_or(HsmError::InternalError)
-    }
-
-    fn part_id_pub_key(&self, io: &impl HsmIo, out: Option<&mut [u8]>) -> HsmResult<usize> {
-        copy_out(&self.active_part(io.pid())?.id_pub_key, out)
-    }
-
-    fn part_establish_cred_key_id(&self, io: &impl HsmIo) -> HsmResult<Option<HsmKeyId>> {
-        Ok(self.enabled_part(u8::from(io.pid()))?.establish_cred_key_id)
-    }
-
-    fn part_establish_cred_pub_key(
+    fn part_prop_set_u8(
         &self,
         io: &impl HsmIo,
-        out: Option<&mut [u8]>,
-    ) -> HsmResult<usize> {
-        // Stored internally as big-endian `x ∥ y` (OpenSSL convention).
-        // The wire contract — matching real PKA hardware — is
-        // little-endian, and the host-side `post_decode_fn` on
-        // `DdiDerPublicKey` reverses each coord back to big-endian
-        // before DER-encoding.  Reverse each coord here so the wire
-        // bytes are LE.
-        let raw = &self
-            .enabled_part(u8::from(io.pid()))?
-            .establish_cred_pub_key;
-        copy_out_pub_key_le(raw, out)
-    }
-
-    fn part_session_enc_key_id(&self, io: &impl HsmIo) -> HsmResult<HsmKeyId> {
-        self.enabled_part(u8::from(io.pid()))?
-            .session_enc_key_id
-            .ok_or(HsmError::InternalError)
-    }
-
-    fn part_session_enc_pub_key(
-        &self,
-        io: &impl HsmIo,
-        out: Option<&mut [u8]>,
-    ) -> HsmResult<usize> {
-        // Stored internally as big-endian `x ∥ y` (OpenSSL convention).
-        // The wire contract — matching real PKA hardware — is
-        // little-endian, and the host-side `post_decode_fn` on
-        // `DdiDerPublicKey` reverses each coord back to big-endian
-        // before DER-encoding.  Reverse each coord here so the wire
-        // bytes are LE.
-        let raw = &self.enabled_part(u8::from(io.pid()))?.session_enc_pub_key;
-        copy_out_pub_key_le(raw, out)
-    }
-
-    fn part_clear_establish_cred_key(&self, io: &impl HsmIo) -> HsmResult<()> {
-        let entry = self.enabled_part_mut(u8::from(io.pid()))?;
-        if let Some(kid) = entry.establish_cred_key_id.take() {
-            let _ = entry.vault.delete(kid);
-        }
-        entry.establish_cred_pub_key.fill(0);
-        Ok(())
-    }
-
-    fn part_nonce(&self, io: &impl HsmIo, out: Option<&mut [u8]>) -> HsmResult<usize> {
-        copy_out(&self.enabled_part(u8::from(io.pid()))?.nonce, out)
-    }
-
-    fn part_nonce_refresh(&self, io: &impl HsmIo) -> HsmResult<()> {
-        let entry = self.enabled_part_mut(u8::from(io.pid()))?;
-        Rng::rand_bytes(&mut entry.nonce).map_err(|_| HsmError::InternalError)
-    }
-
-    fn part_sealed_bk3(&self, io: &impl HsmIo, out: Option<&mut [u8]>) -> HsmResult<usize> {
-        let entry = self.active_part(io.pid())?;
-        let len = entry.sealed_bk3_len as usize;
-        copy_out(&entry.sealed_bk3[..len], out)
-    }
-
-    fn part_set_sealed_bk3(&self, io: &impl HsmIo, data: &[u8]) -> HsmResult<()> {
-        let entry = self.active_part_mut(io.pid())?;
-        if entry.sealed_bk3_len != 0 {
-            return Err(HsmError::SealedBk3AlreadySet);
-        }
-        if data.len() > SEALED_BK3_SIZE {
-            return Err(HsmError::SealedBk3TooLarge);
-        }
-        entry.sealed_bk3[..data.len()].copy_from_slice(data);
-        entry.sealed_bk3_len = data.len() as u32;
-        Ok(())
-    }
-
-    fn part_vm_launch_guid(&self, io: &impl HsmIo, out: Option<&mut [u8]>) -> HsmResult<usize> {
-        let entry = self.active_part(io.pid())?;
-        copy_out(&entry.vm_launch_guid, out)
-    }
-
-    fn part_svn(&self, io: &impl HsmIo) -> HsmResult<u64> {
-        // Validate enabled state but discard the borrow; the value is a
-        // platform constant on the std PAL.
-        let _entry = self.active_part(io.pid())?;
-        Ok(STD_SVN)
-    }
-
-    fn part_bks2_id(&self, io: &impl HsmIo) -> HsmResult<u16> {
-        // No BKS2 selector modelled in the emulator; return slot 0 for
-        // wire-format compatibility.
-        let _entry = self.active_part(io.pid())?;
-        Ok(0)
-    }
-
-    fn part_bk_boot(&self, io: &impl HsmIo, out: Option<&mut [u8]>) -> HsmResult<usize> {
-        let entry = self.active_part(io.pid())?;
-        if let Some(buf) = out {
-            if buf.len() < BK_BOOT_LEN {
-                return Err(HsmError::InvalidArg);
-            }
-            buf[..BK_BOOT_LEN].copy_from_slice(&entry.bk_boot);
-        }
-        Ok(BK_BOOT_LEN)
-    }
-
-    fn part_is_bk3_initialized(&self, io: &impl HsmIo) -> HsmResult<bool> {
-        let entry = self.enabled_part(u8::from(io.pid()))?;
-        Ok(entry.bk3_initialized)
-    }
-
-    fn part_mark_bk3_initialized(&self, io: &impl HsmIo) -> HsmResult<()> {
-        let entry = self.enabled_part_mut(u8::from(io.pid()))?;
-        if entry.bk3_initialized {
-            return Err(HsmError::Bk3AlreadyInitialized);
-        }
-        entry.bk3_initialized = true;
-        Ok(())
-    }
-
-    fn part_masked_bk_boot(&self, io: &impl HsmIo, out: Option<&mut [u8]>) -> HsmResult<usize> {
-        let entry = self.enabled_part(u8::from(io.pid()))?;
-        let len = entry.masked_bk_boot_len as usize;
-        copy_out(&entry.masked_bk_boot[..len], out)
-    }
-
-    fn part_set_masked_bk_boot(&self, io: &impl HsmIo, data: &[u8]) -> HsmResult<()> {
-        if data.len() > MASKED_BK_BOOT_LEN {
-            return Err(HsmError::InvalidArg);
-        }
-        let entry = self.enabled_part_mut(u8::from(io.pid()))?;
-        entry.masked_bk_boot[..data.len()].copy_from_slice(data);
-        entry.masked_bk_boot_len = data.len() as u32;
-        Ok(())
-    }
-
-    fn fw_seed(&self) -> &[u8] {
-        &STD_FW_SEED
-    }
-
-    async fn derive_masking_key(
-        &self,
-        io: &impl HsmIo,
-        kdk: &[u8],
-        label: &[u8],
-        extra_context: &[u8],
-        svn: u64,
-        bks2_index: u16,
-        output: &mut DmaBuf,
+        id: PartPropId,
+        idx: u16,
+        value: u8,
     ) -> HsmResult<()> {
-        self.active_part(io.pid())?;
-
-        // Std PAL models a single SVN + single BKS2 lineage; reject any
-        // out-of-range selector.
-        if svn != 0 || bks2_index != 0 {
-            return Err(HsmError::InvalidArg);
-        }
-
-        // Co-locate all KDF inputs (KDK, label, context) in one DMA
-        // alloc; pad each region to 4-byte alignment so DMA-driven
-        // engines on real hardware see the same layout as
-        // per-allocation arrangements.
-        let kdk_area_len = kdk.len().next_multiple_of(4);
-        let label_area_len = label.len().next_multiple_of(4);
-        let ctx_len = STD_BKS1.len() + STD_BKS2.len() + extra_context.len();
-
-        let arena = self.dma_alloc(io, kdk_area_len + label_area_len + ctx_len)?;
-        let (kdk_area, rest) = arena.split_at_mut(kdk_area_len);
-        let (key_dma, _kdk_pad) = kdk_area.split_at_mut(kdk.len());
-        let (label_area, ctx_dma) = rest.split_at_mut(label_area_len);
-        let (label_dma, _label_pad) = label_area.split_at_mut(label.len());
-
-        if !kdk.is_empty() {
-            key_dma.copy_from_slice(kdk);
-        }
-        if !label.is_empty() {
-            label_dma.copy_from_slice(label);
-        }
-        {
-            let (bks1_slot, ctx_rest) = ctx_dma.split_at_mut(STD_BKS1.len());
-            let (bks2_slot, extra_slot) = ctx_rest.split_at_mut(STD_BKS2.len());
-            bks1_slot.copy_from_slice(&STD_BKS1);
-            bks2_slot.copy_from_slice(&STD_BKS2);
-            if !extra_context.is_empty() {
-                extra_slot.copy_from_slice(extra_context);
-            }
-        }
-
-        self.sp800_108_kdf(
-            io,
-            HsmHashAlgo::Sha384,
-            key_dma,
-            Some(label_dma),
-            Some(ctx_dma),
-            output,
-        )
-        .await
+        self.prop_set_u8(io, id, idx, value)
     }
 
-    fn part_verify_nonce(&self, io: &impl HsmIo, nonce: &[u8]) -> HsmResult<()> {
-        let part = self.enabled_part(u8::from(io.pid()))?;
-        if part.nonce != nonce {
-            return Err(HsmError::NonceMismatch);
-        }
-        Ok(())
+    fn part_prop_get_u16(&self, io: &impl HsmIo, id: PartPropId, idx: u16) -> HsmResult<u16> {
+        self.prop_get_u16(io, id, idx)
     }
 
-    fn part_set_credential(&self, io: &impl HsmIo, id: &[u8], pin: &[u8]) -> HsmResult<()> {
-        if id.len() != 16 || pin.len() != 16 {
-            return Err(HsmError::InvalidArg);
-        }
-        let part = self.enabled_part_mut(u8::from(io.pid()))?;
-        if part.credential_set {
-            return Err(HsmError::VaultAppLimitReached);
-        }
-        // Reject all-zero ID or PIN — matches the reference firmware's
-        // `cred_mgr::change_user_cred` invariant and is also what
-        // `verify_user_cred_is_set` uses as the sentinel for "unset".
-        if id == [0u8; 16].as_slice() || pin == [0u8; 16].as_slice() {
-            return Err(HsmError::InvalidAppCredentials);
-        }
-        part.credential_id.copy_from_slice(id);
-        part.credential_pin.copy_from_slice(pin);
-        part.credential_set = true;
-        Ok(())
-    }
-
-    fn part_is_credential_set(&self, io: &impl HsmIo) -> HsmResult<bool> {
-        Ok(self.enabled_part(u8::from(io.pid()))?.credential_set)
-    }
-
-    fn part_verify_credential(&self, io: &impl HsmIo, id: &[u8], pin: &[u8]) -> HsmResult<()> {
-        if id.len() != 16 || pin.len() != 16 {
-            return Err(HsmError::InvalidArg);
-        }
-        let part = self.enabled_part(u8::from(io.pid()))?;
-        if !part.credential_set {
-            return Err(HsmError::InvalidAppCredentials);
-        }
-        // Constant-time compare both fields fully regardless of any
-        // mismatch in either, so we don't leak which one was wrong via
-        // timing.
-        let mut diff = 0u8;
-        for i in 0..16 {
-            diff |= part.credential_id[i] ^ id[i];
-            diff |= part.credential_pin[i] ^ pin[i];
-        }
-        if diff != 0 {
-            return Err(HsmError::InvalidAppCredentials);
-        }
-        Ok(())
-    }
-
-    fn part_is_provisioned(&self, io: &impl HsmIo) -> HsmResult<bool> {
-        Ok(self.enabled_part(u8::from(io.pid()))?.mk_key_id.is_some())
-    }
-
-    fn part_set_bk3_session(&self, io: &impl HsmIo, data: &[u8]) -> HsmResult<()> {
-        if data.len() != 48 {
-            return Err(HsmError::InvalidArg);
-        }
-        let part = self.enabled_part_mut(u8::from(io.pid()))?;
-        part.bk3_session.copy_from_slice(data);
-        part.bk3_session_set = true;
-        Ok(())
-    }
-
-    fn part_mk_key_id(&self, io: &impl HsmIo) -> HsmResult<Option<HsmKeyId>> {
-        Ok(self.enabled_part(u8::from(io.pid()))?.mk_key_id)
-    }
-
-    fn part_set_mk_key_id(&self, io: &impl HsmIo, key_id: HsmKeyId) -> HsmResult<()> {
-        let part = self.enabled_part_mut(u8::from(io.pid()))?;
-        part.mk_key_id = Some(key_id);
-        Ok(())
-    }
-
-    fn part_unwrapping_key_id(&self, io: &impl HsmIo) -> HsmResult<Option<HsmKeyId>> {
-        Ok(self.enabled_part(u8::from(io.pid()))?.unwrapping_key_id)
-    }
-
-    fn part_set_unwrapping_key_id(&self, io: &impl HsmIo, key_id: HsmKeyId) -> HsmResult<()> {
-        let part = self.enabled_part_mut(u8::from(io.pid()))?;
-        part.unwrapping_key_id = Some(key_id);
-        Ok(())
-    }
-
-    fn part_psk(&self, io: &impl HsmIo, psk_id: u8, out: Option<&mut [u8]>) -> HsmResult<usize> {
-        if psk_id > 1 {
-            return Err(HsmError::InvalidPskId);
-        }
-        let part = self.serving_part(io.pid())?;
-        let stored: Option<&[u8; PSK_LEN]> = match psk_id {
-            0 => part.psk_co.as_ref(),
-            _ => part.psk_cu.as_ref(),
-        };
-        let src: &[u8] = match stored {
-            Some(rotated) => rotated.as_slice(),
-            None if psk_id == 0 => DEFAULT_PSK_CO.as_slice(),
-            None => DEFAULT_PSK_CU.as_slice(),
-        };
-        match out {
-            None => Ok(PSK_LEN),
-            Some(buf) => {
-                if buf.len() < PSK_LEN {
-                    return Err(HsmError::InvalidArg);
-                }
-                buf[..PSK_LEN].copy_from_slice(src);
-                Ok(PSK_LEN)
-            }
-        }
-    }
-
-    fn part_psk_set(&self, io: &impl HsmIo, psk_id: u8, psk: &[u8]) -> HsmResult<()> {
-        if psk_id > 1 {
-            return Err(HsmError::InvalidPskId);
-        }
-        if psk.len() != PSK_LEN {
-            return Err(HsmError::InvalidArg);
-        }
-        let part = self.serving_part_mut(io.pid())?;
-        let mut buf = [0u8; PSK_LEN];
-        buf.copy_from_slice(psk);
-        if psk_id == 0 {
-            part.psk_co = Some(buf);
-        } else {
-            part.psk_cu = Some(buf);
-        }
-        Ok(())
-    }
-
-    fn part_uds(&self, io: &impl HsmIo, out: Option<&mut [u8]>) -> HsmResult<usize> {
-        copy_out(&self.serving_part(io.pid())?.uds, out)
-    }
-
-    fn part_set_pta_key(
+    fn part_prop_set_u16(
         &self,
         io: &impl HsmIo,
-        key_id: HsmKeyId,
-        pub_sec1: &[u8],
+        id: PartPropId,
+        idx: u16,
+        value: u16,
     ) -> HsmResult<()> {
-        let part = self.active_part_mut(io.pid())?;
-        if pub_sec1.len() != P384_PUB_SEC1_LEN {
-            return Err(HsmError::InvalidArg);
-        }
-        if part.pta_key_id.is_some() {
-            return Err(HsmError::PtaKeyAlreadySet);
-        }
-        if part.state != PartState::Enabled {
-            return Err(HsmError::InvalidArg);
-        }
-
-        let mut buf = [0u8; P384_PUB_SEC1_LEN];
-        buf.copy_from_slice(pub_sec1);
-        part.pta_key_id = Some(key_id);
-        part.pta_pub_sec1 = Some(buf);
-        Ok(())
+        self.prop_set_u16(io, id, idx, value)
     }
 
-    fn part_set_policy(&self, io: &impl HsmIo, policy: &[u8]) -> HsmResult<()> {
-        let part = self.enabled_part_mut(u8::from(io.pid()))?;
-        if policy.len() != PART_POLICY_LEN {
-            return Err(HsmError::InvalidArg);
-        }
-        if part.part_policy_buf.is_some() {
-            return Err(HsmError::InvalidArg);
-        }
-
-        let mut buf = [0u8; PART_POLICY_LEN];
-        buf.copy_from_slice(policy);
-        part.part_policy_buf = Some(buf);
-        Ok(())
+    fn part_prop_get_u32(&self, io: &impl HsmIo, id: PartPropId, idx: u16) -> HsmResult<u32> {
+        self.prop_get_u32(io, id, idx)
     }
 
-    fn part_set_pota_thumbprint(&self, io: &impl HsmIo, thumb: &[u8]) -> HsmResult<()> {
-        let part = self.enabled_part_mut(u8::from(io.pid()))?;
-        if thumb.len() != POTA_THUMBPRINT_LEN {
-            return Err(HsmError::InvalidArg);
-        }
-        if part.pota_thumbprint.is_some() {
-            return Err(HsmError::InvalidArg);
-        }
-
-        let mut buf = [0u8; POTA_THUMBPRINT_LEN];
-        buf.copy_from_slice(thumb);
-        part.pota_thumbprint = Some(buf);
-        Ok(())
+    fn part_prop_set_u32(
+        &self,
+        io: &impl HsmIo,
+        id: PartPropId,
+        idx: u16,
+        value: u32,
+    ) -> HsmResult<()> {
+        self.prop_set_u32(io, id, idx, value)
     }
 
-    fn part_set_ums_key(&self, io: &impl HsmIo, key_id: HsmKeyId) -> HsmResult<()> {
-        let part = self.active_part_mut(io.pid())?;
-        if part.ums_key_id.is_some() {
-            return Err(HsmError::UmsKeyAlreadySet);
-        }
-        if part.state != PartState::Enabled {
-            return Err(HsmError::InvalidArg);
-        }
-        part.ums_key_id = Some(key_id);
-        Ok(())
+    fn part_prop_get_u64(&self, io: &impl HsmIo, id: PartPropId, idx: u16) -> HsmResult<u64> {
+        self.prop_get_u64(io, id, idx)
     }
 
-    fn part_ums_key_id(&self, io: &impl HsmIo) -> HsmResult<HsmKeyId> {
-        let part = self.active_part(io.pid())?;
-        part.ums_key_id.ok_or(HsmError::UmsKeyNotSet)
+    fn part_prop_set_u64(
+        &self,
+        io: &impl HsmIo,
+        id: PartPropId,
+        idx: u16,
+        value: u64,
+    ) -> HsmResult<()> {
+        self.prop_set_u64(io, id, idx, value)
     }
 
-    fn part_mark_initializing(&self, io: &impl HsmIo) -> HsmResult<()> {
-        let part = self.enabled_part_mut(u8::from(io.pid()))?;
-        if part.pta_key_id.is_none()
-            || part.ums_key_id.is_none()
-            || part.part_policy_buf.is_none()
-            || part.pota_thumbprint.is_none()
-        {
-            return Err(HsmError::InvalidArg);
-        }
-        part.state = PartState::Initializing;
-        Ok(())
+    fn part_prop_get_bool(&self, io: &impl HsmIo, id: PartPropId, idx: u16) -> HsmResult<bool> {
+        self.prop_get_bool(io, id, idx)
     }
 
-    fn part_psk_is_default(&self, io: &impl HsmIo, psk_id: u8) -> HsmResult<bool> {
-        if psk_id > 1 {
-            return Err(HsmError::InvalidPskId);
-        }
-        let part = self.active_part(io.pid())?;
-        // Authoritative byte-compare against the compiled-in default,
-        // not just `Option::is_some()`.  This way the gate cannot be
-        // bypassed by a (malformed/malicious) `ChangePsk` that writes
-        // the public default bytes back into the slot — the slot then
-        // shows up as `Some(default)`, but `is_default` still reports
-        // `true` because the effective PSK is still the public one.
-        let stored: &[u8] = match psk_id {
-            0 => part.psk_co.as_ref().map_or(&DEFAULT_PSK_CO[..], |k| &k[..]),
-            _ => part.psk_cu.as_ref().map_or(&DEFAULT_PSK_CU[..], |k| &k[..]),
-        };
-        let default: &[u8] = match psk_id {
-            0 => &DEFAULT_PSK_CO[..],
-            _ => &DEFAULT_PSK_CU[..],
-        };
-        Ok(stored == default)
+    fn part_prop_set_bool(
+        &self,
+        io: &impl HsmIo,
+        id: PartPropId,
+        idx: u16,
+        value: bool,
+    ) -> HsmResult<()> {
+        self.prop_set_bool(io, id, idx, value)
+    }
+
+    fn part_prop_get_bytes<'a>(
+        &'a self,
+        io: &impl HsmIo,
+        id: PartPropId,
+        idx: u16,
+    ) -> HsmResult<&'a DmaBuf> {
+        self.prop_get_bytes(io, id, idx)
+    }
+
+    fn part_prop_set_bytes(
+        &self,
+        io: &impl HsmIo,
+        id: PartPropId,
+        idx: u16,
+        data: &DmaBuf,
+    ) -> HsmResult<()> {
+        self.prop_set_bytes(io, id, idx, data)
+    }
+
+    fn part_prop_clear(&self, io: &impl HsmIo, id: PartPropId, idx: u16) -> HsmResult<()> {
+        self.prop_clear(io, id, idx)
     }
 }
 
@@ -954,6 +547,59 @@ impl HsmPartitionManager for StdHsmPal {
 // ---------------------------------------------------------------------------
 
 impl StdHsmPal {
+    /// Borrow the `PartitionTable` through the `UnsafeCell`.  Safe
+    /// because the std PAL runs on a single-threaded Embassy executor
+    /// (see the module-level architecture note).
+    #[allow(clippy::mut_from_ref)]
+    #[inline]
+    fn table_mut(&self) -> &mut PartitionTable {
+        unsafe { &mut *self.part_table.get() }
+    }
+
+    #[inline]
+    fn table(&self) -> &PartitionTable {
+        unsafe { &*self.part_table.get() }
+    }
+
+    /// Validate `pid` and return its array index, or `InvalidArg`.
+    #[inline]
+    fn part_idx(pid: HsmPartId) -> HsmResult<usize> {
+        let idx = u8::from(pid) as usize;
+        if idx >= NUM_PARTITIONS {
+            return Err(HsmError::InvalidArg);
+        }
+        Ok(idx)
+    }
+
+    /// Borrow a partition whose state passes `accept`.
+    fn part_if(
+        &self,
+        pid: HsmPartId,
+        accept: impl FnOnce(PartState) -> bool,
+    ) -> HsmResult<&PartitionEntry> {
+        let idx = Self::part_idx(pid)?;
+        let entry = &self.table().entries[idx];
+        if !accept(entry.state) {
+            return Err(HsmError::InvalidArg);
+        }
+        Ok(entry)
+    }
+
+    /// Mutable counterpart to [`Self::part_if`].
+    #[allow(clippy::mut_from_ref)]
+    fn part_if_mut(
+        &self,
+        pid: HsmPartId,
+        accept: impl FnOnce(PartState) -> bool,
+    ) -> HsmResult<&mut PartitionEntry> {
+        let idx = Self::part_idx(pid)?;
+        let entry = &mut self.table_mut().entries[idx];
+        if !accept(entry.state) {
+            return Err(HsmError::InvalidArg);
+        }
+        Ok(entry)
+    }
+
     /// Returns the partition incarnation counter.
     ///
     /// Captured by RAII guards (`StdVaultKeyGuard`, `StdSessionGuard`)
@@ -961,39 +607,21 @@ impl StdHsmPal {
     /// has outlived its partition incarnation and skips rollback to
     /// avoid corrupting a re-allocated partition.
     pub(crate) fn partition_gen(&self, pid: HsmPartId) -> u32 {
-        let table = unsafe { &*self.part_table.get() };
-        let idx = u8::from(pid) as usize;
-        if idx >= NUM_PARTITIONS {
+        let Ok(idx) = Self::part_idx(pid) else {
             return 0;
-        }
-        table.entries[idx].gen
+        };
+        self.table().entries[idx].gen
     }
 
     /// Borrow a partition entry that is not Unallocated.
     pub(crate) fn active_part(&self, pid: HsmPartId) -> HsmResult<&PartitionEntry> {
-        let table = unsafe { &*self.part_table.get() };
-        let idx = u8::from(pid) as usize;
-        if idx >= NUM_PARTITIONS {
-            return Err(HsmError::InvalidArg);
-        }
-        if table.entries[idx].state == PartState::Unallocated {
-            return Err(HsmError::InvalidArg);
-        }
-        Ok(&table.entries[idx])
+        self.part_if(pid, |s| s != PartState::Unallocated)
     }
 
     /// Borrow a partition entry that is not Unallocated (mutable).
     #[allow(clippy::mut_from_ref)]
     pub(crate) fn active_part_mut(&self, pid: HsmPartId) -> HsmResult<&mut PartitionEntry> {
-        let table = unsafe { &mut *self.part_table.get() };
-        let idx = u8::from(pid) as usize;
-        if idx >= NUM_PARTITIONS {
-            return Err(HsmError::InvalidArg);
-        }
-        if table.entries[idx].state == PartState::Unallocated {
-            return Err(HsmError::InvalidArg);
-        }
-        Ok(&mut table.entries[idx])
+        self.part_if_mut(pid, |s| s != PartState::Unallocated)
     }
 
     /// Borrow a partition that is actively serving host traffic.
@@ -1003,112 +631,20 @@ impl StdHsmPal {
     /// caller's incarnation and may legitimately expose per-incarnation
     /// secrets (PSK, UDS).  Stricter than [`Self::active_part`] (which
     /// permits Allocated and Disabled too) so that PSK/UDS reads cannot
-    /// leak across the allocate/enable boundary, and looser than
-    /// [`Self::enabled_part`] so that PartInit handlers running in
-    /// `Initializing` still observe the rotated PSKs and UDS.
+    /// leak across the allocate/enable boundary.
     fn serving_part(&self, pid: HsmPartId) -> HsmResult<&PartitionEntry> {
-        let table = unsafe { &*self.part_table.get() };
-        let idx = u8::from(pid) as usize;
-        if idx >= NUM_PARTITIONS {
-            return Err(HsmError::InvalidArg);
-        }
-        if !matches!(
-            table.entries[idx].state,
-            PartState::Enabled | PartState::Initializing
-        ) {
-            return Err(HsmError::InvalidArg);
-        }
-        Ok(&table.entries[idx])
+        self.part_if(pid, |s| {
+            matches!(s, PartState::Enabled | PartState::Initializing)
+        })
     }
 
     /// Mutable counterpart to [`Self::serving_part`].
     #[allow(clippy::mut_from_ref)]
     fn serving_part_mut(&self, pid: HsmPartId) -> HsmResult<&mut PartitionEntry> {
-        let table = unsafe { &mut *self.part_table.get() };
-        let idx = u8::from(pid) as usize;
-        if idx >= NUM_PARTITIONS {
-            return Err(HsmError::InvalidArg);
-        }
-        if !matches!(
-            table.entries[idx].state,
-            PartState::Enabled | PartState::Initializing
-        ) {
-            return Err(HsmError::InvalidArg);
-        }
-        Ok(&mut table.entries[idx])
+        self.part_if_mut(pid, |s| {
+            matches!(s, PartState::Enabled | PartState::Initializing)
+        })
     }
-
-    /// Borrow a partition that is in Enabled state.
-    fn enabled_part(&self, pid: u8) -> HsmResult<&PartitionEntry> {
-        let table = unsafe { &*self.part_table.get() };
-        let idx = pid as usize;
-        if idx >= NUM_PARTITIONS {
-            return Err(HsmError::InvalidArg);
-        }
-        if table.entries[idx].state != PartState::Enabled {
-            return Err(HsmError::InvalidArg);
-        }
-        Ok(&table.entries[idx])
-    }
-
-    /// Borrow a partition that is in Enabled state (mutable).
-    #[allow(clippy::mut_from_ref)]
-    fn enabled_part_mut(&self, pid: u8) -> HsmResult<&mut PartitionEntry> {
-        let table = unsafe { &mut *self.part_table.get() };
-        let idx = pid as usize;
-        if idx >= NUM_PARTITIONS {
-            return Err(HsmError::InvalidArg);
-        }
-        if table.entries[idx].state != PartState::Enabled {
-            return Err(HsmError::InvalidArg);
-        }
-        Ok(&mut table.entries[idx])
-    }
-}
-
-/// Copy `data` into `out` if provided, return length.
-///
-/// Returns [`HsmError::InvalidArg`] (per the new partition trait
-/// docs) when the caller-supplied buffer is too small.
-fn copy_out(data: &[u8], out: Option<&mut [u8]>) -> HsmResult<usize> {
-    if let Some(buf) = out {
-        if buf.len() < data.len() {
-            return Err(HsmError::InvalidArg);
-        }
-        buf[..data.len()].copy_from_slice(data);
-    }
-    Ok(data.len())
-}
-
-/// Copy a raw P-384 public key (`x ∥ y`, big-endian) into `out`,
-/// reversing each coord so the bytes on the wire are little-endian.
-///
-/// This is the byte-order pivot point between the firmware's internal
-/// big-endian representation (matches OpenSSL conventions and is used
-/// by cert generation and other crypto consumers) and the wire contract
-/// expected by the host-side `post_decode_fn` on
-/// [`DdiDerPublicKey`](azihsm_ddi_types::DdiDerPublicKey), which expects
-/// little-endian raw coords (matching real PKA hardware) and reverses
-/// them back to big-endian before DER-encoding.
-///
-/// `data` must be exactly `P384_PUB_KEY_LEN` bytes; returns
-/// [`HsmError::InvalidArg`] when `out` is too small.
-fn copy_out_pub_key_le(data: &[u8; P384_PUB_KEY_LEN], out: Option<&mut [u8]>) -> HsmResult<usize> {
-    if let Some(buf) = out {
-        if buf.len() < P384_PUB_KEY_LEN {
-            return Err(HsmError::InvalidArg);
-        }
-        let half = P384_PUB_KEY_LEN / 2;
-        let (x_be, y_be) = data.split_at(half);
-        let (x_out, y_out) = buf.split_at_mut(half);
-        for (dst, src) in x_out.iter_mut().zip(x_be.iter().rev()) {
-            *dst = *src;
-        }
-        for (dst, src) in y_out[..half].iter_mut().zip(y_be.iter().rev()) {
-            *dst = *src;
-        }
-    }
-    Ok(P384_PUB_KEY_LEN)
 }
 
 // ---------------------------------------------------------------------------
@@ -1120,7 +656,7 @@ impl StdHsmPal {
     ///
     /// Transitions `Unallocated → Allocated`.
     pub async fn part_alloc_internal(&self, pid: u8, res_mask: u128) -> HsmResult<()> {
-        let table = unsafe { &mut *self.part_table.get() };
+        let table = self.table_mut();
         let idx = pid as usize;
         if idx >= NUM_PARTITIONS {
             return Err(HsmError::InvalidArg);
@@ -1168,7 +704,7 @@ impl StdHsmPal {
             .await;
 
         // Commit or rollback.
-        let table = unsafe { &mut *self.part_table.get() };
+        let table = self.table_mut();
         let entry = &mut table.entries[idx];
         match id_result {
             Ok(id_kid) => {
@@ -1193,7 +729,7 @@ impl StdHsmPal {
     ///
     /// Transitions `Allocated | Disabled → Enabled`.
     pub async fn part_enable_internal(&self, pid: u8) -> HsmResult<()> {
-        let table = unsafe { &mut *self.part_table.get() };
+        let table = self.table_mut();
         let idx = pid as usize;
         if idx >= NUM_PARTITIONS {
             return Err(HsmError::InvalidArg);
@@ -1228,7 +764,7 @@ impl StdHsmPal {
                     &mut id_pub,
                 )
                 .await?;
-            let table = unsafe { &mut *self.part_table.get() };
+            let table = self.table_mut();
             let entry = &mut table.entries[idx];
             entry.id_key_id = Some(id_kid);
             entry.id_pub_key = id_pub;
@@ -1252,7 +788,7 @@ impl StdHsmPal {
             )
             .await?;
 
-        let table = unsafe { &mut *self.part_table.get() };
+        let table = self.table_mut();
         let entry = &mut table.entries[idx];
         entry.establish_cred_key_id = Some(ec_kid);
         entry.establish_cred_pub_key = ec_pub;
@@ -1269,7 +805,7 @@ impl StdHsmPal {
             )
             .await;
 
-        let table = unsafe { &mut *self.part_table.get() };
+        let table = self.table_mut();
         let entry = &mut table.entries[idx];
         match se_result {
             Ok(se_kid) => {
@@ -1310,7 +846,7 @@ impl StdHsmPal {
     ///
     /// Transitions `Enabled → Disabled`.
     pub fn part_disable_internal(&self, pid: u8) -> HsmResult<()> {
-        let table = unsafe { &mut *self.part_table.get() };
+        let table = self.table_mut();
         let idx = pid as usize;
         if idx >= NUM_PARTITIONS {
             return Err(HsmError::InvalidArg);
@@ -1332,7 +868,7 @@ impl StdHsmPal {
     /// Accepts `Allocated | Enabled | Disabled → Unallocated`.
     /// If `Enabled`, implicitly clears internal keys first.
     pub fn part_free_internal(&self, pid: u8) -> HsmResult<()> {
-        let table = unsafe { &mut *self.part_table.get() };
+        let table = self.table_mut();
         let idx = pid as usize;
         if idx >= NUM_PARTITIONS {
             return Err(HsmError::InvalidArg);
@@ -1412,7 +948,7 @@ impl StdHsmPal {
             .map_err(|_| HsmError::EccExportError)?;
 
         // Store raw HSM private-key bytes in vault.
-        let table = unsafe { &mut *self.part_table.get() };
+        let table = self.table_mut();
         let entry = &mut table.entries[pid as usize];
         entry
             .vault
@@ -1430,87 +966,79 @@ impl StdHsmPal {
     /// state are all zeroized together whenever the partition's
     /// enabled lifecycle ends.
     fn clear_enabled_state(entry: &mut PartitionEntry) {
-        if let Some(kid) = entry.establish_cred_key_id.take() {
-            let _ = entry.vault.delete(kid);
+        // Drop a vault-backed key if present and best-effort delete its
+        // backing slot.  Vault errors are ignored: the slot is about
+        // to be overwritten or released wholesale.
+        fn drop_key(vault: &mut KeyVault, kid: &mut Option<HsmKeyId>) {
+            if let Some(k) = kid.take() {
+                let _ = vault.delete(k);
+            }
         }
-        entry.establish_cred_pub_key.fill(0);
 
-        if let Some(kid) = entry.session_enc_key_id.take() {
-            let _ = entry.vault.delete(kid);
+        // Zeroize an `Option<[u8; N]>` payload in place before
+        // dropping the `Some`, so the bytes that live inside the
+        // entry struct are overwritten (not just the discriminant —
+        // `Option<[u8; N]>` has no niche, so payload storage is
+        // stable).
+        fn drop_secret<const N: usize>(slot: &mut Option<[u8; N]>) {
+            if let Some(buf) = slot.as_mut() {
+                buf.fill(0);
+            }
+            *slot = None;
         }
-        entry.session_enc_pub_key.fill(0);
 
-        entry.nonce.fill(0);
-
-        // Take id_key_id BEFORE vault.clear() so part_enable_internal
-        // knows the identity key was wiped and needs to be regenerated.
-        // The cached leaf cert is keyed off the old id_pub_key so it
-        // must also be invalidated.
+        // Vault-backed keys whose ids live in this entry.  `id_key_id`
+        // is taken (rather than vault-deleted) so `part_enable_internal`
+        // knows to regenerate the identity key on the next enable; the
+        // vault itself is cleared wholesale below.
+        drop_key(&mut entry.vault, &mut entry.establish_cred_key_id);
+        drop_key(&mut entry.vault, &mut entry.session_enc_key_id);
+        drop_key(&mut entry.vault, &mut entry.mk_key_id);
+        drop_key(&mut entry.vault, &mut entry.unwrapping_key_id);
+        drop_key(&mut entry.vault, &mut entry.pta_key_id);
+        drop_key(&mut entry.vault, &mut entry.ups_key_id);
         entry.id_key_id = None;
+
+        // Public-key mirrors and other non-secret fixed buffers.
+        entry.establish_cred_pub_key.fill(0);
+        entry.session_enc_pub_key.fill(0);
+        entry.nonce.fill(0);
         entry.leaf_cert[..entry.leaf_cert_len].fill(0);
         entry.leaf_cert_len = 0;
 
+        // Drop the vault and per-partition session table.
         entry.vault.clear();
         entry.session_table = SessionTable::new();
+
+        // Variable-length opaque blobs — zeroize only the valid
+        // prefix to keep `clear_enabled_state` proportional to
+        // touched bytes.
         entry.sealed_bk3[..entry.sealed_bk3_len as usize].fill(0);
         entry.sealed_bk3_len = 0;
+        entry.masked_bk_boot[..entry.masked_bk_boot_len as usize].fill(0);
+        entry.masked_bk_boot_len = 0;
 
         // Boot-key + BK3-incarnation state — mirrors the prior
         // reference firmware's `clear_partition_info` zeroize
         // grouping.
         entry.bk_boot.fill(0);
-        entry.masked_bk_boot[..entry.masked_bk_boot_len as usize].fill(0);
-        entry.masked_bk_boot_len = 0;
         entry.vm_launch_guid.fill(0);
         entry.bk3_initialized = false;
 
-        entry.credential_id.fill(0);
-        entry.credential_pin.fill(0);
+        // Caller-presented secrets and per-session derived material.
+        entry.credential.fill(0);
         entry.credential_set = false;
         entry.bk3_session.fill(0);
         entry.bk3_session_set = false;
-        if let Some(kid) = entry.mk_key_id.take() {
-            let _ = entry.vault.delete(kid);
-        }
-        if let Some(kid) = entry.unwrapping_key_id.take() {
-            let _ = entry.vault.delete(kid);
-        }
 
-        if let Some(kid) = entry.pta_key_id.take() {
-            let _ = entry.vault.delete(kid);
-        }
-        if let Some(kid) = entry.ums_key_id.take() {
-            let _ = entry.vault.delete(kid);
-        }
-        if let Some(pub_sec1) = entry.pta_pub_sec1.as_mut() {
-            pub_sec1.fill(0);
-        }
-        entry.pta_pub_sec1 = None;
-        if let Some(policy) = entry.part_policy_buf.as_mut() {
-            policy.fill(0);
-        }
-        entry.part_policy_buf = None;
-        if let Some(thumb) = entry.pota_thumbprint.as_mut() {
-            thumb.fill(0);
-        }
-        entry.pota_thumbprint = None;
+        // Provisioning material (write-once fields bound by PartInit).
+        drop_secret(&mut entry.pta_pub_sec1);
+        drop_secret(&mut entry.part_policy_buf);
+        drop_secret(&mut entry.pota_thumbprint);
 
-        // Wipe rotated PSK material in place before dropping the
-        // `Option`.  Using `as_mut().fill(0)` ensures the bytes that
-        // live inside `entry`'s `Option<[u8; PSK_LEN]>` payload are
-        // overwritten on the struct itself; the subsequent
-        // `= None` write only changes the discriminant and leaves
-        // those zeros in place (an `Option<[u8; N]>` has no niche so
-        // the payload bytes are stable storage, not a reused
-        // tagged-union slot).
-        if let Some(psk) = entry.psk_co.as_mut() {
-            psk.fill(0);
-        }
-        entry.psk_co = None;
-        if let Some(psk) = entry.psk_cu.as_mut() {
-            psk.fill(0);
-        }
-        entry.psk_cu = None;
+        // Rotated PSK material.
+        drop_secret(&mut entry.psk_co);
+        drop_secret(&mut entry.psk_cu);
     }
 }
 
@@ -1528,4 +1056,1132 @@ fn derive_sim_uds(pid: u8) -> [u8; UDS_LEN] {
         *b = pid ^ 0x55 ^ (i as u8).wrapping_mul(0x3d);
     }
     uds
+}
+
+// ═════════════════════════════════════════════════════════════════════════
+// Property-API routing layer (formerly part_prop.rs)
+// ═════════════════════════════════════════════════════════════════════════
+
+// ─── Validation helpers ──────────────────────────────────────────────────
+
+/// Resolve the meta for an id, validate idx, and validate that the
+/// expected wire-kind matches the one declared by the property.
+fn validate_meta(id: PartPropId, idx: u16, expected: ExpectedKind) -> HsmResult<PartPropMeta> {
+    let meta = id.meta().ok_or(HsmError::InvalidArg)?;
+    if idx >= meta.cardinality {
+        return Err(HsmError::InvalidArg);
+    }
+    if !expected.matches(meta.kind) {
+        return Err(HsmError::InvalidArg);
+    }
+    Ok(meta)
+}
+
+fn validate_set(
+    id: PartPropId,
+    idx: u16,
+    expected: ExpectedKind,
+    bytes_len: Option<usize>,
+) -> HsmResult<PartPropMeta> {
+    let meta = validate_meta(id, idx, expected)?;
+    if meta.access != PartPropAccess::Rw {
+        return Err(HsmError::InvalidArg);
+    }
+    if let Some(n) = bytes_len {
+        match meta.kind {
+            PartPropKind::FixedBytes { len } if n == usize::from(len) => {}
+            PartPropKind::VarBytes { max } if n <= usize::from(max) => {}
+            _ => return Err(HsmError::InvalidArg),
+        }
+    }
+    Ok(meta)
+}
+
+fn validate_clear(id: PartPropId, idx: u16) -> HsmResult<PartPropMeta> {
+    let meta = id.meta().ok_or(HsmError::InvalidArg)?;
+    if idx >= meta.cardinality {
+        return Err(HsmError::InvalidArg);
+    }
+    if meta.access != PartPropAccess::Rw {
+        return Err(HsmError::InvalidArg);
+    }
+    if meta.default != PartPropDefault::AbsentUntilSet {
+        return Err(HsmError::InvalidArg);
+    }
+    Ok(meta)
+}
+
+/// Caller-side expectation of the wire-kind for a typed accessor.
+#[derive(Clone, Copy)]
+enum ExpectedKind {
+    U8,
+    U16,
+    U32,
+    U64,
+    Bool,
+    Bytes,
+}
+
+impl ExpectedKind {
+    fn matches(self, kind: PartPropKind) -> bool {
+        matches!(
+            (self, kind),
+            (ExpectedKind::U8, PartPropKind::U8)
+                | (ExpectedKind::U16, PartPropKind::U16)
+                | (ExpectedKind::U32, PartPropKind::U32)
+                | (ExpectedKind::U64, PartPropKind::U64)
+                | (ExpectedKind::Bool, PartPropKind::Bool)
+                | (
+                    ExpectedKind::Bytes,
+                    PartPropKind::FixedBytes { .. } | PartPropKind::VarBytes { .. }
+                )
+        )
+    }
+}
+
+// ─── std PAL constants mirrored by RO props ──────────────────────────────
+
+/// `FW_SEED` returned via [`PartPropId::FW_SEED`].  Length matches
+/// the property's `FixedBytes { len: 48 }` (the SHA-384-sized seed
+/// used by std-PAL masking-key derivation).
+const STD_FW_SEED48: [u8; 48] = [0x42u8; 48];
+
+// ─── DmaBuf branding ─────────────────────────────────────────────────────
+
+/// Brand a borrowed byte slice from the partition table as a
+/// `&DmaBuf`.  Safe on the std PAL because the partition table is
+/// host-heap-resident; no real DMA constraints apply.
+#[inline(always)]
+fn dma(buf: &[u8]) -> &DmaBuf {
+    // SAFETY: std PAL has no DMA-region constraint.
+    unsafe { DmaBuf::from_raw(buf) }
+}
+
+/// Resolve a row of an indexed PAL-global seed table
+/// ([`PartPropId::MFGR_SEED`] / [`PartPropId::DEV_OWNER_SEED`]).
+///
+/// The std PAL emulator provisions only row 0 of each table; other
+/// `idx` values (still within `0..cardinality`) return
+/// [`HsmError::PartPropNotFound`] to signal "no row provisioned for
+/// this PAL".
+fn std_indexed_seed_row(id: PartPropId, idx: u16) -> HsmResult<&'static [u8]> {
+    match (id, idx) {
+        (PartPropId::MFGR_SEED, 0) => Ok(&STD_MFGR_SEED_ROW0),
+        (PartPropId::DEV_OWNER_SEED, 0) => Ok(&STD_DEV_OWNER_SEED_ROW0),
+        (PartPropId::MFGR_SEED | PartPropId::DEV_OWNER_SEED, _) => Err(HsmError::PartPropNotFound),
+        _ => Err(HsmError::InternalError),
+    }
+}
+
+// ─── PartitionEntry property dispatch ────────────────────────────────────
+
+impl PartitionEntry {
+    /// Apply a caller-driven STATE transition through the property API.
+    ///
+    /// The internal device-command lifecycle (`part_alloc_internal`,
+    /// `part_enable_internal`, `part_disable_internal`,
+    /// `part_free_internal`) drives all other transitions; the prop
+    /// API only exposes the single caller-facing one:
+    /// `Enabled → Initializing`, which additionally requires the four
+    /// write-once provisioning fields (PTA key, UMS key, policy,
+    /// POTA thumbprint) to be present.  Any other source/target pair
+    /// is rejected with [`HsmError::InvalidArg`].
+    fn transition_state_via_prop(&mut self, target: PartState) -> HsmResult<()> {
+        match (self.state, target) {
+            (PartState::Enabled, PartState::Initializing) => {
+                if self.pta_key_id.is_none()
+                    || self.ups_key_id.is_none()
+                    || self.part_policy_buf.is_none()
+                    || self.pota_thumbprint.is_none()
+                {
+                    return Err(HsmError::InvalidArg);
+                }
+                self.state = PartState::Initializing;
+                Ok(())
+            }
+            // No-op writes (same state) are accepted as a convenience.
+            (cur, tgt) if cur == tgt => Ok(()),
+            // All other transitions are PAL-internal — reject from the
+            // prop API.
+            _ => Err(HsmError::InvalidArg),
+        }
+    }
+
+    /// Translate `id` to the matching scalar field on this entry.
+    /// All values are widened to `u32` for a uniform return type;
+    /// the trait wrapper narrows back to the requested kind.
+    fn prop_get_scalar(&self, id: PartPropId) -> HsmResult<u32> {
+        match id {
+            PartPropId::STATE => Ok(u32::from(self.state as u8)),
+            PartPropId::GEN => Ok(self.gen),
+            PartPropId::RES_COUNT => Ok(self.res_mask.count_ones()),
+            PartPropId::BK3_INITIALIZED => Ok(u32::from(self.bk3_initialized)),
+            PartPropId::BKS2_ID => Ok(0),
+            PartPropId::ID_KEY_ID => key_id_to_u32(self.id_key_id),
+            PartPropId::MK_KEY_ID => key_id_to_u32(self.mk_key_id),
+            PartPropId::UPS_KEY_ID => key_id_to_u32(self.ups_key_id),
+            PartPropId::PTA_KEY_ID => key_id_to_u32(self.pta_key_id),
+            PartPropId::RSA_UNWRAPPING_KEY_ID => key_id_to_u32(self.unwrapping_key_id),
+            PartPropId::SESSION_ENC_KEY_ID => key_id_to_u32(self.session_enc_key_id),
+            PartPropId::ESTABLISH_CRED_KEY_ID => key_id_to_u32(self.establish_cred_key_id),
+            _ => Err(HsmError::InvalidArg),
+        }
+    }
+
+    /// Write a scalar property; `value` is in the property's native
+    /// width, already validated by the trait wrapper.
+    fn prop_set_scalar(&mut self, id: PartPropId, value: u32) -> HsmResult<()> {
+        match id {
+            PartPropId::STATE => {
+                let target = PartState::from_u8(value as u8).ok_or(HsmError::InvalidArg)?;
+                self.transition_state_via_prop(target)
+            }
+            PartPropId::MK_KEY_ID => {
+                self.mk_key_id = Some(HsmKeyId::from(value as u16));
+                Ok(())
+            }
+            PartPropId::UPS_KEY_ID => {
+                if self.ups_key_id.is_some() {
+                    return Err(HsmError::UpsKeyAlreadySet);
+                }
+                self.ups_key_id = Some(HsmKeyId::from(value as u16));
+                Ok(())
+            }
+            PartPropId::PTA_KEY_ID => {
+                if self.pta_key_id.is_some() {
+                    return Err(HsmError::PtaKeyAlreadySet);
+                }
+                self.pta_key_id = Some(HsmKeyId::from(value as u16));
+                Ok(())
+            }
+            PartPropId::SESSION_ENC_KEY_ID => {
+                self.session_enc_key_id = Some(HsmKeyId::from(value as u16));
+                Ok(())
+            }
+            PartPropId::ESTABLISH_CRED_KEY_ID => {
+                self.establish_cred_key_id = Some(HsmKeyId::from(value as u16));
+                Ok(())
+            }
+            PartPropId::BK3_INITIALIZED => {
+                // One-shot gate: false→true is the only legal
+                // transition.  Re-asserting true returns
+                // Bk3AlreadyInitialized; clearing back to false is
+                // rejected (reset happens PAL-internally on free /
+                // NSSR).
+                let want = value != 0;
+                if !want {
+                    return Err(HsmError::InvalidArg);
+                }
+                if self.bk3_initialized {
+                    return Err(HsmError::Bk3AlreadyInitialized);
+                }
+                self.bk3_initialized = true;
+                Ok(())
+            }
+            // GEN/SVN/RES_COUNT/ID_KEY_ID/RSA_UNWRAPPING_KEY_ID are Ro
+            // — rejected by validate_set.  Non-scalar ids — rejected
+            // by the kind check.
+            _ => Err(HsmError::InvalidArg),
+        }
+    }
+
+    /// Read a u64-scalar property.
+    fn prop_get_scalar_u64(&self, id: PartPropId) -> HsmResult<u64> {
+        match id {
+            PartPropId::SVN => Ok(STD_SVN),
+            _ => Err(HsmError::InvalidArg),
+        }
+    }
+
+    /// Write a u64-scalar property.
+    fn prop_set_scalar_u64(&mut self, _id: PartPropId, _value: u64) -> HsmResult<()> {
+        // SVN is Ro — rejected by validate_set.
+        Err(HsmError::InvalidArg)
+    }
+
+    /// Borrow the bytes of a present byte property, or
+    /// `Err(PartPropNotFound)` if the slot is absent.
+    fn prop_get_bytes(&self, id: PartPropId) -> HsmResult<&[u8]> {
+        match id {
+            PartPropId::ID => Ok(&self.id),
+            PartPropId::UDS => Ok(&self.uds),
+            PartPropId::FW_SEED => Ok(&STD_FW_SEED48),
+            PartPropId::PSK_CO => Ok(self
+                .psk_co
+                .as_ref()
+                .map(|a| a.as_slice())
+                .unwrap_or(DEFAULT_PSK_CO.as_slice())),
+            PartPropId::PSK_CU => Ok(self
+                .psk_cu
+                .as_ref()
+                .map(|a| a.as_slice())
+                .unwrap_or(DEFAULT_PSK_CU.as_slice())),
+            PartPropId::CREDENTIAL => {
+                if !self.credential_set {
+                    return Err(HsmError::PartPropNotFound);
+                }
+                // CREDENTIAL is 32 B: id (16) ‖ pin (16) — returned as
+                // the full blob.  Consumers in `fw/core/lib` (e.g.
+                // `part_verify_credential`) compare both halves in
+                // constant time.
+                Ok(&self.credential)
+            }
+            PartPropId::NONCE => Ok(&self.nonce),
+            PartPropId::SEALED_BK3 => {
+                let n = self.sealed_bk3_len as usize;
+                if n == 0 {
+                    return Err(HsmError::PartPropNotFound);
+                }
+                Ok(&self.sealed_bk3[..n])
+            }
+            PartPropId::MASKED_BK_BOOT => {
+                let n = self.masked_bk_boot_len as usize;
+                if n == 0 {
+                    return Err(HsmError::PartPropNotFound);
+                }
+                Ok(&self.masked_bk_boot[..n])
+            }
+            PartPropId::BK_BOOT => Ok(&self.bk_boot),
+            PartPropId::VM_LAUNCH_GUID => Ok(&self.vm_launch_guid),
+            PartPropId::ID_PUB_KEY => Ok(&self.id_pub_key),
+            PartPropId::SESSION_ENC_PUB_KEY => Ok(&self.session_enc_pub_key),
+            PartPropId::ESTABLISH_CRED_PUB_KEY => Ok(&self.establish_cred_pub_key),
+            PartPropId::PTA_PUB_SEC1 => self
+                .pta_pub_sec1
+                .as_ref()
+                .map(|a| a.as_slice())
+                .ok_or(HsmError::PartPropNotFound),
+            PartPropId::BK3_SESSION => {
+                if !self.bk3_session_set {
+                    return Err(HsmError::PartPropNotFound);
+                }
+                Ok(&self.bk3_session)
+            }
+            PartPropId::POLICY => self
+                .part_policy_buf
+                .as_ref()
+                .map(|a| a.as_slice())
+                .ok_or(HsmError::PartPropNotFound),
+            PartPropId::POTA_THUMBPRINT => self
+                .pota_thumbprint
+                .as_ref()
+                .map(|a| a.as_slice())
+                .ok_or(HsmError::PartPropNotFound),
+            _ => Err(HsmError::InvalidArg),
+        }
+    }
+
+    /// Write a byte property; `data` length already validated.
+    fn prop_set_bytes(&mut self, id: PartPropId, data: &[u8]) -> HsmResult<()> {
+        match id {
+            PartPropId::PSK_CO => {
+                if let Some(prev) = self.psk_co.as_mut() {
+                    prev.fill(0);
+                }
+                let mut buf = [0u8; PSK_LEN];
+                buf.copy_from_slice(data);
+                self.psk_co = Some(buf);
+                Ok(())
+            }
+            PartPropId::PSK_CU => {
+                if let Some(prev) = self.psk_cu.as_mut() {
+                    prev.fill(0);
+                }
+                let mut buf = [0u8; PSK_LEN];
+                buf.copy_from_slice(data);
+                self.psk_cu = Some(buf);
+                Ok(())
+            }
+            PartPropId::CREDENTIAL => {
+                // Write-once per credential lifecycle: production
+                // re-set is rejected with `VaultAppLimitReached`,
+                // matching the reference firmware's
+                // `verify_cred_is_not_set` invariant.  Internal reset
+                // (partition free / NSSR) goes through `prop_clear` /
+                // direct field zeroing, not this path.
+                if self.credential_set {
+                    return Err(HsmError::VaultAppLimitReached);
+                }
+                // Reject all-zero id or pin halves — that value is the
+                // sentinel `verify_user_cred_is_set` uses for "unset",
+                // so accepting it would corrupt the lifecycle.
+                if data[..16] == [0u8; 16] || data[16..32] == [0u8; 16] {
+                    return Err(HsmError::InvalidAppCredentials);
+                }
+                self.credential.fill(0);
+                self.credential.copy_from_slice(&data[..32]);
+                self.credential_set = true;
+                Ok(())
+            }
+            PartPropId::SEALED_BK3 => {
+                self.sealed_bk3.fill(0);
+                self.sealed_bk3[..data.len()].copy_from_slice(data);
+                self.sealed_bk3_len = data.len() as u32;
+                Ok(())
+            }
+            PartPropId::MASKED_BK_BOOT => {
+                self.masked_bk_boot.fill(0);
+                self.masked_bk_boot[..data.len()].copy_from_slice(data);
+                self.masked_bk_boot_len = data.len() as u32;
+                Ok(())
+            }
+            PartPropId::POLICY => {
+                if self.part_policy_buf.is_some() {
+                    return Err(HsmError::InvalidArg);
+                }
+                let mut buf = [0u8; PART_POLICY_LEN];
+                buf.copy_from_slice(data);
+                self.part_policy_buf = Some(buf);
+                Ok(())
+            }
+            PartPropId::POTA_THUMBPRINT => {
+                if self.pota_thumbprint.is_some() {
+                    return Err(HsmError::InvalidArg);
+                }
+                let mut buf = [0u8; 48];
+                buf.copy_from_slice(data);
+                self.pota_thumbprint = Some(buf);
+                Ok(())
+            }
+            PartPropId::PTA_PUB_SEC1 => {
+                if self.pta_pub_sec1.is_some() {
+                    return Err(HsmError::InvalidArg);
+                }
+                let mut buf = [0u8; P384_PUB_SEC1_LEN];
+                buf.copy_from_slice(data);
+                self.pta_pub_sec1 = Some(buf);
+                Ok(())
+            }
+            PartPropId::BK3_SESSION => {
+                self.bk3_session.fill(0);
+                self.bk3_session.copy_from_slice(data);
+                self.bk3_session_set = true;
+                Ok(())
+            }
+            PartPropId::NONCE => {
+                self.nonce.copy_from_slice(data);
+                Ok(())
+            }
+            // ID/UDS/FW_SEED/BK_BOOT/VM_LAUNCH_GUID are Ro —
+            // rejected by validate_set.  Others are non-byte kinds.
+            _ => Err(HsmError::InvalidArg),
+        }
+    }
+
+    /// Reset a property to its absent state.  Only `AbsentUntilSet`
+    /// props reach here (enforced by validate_clear).
+    fn prop_clear(&mut self, id: PartPropId) -> HsmResult<()> {
+        match id {
+            // Scalar Rw + Abs.
+            PartPropId::MK_KEY_ID => {
+                self.mk_key_id = None;
+                Ok(())
+            }
+            PartPropId::UPS_KEY_ID => {
+                self.ups_key_id = None;
+                Ok(())
+            }
+            PartPropId::PTA_KEY_ID => {
+                self.pta_key_id = None;
+                Ok(())
+            }
+            PartPropId::SESSION_ENC_KEY_ID => {
+                self.session_enc_key_id = None;
+                Ok(())
+            }
+            PartPropId::ESTABLISH_CRED_KEY_ID => {
+                self.establish_cred_key_id = None;
+                Ok(())
+            }
+            // Byte Rw + Abs.
+            PartPropId::PSK_CO => {
+                if let Some(prev) = self.psk_co.as_mut() {
+                    prev.fill(0);
+                }
+                self.psk_co = None;
+                Ok(())
+            }
+            PartPropId::PSK_CU => {
+                if let Some(prev) = self.psk_cu.as_mut() {
+                    prev.fill(0);
+                }
+                self.psk_cu = None;
+                Ok(())
+            }
+            PartPropId::CREDENTIAL => {
+                self.credential.fill(0);
+                self.credential_set = false;
+                Ok(())
+            }
+            PartPropId::SEALED_BK3 => {
+                self.sealed_bk3.fill(0);
+                self.sealed_bk3_len = 0;
+                Ok(())
+            }
+            PartPropId::MASKED_BK_BOOT => {
+                self.masked_bk_boot.fill(0);
+                self.masked_bk_boot_len = 0;
+                Ok(())
+            }
+            PartPropId::POLICY => {
+                self.part_policy_buf = None;
+                Ok(())
+            }
+            PartPropId::POTA_THUMBPRINT => {
+                self.pota_thumbprint = None;
+                Ok(())
+            }
+            PartPropId::PTA_PUB_SEC1 => {
+                self.pta_pub_sec1 = None;
+                Ok(())
+            }
+            PartPropId::BK3_SESSION => {
+                self.bk3_session.fill(0);
+                self.bk3_session_set = false;
+                Ok(())
+            }
+            _ => Err(HsmError::InvalidArg),
+        }
+    }
+}
+
+fn key_id_to_u32(opt: Option<HsmKeyId>) -> HsmResult<u32> {
+    opt.map(|k| u32::from(u16::from(k)))
+        .ok_or(HsmError::PartPropNotFound)
+}
+
+// ─── StdHsmPal inherent property impls ───────────────────────────────────
+
+impl StdHsmPal {
+    /// Borrow `&PartitionEntry` for the calling partition with the
+    /// lifecycle gate appropriate for reading the property.
+    ///
+    /// - STATE: any state (including Unallocated) — direct array access.
+    /// - sensitive: Enabled | Initializing (via `serving_part`).
+    /// - other:    Allocated | Initializing | Enabled | Disabled
+    ///   (via `active_part`).
+    fn prop_borrow_get(
+        &self,
+        io: &impl HsmIo,
+        id: PartPropId,
+        meta: &PartPropMeta,
+    ) -> HsmResult<&PartitionEntry> {
+        if id == PartPropId::STATE {
+            let idx = Self::part_idx(io.pid())?;
+            return Ok(&self.table().entries[idx]);
+        }
+        if meta.sensitive {
+            self.serving_part(io.pid())
+        } else {
+            self.active_part(io.pid())
+        }
+    }
+
+    /// Mutable counterpart of [`Self::prop_borrow_get`].  Writes use
+    /// the same gating but always need at least Allocated.
+    #[allow(clippy::mut_from_ref)]
+    fn prop_borrow_set(
+        &self,
+        io: &impl HsmIo,
+        id: PartPropId,
+        meta: &PartPropMeta,
+    ) -> HsmResult<&mut PartitionEntry> {
+        if id == PartPropId::STATE {
+            let idx = Self::part_idx(io.pid())?;
+            return Ok(&mut self.table_mut().entries[idx]);
+        }
+        if meta.sensitive {
+            self.serving_part_mut(io.pid())
+        } else {
+            self.active_part_mut(io.pid())
+        }
+    }
+
+    pub(crate) fn prop_get_u8(&self, io: &impl HsmIo, id: PartPropId, idx: u16) -> HsmResult<u8> {
+        let meta = validate_meta(id, idx, ExpectedKind::U8)?;
+        let entry = self.prop_borrow_get(io, id, &meta)?;
+        Ok(entry.prop_get_scalar(id)? as u8)
+    }
+
+    pub(crate) fn prop_set_u8(
+        &self,
+        io: &impl HsmIo,
+        id: PartPropId,
+        idx: u16,
+        value: u8,
+    ) -> HsmResult<()> {
+        let meta = validate_set(id, idx, ExpectedKind::U8, None)?;
+        let entry = self.prop_borrow_set(io, id, &meta)?;
+        entry.prop_set_scalar(id, u32::from(value))
+    }
+
+    pub(crate) fn prop_get_u16(&self, io: &impl HsmIo, id: PartPropId, idx: u16) -> HsmResult<u16> {
+        let meta = validate_meta(id, idx, ExpectedKind::U16)?;
+        let entry = self.prop_borrow_get(io, id, &meta)?;
+        Ok(entry.prop_get_scalar(id)? as u16)
+    }
+
+    pub(crate) fn prop_set_u16(
+        &self,
+        io: &impl HsmIo,
+        id: PartPropId,
+        idx: u16,
+        value: u16,
+    ) -> HsmResult<()> {
+        let meta = validate_set(id, idx, ExpectedKind::U16, None)?;
+        let entry = self.prop_borrow_set(io, id, &meta)?;
+        entry.prop_set_scalar(id, u32::from(value))
+    }
+
+    pub(crate) fn prop_get_u32(&self, io: &impl HsmIo, id: PartPropId, idx: u16) -> HsmResult<u32> {
+        let meta = validate_meta(id, idx, ExpectedKind::U32)?;
+        let entry = self.prop_borrow_get(io, id, &meta)?;
+        entry.prop_get_scalar(id)
+    }
+
+    pub(crate) fn prop_set_u32(
+        &self,
+        io: &impl HsmIo,
+        id: PartPropId,
+        idx: u16,
+        value: u32,
+    ) -> HsmResult<()> {
+        let meta = validate_set(id, idx, ExpectedKind::U32, None)?;
+        let entry = self.prop_borrow_set(io, id, &meta)?;
+        entry.prop_set_scalar(id, value)
+    }
+
+    pub(crate) fn prop_get_u64(&self, io: &impl HsmIo, id: PartPropId, idx: u16) -> HsmResult<u64> {
+        let meta = validate_meta(id, idx, ExpectedKind::U64)?;
+        let entry = self.prop_borrow_get(io, id, &meta)?;
+        entry.prop_get_scalar_u64(id)
+    }
+
+    pub(crate) fn prop_set_u64(
+        &self,
+        io: &impl HsmIo,
+        id: PartPropId,
+        idx: u16,
+        value: u64,
+    ) -> HsmResult<()> {
+        let meta = validate_set(id, idx, ExpectedKind::U64, None)?;
+        let entry = self.prop_borrow_set(io, id, &meta)?;
+        entry.prop_set_scalar_u64(id, value)
+    }
+
+    pub(crate) fn prop_get_bool(
+        &self,
+        io: &impl HsmIo,
+        id: PartPropId,
+        idx: u16,
+    ) -> HsmResult<bool> {
+        let meta = validate_meta(id, idx, ExpectedKind::Bool)?;
+        let entry = self.prop_borrow_get(io, id, &meta)?;
+        Ok(entry.prop_get_scalar(id)? != 0)
+    }
+
+    pub(crate) fn prop_set_bool(
+        &self,
+        io: &impl HsmIo,
+        id: PartPropId,
+        idx: u16,
+        value: bool,
+    ) -> HsmResult<()> {
+        let meta = validate_set(id, idx, ExpectedKind::Bool, None)?;
+        let entry = self.prop_borrow_set(io, id, &meta)?;
+        entry.prop_set_scalar(id, u32::from(value))
+    }
+
+    pub(crate) fn prop_get_bytes<'a>(
+        &'a self,
+        io: &impl HsmIo,
+        id: PartPropId,
+        idx: u16,
+    ) -> HsmResult<&'a DmaBuf> {
+        let meta = validate_meta(id, idx, ExpectedKind::Bytes)?;
+        // Sensitive PAL-global indexed seeds (MFGR_SEED / DEV_OWNER_SEED)
+        // are not held per-partition: gate via the standard
+        // `prop_borrow_get` (so the sensitive-prop serving-partition
+        // check still runs) and then dispatch to the global row table.
+        if matches!(id, PartPropId::MFGR_SEED | PartPropId::DEV_OWNER_SEED) {
+            let _ = self.prop_borrow_get(io, id, &meta)?;
+            let bytes = std_indexed_seed_row(id, idx)?;
+            return Ok(dma(bytes));
+        }
+        let entry = self.prop_borrow_get(io, id, &meta)?;
+        let bytes = entry.prop_get_bytes(id)?;
+        if let PartPropKind::FixedBytes { len } = meta.kind {
+            if bytes.len() != usize::from(len) {
+                return Err(HsmError::InternalError);
+            }
+        }
+        Ok(dma(bytes))
+    }
+
+    pub(crate) fn prop_set_bytes(
+        &self,
+        io: &impl HsmIo,
+        id: PartPropId,
+        idx: u16,
+        data: &DmaBuf,
+    ) -> HsmResult<()> {
+        let meta = validate_set(id, idx, ExpectedKind::Bytes, Some(data.len()))?;
+        let entry = self.prop_borrow_set(io, id, &meta)?;
+        entry.prop_set_bytes(id, data)
+    }
+
+    pub(crate) fn prop_clear(&self, io: &impl HsmIo, id: PartPropId, idx: u16) -> HsmResult<()> {
+        let meta = validate_clear(id, idx)?;
+        let entry = self.prop_borrow_set(io, id, &meta)?;
+        entry.prop_clear(id)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn fresh_entry() -> PartitionEntry {
+        PartitionEntry::default()
+    }
+
+    #[test]
+    fn validate_meta_rejects_unknown_id() {
+        let bad = PartPropId::from(0xFFFFu16);
+        assert!(matches!(
+            validate_meta(bad, 0, ExpectedKind::U8),
+            Err(HsmError::InvalidArg)
+        ));
+    }
+
+    #[test]
+    fn validate_meta_rejects_idx_out_of_range() {
+        assert!(matches!(
+            validate_meta(PartPropId::STATE, 1, ExpectedKind::U8),
+            Err(HsmError::InvalidArg)
+        ));
+        // Indexed seed props have cardinality 64; idx == 64 is OOB.
+        assert!(matches!(
+            validate_meta(PartPropId::MFGR_SEED, 64, ExpectedKind::Bytes),
+            Err(HsmError::InvalidArg)
+        ));
+        assert!(matches!(
+            validate_meta(PartPropId::DEV_OWNER_SEED, 64, ExpectedKind::Bytes),
+            Err(HsmError::InvalidArg)
+        ));
+    }
+
+    #[test]
+    fn indexed_seed_row0_returns_provisioned_bytes() {
+        // Row 0 is the only provisioned row in the std PAL.
+        let row = std_indexed_seed_row(PartPropId::MFGR_SEED, 0).unwrap();
+        assert_eq!(row, &STD_MFGR_SEED_ROW0[..]);
+        let row = std_indexed_seed_row(PartPropId::DEV_OWNER_SEED, 0).unwrap();
+        assert_eq!(row, &STD_DEV_OWNER_SEED_ROW0[..]);
+    }
+
+    #[test]
+    fn indexed_seed_unprovisioned_rows_return_not_found() {
+        for idx in [1u16, 5, 63] {
+            assert!(matches!(
+                std_indexed_seed_row(PartPropId::MFGR_SEED, idx),
+                Err(HsmError::PartPropNotFound)
+            ));
+            assert!(matches!(
+                std_indexed_seed_row(PartPropId::DEV_OWNER_SEED, idx),
+                Err(HsmError::PartPropNotFound)
+            ));
+        }
+    }
+
+    #[test]
+    fn validate_meta_rejects_kind_mismatch() {
+        // STATE is U8; asking via U32 must fail.
+        assert!(matches!(
+            validate_meta(PartPropId::STATE, 0, ExpectedKind::U32),
+            Err(HsmError::InvalidArg)
+        ));
+    }
+
+    #[test]
+    fn validate_set_rejects_ro_props() {
+        // GEN is Ro.
+        assert!(matches!(
+            validate_set(PartPropId::GEN, 0, ExpectedKind::U32, None),
+            Err(HsmError::InvalidArg)
+        ));
+    }
+
+    #[test]
+    fn validate_set_rejects_bad_bytes_len() {
+        // POLICY is FixedBytes{PART_POLICY_LEN}; wrong len rejected.
+        assert!(matches!(
+            validate_set(
+                PartPropId::POLICY,
+                0,
+                ExpectedKind::Bytes,
+                Some(PART_POLICY_LEN + 1)
+            ),
+            Err(HsmError::InvalidArg)
+        ));
+        // SEALED_BK3 is VarBytes{SEALED_BK3_MAX_LEN}; over max rejected.
+        assert!(matches!(
+            validate_set(
+                PartPropId::SEALED_BK3,
+                0,
+                ExpectedKind::Bytes,
+                Some(usize::from(SEALED_BK3_MAX_LEN) + 1)
+            ),
+            Err(HsmError::InvalidArg)
+        ));
+        // SEALED_BK3 accepts <= max (including zero).
+        assert!(validate_set(PartPropId::SEALED_BK3, 0, ExpectedKind::Bytes, Some(0)).is_ok());
+    }
+
+    #[test]
+    fn validate_clear_rejects_required_present() {
+        // NONCE is Required + Ro.
+        assert!(matches!(
+            validate_clear(PartPropId::NONCE, 0),
+            Err(HsmError::InvalidArg)
+        ));
+        // PSK_CO is Required + Rw; clear still rejected.
+        assert!(matches!(
+            validate_clear(PartPropId::PSK_CO, 0),
+            Err(HsmError::InvalidArg)
+        ));
+    }
+
+    #[test]
+    fn scalar_round_trip_mk_key_id() {
+        let mut e = fresh_entry();
+        // Absent until set.
+        assert!(matches!(
+            e.prop_get_scalar(PartPropId::MK_KEY_ID),
+            Err(HsmError::PartPropNotFound)
+        ));
+        e.prop_set_scalar(PartPropId::MK_KEY_ID, 0x4242).unwrap();
+        assert_eq!(e.prop_get_scalar(PartPropId::MK_KEY_ID).unwrap(), 0x4242u32);
+        e.prop_clear(PartPropId::MK_KEY_ID).unwrap();
+        assert!(matches!(
+            e.prop_get_scalar(PartPropId::MK_KEY_ID),
+            Err(HsmError::PartPropNotFound)
+        ));
+    }
+
+    #[test]
+    fn scalar_state_round_trip() {
+        let mut e = fresh_entry();
+        assert_eq!(e.prop_get_scalar(PartPropId::STATE).unwrap(), 0); // Unallocated
+                                                                      // No-op writes (same → same) are accepted.
+        e.prop_set_scalar(PartPropId::STATE, PartState::Unallocated as u32)
+            .unwrap();
+        // Invalid state byte rejected.
+        assert!(matches!(
+            e.prop_set_scalar(PartPropId::STATE, 250),
+            Err(HsmError::InvalidArg)
+        ));
+        // Caller-facing transition Unallocated → Enabled is rejected
+        // (must go through PAL-internal lifecycle methods).
+        assert!(matches!(
+            e.prop_set_scalar(PartPropId::STATE, PartState::Enabled as u32),
+            Err(HsmError::InvalidArg)
+        ));
+    }
+
+    #[test]
+    fn scalar_state_enabled_to_initializing_requires_provisioning_fields() {
+        let mut e = fresh_entry();
+        e.state = PartState::Enabled;
+        // Missing all four write-once fields → reject.
+        assert!(matches!(
+            e.prop_set_scalar(PartPropId::STATE, PartState::Initializing as u32),
+            Err(HsmError::InvalidArg)
+        ));
+        // Set the four required fields then transition.
+        e.pta_key_id = Some(HsmKeyId::from(1u16));
+        e.ups_key_id = Some(HsmKeyId::from(2u16));
+        e.part_policy_buf = Some([0u8; PART_POLICY_LEN]);
+        e.pota_thumbprint = Some([0u8; 48]);
+        e.prop_set_scalar(PartPropId::STATE, PartState::Initializing as u32)
+            .unwrap();
+        assert_eq!(
+            e.prop_get_scalar(PartPropId::STATE).unwrap(),
+            PartState::Initializing as u32
+        );
+    }
+
+    #[test]
+    fn scalar_state_other_transitions_rejected_via_prop() {
+        let mut e = fresh_entry();
+        e.state = PartState::Enabled;
+        // Enabled → Disabled must go through part_disable_internal.
+        assert!(matches!(
+            e.prop_set_scalar(PartPropId::STATE, PartState::Disabled as u32),
+            Err(HsmError::InvalidArg)
+        ));
+        // Enabled → Allocated is nonsense.
+        assert!(matches!(
+            e.prop_set_scalar(PartPropId::STATE, PartState::Allocated as u32),
+            Err(HsmError::InvalidArg)
+        ));
+    }
+
+    #[test]
+    fn bytes_round_trip_policy() {
+        let mut e = fresh_entry();
+        assert!(matches!(
+            e.prop_get_bytes(PartPropId::POLICY),
+            Err(HsmError::PartPropNotFound)
+        ));
+        let payload = [0xABu8; PART_POLICY_LEN];
+        e.prop_set_bytes(PartPropId::POLICY, &payload).unwrap();
+        assert_eq!(e.prop_get_bytes(PartPropId::POLICY).unwrap(), &payload[..]);
+        e.prop_clear(PartPropId::POLICY).unwrap();
+        assert!(matches!(
+            e.prop_get_bytes(PartPropId::POLICY),
+            Err(HsmError::PartPropNotFound)
+        ));
+    }
+
+    #[test]
+    fn bytes_round_trip_sealed_bk3_var() {
+        let mut e = fresh_entry();
+        let payload = [0x12u8; 40];
+        e.prop_set_bytes(PartPropId::SEALED_BK3, &payload).unwrap();
+        assert_eq!(
+            e.prop_get_bytes(PartPropId::SEALED_BK3).unwrap(),
+            &payload[..]
+        );
+        e.prop_clear(PartPropId::SEALED_BK3).unwrap();
+        assert!(matches!(
+            e.prop_get_bytes(PartPropId::SEALED_BK3),
+            Err(HsmError::PartPropNotFound)
+        ));
+    }
+
+    #[test]
+    fn sensitive_set_zeroizes_prior() {
+        let mut e = fresh_entry();
+        // Prime CREDENTIAL with payload A, clear, then set payload B,
+        // confirming the entire id/pin region is rewritten cleanly.
+        // `prop_set_bytes` is now write-once, so reuse requires an
+        // explicit `prop_clear` between sets.
+        let payload_a = [0xAAu8; 32];
+        let mut payload_b = [0u8; 32];
+        for (i, b) in payload_b.iter_mut().enumerate() {
+            *b = (i as u8) | 0x80;
+        }
+        e.prop_set_bytes(PartPropId::CREDENTIAL, &payload_a)
+            .unwrap();
+        e.prop_clear(PartPropId::CREDENTIAL).unwrap();
+        e.prop_set_bytes(PartPropId::CREDENTIAL, &payload_b)
+            .unwrap();
+        let stored = e.prop_get_bytes(PartPropId::CREDENTIAL).unwrap();
+        assert_eq!(stored, &payload_b[..]);
+        // Clear zeroes the full 32 B blob.
+        e.prop_clear(PartPropId::CREDENTIAL).unwrap();
+        assert!(matches!(
+            e.prop_get_bytes(PartPropId::CREDENTIAL),
+            Err(HsmError::PartPropNotFound)
+        ));
+        assert_eq!(&e.credential[..], &[0u8; 32]);
+    }
+
+    #[test]
+    fn credential_prop_set_is_write_once() {
+        let mut e = fresh_entry();
+        let payload = [0x5Au8; 32];
+        e.prop_set_bytes(PartPropId::CREDENTIAL, &payload).unwrap();
+        // Second set without an intervening clear is rejected.
+        assert!(matches!(
+            e.prop_set_bytes(PartPropId::CREDENTIAL, &payload),
+            Err(HsmError::VaultAppLimitReached)
+        ));
+    }
+
+    #[test]
+    fn credential_prop_set_rejects_zero_halves() {
+        let mut e = fresh_entry();
+        // Zero id half.
+        let mut payload = [0u8; 32];
+        payload[16..].copy_from_slice(&[0x33u8; 16]);
+        assert!(matches!(
+            e.prop_set_bytes(PartPropId::CREDENTIAL, &payload),
+            Err(HsmError::InvalidAppCredentials)
+        ));
+        // Zero pin half.
+        let mut payload = [0u8; 32];
+        payload[..16].copy_from_slice(&[0x33u8; 16]);
+        assert!(matches!(
+            e.prop_set_bytes(PartPropId::CREDENTIAL, &payload),
+            Err(HsmError::InvalidAppCredentials)
+        ));
+        // Both zero.
+        assert!(matches!(
+            e.prop_set_bytes(PartPropId::CREDENTIAL, &[0u8; 32]),
+            Err(HsmError::InvalidAppCredentials)
+        ));
+    }
+
+    #[test]
+    fn psk_get_returns_default_when_absent() {
+        let e = fresh_entry();
+        assert_eq!(
+            e.prop_get_bytes(PartPropId::PSK_CO).unwrap(),
+            DEFAULT_PSK_CO.as_slice()
+        );
+        assert_eq!(
+            e.prop_get_bytes(PartPropId::PSK_CU).unwrap(),
+            DEFAULT_PSK_CU.as_slice()
+        );
+    }
+
+    // ── Phase A new-id coverage ────────────────────────────────────
+
+    #[test]
+    fn bk3_initialized_one_shot_transition() {
+        let mut e = fresh_entry();
+        // Reads via scalar widening (Bool maps to 0/1 in prop_get_scalar).
+        assert_eq!(e.prop_get_scalar(PartPropId::BK3_INITIALIZED).unwrap(), 0);
+        // First true write succeeds.
+        e.prop_set_scalar(PartPropId::BK3_INITIALIZED, 1).unwrap();
+        assert_eq!(e.prop_get_scalar(PartPropId::BK3_INITIALIZED).unwrap(), 1);
+        assert!(e.bk3_initialized);
+        // Re-asserting true returns Bk3AlreadyInitialized.
+        assert!(matches!(
+            e.prop_set_scalar(PartPropId::BK3_INITIALIZED, 1),
+            Err(HsmError::Bk3AlreadyInitialized)
+        ));
+        // Clearing back to false is rejected.
+        assert!(matches!(
+            e.prop_set_scalar(PartPropId::BK3_INITIALIZED, 0),
+            Err(HsmError::InvalidArg)
+        ));
+    }
+
+    #[test]
+    fn bk3_initialized_accepts_bool_writes() {
+        // The trait-level Bool setter (validate_set with ExpectedKind::Bool)
+        // is now accepted because BK3_INITIALIZED is Rw.
+        assert!(validate_set(PartPropId::BK3_INITIALIZED, 0, ExpectedKind::Bool, None).is_ok());
+        // U8-kind requests are rejected by the kind mismatch.
+        assert!(matches!(
+            validate_set(PartPropId::BK3_INITIALIZED, 0, ExpectedKind::U8, None),
+            Err(HsmError::InvalidArg)
+        ));
+    }
+
+    #[test]
+    fn bks2_id_returns_constant_zero() {
+        let e = fresh_entry();
+        assert_eq!(e.prop_get_scalar(PartPropId::BKS2_ID).unwrap(), 0);
+    }
+
+    #[test]
+    fn bks2_id_is_read_only() {
+        assert!(matches!(
+            validate_set(PartPropId::BKS2_ID, 0, ExpectedKind::U16, None),
+            Err(HsmError::InvalidArg)
+        ));
+    }
+
+    #[test]
+    fn id_pub_key_returns_fixed_size_buffer() {
+        let mut e = fresh_entry();
+        e.id_pub_key[0] = 0xAA;
+        let got = e.prop_get_bytes(PartPropId::ID_PUB_KEY).unwrap();
+        assert_eq!(got.len(), 96);
+        assert_eq!(got[0], 0xAA);
+    }
+
+    #[test]
+    fn id_pub_key_is_read_only() {
+        assert!(matches!(
+            validate_set(PartPropId::ID_PUB_KEY, 0, ExpectedKind::Bytes, Some(96)),
+            Err(HsmError::InvalidArg)
+        ));
+    }
+
+    #[test]
+    fn session_enc_pub_key_returns_field() {
+        let mut e = fresh_entry();
+        e.session_enc_pub_key[1] = 0x5A;
+        let got = e.prop_get_bytes(PartPropId::SESSION_ENC_PUB_KEY).unwrap();
+        assert_eq!(got.len(), 96);
+        assert_eq!(got[1], 0x5A);
+    }
+
+    #[test]
+    fn establish_cred_pub_key_returns_field() {
+        let mut e = fresh_entry();
+        e.establish_cred_pub_key[95] = 0x77;
+        let got = e
+            .prop_get_bytes(PartPropId::ESTABLISH_CRED_PUB_KEY)
+            .unwrap();
+        assert_eq!(got.len(), 96);
+        assert_eq!(got[95], 0x77);
+    }
+
+    #[test]
+    fn pta_pub_sec1_round_trip() {
+        let mut e = fresh_entry();
+        assert!(matches!(
+            e.prop_get_bytes(PartPropId::PTA_PUB_SEC1),
+            Err(HsmError::PartPropNotFound)
+        ));
+        let payload = [0x33u8; P384_PUB_SEC1_LEN];
+        e.prop_set_bytes(PartPropId::PTA_PUB_SEC1, &payload)
+            .unwrap();
+        assert_eq!(
+            e.prop_get_bytes(PartPropId::PTA_PUB_SEC1).unwrap(),
+            &payload[..]
+        );
+        e.prop_clear(PartPropId::PTA_PUB_SEC1).unwrap();
+        assert!(matches!(
+            e.prop_get_bytes(PartPropId::PTA_PUB_SEC1),
+            Err(HsmError::PartPropNotFound)
+        ));
+    }
+
+    #[test]
+    fn pta_pub_sec1_wrong_size_rejected() {
+        assert!(matches!(
+            validate_set(
+                PartPropId::PTA_PUB_SEC1,
+                0,
+                ExpectedKind::Bytes,
+                Some(P384_PUB_SEC1_LEN - 1)
+            ),
+            Err(HsmError::InvalidArg)
+        ));
+    }
+
+    #[test]
+    fn bk3_session_round_trip_and_zeroize() {
+        let mut e = fresh_entry();
+        assert!(matches!(
+            e.prop_get_bytes(PartPropId::BK3_SESSION),
+            Err(HsmError::PartPropNotFound)
+        ));
+        let payload = [0x9Eu8; 48];
+        e.prop_set_bytes(PartPropId::BK3_SESSION, &payload).unwrap();
+        assert_eq!(
+            e.prop_get_bytes(PartPropId::BK3_SESSION).unwrap(),
+            &payload[..]
+        );
+        e.prop_clear(PartPropId::BK3_SESSION).unwrap();
+        assert!(matches!(
+            e.prop_get_bytes(PartPropId::BK3_SESSION),
+            Err(HsmError::PartPropNotFound)
+        ));
+        // Clear must zeroize the backing field.
+        assert_eq!(&e.bk3_session[..], &[0u8; 48]);
+    }
+
+    #[test]
+    fn bk3_session_marked_sensitive_in_catalogue() {
+        let meta = PartPropId::BK3_SESSION.meta().unwrap();
+        assert!(meta.sensitive);
+    }
 }


### PR DESCRIPTION
## Summary

Collapses the per-field "typed action" partition methods on `HsmPartitionManager` into a single property-based API (`part_prop_get_*` / `part_prop_set_*` / `part_prop_clear`) addressed by a typed catalogue (`PartPropId` / `PartPropMeta`). Behaviour-equivalent typed wrappers live in the new `fw/core/lib/src/part_state.rs` free-function module so call sites read the same as before.

## Trait surface

- `HsmPartitionManager` now contains **only** the 13 required `part_prop_*` accessors (`get` / `set` for `u8` / `u16` / `u32` / `u64` / `bool` / `bytes` + `clear`).
- `UnsupportedCmd` default bodies removed so future PALs are forced to implement the full property API at compile time (silent runtime fallback gone).
- All typed action methods removed: `part_set_credential`, `part_verify_credential`, `part_verify_nonce`, `part_is_provisioned`, `part_mark_bk3_initialized`, `part_set_pta_key`, `part_set_ums_key`, `part_set_policy`, `part_set_pota_thumbprint`, `part_mark_initializing`, `derive_masking_key`, plus all length-probe getters (`part_uds(io, None)`, `part_nonce(io, None)`, etc.).

## Catalogue additions

- `PartPropId::MFGR_SEED` (0x000A) and `DEV_OWNER_SEED` (0x000B): PAL-private root-of-trust seed tables exposed as indexed sensitive properties. Cardinality 64 each, only row 0 provisioned in std PAL; `idx > 0` → `PartPropNotFound`, `idx >= 64` → `InvalidArg`. Lets `fw/core` derive masking keys without exposing the seeds as a separate PAL primitive.
- `PartPropMeta::fixed_indexed(len, cardinality, …)` constructor.

## PAL state invariants preserved

- `CREDENTIAL` is write-once (re-set without `clear` → `VaultAppLimitReached`) and rejects zero id/pin halves (`InvalidAppCredentials`). Storage consolidated (`credential_id + credential_pin` → `credential: [u8;32]`) so the full blob is reachable via the prop getter for CT verify.
- `PTA_KEY_ID` re-set → `PtaKeyAlreadySet`; `UPS_KEY_ID` re-set → `UmsKeyAlreadySet`; `POLICY` / `POTA_THUMBPRINT` / `PTA_PUB_SEC1` re-set → `InvalidArg`.
- `BK3_INITIALIZED` stays a one-shot `false → true` gate; clearing back to `false` is rejected and only PAL-internal reset paths (free / NSSR) clear it.
- `STD_MFGR_SEED_ROW0` / `STD_DEV_OWNER_SEED_ROW0` (formerly `STD_BKS1` / `STD_BKS2`) routed through `std_indexed_seed_row`.

## fw/core helpers

- `part_state.rs` typed wrappers for every prop, including `part_verify_credential` (CT compare both 16 B halves), `part_is_provisioned` (derives from `MK_KEY_ID` presence), `part_mfgr_seed` / `part_dev_owner_seed`.
- `derive_masking_key` migrated into `ddi/mbor/establish_credential.rs` as a `pub(crate)` async helper reading `MFGR_SEED` + `DEV_OWNER_SEED` via the prop API; `init_bk3` reuses it via `super::derive_masking_key`.

## Call-site migration

All MBOR/TBOR handlers (`establish_credential`, `init_bk3`, `open_session`, `get_session_encryption_key`, `get_sealed_bk3`, `set_sealed_bk3`, `get_establish_cred_encryption_key`, `get_device_info`, `change_psk`, `open_session_init/finish`, `part_init`) switched from `pal.part_*(…)` to `crate::part_state::part_*(…)`.

## Verification

- `cargo check --workspace` clean
- 158 `azihsm_fw_hsm_pal_std` tests pass
- 38 `azihsm_fw_hsm_std` tests pass
- 52 `azihsm_ddi_tbor_types --features emu` tests pass
- `cargo +nightly xtask fmt --fix` + `cargo xtask copyright --fix` clean