### PR TITLE
Add mock only cfg for init, seal bk3 tests

### DIFF
--- a/ddi/mbor/types/tests/integration/init_bk3_smoke.rs
+++ b/ddi/mbor/types/tests/integration/init_bk3_smoke.rs
@@ -21,6 +21,7 @@
 //!   called again — the new `BK_BOOT` produces a different
 //!   `masked_bk3`.
 
+#![cfg(any(feature = "emu", feature = "mock"))]
 #![cfg(test)]
 
 use azihsm_ddi::*;

--- a/ddi/mbor/types/tests/integration/sealed_bk3_smoke.rs
+++ b/ddi/mbor/types/tests/integration/sealed_bk3_smoke.rs
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 //! SetSealedBk3 / GetSealedBk3 smoke tests for the emu backend.
-
+#![cfg(any(feature = "emu", feature = "mock"))]
 #![cfg(test)]
 
 use azihsm_ddi::*;


### PR DESCRIPTION
This pull request adds conditional compilation attributes to restrict the execution of certain integration tests to specific build features. The main change ensures that the smoke tests for `init_bk3` and `sealed_bk3` are only run when either the `emu` or `mock` feature is enabled.

Test configuration improvements:

* Added `#![cfg(any(feature = "emu", feature = "mock"))]` to the top of `init_bk3_smoke.rs` and `sealed_bk3_smoke.rs` to ensure these integration tests only run when the `emu` or `mock` feature is enabled, preventing unintended execution in other configurations.