### PR TITLE
feat(engine): typed ex_data + ENGINE_set_destroy wiring

### DIFF
--- a/.github/workflows/engine-matrix.yml
+++ b/.github/workflows/engine-matrix.yml
@@ -100,5 +100,11 @@ jobs:
           cargo clippy -p azihsm_engine -p openssl-engine -p openssl-sys-engine \
             --features engine --all-targets -- -D warnings
 
+      # openssl-engine's unit tests (error queue, ex_data, set_destroy) depend
+      # only on the 1.1 FFI, so they run here. The azihsm_engine mock lifecycle
+      # tests pull the OpenSSL-3.x SDK and need separate handling (roadmap #19).
+      - name: Test openssl-engine
+        run: cargo test -p openssl-engine --features engine
+
       - name: Load engine
         run: openssl engine -t "$(pwd)/target/debug/libazihsm_engine.so"

--- a/plugins/ossl_engine/engine/src/lib.rs
+++ b/plugins/ossl_engine/engine/src/lib.rs
@@ -87,7 +87,7 @@ mod engine_impl {
 
     /// Engine setup invoked by [`Engine::bind`]: reject a request for a
     /// different engine id, then register this engine's id and name.
-    fn bind_helper(engine: &Engine, id: &CStr) -> EngineResult<()> {
+    fn bind_helper(engine: &mut Engine, id: &CStr) -> EngineResult<()> {
         let id_bytes = id.to_bytes();
         if !id_bytes.is_empty() && !id_bytes.contains(&b'/') && id != ENGINE_ID {
             return Err(EngineError::IdMismatch);

--- a/plugins/ossl_engine/openssl-engine/src/engine.rs
+++ b/plugins/ossl_engine/openssl-engine/src/engine.rs
@@ -5,6 +5,7 @@
 
 use std::ffi::CStr;
 use std::ffi::c_char;
+use std::ffi::c_int;
 use std::ptr::NonNull;
 use std::ptr::null_mut;
 
@@ -12,7 +13,10 @@ use openssl_sys_engine as ffi;
 
 use crate::error::EngineError;
 use crate::error::EngineResult;
+use crate::error::RetCode;
+use crate::error::catch_panic;
 use crate::error::ossl_check;
+use crate::error::result_to_int;
 
 pub struct Engine {
     ptr: *mut ffi::ENGINE,
@@ -33,6 +37,11 @@ impl Engine {
         Self { ptr: ptr.as_ptr() }
     }
 
+    /// The raw `*mut ENGINE`, for FFI calls that need the pointer directly.
+    pub(crate) fn as_ptr(&self) -> *mut ffi::ENGINE {
+        self.ptr
+    }
+
     /// Synchronize memory allocators with the host, then call `f`.
     ///
     /// # Safety
@@ -41,10 +50,10 @@ impl Engine {
     #[allow(unsafe_code)]
     #[allow(clippy::not_unsafe_ptr_arg_deref)]
     pub unsafe fn bind(
-        &self,
+        &mut self,
         id: *const c_char,
         fns: NonNull<ffi::dynamic_fns>,
-        f: fn(&Engine, &CStr) -> EngineResult<()>,
+        f: fn(&mut Engine, &CStr) -> EngineResult<()>,
     ) -> EngineResult<()> {
         let fns_ptr = fns.as_ptr();
 
@@ -95,5 +104,102 @@ impl Engine {
             unsafe { ffi::ENGINE_set_name(self.ptr, name.as_ptr()) },
             EngineError::SetNameFailed,
         )
+    }
+
+    /// Register a destroy callback. `H::destroy` runs when OpenSSL tears
+    /// the engine down (after the last `ENGINE_free`). Each `H` produces a
+    /// distinct monomorphized C trampoline, so distinct engines may use
+    /// distinct handlers without global state.
+    #[allow(unsafe_code)]
+    pub fn set_destroy<H: DestroyHandler>(&self) -> EngineResult<()> {
+        // SAFETY: self.ptr is valid (from NonNull); c_destroy::<H> has the
+        // correct C signature and stays valid for the lifetime of the
+        // process (it's a 'static fn item).
+        ossl_check(
+            unsafe { ffi::ENGINE_set_destroy_function(self.ptr, Some(c_destroy::<H>)) },
+            EngineError::SetDestroyFailed,
+        )
+    }
+}
+
+/// Caller-supplied destroy logic, invoked by OpenSSL when an `ENGINE` is
+/// torn down. Implement this on a zero-sized marker type and pass it as
+/// the type parameter to [`Engine::set_destroy`].
+///
+/// Takes `&mut Engine` so a handler can `take()` ex_data (which requires
+/// exclusive access) to drop attached state during teardown.
+pub trait DestroyHandler {
+    fn destroy(engine: &mut Engine) -> EngineResult<()>;
+}
+
+/// C trampoline for `ENGINE_set_destroy_function`. Catches panics and
+/// dispatches to `H::destroy`. One instantiation per `H`.
+///
+/// # Safety
+/// Called only by OpenSSL during `ENGINE_free`. `e` is the ENGINE being
+/// destroyed (may be NULL on malformed input, handled by the trampoline).
+#[allow(unsafe_code)]
+unsafe extern "C" fn c_destroy<H: DestroyHandler>(e: *mut ffi::ENGINE) -> c_int {
+    catch_panic(
+        // SAFETY: `e` is the ENGINE OpenSSL is destroying, per the
+        // ENGINE_set_destroy_function callback contract.
+        || result_to_int(unsafe { destroy_inner::<H>(e) }),
+        RetCode::Fail.into(),
+    )
+}
+
+/// Inner body of [`c_destroy`]: rebuild a safe [`Engine`] from the raw pointer
+/// and run the handler. Split out for readability (see [`c_destroy`]).
+///
+/// # Safety
+/// `e` must be the `ENGINE` OpenSSL is destroying (may be NULL).
+#[allow(unsafe_code)]
+unsafe fn destroy_inner<H: DestroyHandler>(e: *mut ffi::ENGINE) -> EngineResult<()> {
+    let nn = NonNull::new(e).ok_or(EngineError::NullParam("engine"))?;
+    // SAFETY: `e` is the ENGINE OpenSSL is destroying; valid for this call.
+    let mut engine = unsafe { Engine::from_ptr(nn) };
+    H::destroy(&mut engine)
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used)]
+
+    use std::sync::atomic::AtomicUsize;
+    use std::sync::atomic::Ordering;
+
+    use super::*;
+
+    static DESTROY_COUNT: AtomicUsize = AtomicUsize::new(0);
+
+    struct CountingDestroy;
+    impl DestroyHandler for CountingDestroy {
+        fn destroy(_: &mut Engine) -> EngineResult<()> {
+            DESTROY_COUNT.fetch_add(1, Ordering::SeqCst);
+            Ok(())
+        }
+    }
+
+    #[test]
+    #[allow(unsafe_code)]
+    fn set_destroy_runs_on_engine_free() {
+        // SAFETY: ENGINE_new / ENGINE_free are standard OpenSSL entry points
+        // taking no arguments / a valid ENGINE pointer respectively.
+        let raw = unsafe { ffi::ENGINE_new() };
+        let nn = NonNull::new(raw).expect("ENGINE_new returned NULL");
+        // SAFETY: nn is non-null and owned until ENGINE_free below.
+        let e = unsafe { Engine::from_ptr(nn) };
+
+        let before = DESTROY_COUNT.load(Ordering::SeqCst);
+        e.set_destroy::<CountingDestroy>().unwrap();
+        assert_eq!(DESTROY_COUNT.load(Ordering::SeqCst), before);
+
+        // SAFETY: same as above.
+        unsafe { ffi::ENGINE_free(e.as_ptr()) };
+        assert_eq!(
+            DESTROY_COUNT.load(Ordering::SeqCst),
+            before + 1,
+            "destroy callback should run exactly once on ENGINE_free"
+        );
     }
 }

--- a/plugins/ossl_engine/openssl-engine/src/exdata.rs
+++ b/plugins/ossl_engine/openssl-engine/src/exdata.rs
@@ -116,27 +116,31 @@ impl<T: Send + Sync + 'static> EngineExData<T> {
         unsafe { ptr.as_ref() }
     }
 
-    /// Detach and return the stored value, if any. The slot is cleared.
+    /// Detach and return the stored value: `Ok(Some(_))` if present,
+    /// `Ok(None)` if the slot was empty.
     ///
     /// Takes `&mut Engine` for the same reason as [`set`](Self::set): it must
     /// not run while a `&T` from [`get`](Self::get) is still live.
+    ///
+    /// Returns `Err(ExDataSetFailed)` if clearing the slot fails. In that case
+    /// the value is intentionally left attached to the `ENGINE` (not reclaimed)
+    /// so there is no use-after-free — the slot may still be populated.
     #[allow(unsafe_code)]
-    pub fn take(&self, engine: &mut Engine) -> Option<Box<T>> {
+    pub fn take(&self, engine: &mut Engine) -> EngineResult<Option<Box<T>>> {
         // SAFETY: engine.as_ptr() is a valid ENGINE; self.idx is a registered slot.
         let ptr = unsafe { ffi::ENGINE_get_ex_data(engine.as_ptr(), self.idx) } as *mut T;
         if ptr.is_null() {
-            return None;
+            return Ok(None);
         }
         // SAFETY: engine.as_ptr() is a valid ENGINE; self.idx is a registered slot.
         let rc =
             unsafe { ffi::ENGINE_set_ex_data(engine.as_ptr(), self.idx, null_mut::<c_void>()) };
         // Clear the slot before reclaiming the box. If the clear fails the
-        // ENGINE still references `ptr`, so leave it in place (return None,
-        // leaking) rather than hand back a box the ENGINE could free later —
-        // a use-after-free.
-        ossl_check(rc, EngineError::ExDataSetFailed).ok()?;
+        // ENGINE still references `ptr`, so leave it attached and surface the
+        // error rather than hand back a box the ENGINE could free later (UAF).
+        ossl_check(rc, EngineError::ExDataSetFailed)?;
         // SAFETY: `ptr` was put there by `set`; the slot is now cleared.
-        Some(unsafe { Box::from_raw(ptr) })
+        Ok(Some(unsafe { Box::from_raw(ptr) }))
     }
 }
 
@@ -182,7 +186,7 @@ mod tests {
 
         assert_eq!(slot.get(&e), Some(&0xDEAD_BEEF));
 
-        let taken = slot.take(&mut e).unwrap();
+        let taken = slot.take(&mut e).unwrap().expect("slot populated");
         assert_eq!(*taken, 0xDEAD_BEEF);
         assert!(slot.get(&e).is_none(), "slot should be empty after take");
 
@@ -220,7 +224,7 @@ mod tests {
 
         slot.set(&mut e, Box::new(DropCounter(Arc::clone(&counter))))
             .unwrap();
-        let taken = slot.take(&mut e).unwrap();
+        let taken = slot.take(&mut e).unwrap().expect("slot populated");
         assert_eq!(counter.load(Ordering::SeqCst), 0);
 
         drop(taken);

--- a/plugins/ossl_engine/openssl-engine/src/exdata.rs
+++ b/plugins/ossl_engine/openssl-engine/src/exdata.rs
@@ -80,8 +80,9 @@ impl<T: Send + Sync + 'static> EngineExData<T> {
         })
     }
 
-    /// Attach `value`, returning any previously-stored value (which the caller
-    /// must drop — there is no auto-free callback; see module docs).
+    /// Attach `value`. Returns any previously-stored value, already detached
+    /// from the `ENGINE` — drop it directly. (The newly stored `value` has no
+    /// auto-free callback; reclaim it later via [`take`](Self::take).)
     ///
     /// `&mut Engine`: a live `&T` from [`get`](Self::get) then statically
     /// conflicts with detaching the value, closing a safe-code use-after-free.
@@ -126,10 +127,15 @@ impl<T: Send + Sync + 'static> EngineExData<T> {
         if ptr.is_null() {
             return None;
         }
-        // Clear the slot so the free callback (if it fires later) is a no-op.
-        // SAFETY: same as above.
-        let _ = unsafe { ffi::ENGINE_set_ex_data(engine.as_ptr(), self.idx, null_mut::<c_void>()) };
-        // SAFETY: `ptr` was put there by `set` and OpenSSL has not freed it.
+        // SAFETY: engine.as_ptr() is a valid ENGINE; self.idx is a registered slot.
+        let rc =
+            unsafe { ffi::ENGINE_set_ex_data(engine.as_ptr(), self.idx, null_mut::<c_void>()) };
+        // Clear the slot before reclaiming the box. If the clear fails the
+        // ENGINE still references `ptr`, so leave it in place (return None,
+        // leaking) rather than hand back a box the ENGINE could free later —
+        // a use-after-free.
+        ossl_check(rc, EngineError::ExDataSetFailed).ok()?;
+        // SAFETY: `ptr` was put there by `set`; the slot is now cleared.
         Some(unsafe { Box::from_raw(ptr) })
     }
 }

