### PR TITLE
Added check to validate key usage for GenericSecretKeys

### DIFF
--- a/api/lib/src/algo/secret/key.rs
+++ b/api/lib/src/algo/secret/key.rs
@@ -43,6 +43,29 @@ impl HsmGenericSecretKey {
         props.check_supported_flags(supported_flag)
     }
 
+    /// Returns whether `props.flags()` contains the required usage flags for `props.kind()`.
+    ///
+    /// Required flags per supported kind:
+    /// - [`HsmKeyKind::SharedSecret`] must contain `DERIVE`
+    /// - [`HsmKeyKind::Aes`] must contain `ENCRYPT | DECRYPT`
+    /// - [`HsmKeyKind::HmacSha256`]/[`HsmKeyKind::HmacSha384`]/[`HsmKeyKind::HmacSha512`]
+    ///   must contain `SIGN | VERIFY`
+    ///
+    /// Any other kind is rejected.
+    fn check_key_usage(props: &HsmKeyProps) -> bool {
+        //check if key usage flags are valid for the key kind
+        match props.kind() {
+            HsmKeyKind::SharedSecret => props.flags().contains(HsmKeyFlags::DERIVE),
+            HsmKeyKind::Aes => props
+                .flags()
+                .contains(HsmKeyFlags::ENCRYPT | HsmKeyFlags::DECRYPT),
+            HsmKeyKind::HmacSha256 | HsmKeyKind::HmacSha384 | HsmKeyKind::HmacSha512 => props
+                .flags()
+                .contains(HsmKeyFlags::SIGN | HsmKeyFlags::VERIFY),
+            _ => false,
+        }
+    }
+
     /// Validates that these key properties describe a well-formed generic secret key.
     ///
     /// This is used by higher-level operations (e.g. ECDH/HKDF) to fail fast before issuing
@@ -61,6 +84,11 @@ impl HsmGenericSecretKey {
 
         //check key kind, GenericSecretKey can be of kind SharedSecret, AES or HMAC
         if !Self::check_key_kind(props) {
+            Err(HsmError::InvalidKeyProps)?;
+        }
+
+        //check key usage flags, GenericSecretKey can be of kind SharedSecret, AES or HMAC
+        if !Self::check_key_usage(props) {
             Err(HsmError::InvalidKeyProps)?;
         }
 

--- a/api/lib/src/algo/secret/key.rs
+++ b/api/lib/src/algo/secret/key.rs
@@ -55,13 +55,11 @@ impl HsmGenericSecretKey {
     fn check_key_usage(props: &HsmKeyProps) -> bool {
         //check if key usage flags are valid for the key kind
         match props.kind() {
-            HsmKeyKind::SharedSecret => props.flags().contains(HsmKeyFlags::DERIVE),
-            HsmKeyKind::Aes => props
-                .flags()
-                .contains(HsmKeyFlags::ENCRYPT | HsmKeyFlags::DECRYPT),
-            HsmKeyKind::HmacSha256 | HsmKeyKind::HmacSha384 | HsmKeyKind::HmacSha512 => props
-                .flags()
-                .contains(HsmKeyFlags::SIGN | HsmKeyFlags::VERIFY),
+            HsmKeyKind::SharedSecret => props.can_derive(),
+            HsmKeyKind::Aes => props.can_encrypt() && props.can_decrypt(),
+            HsmKeyKind::HmacSha256 | HsmKeyKind::HmacSha384 | HsmKeyKind::HmacSha512 => {
+                props.can_sign() && props.can_verify()
+            }
             _ => false,
         }
     }

--- a/api/tests/cpp/algo/hmac/keygen_tests.cpp
+++ b/api/tests/cpp/algo/hmac/keygen_tests.cpp
@@ -964,7 +964,7 @@ TEST_F(azihsm_hmac_keygen, derive_rejects_missing_hmac_usage_flags)
                 props,
                 hmac_key
             );
-            ASSERT_NE(err, AZIHSM_STATUS_SUCCESS);
+            ASSERT_EQ(err, AZIHSM_STATUS_INVALID_KEY_PROPS);
             ASSERT_EQ(hmac_key, 0);
         }
     });

--- a/api/tests/src/algo/hmac/key_prop_tests.rs
+++ b/api/tests/src/algo/hmac/key_prop_tests.rs
@@ -348,7 +348,7 @@ fn test_hmac_derived_key_prop_no_usage_flags_rejected(session: HsmSession) {
         .expect("Failed to build HMAC key props");
 
     let result = derive_hmac_key_with_props(&session, &base_secret, HsmHashAlgo::Sha256, props);
-    assert!(matches!(result, Err(HsmError::DdiCmdFailure)));
+    assert!(matches!(result, Err(HsmError::InvalidKeyProps)));
 }
 
 /// Minimal valid HMAC props (only sign + verify) should succeed

--- a/api/tests/src/algo/kdf/hkdf_tests.rs
+++ b/api/tests/src/algo/kdf/hkdf_tests.rs
@@ -1151,7 +1151,7 @@ fn test_ecdh_rejects_non_derivable_shared_secret(session: HsmSession) {
         ecdh_derive_shared_secret_with_props(&session, &priv_a, &pub_b, non_derivable_props);
 
     assert!(
-        matches!(result, Err(HsmError::DdiCmdFailure)),
+        matches!(result, Err(HsmError::InvalidKeyProps)),
         "ECDH should reject creating a shared secret without can_derive flag"
     );
 }


### PR DESCRIPTION
This pull request strengthens the validation of key usage flags for generic secret keys in the HSM (Hardware Security Module) library. It introduces stricter checks to ensure that only keys with the correct usage flags for their type are accepted, and updates error handling to consistently use `InvalidKeyProps` when these checks fail. Related tests have also been updated to reflect these changes.

Key validation improvements:

* Added a new `check_key_usage` function in `HsmGenericSecretKey` that enforces required usage flags for each supported key kind (`SharedSecret`, `Aes`, and HMAC variants), rejecting any other kind or missing required flags.
* Integrated the `check_key_usage` validation into the main key property validation logic, so that keys with incorrect usage flags are now rejected earlier and more consistently.

Error handling and test updates:

* Updated C++ test `derive_rejects_missing_hmac_usage_flags` to expect `AZIHSM_STATUS_INVALID_KEY_PROPS` instead of a generic failure, aligning with the new stricter validation.
* Updated Rust test `test_hmac_derived_key_prop_no_usage_flags_rejected` to expect `HsmError::InvalidKeyProps` instead of `DdiCmdFailure`.
* Updated Rust test `test_ecdh_rejects_non_derivable_shared_secret` to expect `HsmError::InvalidKeyProps` for missing `DERIVE` flag in shared secrets.