### PR TITLE
Remove target folder before running coverage tests in CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -66,6 +66,10 @@ jobs:
       id: test-tbor-emu
       run: cargo xtask precheck --nextest --package azihsm_ddi_tbor_types --features emu --profile ci-tbor-emu
       continue-on-error: true
+    - name: Free target/ before coverage build
+      # Freeing target/ directory to ensure disk space for coverage report generation
+      run: |
+        rm -rf target/debug target/tmp
     - name: Run all mock tests with code coverage
       id: test-mock-coverage
       run: cargo xtask precheck --coverage

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -68,8 +68,7 @@ jobs:
       continue-on-error: true
     - name: Free target/ before coverage build
       # Freeing target/ directory to ensure disk space for coverage report generation
-      run: |
-        rm -rf target/debug target/tmp
+      run: rm -rf target/debug target/tmp
     - name: Run all mock tests with code coverage
       id: test-mock-coverage
       run: cargo xtask precheck --coverage


### PR DESCRIPTION
This pull request introduces a small but important change to the GitHub Actions workflow for Rust. The change ensures that disk space is freed before generating code coverage reports by removing specific build directories.

Workflow improvements:

* Added a step to delete the `target/debug` and `target/tmp` directories before running code coverage tests to prevent disk space issues during report generation in `.github/workflows/rust.yml`.