--- a/plugins/ossl_engine/openssl-engine/src/exdata.rs
+++ b/plugins/ossl_engine/openssl-engine/src/exdata.rs
@@ -1,0 +1,258 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Typed ex_data slot for `ENGINE` objects: attaches a `Box<T>` to an
+//! `ENGINE`.
+//!
+//! No per-slot free callback is registered — `libcrypto`'s late `atexit`
+//! cleanup can run after the engine `.so` is unmapped, leaving a dangling
+//! function pointer. Callers must instead drop the box via [`take`] from a
+//! [`DestroyHandler`](crate::engine::DestroyHandler), which runs while the
+//! `.so` is loaded.
+//!
+//! `CRYPTO_get_ex_new_index` allocates a fresh slot per call (no dedupe), so
+//! callers must cache the [`register`] result (e.g. in a `OnceLock`).
+//!
+//! [`register`]: EngineExData::register
+//! [`take`]: EngineExData::take
+
+use std::ffi::c_int;
+use std::ffi::c_void;
+use std::marker::PhantomData;
+use std::ptr::null_mut;
+
+use openssl_sys_engine as ffi;
+
+use crate::engine::Engine;
+use crate::error::EngineError;
+use crate::error::EngineResult;
+use crate::error::ossl_check;
+
+/// Sentinel `CRYPTO_get_ex_new_index` returns on allocation failure; any
+/// other (non-negative) value is a valid slot index.
+const EX_NEW_INDEX_FAILURE: c_int = -1;
+
+/// Typed handle to an ex_data slot on `ENGINE` for values of type `T`. `Copy`
+/// (holds only the slot index).
+///
+/// `T: Sync` is required: [`get`](Self::get) hands out a `&T` through a shared
+/// `&Engine` (which is `Sync`), so the `&T` may be read from multiple threads.
+pub struct EngineExData<T: Send + Sync + 'static> {
+    idx: c_int,
+    _marker: PhantomData<fn() -> T>,
+}
+
+impl<T: Send + Sync + 'static> Clone for EngineExData<T> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+impl<T: Send + Sync + 'static> Copy for EngineExData<T> {}
+
+impl<T: Send + Sync + 'static> EngineExData<T> {
+    /// Allocate a new ex_data index on the `ENGINE` class for `T`.
+    ///
+    /// Each call allocates a fresh slot, so callers must cache the result
+    /// (see module docs). No per-slot free callback is registered — see
+    /// module docs for the rationale; callers must `take()` to drop the
+    /// stored value.
+    pub fn register() -> EngineResult<Self> {
+        // SAFETY: All inputs are constants or 'static. No callbacks are
+        // registered (see module docs).
+        #[allow(unsafe_code)]
+        let idx = unsafe {
+            ffi::CRYPTO_get_ex_new_index(
+                ffi::CRYPTO_EX_INDEX_ENGINE as c_int,
+                0,
+                null_mut(),
+                None,
+                None,
+                None,
+            )
+        };
+        if idx == EX_NEW_INDEX_FAILURE {
+            return Err(EngineError::ExDataRegisterFailed);
+        }
+        Ok(Self {
+            idx,
+            _marker: PhantomData,
+        })
+    }
+
+    /// Attach `value`, returning any previously-stored value (which the caller
+    /// must drop — there is no auto-free callback; see module docs).
+    ///
+    /// `&mut Engine`: a live `&T` from [`get`](Self::get) then statically
+    /// conflicts with detaching the value, closing a safe-code use-after-free.
+    #[allow(unsafe_code)]
+    pub fn set(&self, engine: &mut Engine, value: Box<T>) -> EngineResult<Option<Box<T>>> {
+        let new_raw = Box::into_raw(value);
+        // SAFETY: engine.as_ptr() is a valid ENGINE; self.idx is a registered slot.
+        let prev = unsafe { ffi::ENGINE_get_ex_data(engine.as_ptr(), self.idx) } as *mut T;
+        // SAFETY: same as above; new_raw is a fresh Box::into_raw of T.
+        let rc =
+            unsafe { ffi::ENGINE_set_ex_data(engine.as_ptr(), self.idx, new_raw.cast::<c_void>()) };
+        if let Err(e) = ossl_check(rc, EngineError::ExDataSetFailed) {
+            // SAFETY: OpenSSL did not take ownership; reclaim the box.
+            let _ = unsafe { Box::from_raw(new_raw) };
+            return Err(e);
+        }
+        if prev.is_null() {
+            Ok(None)
+        } else {
+            // SAFETY: `prev` was put there by an earlier `set` (Box::into_raw of T).
+            Ok(Some(unsafe { Box::from_raw(prev) }))
+        }
+    }
+
+    /// Borrow the stored value, if any. Lifetime tied to the `engine` borrow.
+    #[allow(unsafe_code)]
+    pub fn get<'e>(&self, engine: &'e Engine) -> Option<&'e T> {
+        // SAFETY: engine.as_ptr() is a valid ENGINE; self.idx is a registered slot.
+        let ptr = unsafe { ffi::ENGINE_get_ex_data(engine.as_ptr(), self.idx) } as *const T;
+        // SAFETY: non-null implies `set` placed a `Box::into_raw` of T here.
+        unsafe { ptr.as_ref() }
+    }
+
+    /// Detach and return the stored value, if any. The slot is cleared.
+    ///
+    /// Takes `&mut Engine` for the same reason as [`set`](Self::set): it must
+    /// not run while a `&T` from [`get`](Self::get) is still live.
+    #[allow(unsafe_code)]
+    pub fn take(&self, engine: &mut Engine) -> Option<Box<T>> {
+        // SAFETY: engine.as_ptr() is a valid ENGINE; self.idx is a registered slot.
+        let ptr = unsafe { ffi::ENGINE_get_ex_data(engine.as_ptr(), self.idx) } as *mut T;
+        if ptr.is_null() {
+            return None;
+        }
+        // Clear the slot so the free callback (if it fires later) is a no-op.
+        // SAFETY: same as above.
+        let _ = unsafe { ffi::ENGINE_set_ex_data(engine.as_ptr(), self.idx, null_mut::<c_void>()) };
+        // SAFETY: `ptr` was put there by `set` and OpenSSL has not freed it.
+        Some(unsafe { Box::from_raw(ptr) })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used, clippy::panic)]
+
+    use std::ptr::NonNull;
+    use std::sync::Arc;
+    use std::sync::atomic::AtomicUsize;
+    use std::sync::atomic::Ordering;
+
+    use super::*;
+
+    /// Create a fresh ENGINE for a test. Caller must `ENGINE_free` it.
+    #[allow(unsafe_code)]
+    fn new_engine() -> Engine {
+        // SAFETY: ENGINE_new returns either a fresh, heap-allocated
+        // ENGINE or NULL on allocation failure (which we treat as a
+        // test setup failure).
+        let raw = unsafe { ffi::ENGINE_new() };
+        let nn = NonNull::new(raw).expect("ENGINE_new returned NULL");
+        // SAFETY: nn is non-null and owned by us until ENGINE_free below.
+        unsafe { Engine::from_ptr(nn) }
+    }
+
+    /// Release an ENGINE created by `new_engine`. Triggers free callbacks.
+    #[allow(unsafe_code)]
+    fn free_engine(e: Engine) {
+        // SAFETY: e was obtained from new_engine and not consumed elsewhere.
+        unsafe { ffi::ENGINE_free(e.as_ptr()) };
+    }
+
+    #[test]
+    fn round_trip_set_get_take() {
+        let slot = EngineExData::<u32>::register().unwrap();
+        let mut e = new_engine();
+
+        assert!(slot.get(&e).is_none());
+
+        let prev = slot.set(&mut e, Box::new(0xDEAD_BEEF)).unwrap();
+        assert!(prev.is_none(), "first set should have no previous value");
+
+        assert_eq!(slot.get(&e), Some(&0xDEAD_BEEF));
+
+        let taken = slot.take(&mut e).unwrap();
+        assert_eq!(*taken, 0xDEAD_BEEF);
+        assert!(slot.get(&e).is_none(), "slot should be empty after take");
+
+        free_engine(e);
+    }
+
+    #[test]
+    fn set_returns_previous_value() {
+        let slot = EngineExData::<String>::register().unwrap();
+        let mut e = new_engine();
+
+        slot.set(&mut e, Box::new("first".to_owned())).unwrap();
+        let prev = slot.set(&mut e, Box::new("second".to_owned())).unwrap();
+
+        assert_eq!(prev.as_deref().map(String::as_str), Some("first"));
+        assert_eq!(slot.get(&e).map(String::as_str), Some("second"));
+
+        free_engine(e);
+    }
+
+    /// Counts Drop calls on the contained value.
+    struct DropCounter(Arc<AtomicUsize>);
+
+    impl Drop for DropCounter {
+        fn drop(&mut self) {
+            self.0.fetch_add(1, Ordering::SeqCst);
+        }
+    }
+
+    #[test]
+    fn take_drops_box_exactly_once() {
+        let counter = Arc::new(AtomicUsize::new(0));
+        let slot = EngineExData::<DropCounter>::register().unwrap();
+        let mut e = new_engine();
+
+        slot.set(&mut e, Box::new(DropCounter(Arc::clone(&counter))))
+            .unwrap();
+        let taken = slot.take(&mut e).unwrap();
+        assert_eq!(counter.load(Ordering::SeqCst), 0);
+
+        drop(taken);
+        assert_eq!(counter.load(Ordering::SeqCst), 1);
+
+        free_engine(e);
+        assert_eq!(
+            counter.load(Ordering::SeqCst),
+            1,
+            "ENGINE_free must not re-drop after take()"
+        );
+    }
+
+    /// Pins the contract that `register` does NOT install a libcrypto-side
+    /// free callback. If this test ever fails to leak, revisit the module
+    /// docs — the caller-side `take()` contract relies on libcrypto being
+    /// unaware of `T` so a late `atexit` cleanup can never call back into
+    /// our (possibly unmapped) `.so`.
+    #[test]
+    fn engine_free_without_take_leaks_the_box() {
+        let counter = Arc::new(AtomicUsize::new(0));
+        let slot = EngineExData::<DropCounter>::register().unwrap();
+        let mut e = new_engine();
+
+        slot.set(&mut e, Box::new(DropCounter(Arc::clone(&counter))))
+            .unwrap();
+        free_engine(e);
+        assert_eq!(
+            counter.load(Ordering::SeqCst),
+            0,
+            "with no auto-free callback, ENGINE_free must NOT drop the box"
+        );
+    }
+
+    #[test]
+    fn distinct_types_get_distinct_indices() {
+        let a = EngineExData::<u32>::register().unwrap();
+        let b = EngineExData::<u64>::register().unwrap();
+        assert_ne!(a.idx, b.idx);
+    }
+}

--- a/plugins/ossl_engine/openssl-engine/src/lib.rs
+++ b/plugins/ossl_engine/openssl-engine/src/lib.rs
@@ -15,5 +15,7 @@
 pub mod engine;
 #[cfg(all(target_os = "linux", feature = "engine"))]
 pub mod error;
+#[cfg(all(target_os = "linux", feature = "engine"))]
+pub mod exdata;
 
 pub use openssl_sys_engine as ffi;


### PR DESCRIPTION
Add EngineExData<T> (typed CRYPTO_get_ex_new_index slots) and Engine::set_destroy/c_destroy with the DestroyHandler trait. Adopt the &mut Engine borrow model so an outstanding &T from EngineExData::get statically conflicts with set/take detaching it (closes a safe-code use-after-free); rippled through Engine::bind and bind_helper.