### PR TITLE
feat(engine): error-handling toolkit for ossl_engine

### DIFF
--- a/plugins/ossl_engine/engine/src/lib.rs
+++ b/plugins/ossl_engine/engine/src/lib.rs
@@ -15,9 +15,14 @@ mod engine_impl {
     use std::ffi::CStr;
     use std::ffi::c_int;
     use std::ffi::c_ulong;
+    use std::ptr::NonNull;
 
     use openssl_engine::engine::Engine;
-    use openssl_engine::engine::bind_entry;
+    use openssl_engine::error::EngineError;
+    use openssl_engine::error::EngineResult;
+    use openssl_engine::error::RetCode;
+    use openssl_engine::error::catch_panic;
+    use openssl_engine::error::result_to_int;
     use openssl_engine::ffi;
 
     const ENGINE_ID: &CStr = c"azihsm";
@@ -35,40 +40,47 @@ mod engine_impl {
 
     /// Engine entry point exported for OpenSSL's dynamic loader.
     ///
-    /// The raw-pointer validation and the unsafe FFI glue live in
-    /// [`openssl_engine::engine::bind_entry`]; this export just forwards to it.
+    /// Validates the raw pointers, then runs the bind logic inside
+    /// [`catch_panic`] so a panic can never unwind across the FFI boundary;
+    /// failures are reported through the OpenSSL error queue and a `0` return.
     ///
     /// # Safety
     /// `engine_ptr` and `fns` must be valid for the duration of the call and
     /// `id` must be null or a valid C string — guaranteed by OpenSSL's dynamic
     /// engine loader per the `bind_engine`/`v_check` ABI contract.
-    // `#[allow(unsafe_code)]` covers the `#[unsafe(no_mangle)]` export
-    // attribute and the `unsafe extern "C"` signature; the body itself
-    // contains no `unsafe` block.
     #[unsafe(no_mangle)]
     #[allow(unsafe_code)]
-    #[allow(unsafe_op_in_unsafe_fn)]
     pub unsafe extern "C" fn bind_engine(
         engine_ptr: *mut ffi::ENGINE,
         id: *const std::ffi::c_char,
         fns: *mut ffi::dynamic_fns,
     ) -> c_int {
-        bind_entry(engine_ptr, id, fns, bind_helper)
+        catch_panic(
+            || {
+                let result = (|| -> EngineResult<()> {
+                    let engine_ptr =
+                        NonNull::new(engine_ptr).ok_or(EngineError::NullParam("engine"))?;
+                    let fns = NonNull::new(fns).ok_or(EngineError::NullParam("fns"))?;
+
+                    // SAFETY: engine_ptr and fns are non-null (checked above) and
+                    // valid for this call (provided by OpenSSL's dynamic loader).
+                    unsafe { Engine::from_ptr(engine_ptr).bind(id, fns, bind_helper) }
+                })();
+                result_to_int(result)
+            },
+            RetCode::Fail.into(),
+        )
     }
 
-    fn bind_helper(engine: &Engine, id: &CStr) -> c_int {
+    fn bind_helper(engine: &Engine, id: &CStr) -> EngineResult<()> {
         let id_bytes = id.to_bytes();
         if !id_bytes.is_empty() && !id_bytes.contains(&b'/') && id != ENGINE_ID {
-            return 0;
+            return Err(EngineError::IdMismatch);
         }
 
-        if engine.set_id(ENGINE_ID) != 1 {
-            return 0;
-        }
-        if engine.set_name(ENGINE_NAME) != 1 {
-            return 0;
-        }
+        engine.set_id(ENGINE_ID)?;
+        engine.set_name(ENGINE_NAME)?;
 
-        1
+        Ok(())
     }
 }

--- a/plugins/ossl_engine/engine/src/lib.rs
+++ b/plugins/ossl_engine/engine/src/lib.rs
@@ -57,21 +57,36 @@ mod engine_impl {
     ) -> c_int {
         catch_panic(
             || {
-                let result = (|| -> EngineResult<()> {
-                    let engine_ptr =
-                        NonNull::new(engine_ptr).ok_or(EngineError::NullParam("engine"))?;
-                    let fns = NonNull::new(fns).ok_or(EngineError::NullParam("fns"))?;
-
-                    // SAFETY: engine_ptr and fns are non-null (checked above) and
-                    // valid for this call (provided by OpenSSL's dynamic loader).
-                    unsafe { Engine::from_ptr(engine_ptr).bind(id, fns, bind_helper) }
-                })();
-                result_to_int(result)
+                // SAFETY: forwarding the pointers OpenSSL's dynamic loader
+                // passed to bind_engine, per its ABI contract.
+                result_to_int(unsafe { bind_inner(engine_ptr, id, fns) })
             },
             RetCode::Fail.into(),
         )
     }
 
+    /// Validate the raw pointers from OpenSSL's dynamic loader and dispatch
+    /// to [`bind_helper`] with a safe [`Engine`].
+    ///
+    /// # Safety
+    /// `engine_ptr`, `id`, and `fns` must be the pointers OpenSSL's dynamic
+    /// loader passes to [`bind_engine`] (see its contract).
+    #[allow(unsafe_code)]
+    unsafe fn bind_inner(
+        engine_ptr: *mut ffi::ENGINE,
+        id: *const std::ffi::c_char,
+        fns: *mut ffi::dynamic_fns,
+    ) -> EngineResult<()> {
+        let engine_ptr = NonNull::new(engine_ptr).ok_or(EngineError::NullParam("engine"))?;
+        let fns = NonNull::new(fns).ok_or(EngineError::NullParam("fns"))?;
+
+        // SAFETY: engine_ptr and fns are non-null (checked above) and valid
+        // for this call (provided by OpenSSL's dynamic loader).
+        unsafe { Engine::from_ptr(engine_ptr).bind(id, fns, bind_helper) }
+    }
+
+    /// Engine setup invoked by [`Engine::bind`]: reject a request for a
+    /// different engine id, then register this engine's id and name.
     fn bind_helper(engine: &Engine, id: &CStr) -> EngineResult<()> {
         let id_bytes = id.to_bytes();
         if !id_bytes.is_empty() && !id_bytes.contains(&b'/') && id != ENGINE_ID {

--- a/plugins/ossl_engine/openssl-engine/Cargo.toml
+++ b/plugins/ossl_engine/openssl-engine/Cargo.toml
@@ -13,6 +13,8 @@ engine = ["openssl-sys-engine/engine"]
 
 [dependencies]
 openssl-sys-engine.workspace = true
+thiserror.workspace = true
+tracing.workspace = true
 
 [lints]
 workspace = true

--- a/plugins/ossl_engine/openssl-engine/Cargo.toml
+++ b/plugins/ossl_engine/openssl-engine/Cargo.toml
@@ -9,12 +9,12 @@ version = "0.1.0"
 
 [features]
 default = []
-engine = ["openssl-sys-engine/engine"]
+engine = ["dep:thiserror", "dep:tracing", "openssl-sys-engine/engine"]
 
 [dependencies]
 openssl-sys-engine.workspace = true
-thiserror.workspace = true
-tracing.workspace = true
+thiserror = { optional = true, workspace = true }
+tracing = { optional = true, workspace = true }
 
 [lints]
 workspace = true

--- a/plugins/ossl_engine/openssl-engine/src/engine.rs
+++ b/plugins/ossl_engine/openssl-engine/src/engine.rs
@@ -12,6 +12,7 @@ use openssl_sys_engine as ffi;
 
 use crate::error::EngineError;
 use crate::error::EngineResult;
+use crate::error::ossl_check;
 
 pub struct Engine {
     ptr: *mut ffi::ENGINE,
@@ -50,17 +51,18 @@ impl Engine {
         // SAFETY: Caller guarantees fns points to a valid dynamic_fns.
         unsafe {
             if ffi::ENGINE_get_static_state() != (*fns_ptr).static_state {
-                if ffi::CRYPTO_set_mem_functions(
-                    (*fns_ptr).mem_fns.malloc_fn,
-                    (*fns_ptr).mem_fns.realloc_fn,
-                    (*fns_ptr).mem_fns.free_fn,
-                ) != 1
-                {
-                    return Err(EngineError::CryptoSetMemFunctionsFailed);
-                }
-                if ffi::OPENSSL_init_crypto(ffi::OPENSSL_INIT_NO_ATEXIT as u64, null_mut()) != 1 {
-                    return Err(EngineError::OpensslInitCryptoFailed);
-                }
+                ossl_check(
+                    ffi::CRYPTO_set_mem_functions(
+                        (*fns_ptr).mem_fns.malloc_fn,
+                        (*fns_ptr).mem_fns.realloc_fn,
+                        (*fns_ptr).mem_fns.free_fn,
+                    ),
+                    EngineError::CryptoSetMemFunctionsFailed,
+                )?;
+                ossl_check(
+                    ffi::OPENSSL_init_crypto(ffi::OPENSSL_INIT_NO_ATEXIT as u64, null_mut()),
+                    EngineError::OpensslInitCryptoFailed,
+                )?;
             }
         }
 
@@ -74,21 +76,24 @@ impl Engine {
         f(self, id)
     }
 
+    /// Set the engine's id — the short identifier OpenSSL matches against
+    /// (e.g. in `ENGINE_by_id`).
     #[allow(unsafe_code)]
     pub fn set_id(&self, id: &CStr) -> EngineResult<()> {
         // SAFETY: self.ptr is valid (from NonNull), id is a valid CStr.
-        match unsafe { ffi::ENGINE_set_id(self.ptr, id.as_ptr()) } {
-            1 => Ok(()),
-            _ => Err(EngineError::SetIdFailed),
-        }
+        ossl_check(
+            unsafe { ffi::ENGINE_set_id(self.ptr, id.as_ptr()) },
+            EngineError::SetIdFailed,
+        )
     }
 
+    /// Set the engine's human-readable display name.
     #[allow(unsafe_code)]
     pub fn set_name(&self, name: &CStr) -> EngineResult<()> {
         // SAFETY: self.ptr is valid (from NonNull), name is a valid CStr.
-        match unsafe { ffi::ENGINE_set_name(self.ptr, name.as_ptr()) } {
-            1 => Ok(()),
-            _ => Err(EngineError::SetNameFailed),
-        }
+        ossl_check(
+            unsafe { ffi::ENGINE_set_name(self.ptr, name.as_ptr()) },
+            EngineError::SetNameFailed,
+        )
     }
 }

--- a/plugins/ossl_engine/openssl-engine/src/engine.rs
+++ b/plugins/ossl_engine/openssl-engine/src/engine.rs
@@ -5,41 +5,16 @@
 
 use std::ffi::CStr;
 use std::ffi::c_char;
-use std::ffi::c_int;
 use std::ptr::NonNull;
 use std::ptr::null_mut;
 
 use openssl_sys_engine as ffi;
 
+use crate::error::EngineError;
+use crate::error::EngineResult;
+
 pub struct Engine {
     ptr: *mut ffi::ENGINE,
-}
-
-/// Entry-point glue for a dynamic engine's `bind_engine` export.
-///
-/// Validates the raw pointers OpenSSL's dynamic loader passes to
-/// `bind_engine` and dispatches to `f` with a safe [`Engine`].
-///
-/// # Safety
-/// `engine`, `id`, and `fns` must be the pointers supplied by OpenSSL's
-/// dynamic engine loader: `engine` and `fns`, if non-null, valid for this
-/// call, and `id`, if non-null, a valid C string.
-#[allow(unsafe_code)]
-pub unsafe fn bind_entry(
-    engine: *mut ffi::ENGINE,
-    id: *const c_char,
-    fns: *mut ffi::dynamic_fns,
-    f: fn(&Engine, &CStr) -> c_int,
-) -> c_int {
-    let Some(engine) = NonNull::new(engine) else {
-        return 0;
-    };
-    let Some(fns) = NonNull::new(fns) else {
-        return 0;
-    };
-    // SAFETY: engine and fns are non-null (checked above) and valid for this
-    // call (provided by OpenSSL's dynamic loader).
-    unsafe { Engine::from_ptr(engine).bind(id, fns, f) }
 }
 
 // SAFETY: ENGINE access is serialized by OpenSSL's CRYPTO_LOCK_ENGINE.
@@ -68,8 +43,8 @@ impl Engine {
         &self,
         id: *const c_char,
         fns: NonNull<ffi::dynamic_fns>,
-        f: fn(&Engine, &CStr) -> c_int,
-    ) -> c_int {
+        f: fn(&Engine, &CStr) -> EngineResult<()>,
+    ) -> EngineResult<()> {
         let fns_ptr = fns.as_ptr();
 
         // SAFETY: Caller guarantees fns points to a valid dynamic_fns.
@@ -81,10 +56,10 @@ impl Engine {
                     (*fns_ptr).mem_fns.free_fn,
                 ) != 1
                 {
-                    return 0;
+                    return Err(EngineError::CryptoSetMemFunctionsFailed);
                 }
                 if ffi::OPENSSL_init_crypto(ffi::OPENSSL_INIT_NO_ATEXIT as u64, null_mut()) != 1 {
-                    return 0;
+                    return Err(EngineError::OpensslInitCryptoFailed);
                 }
             }
         }
@@ -100,14 +75,20 @@ impl Engine {
     }
 
     #[allow(unsafe_code)]
-    pub fn set_id(&self, id: &CStr) -> c_int {
+    pub fn set_id(&self, id: &CStr) -> EngineResult<()> {
         // SAFETY: self.ptr is valid (from NonNull), id is a valid CStr.
-        unsafe { ffi::ENGINE_set_id(self.ptr, id.as_ptr()) }
+        match unsafe { ffi::ENGINE_set_id(self.ptr, id.as_ptr()) } {
+            1 => Ok(()),
+            _ => Err(EngineError::SetIdFailed),
+        }
     }
 
     #[allow(unsafe_code)]
-    pub fn set_name(&self, name: &CStr) -> c_int {
+    pub fn set_name(&self, name: &CStr) -> EngineResult<()> {
         // SAFETY: self.ptr is valid (from NonNull), name is a valid CStr.
-        unsafe { ffi::ENGINE_set_name(self.ptr, name.as_ptr()) }
+        match unsafe { ffi::ENGINE_set_name(self.ptr, name.as_ptr()) } {
+            1 => Ok(()),
+            _ => Err(EngineError::SetNameFailed),
+        }
     }
 }

--- a/plugins/ossl_engine/openssl-engine/src/error.rs
+++ b/plugins/ossl_engine/openssl-engine/src/error.rs
@@ -1,0 +1,260 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Error types and OpenSSL error queue integration for the engine toolkit.
+//!
+//! Engine callbacks run across an FFI boundary that cannot unwind Rust
+//! panics.  This module provides three pieces that together make that
+//! boundary safe and observable:
+//!
+//! - [`EngineError`] + [`EngineResult`] — typed failure modes the toolkit
+//!   emits.  Variants are added as features land.
+//! - [`openssl_err`] / [`result_to_int`] — push human-readable messages
+//!   onto the OpenSSL ERR queue so callers can recover them via
+//!   `ERR_get_error` (and `openssl errstr` on the CLI side).
+//! - [`catch_panic`] — wrap a C entry point so a Rust panic returns a
+//!   caller-supplied fallback instead of unwinding into C (which is UB).
+
+use std::ffi::CString;
+use std::ffi::c_int;
+use std::panic::UnwindSafe;
+use std::panic::catch_unwind;
+
+use openssl_sys_engine as ffi;
+
+/// Result type used throughout the engine toolkit.
+pub type EngineResult<T> = Result<T, EngineError>;
+
+/// Failure modes emitted by the engine toolkit.
+///
+/// Variants are added as features land — only the ones currently
+/// emitted appear here.
+#[derive(Debug, thiserror::Error)]
+pub enum EngineError {
+    #[error("engine ID mismatch")]
+    IdMismatch,
+
+    #[error("ENGINE_set_id failed")]
+    SetIdFailed,
+
+    #[error("ENGINE_set_name failed")]
+    SetNameFailed,
+
+    #[error("CRYPTO_set_mem_functions failed")]
+    CryptoSetMemFunctionsFailed,
+
+    #[error("OPENSSL_init_crypto failed")]
+    OpensslInitCryptoFailed,
+
+    #[error("null parameter: {0}")]
+    NullParam(&'static str),
+
+    #[error("CRYPTO_get_ex_new_index failed")]
+    ExDataRegisterFailed,
+
+    #[error("ENGINE_set_ex_data failed")]
+    ExDataSetFailed,
+
+    #[error("ENGINE_set_destroy_function failed")]
+    SetDestroyFailed,
+
+    /// A standalone message with no underlying error.
+    #[error("{0}")]
+    Other(String),
+
+    /// A contextual message wrapping an underlying error. Display renders
+    /// `context: source`; the source is preserved for programmatic
+    /// inspection via [`std::error::Error::source`].
+    #[error("{context}: {source}")]
+    Wrapped {
+        context: String,
+        #[source]
+        source: Box<dyn std::error::Error + Send + Sync + 'static>,
+    },
+}
+
+impl EngineError {
+    /// Wrap `source` with human-readable `context`, preserving the error
+    /// chain. Prefer this over `Other(format!("…: {e}"))` when there is an
+    /// underlying error, so callers can still walk `.source()`.
+    pub fn wrap(
+        context: impl Into<String>,
+        source: impl std::error::Error + Send + Sync + 'static,
+    ) -> Self {
+        Self::Wrapped {
+            context: context.into(),
+            source: Box::new(source),
+        }
+    }
+}
+
+impl From<&EngineError> for c_int {
+    fn from(e: &EngineError) -> c_int {
+        match e {
+            EngineError::NullParam(_) => ffi::ERR_R_PASSED_NULL_PARAMETER as c_int,
+            _ => ffi::ERR_R_INTERNAL_ERROR as c_int,
+        }
+    }
+}
+
+/// OpenSSL return-code convention: 1 success, 0 failure.
+#[repr(i32)]
+#[derive(Clone, Copy)]
+pub enum RetCode {
+    Fail = 0,
+    Success = 1,
+}
+
+impl From<RetCode> for c_int {
+    fn from(code: RetCode) -> c_int {
+        code as c_int
+    }
+}
+
+/// Push a human-readable message onto the OpenSSL ERR queue.
+///
+/// `reason` is an `ERR_R_*` constant from `openssl-sys-engine`.  Empty or
+/// NUL-containing messages are dropped silently — OpenSSL has no way to
+/// represent them.  OpenSSL copies the string internally; callers may free
+/// after return.
+#[allow(unsafe_code)]
+pub fn openssl_err(reason: c_int, msg: &str) {
+    let Ok(msg_c) = CString::new(msg) else {
+        return;
+    };
+
+    // SAFETY: ERR_put_error stores the file pointer as-is; we pass a
+    // 'static empty C string so it remains valid for the lifetime of the
+    // ERR queue entry. ERR_add_error_data copies its argument internally.
+    unsafe {
+        ffi::ERR_put_error(ffi::ERR_LIB_ENGINE as c_int, -1, reason, c"".as_ptr(), 0);
+        ffi::ERR_add_error_data(1, msg_c.as_ptr());
+    }
+}
+
+/// Convert an [`EngineResult`] into an OpenSSL C return code.
+///
+/// On `Err` the message is pushed onto the OpenSSL ERR queue and logged
+/// via `tracing`.  Successful results return [`RetCode::Success`].
+pub fn result_to_int<T>(result: EngineResult<T>) -> c_int {
+    match result {
+        Ok(_) => RetCode::Success.into(),
+        Err(e) => {
+            let reason = c_int::from(&e);
+            openssl_err(reason, &e.to_string());
+            tracing::error!("{e}");
+            RetCode::Fail.into()
+        }
+    }
+}
+
+/// Run `f` under [`catch_unwind`].  A panic is logged and turned into the
+/// caller-supplied `on_panic` value.
+///
+/// Every `extern "C"` entry point that calls into Rust should wrap its
+/// body in this helper.  Letting a panic unwind across the FFI boundary
+/// is undefined behavior.
+pub fn catch_panic<F, R>(f: F, on_panic: R) -> R
+where
+    F: FnOnce() -> R + UnwindSafe,
+{
+    match catch_unwind(f) {
+        Ok(v) => v,
+        Err(_) => {
+            tracing::error!("panic caught at FFI boundary");
+            on_panic
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::panic, clippy::unwrap_used)]
+
+    use super::*;
+
+    /// Round-trip: push a message and read back the reason code.
+    #[test]
+    #[allow(unsafe_code)]
+    fn openssl_err_round_trip() {
+        // SAFETY: ERR_clear_error / ERR_get_error are thread-safe and
+        // take no arguments; the ERR queue is thread-local in 1.1.x.
+        unsafe { ffi::ERR_clear_error() };
+
+        openssl_err(ffi::ERR_R_INTERNAL_ERROR as c_int, "boom");
+
+        // SAFETY: same as above.
+        let code = unsafe { ffi::ERR_get_error() };
+        assert_ne!(code, 0, "expected an error on the queue");
+
+        // ERR_GET_REASON masks the reason out of the packed code; the
+        // exact bit layout is internal to OpenSSL but the low 12 bits
+        // hold the reason in 1.1.x.
+        let reason = (code & 0xfff) as c_int;
+        assert_eq!(reason, ffi::ERR_R_INTERNAL_ERROR as c_int);
+
+        // Drain anything else this test pushed.
+        // SAFETY: same as above.
+        unsafe { ffi::ERR_clear_error() };
+    }
+
+    #[test]
+    fn result_to_int_success() {
+        let r: EngineResult<()> = Ok(());
+        assert_eq!(result_to_int(r), RetCode::Success.into());
+    }
+
+    #[test]
+    fn result_to_int_failure_pushes_error() {
+        // SAFETY: see openssl_err_round_trip.
+        #[allow(unsafe_code)]
+        unsafe {
+            ffi::ERR_clear_error()
+        };
+
+        let r: EngineResult<()> = Err(EngineError::IdMismatch);
+        assert_eq!(result_to_int(r), RetCode::Fail.into());
+
+        // SAFETY: see openssl_err_round_trip.
+        #[allow(unsafe_code)]
+        let code = unsafe { ffi::ERR_get_error() };
+        assert_ne!(code, 0, "Err result should push onto the ERR queue");
+
+        // SAFETY: see openssl_err_round_trip.
+        #[allow(unsafe_code)]
+        unsafe {
+            ffi::ERR_clear_error()
+        };
+    }
+
+    #[test]
+    fn catch_panic_returns_normal_value() {
+        let result = catch_panic(|| 42, 0);
+        assert_eq!(result, 42);
+    }
+
+    #[test]
+    fn catch_panic_returns_fallback_on_panic() {
+        let result = catch_panic(
+            || {
+                panic!("simulated");
+                #[allow(unreachable_code)]
+                42
+            },
+            -1,
+        );
+        assert_eq!(result, -1);
+    }
+
+    #[test]
+    fn null_param_maps_to_passed_null_parameter() {
+        let e = EngineError::NullParam("engine");
+        assert_eq!(c_int::from(&e), ffi::ERR_R_PASSED_NULL_PARAMETER as c_int);
+    }
+
+    #[test]
+    fn id_mismatch_maps_to_internal_error() {
+        let e = EngineError::IdMismatch;
+        assert_eq!(c_int::from(&e), ffi::ERR_R_INTERNAL_ERROR as c_int);
+    }
+}

--- a/plugins/ossl_engine/openssl-engine/src/error.rs
+++ b/plugins/ossl_engine/openssl-engine/src/error.rs
@@ -9,9 +9,11 @@
 //!
 //! - [`EngineError`] + [`EngineResult`] — typed failure modes the toolkit
 //!   emits.  Variants are added as features land.
-//! - [`openssl_err`] / [`result_to_int`] — push human-readable messages
-//!   onto the OpenSSL ERR queue so callers can recover them via
-//!   `ERR_get_error` (and `openssl errstr` on the CLI side).
+//! - [`openssl_err`] / [`result_to_int`] — record the reason code on the
+//!   OpenSSL ERR queue, with a human-readable detail string attached via
+//!   `ERR_add_error_data`. Callers read the code with `ERR_get_error`; the
+//!   detail string is surfaced via `ERR_print_errors*` (or programmatically
+//!   via `ERR_get_error_line_data`).
 //! - [`catch_panic`] — wrap a C entry point so a Rust panic returns a
 //!   caller-supplied fallback instead of unwinding into C (which is UB).
 
@@ -141,8 +143,9 @@ pub fn openssl_err(reason: c_int, msg: &str) {
     // SAFETY: ERR_put_error stores the file pointer as-is; we pass a
     // 'static empty C string so it remains valid for the lifetime of the
     // ERR queue entry. ERR_add_error_data copies its argument internally.
+    // func is 0 ("unknown"): a negative value packs an invalid function code.
     unsafe {
-        ffi::ERR_put_error(ffi::ERR_LIB_ENGINE as c_int, -1, reason, c"".as_ptr(), 0);
+        ffi::ERR_put_error(ffi::ERR_LIB_ENGINE as c_int, 0, reason, c"".as_ptr(), 0);
         ffi::ERR_add_error_data(1, msg_c.as_ptr());
     }
 }

--- a/plugins/ossl_engine/openssl-engine/src/error.rs
+++ b/plugins/ossl_engine/openssl-engine/src/error.rs
@@ -113,15 +113,19 @@ impl From<RetCode> for c_int {
 
 /// Push a human-readable message onto the OpenSSL ERR queue.
 ///
-/// `reason` is an `ERR_R_*` constant from `openssl-sys-engine`.  Empty or
-/// NUL-containing messages are dropped silently — OpenSSL has no way to
-/// represent them.  OpenSSL copies the string internally; callers may free
-/// after return.
+/// `reason` is an `ERR_R_*` constant from `openssl-sys-engine`.  The reason
+/// code is always recorded; the message is best-effort and is truncated at
+/// the first interior NUL (rather than dropping the error entirely), since
+/// OpenSSL cannot represent the bytes past it.  OpenSSL copies the string
+/// internally; callers may free after return.
 #[allow(unsafe_code)]
 pub fn openssl_err(reason: c_int, msg: &str) {
-    let Ok(msg_c) = CString::new(msg) else {
-        return;
+    // Truncate at the first interior NUL so the reason code is never lost.
+    let msg = match msg.find('\0') {
+        Some(i) => &msg[..i],
+        None => msg,
     };
+    let msg_c = CString::new(msg).unwrap_or_default();
 
     // SAFETY: ERR_put_error stores the file pointer as-is; we pass a
     // 'static empty C string so it remains valid for the lifetime of the
@@ -162,6 +166,12 @@ where
         Ok(v) => v,
         Err(_) => {
             tracing::error!("panic caught at FFI boundary");
+            // Surface the panic on the ERR queue too, so a caller that only
+            // inspects OpenSSL errors still sees why the call returned 0.
+            openssl_err(
+                ffi::ERR_R_INTERNAL_ERROR as c_int,
+                "panic caught at FFI boundary",
+            );
             on_panic
         }
     }
@@ -244,6 +254,50 @@ mod tests {
             -1,
         );
         assert_eq!(result, -1);
+    }
+
+    /// A panic at the FFI boundary must also leave an entry on the ERR queue.
+    #[test]
+    #[allow(unsafe_code)]
+    fn catch_panic_pushes_error_on_panic() {
+        // SAFETY: see openssl_err_round_trip.
+        unsafe { ffi::ERR_clear_error() };
+
+        let result = catch_panic(
+            || {
+                panic!("simulated");
+                #[allow(unreachable_code)]
+                0
+            },
+            -1,
+        );
+        assert_eq!(result, -1);
+
+        // SAFETY: same as above.
+        let code = unsafe { ffi::ERR_get_error() };
+        assert_ne!(code, 0, "a panic should push onto the ERR queue");
+        assert_eq!((code & 0xfff) as c_int, ffi::ERR_R_INTERNAL_ERROR as c_int);
+
+        // SAFETY: same as above.
+        unsafe { ffi::ERR_clear_error() };
+    }
+
+    /// An interior NUL truncates the message but still records the reason.
+    #[test]
+    #[allow(unsafe_code)]
+    fn openssl_err_with_interior_nul_still_records_reason() {
+        // SAFETY: see openssl_err_round_trip.
+        unsafe { ffi::ERR_clear_error() };
+
+        openssl_err(ffi::ERR_R_INTERNAL_ERROR as c_int, "before\0after");
+
+        // SAFETY: same as above.
+        let code = unsafe { ffi::ERR_get_error() };
+        assert_ne!(code, 0, "interior NUL must not drop the error");
+        assert_eq!((code & 0xfff) as c_int, ffi::ERR_R_INTERNAL_ERROR as c_int);
+
+        // SAFETY: same as above.
+        unsafe { ffi::ERR_clear_error() };
     }
 
     #[test]

--- a/plugins/ossl_engine/openssl-engine/src/error.rs
+++ b/plugins/ossl_engine/openssl-engine/src/error.rs
@@ -111,6 +111,17 @@ impl From<RetCode> for c_int {
     }
 }
 
+/// Map an OpenSSL `1`(success)/`0`(failure) return code into a result,
+/// attaching `err` on failure. Keeps the bare `1`/`!= 1` literal out of
+/// the call sites.
+pub(crate) fn ossl_check(rc: c_int, err: EngineError) -> EngineResult<()> {
+    if rc == RetCode::Success as c_int {
+        Ok(())
+    } else {
+        Err(err)
+    }
+}
+
 /// Push a human-readable message onto the OpenSSL ERR queue.
 ///
 /// `reason` is an `ERR_R_*` constant from `openssl-sys-engine`.  The reason

--- a/plugins/ossl_engine/openssl-engine/src/lib.rs
+++ b/plugins/ossl_engine/openssl-engine/src/lib.rs
@@ -13,5 +13,7 @@
 
 #[cfg(all(target_os = "linux", feature = "engine"))]
 pub mod engine;
+#[cfg(all(target_os = "linux", feature = "engine"))]
+pub mod error;
 
 pub use openssl_sys_engine as ffi;

--- a/plugins/ossl_engine/openssl-sys-engine/build.rs
+++ b/plugins/ossl_engine/openssl-sys-engine/build.rs
@@ -84,6 +84,8 @@ fn main() {
         .allowlist_function("EC_GROUP_.*")
         .allowlist_function("ERR_put_error")
         .allowlist_function("ERR_add_error_data")
+        .allowlist_function("ERR_get_error")
+        .allowlist_function("ERR_clear_error")
         .allowlist_function("CRYPTO_get_ex_new_index")
         .allowlist_function("CRYPTO_set_mem_functions")
         .allowlist_function("OPENSSL_init_crypto")


### PR DESCRIPTION
Add openssl-engine error layer: EngineError/EngineResult/RetCode, openssl_err() (ERR_put_error + ERR_add_error_data), and catch_panic()/result_to_int() panic-safe FFI trampolines. Wire bind_engine through catch_panic so a Rust panic can never unwind across the C ABI; failures surface via the OpenSSL error queue and a 0 return.

Engine wrapper methods return EngineResult instead of raw 1/0.