### PR TITLE
feat(engine): engine-resiliency crate (storage, lock, callbacks, config)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,6 +62,7 @@ members = [
   "fw/plat/std/x509",
   "fw/plat/std/x509/gen",
   "plugins/ossl_engine/engine",
+  "plugins/ossl_engine/engine-resiliency",
   "plugins/ossl_engine/openssl-engine",
   "plugins/ossl_engine/openssl-sys-engine",
   "plugins/ossl_prov",

--- a/plugins/ossl_engine/engine-resiliency/Cargo.toml
+++ b/plugins/ossl_engine/engine-resiliency/Cargo.toml
@@ -14,10 +14,11 @@ parking_lot.workspace = true
 thiserror.workspace = true
 zeroize.workspace = true
 
-# The engine is Linux-only (see src/lib.rs crate gate). `openssl` pulls
-# `openssl-sys`, which can't build on Windows without a system OpenSSL, so
-# gate it to Linux to keep the workspace `build_windows` clippy green.
+# The engine is Linux-only (see src/lib.rs crate gate); these deps pull
+# OpenSSL, which can't build on Windows without a system OpenSSL, so gate
+# them to Linux to keep the workspace `build_windows` clippy green.
 [target.'cfg(target_os = "linux")'.dependencies]
+azihsm_crypto.workspace = true
 openssl.workspace = true
 
 [target.'cfg(unix)'.dependencies]

--- a/plugins/ossl_engine/engine-resiliency/Cargo.toml
+++ b/plugins/ossl_engine/engine-resiliency/Cargo.toml
@@ -1,0 +1,27 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+[package]
+edition = "2024"
+name = "engine-resiliency"
+publish = false
+version = "0.1.0"
+
+[dependencies]
+azihsm_api.workspace = true
+fs2.workspace = true
+parking_lot.workspace = true
+thiserror.workspace = true
+zeroize.workspace = true
+
+# The engine is Linux-only (see src/lib.rs crate gate). `openssl` pulls
+# `openssl-sys`, which can't build on Windows without a system OpenSSL, so
+# gate it to Linux to keep the workspace `build_windows` clippy green.
+[target.'cfg(target_os = "linux")'.dependencies]
+openssl.workspace = true
+
+[target.'cfg(unix)'.dependencies]
+libc.workspace = true
+
+[lints]
+workspace = true

--- a/plugins/ossl_engine/engine-resiliency/src/callbacks.rs
+++ b/plugins/ossl_engine/engine-resiliency/src/callbacks.rs
@@ -66,8 +66,8 @@ impl PotaEndorsementCallback for FilePotaCallback {
     }
 }
 
-/// OBK provider that re-reads the OBK file on demand. The file must be at
-/// least [`OBK_LEN`] bytes; anything shorter is rejected as invalid.
+/// MOBK provider that re-reads the masked-OBK file on demand. The file must be
+/// at least [`OBK_LEN`] bytes; anything shorter is rejected as invalid.
 pub struct FileMobkCallback {
     path: PathBuf,
 }

--- a/plugins/ossl_engine/engine-resiliency/src/callbacks.rs
+++ b/plugins/ossl_engine/engine-resiliency/src/callbacks.rs
@@ -10,17 +10,16 @@ use azihsm_api::HsmPotaEndorsementData;
 use azihsm_api::HsmResult;
 use azihsm_api::MobkProviderCallback;
 use azihsm_api::PotaEndorsementCallback;
+use azihsm_crypto::EccPrivateKey;
+use azihsm_crypto::EcdsaAlgo;
+use azihsm_crypto::HashAlgo;
+use azihsm_crypto::ImportableKey;
+use azihsm_crypto::Signer;
 use openssl::bn::BigNumContext;
 use openssl::ec::PointConversionForm;
-use openssl::ecdsa::EcdsaSig;
-use openssl::hash::MessageDigest;
 use openssl::pkey::PKey;
-use openssl::sign::Signer;
 use zeroize::Zeroize;
 use zeroize::Zeroizing;
-
-/// Bytes per coordinate of a P-384 point / ECDSA component.
-const P384_COORD_LEN: usize = 48;
 
 /// Minimum length of the masked OBK accepted on load. The native bridge
 /// enforces `len >= OBK_SIZE` (a masked blob may be larger), so anything
@@ -116,27 +115,13 @@ fn pid_pub_key_uncompressed(pid_pub_key_der: &[u8]) -> HsmResult<Vec<u8>> {
     )
 }
 
-/// ECDSA-SHA384 sign `data` with the P-384 key in `priv_der` (PKCS#8 DER
-/// or traditional EC private key DER) and return a raw `r||s` signature
-/// (96 bytes total, each component left-padded to 48 bytes).
+/// ECDSA-SHA384 sign `data` with the P-384 key in `priv_der` (PKCS#8 DER) and
+/// return a raw `r||s` signature (96 bytes for P-384). Uses `azihsm_crypto`,
+/// whose `Signer::sign_vec` emits the raw signature directly.
 fn ecdsa_sha384_raw(priv_der: &[u8], data: &[u8]) -> HsmResult<Vec<u8>> {
-    let pkey = ossl(PKey::private_key_from_der(priv_der))?;
-
-    let mut signer = ossl(Signer::new(MessageDigest::sha384(), &pkey))?;
-    ossl(signer.update(data))?;
-    let der_sig = ossl(signer.sign_to_vec())?;
-
-    let ecdsa = ossl(EcdsaSig::from_der(&der_sig))?;
-    let r = ecdsa.r().to_vec();
-    let s = ecdsa.s().to_vec();
-    if r.len() > P384_COORD_LEN || s.len() > P384_COORD_LEN {
-        return Err(HsmError::InternalError);
-    }
-
-    let mut raw = vec![0u8; 2 * P384_COORD_LEN];
-    raw[P384_COORD_LEN - r.len()..P384_COORD_LEN].copy_from_slice(&r);
-    raw[2 * P384_COORD_LEN - s.len()..].copy_from_slice(&s);
-    Ok(raw)
+    let priv_key = EccPrivateKey::from_bytes(priv_der).map_err(|_| HsmError::InternalError)?;
+    let mut ecdsa = EcdsaAlgo::new(HashAlgo::sha384());
+    Signer::sign_vec(&mut ecdsa, &priv_key, data).map_err(|_| HsmError::InternalError)
 }
 
 #[cfg(test)]
@@ -148,19 +133,25 @@ mod tests {
     use openssl::bn::BigNum;
     use openssl::ec::EcGroup;
     use openssl::ec::EcKey;
+    use openssl::ecdsa::EcdsaSig;
     use openssl::nid::Nid;
     use openssl::pkey::PKey;
 
     use super::*;
     use crate::test_util::Scratch;
 
-    /// Generate a fresh P-384 key pair; return (`PKey`, priv-DER, pub-DER).
+    /// Bytes per coordinate of a P-384 ECDSA component (raw r/s half-length).
+    const P384_COORD_LEN: usize = 48;
+
+    /// Generate a fresh P-384 key pair; return (`PKey`, priv-PKCS#8-DER,
+    /// pub-DER). The private key is PKCS#8 because `ecdsa_sha384_raw` now
+    /// accepts only that format.
     #[allow(clippy::type_complexity)]
     fn fresh_p384() -> (PKey<openssl::pkey::Private>, Vec<u8>, Vec<u8>) {
         let group = EcGroup::from_curve_name(Nid::SECP384R1).unwrap();
         let ec = EcKey::generate(&group).unwrap();
         let pkey = PKey::from_ec_key(ec).unwrap();
-        let priv_der = pkey.private_key_to_der().unwrap();
+        let priv_der = pkey.private_key_to_pkcs8().unwrap();
         let pub_der = pkey.public_key_to_der().unwrap();
         (pkey, priv_der, pub_der)
     }

--- a/plugins/ossl_engine/engine-resiliency/src/callbacks.rs
+++ b/plugins/ossl_engine/engine-resiliency/src/callbacks.rs
@@ -3,9 +3,6 @@
 
 //! File-backed [`PotaEndorsementCallback`] and [`MobkProviderCallback`].
 
-use std::fs::OpenOptions;
-use std::io::Read;
-use std::path::Path;
 use std::path::PathBuf;
 
 use azihsm_api::HsmError;
@@ -25,7 +22,9 @@ use zeroize::Zeroizing;
 /// Bytes per coordinate of a P-384 point / ECDSA component.
 const P384_COORD_LEN: usize = 48;
 
-/// Length of the OBK (owner backup key), enforced on load.
+/// Minimum length of the masked OBK accepted on load. The native bridge
+/// enforces `len >= OBK_SIZE` (a masked blob may be larger), so anything
+/// shorter is rejected.
 const OBK_LEN: usize = 48;
 
 /// POTA endorsement that signs the device's PID public key with a
@@ -53,8 +52,10 @@ impl PotaEndorsementCallback for FilePotaCallback {
         _pid_cert_chain_pem: &[u8],
     ) -> HsmResult<HsmPotaEndorsementData> {
         // Private key is zeroized on drop; the public key is not secret.
-        let priv_der = Zeroizing::new(read_regular_no_follow(&self.priv_path).map_err(io_to_hsm)?);
-        let pub_der = read_regular_no_follow(&self.pub_path).map_err(io_to_hsm)?;
+        let priv_der = Zeroizing::new(
+            crate::read_regular_hardened(&self.priv_path).map_err(crate::io_to_hsm)?,
+        );
+        let pub_der = crate::read_regular_hardened(&self.pub_path).map_err(crate::io_to_hsm)?;
 
         let point_bytes = pid_pub_key_uncompressed(pid_pub_key_der)?;
         let sig_raw = ecdsa_sha384_raw(&priv_der, &point_bytes)?;
@@ -63,8 +64,8 @@ impl PotaEndorsementCallback for FilePotaCallback {
     }
 }
 
-/// OBK provider that re-reads the OBK file on demand. The file must be
-/// exactly [`OBK_LEN`] bytes; anything else is rejected as invalid.
+/// OBK provider that re-reads the OBK file on demand. The file must be at
+/// least [`OBK_LEN`] bytes; anything shorter is rejected as invalid.
 pub struct FileMobkCallback {
     path: PathBuf,
 }
@@ -77,8 +78,8 @@ impl FileMobkCallback {
 
 impl MobkProviderCallback for FileMobkCallback {
     fn get_mobk(&self) -> HsmResult<Vec<u8>> {
-        let mut bytes = read_regular_no_follow(&self.path).map_err(io_to_hsm)?;
-        if bytes.len() != OBK_LEN {
+        let mut bytes = crate::read_regular_hardened(&self.path).map_err(crate::io_to_hsm)?;
+        if bytes.len() < OBK_LEN {
             // Scrub the rejected buffer; it may hold a truncated real OBK.
             // The accepted buffer is returned to the SDK, whose
             // HsmOwnerBackupKeyConfig zeroizes its own copy on drop.
@@ -87,39 +88,6 @@ impl MobkProviderCallback for FileMobkCallback {
         }
         Ok(bytes)
     }
-}
-
-fn io_to_hsm(e: std::io::Error) -> HsmError {
-    if e.kind() == std::io::ErrorKind::NotFound {
-        HsmError::NotFound
-    } else {
-        HsmError::InternalError
-    }
-}
-
-/// Read a file that must be a regular file, refusing to follow a symlink at
-/// the final path component (`O_NOFOLLOW` on unix). The regular-file check
-/// is done via the opened fd's metadata, so there is no TOCTOU window. This
-/// mirrors the provider's hardened secret-material loads
-/// (`load_credentials_from_file` / `resiliency_get_obk`).
-fn read_regular_no_follow(path: &Path) -> std::io::Result<Vec<u8>> {
-    let mut opts = OpenOptions::new();
-    opts.read(true);
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::OpenOptionsExt;
-        opts.custom_flags(libc::O_NOFOLLOW);
-    }
-    let mut file = opts.open(path)?;
-    if !file.metadata()?.is_file() {
-        return Err(std::io::Error::new(
-            std::io::ErrorKind::InvalidInput,
-            "not a regular file",
-        ));
-    }
-    let mut buf = Vec::new();
-    file.read_to_end(&mut buf)?;
-    Ok(buf)
 }
 
 /// Map any OpenSSL error to [`HsmError::InternalError`]. Details land in
@@ -247,13 +215,26 @@ mod tests {
     }
 
     #[test]
-    fn obk_wrong_size_rejected() {
+    fn obk_too_short_rejected() {
         let scratch = Scratch::new("obksz");
         let path = scratch.0.join("obk.bin");
-        fs::write(&path, vec![0u8; OBK_LEN + 1]).unwrap();
+        fs::write(&path, vec![0u8; OBK_LEN - 1]).unwrap();
 
         let cb = FileMobkCallback::new(path);
         assert!(matches!(cb.get_mobk(), Err(HsmError::InvalidArgument)));
+    }
+
+    #[test]
+    fn obk_larger_than_min_accepted() {
+        // A masked OBK blob may exceed OBK_LEN; the native bridge enforces
+        // `>= OBK_SIZE`, so a longer blob must pass through unchanged.
+        let scratch = Scratch::new("obkbig");
+        let path = scratch.0.join("obk.bin");
+        let blob = vec![0xBB; OBK_LEN + 16];
+        fs::write(&path, &blob).unwrap();
+
+        let cb = FileMobkCallback::new(path);
+        assert_eq!(cb.get_mobk().unwrap(), blob);
     }
 
     #[test]

--- a/plugins/ossl_engine/engine-resiliency/src/callbacks.rs
+++ b/plugins/ossl_engine/engine-resiliency/src/callbacks.rs
@@ -1,0 +1,290 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! File-backed [`PotaEndorsementCallback`] and [`MobkProviderCallback`].
+
+use std::fs::OpenOptions;
+use std::io::Read;
+use std::path::Path;
+use std::path::PathBuf;
+
+use azihsm_api::HsmError;
+use azihsm_api::HsmPotaEndorsementData;
+use azihsm_api::HsmResult;
+use azihsm_api::MobkProviderCallback;
+use azihsm_api::PotaEndorsementCallback;
+use openssl::bn::BigNumContext;
+use openssl::ec::PointConversionForm;
+use openssl::ecdsa::EcdsaSig;
+use openssl::hash::MessageDigest;
+use openssl::pkey::PKey;
+use openssl::sign::Signer;
+use zeroize::Zeroize;
+use zeroize::Zeroizing;
+
+/// Bytes per coordinate of a P-384 point / ECDSA component.
+const P384_COORD_LEN: usize = 48;
+
+/// Length of the OBK (owner backup key), enforced on load.
+const OBK_LEN: usize = 48;
+
+/// POTA endorsement that signs the device's PID public key with a
+/// caller-owned P-384 private key loaded from disk. Mirrors the provider's
+/// `resiliency_pota_endorse` path.
+pub struct FilePotaCallback {
+    priv_path: PathBuf,
+    pub_path: PathBuf,
+}
+
+impl FilePotaCallback {
+    pub fn new(priv_path: PathBuf, pub_path: PathBuf) -> Self {
+        Self {
+            priv_path,
+            pub_path,
+        }
+    }
+}
+
+impl PotaEndorsementCallback for FilePotaCallback {
+    fn endorse(
+        &self,
+        _pota_pub_key_der: &[u8],
+        pid_pub_key_der: &[u8],
+        _pid_cert_chain_pem: &[u8],
+    ) -> HsmResult<HsmPotaEndorsementData> {
+        // Private key is zeroized on drop; the public key is not secret.
+        let priv_der = Zeroizing::new(read_regular_no_follow(&self.priv_path).map_err(io_to_hsm)?);
+        let pub_der = read_regular_no_follow(&self.pub_path).map_err(io_to_hsm)?;
+
+        let point_bytes = pid_pub_key_uncompressed(pid_pub_key_der)?;
+        let sig_raw = ecdsa_sha384_raw(&priv_der, &point_bytes)?;
+
+        Ok(HsmPotaEndorsementData::new(&sig_raw, &pub_der))
+    }
+}
+
+/// OBK provider that re-reads the OBK file on demand. The file must be
+/// exactly [`OBK_LEN`] bytes; anything else is rejected as invalid.
+pub struct FileMobkCallback {
+    path: PathBuf,
+}
+
+impl FileMobkCallback {
+    pub fn new(path: PathBuf) -> Self {
+        Self { path }
+    }
+}
+
+impl MobkProviderCallback for FileMobkCallback {
+    fn get_mobk(&self) -> HsmResult<Vec<u8>> {
+        let mut bytes = read_regular_no_follow(&self.path).map_err(io_to_hsm)?;
+        if bytes.len() != OBK_LEN {
+            // Scrub the rejected buffer; it may hold a truncated real OBK.
+            // The accepted buffer is returned to the SDK, whose
+            // HsmOwnerBackupKeyConfig zeroizes its own copy on drop.
+            bytes.zeroize();
+            return Err(HsmError::InvalidArgument);
+        }
+        Ok(bytes)
+    }
+}
+
+fn io_to_hsm(e: std::io::Error) -> HsmError {
+    if e.kind() == std::io::ErrorKind::NotFound {
+        HsmError::NotFound
+    } else {
+        HsmError::InternalError
+    }
+}
+
+/// Read a file that must be a regular file, refusing to follow a symlink at
+/// the final path component (`O_NOFOLLOW` on unix). The regular-file check
+/// is done via the opened fd's metadata, so there is no TOCTOU window. This
+/// mirrors the provider's hardened secret-material loads
+/// (`load_credentials_from_file` / `resiliency_get_obk`).
+fn read_regular_no_follow(path: &Path) -> std::io::Result<Vec<u8>> {
+    let mut opts = OpenOptions::new();
+    opts.read(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        opts.custom_flags(libc::O_NOFOLLOW);
+    }
+    let mut file = opts.open(path)?;
+    if !file.metadata()?.is_file() {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "not a regular file",
+        ));
+    }
+    let mut buf = Vec::new();
+    file.read_to_end(&mut buf)?;
+    Ok(buf)
+}
+
+/// Map any OpenSSL error to [`HsmError::InternalError`]. Details land in
+/// the OpenSSL error queue; this just folds the boundary cast.
+fn ossl<T>(r: Result<T, openssl::error::ErrorStack>) -> HsmResult<T> {
+    r.map_err(|_| HsmError::InternalError)
+}
+
+/// Decode `pid_pub_key_der` (SubjectPublicKeyInfo) and return the public
+/// point as uncompressed `0x04 || X || Y` (97 bytes for P-384).
+fn pid_pub_key_uncompressed(pid_pub_key_der: &[u8]) -> HsmResult<Vec<u8>> {
+    let pkey = ossl(PKey::public_key_from_der(pid_pub_key_der))?;
+    let ec = ossl(pkey.ec_key())?;
+    let mut ctx = ossl(BigNumContext::new())?;
+    ossl(
+        ec.public_key()
+            .to_bytes(ec.group(), PointConversionForm::UNCOMPRESSED, &mut ctx),
+    )
+}
+
+/// ECDSA-SHA384 sign `data` with the P-384 key in `priv_der` (PKCS#8 DER
+/// or traditional EC private key DER) and return a raw `r||s` signature
+/// (96 bytes total, each component left-padded to 48 bytes).
+fn ecdsa_sha384_raw(priv_der: &[u8], data: &[u8]) -> HsmResult<Vec<u8>> {
+    let pkey = ossl(PKey::private_key_from_der(priv_der))?;
+
+    let mut signer = ossl(Signer::new(MessageDigest::sha384(), &pkey))?;
+    ossl(signer.update(data))?;
+    let der_sig = ossl(signer.sign_to_vec())?;
+
+    let ecdsa = ossl(EcdsaSig::from_der(&der_sig))?;
+    let r = ecdsa.r().to_vec();
+    let s = ecdsa.s().to_vec();
+    if r.len() > P384_COORD_LEN || s.len() > P384_COORD_LEN {
+        return Err(HsmError::InternalError);
+    }
+
+    let mut raw = vec![0u8; 2 * P384_COORD_LEN];
+    raw[P384_COORD_LEN - r.len()..P384_COORD_LEN].copy_from_slice(&r);
+    raw[2 * P384_COORD_LEN - s.len()..].copy_from_slice(&s);
+    Ok(raw)
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used)]
+
+    use std::fs;
+
+    use openssl::bn::BigNum;
+    use openssl::ec::EcGroup;
+    use openssl::ec::EcKey;
+    use openssl::nid::Nid;
+    use openssl::pkey::PKey;
+
+    use super::*;
+    use crate::test_util::Scratch;
+
+    /// Generate a fresh P-384 key pair; return (`PKey`, priv-DER, pub-DER).
+    #[allow(clippy::type_complexity)]
+    fn fresh_p384() -> (PKey<openssl::pkey::Private>, Vec<u8>, Vec<u8>) {
+        let group = EcGroup::from_curve_name(Nid::SECP384R1).unwrap();
+        let ec = EcKey::generate(&group).unwrap();
+        let pkey = PKey::from_ec_key(ec).unwrap();
+        let priv_der = pkey.private_key_to_der().unwrap();
+        let pub_der = pkey.public_key_to_der().unwrap();
+        (pkey, priv_der, pub_der)
+    }
+
+    #[test]
+    fn pota_endorse_produces_verifiable_signature() {
+        let scratch = Scratch::new("pota");
+        let (pota_pkey, pota_priv, pota_pub) = fresh_p384();
+        let (_, _, pid_pub) = fresh_p384();
+
+        let priv_path = scratch.0.join("pota_priv.der");
+        let pub_path = scratch.0.join("pota_pub.der");
+        fs::write(&priv_path, &pota_priv).unwrap();
+        fs::write(&pub_path, &pota_pub).unwrap();
+
+        let cb = FilePotaCallback::new(priv_path, pub_path);
+        let data = cb.endorse(&[], &pid_pub, &[]).unwrap();
+
+        // Returned public key DER must match what we wrote.
+        assert_eq!(data.pub_key(), pota_pub.as_slice());
+
+        // Signature must be raw 96-byte r||s, verifiable against POTA pub.
+        assert_eq!(data.signature().len(), 2 * P384_COORD_LEN);
+
+        let r = BigNum::from_slice(&data.signature()[..P384_COORD_LEN]).unwrap();
+        let s = BigNum::from_slice(&data.signature()[P384_COORD_LEN..]).unwrap();
+        let ecdsa = EcdsaSig::from_private_components(r, s).unwrap();
+
+        let point = pid_pub_key_uncompressed(&pid_pub).unwrap();
+        let digest = openssl::sha::sha384(&point);
+
+        let ec_pub = pota_pkey.ec_key().unwrap();
+        assert!(ecdsa.verify(&digest, &ec_pub).unwrap(), "POTA sig invalid");
+    }
+
+    #[test]
+    fn pota_missing_priv_file_is_not_found() {
+        let scratch = Scratch::new("missprv");
+        let (_, _, pid_pub) = fresh_p384();
+
+        let cb = FilePotaCallback::new(
+            scratch.0.join("absent_priv.der"),
+            scratch.0.join("absent_pub.der"),
+        );
+        assert!(matches!(
+            cb.endorse(&[], &pid_pub, &[]),
+            Err(HsmError::NotFound)
+        ));
+    }
+
+    #[test]
+    fn obk_round_trip() {
+        let scratch = Scratch::new("obk");
+        let path = scratch.0.join("obk.bin");
+        let obk = vec![0xAA; OBK_LEN];
+        fs::write(&path, &obk).unwrap();
+
+        let cb = FileMobkCallback::new(path);
+        assert_eq!(cb.get_mobk().unwrap(), obk);
+    }
+
+    #[test]
+    fn obk_wrong_size_rejected() {
+        let scratch = Scratch::new("obksz");
+        let path = scratch.0.join("obk.bin");
+        fs::write(&path, vec![0u8; OBK_LEN + 1]).unwrap();
+
+        let cb = FileMobkCallback::new(path);
+        assert!(matches!(cb.get_mobk(), Err(HsmError::InvalidArgument)));
+    }
+
+    #[test]
+    fn obk_missing_is_not_found() {
+        let scratch = Scratch::new("obkmiss");
+        let cb = FileMobkCallback::new(scratch.0.join("absent.bin"));
+        assert!(matches!(cb.get_mobk(), Err(HsmError::NotFound)));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn obk_via_symlink_rejected() {
+        // O_NOFOLLOW must refuse a symlinked secret-material path even when
+        // the link target is a valid 48-byte OBK.
+        let scratch = Scratch::new("obklink");
+        let real = scratch.0.join("real_obk.bin");
+        fs::write(&real, vec![0xAA; OBK_LEN]).unwrap();
+        let link = scratch.0.join("obk_link.bin");
+        std::os::unix::fs::symlink(&real, &link).unwrap();
+
+        let cb = FileMobkCallback::new(link);
+        // O_NOFOLLOW open of a symlink fails (ELOOP), mapped to InternalError.
+        assert!(matches!(cb.get_mobk(), Err(HsmError::InternalError)));
+    }
+
+    #[test]
+    fn obk_directory_rejected() {
+        // A directory passes open() but must fail the regular-file check,
+        // surfacing as InternalError (InvalidInput is not NotFound).
+        let scratch = Scratch::new("obkdir");
+        let cb = FileMobkCallback::new(scratch.0.clone());
+        assert!(matches!(cb.get_mobk(), Err(HsmError::InternalError)));
+    }
+}

--- a/plugins/ossl_engine/engine-resiliency/src/callbacks.rs
+++ b/plugins/ossl_engine/engine-resiliency/src/callbacks.rs
@@ -51,7 +51,9 @@ impl PotaEndorsementCallback for FilePotaCallback {
         pid_pub_key_der: &[u8],
         _pid_cert_chain_pem: &[u8],
     ) -> HsmResult<HsmPotaEndorsementData> {
-        // Private key is zeroized on drop; the public key is not secret.
+        // The DER buffer is zeroized on drop; the public key is not secret.
+        // Note: OpenSSL's parsed copy (the PKey built from this DER in
+        // ecdsa_sha384_raw) is freed but not guaranteed to be cleansed.
         let priv_der = Zeroizing::new(
             crate::read_regular_hardened(&self.priv_path).map_err(crate::io_to_hsm)?,
         );

--- a/plugins/ossl_engine/engine-resiliency/src/callbacks.rs
+++ b/plugins/ossl_engine/engine-resiliency/src/callbacks.rs
@@ -36,6 +36,8 @@ pub struct FilePotaCallback {
 }
 
 impl FilePotaCallback {
+    /// Create an endorser that signs with the P-384 private key at `priv_path`
+    /// and returns the public key at `pub_path`.
     pub fn new(priv_path: PathBuf, pub_path: PathBuf) -> Self {
         Self {
             priv_path,
@@ -45,6 +47,8 @@ impl FilePotaCallback {
 }
 
 impl PotaEndorsementCallback for FilePotaCallback {
+    /// Sign the device's PID public key with the on-disk P-384 key, returning
+    /// the raw `r‖s` signature paired with the POTA public key.
     fn endorse(
         &self,
         _pota_pub_key_der: &[u8],
@@ -73,12 +77,14 @@ pub struct FileMobkCallback {
 }
 
 impl FileMobkCallback {
+    /// Create a MOBK provider that reads the masked OBK from `path`.
     pub fn new(path: PathBuf) -> Self {
         Self { path }
     }
 }
 
 impl MobkProviderCallback for FileMobkCallback {
+    /// Read and return the masked OBK; rejects a file shorter than [`OBK_LEN`].
     fn get_mobk(&self) -> HsmResult<Vec<u8>> {
         let mut bytes = crate::read_regular_hardened(&self.path).map_err(crate::io_to_hsm)?;
         if bytes.len() < OBK_LEN {

--- a/plugins/ossl_engine/engine-resiliency/src/config.rs
+++ b/plugins/ossl_engine/engine-resiliency/src/config.rs
@@ -94,14 +94,24 @@ impl ResiliencySettings {
         let storage_dir = env_nonempty(ENV_STORAGE_DIR)
             .map(PathBuf::from)
             .unwrap_or_else(|| PathBuf::from(DEFAULT_STORAGE_DIR));
-        let obk_source = parse_obk_source(&std::env::var(ENV_OBK_SOURCE).unwrap_or_default())?;
+        // Sources parse (and can error on a bad value) only when enabled; a
+        // disabled engine must not fail over a var it will never use.
+        let obk_source = if enabled {
+            parse_obk_source(&std::env::var(ENV_OBK_SOURCE).unwrap_or_default())?
+        } else {
+            HsmOwnerBackupKeySource::Caller
+        };
         let obk_path = env_nonempty(ENV_OBK_PATH)
             .map(PathBuf::from)
             .unwrap_or_else(|| PathBuf::from(DEFAULT_OBK_PATH));
         let mobk_path = env_nonempty(ENV_MOBK_PATH)
             .map(PathBuf::from)
             .unwrap_or_else(|| PathBuf::from(DEFAULT_MOBK_PATH));
-        let pota_source = parse_pota_source(&std::env::var(ENV_POTA_SOURCE).unwrap_or_default())?;
+        let pota_source = if enabled {
+            parse_pota_source(&std::env::var(ENV_POTA_SOURCE).unwrap_or_default())?
+        } else {
+            HsmPotaEndorsementSource::Caller
+        };
         let pota_priv_path = env_nonempty(ENV_POTA_PRIV).map(PathBuf::from);
         let pota_pub_path = env_nonempty(ENV_POTA_PUB).map(PathBuf::from);
 

--- a/plugins/ossl_engine/engine-resiliency/src/config.rs
+++ b/plugins/ossl_engine/engine-resiliency/src/config.rs
@@ -62,6 +62,9 @@ pub enum ConfigError {
 
     #[error("resiliency storage directory {0:?} could not be created or is insecure")]
     StorageDir(PathBuf),
+
+    #[error("env var {0} has unsafe path {1:?} (must be non-empty and contain no \"..\")")]
+    UnsafePath(&'static str, PathBuf),
 }
 
 /// Parsed view of the engine's resiliency-related environment variables.
@@ -84,23 +87,35 @@ pub struct ResiliencySettings {
 
 impl ResiliencySettings {
     /// Read settings from the process environment, applying defaults from
-    /// the module docs. Returns an error for malformed values; missing
-    /// optional vars fall back to their defaults.
+    /// the module docs. An empty value is treated as unset (falls back to the
+    /// default, or `None` for optional vars). Returns an error for malformed
+    /// values or unsafe paths (empty or containing `..`).
     pub fn from_env() -> Result<Self, ConfigError> {
         let enabled = parse_bool(ENV_ENABLED, &std::env::var(ENV_ENABLED).unwrap_or_default())?;
-        let storage_dir = std::env::var(ENV_STORAGE_DIR)
+        let storage_dir = env_nonempty(ENV_STORAGE_DIR)
             .map(PathBuf::from)
-            .unwrap_or_else(|_| PathBuf::from(DEFAULT_STORAGE_DIR));
+            .unwrap_or_else(|| PathBuf::from(DEFAULT_STORAGE_DIR));
         let obk_source = parse_obk_source(&std::env::var(ENV_OBK_SOURCE).unwrap_or_default())?;
-        let obk_path = std::env::var(ENV_OBK_PATH)
+        let obk_path = env_nonempty(ENV_OBK_PATH)
             .map(PathBuf::from)
-            .unwrap_or_else(|_| PathBuf::from(DEFAULT_OBK_PATH));
-        let mobk_path = std::env::var(ENV_MOBK_PATH)
+            .unwrap_or_else(|| PathBuf::from(DEFAULT_OBK_PATH));
+        let mobk_path = env_nonempty(ENV_MOBK_PATH)
             .map(PathBuf::from)
-            .unwrap_or_else(|_| PathBuf::from(DEFAULT_MOBK_PATH));
+            .unwrap_or_else(|| PathBuf::from(DEFAULT_MOBK_PATH));
         let pota_source = parse_pota_source(&std::env::var(ENV_POTA_SOURCE).unwrap_or_default())?;
-        let pota_priv_path = std::env::var(ENV_POTA_PRIV).ok().map(PathBuf::from);
-        let pota_pub_path = std::env::var(ENV_POTA_PUB).ok().map(PathBuf::from);
+        let pota_priv_path = env_nonempty(ENV_POTA_PRIV).map(PathBuf::from);
+        let pota_pub_path = env_nonempty(ENV_POTA_PUB).map(PathBuf::from);
+
+        // Reject unsafe paths up front (mirrors the provider's path_is_safe).
+        validate_path(ENV_STORAGE_DIR, &storage_dir)?;
+        validate_path(ENV_OBK_PATH, &obk_path)?;
+        validate_path(ENV_MOBK_PATH, &mobk_path)?;
+        if let Some(p) = &pota_priv_path {
+            validate_path(ENV_POTA_PRIV, p)?;
+        }
+        if let Some(p) = &pota_pub_path {
+            validate_path(ENV_POTA_PUB, p)?;
+        }
 
         Ok(Self {
             enabled,
@@ -190,6 +205,24 @@ fn parse_pota_source(raw: &str) -> Result<HsmPotaEndorsementSource, ConfigError>
             "caller or tpm",
         )),
     }
+}
+
+/// Read an env var, treating unset or empty as "not provided" (mirrors the
+/// provider's `dir_env[0] != '\0'` check).
+fn env_nonempty(var: &str) -> Option<String> {
+    match std::env::var(var) {
+        Ok(v) if !v.is_empty() => Some(v),
+        _ => None,
+    }
+}
+
+/// Reject an empty path or one containing `..`. Mirrors the provider's
+/// `azihsm_path_is_safe` so a configured path can't escape its intended tree.
+fn validate_path(var: &'static str, path: &Path) -> Result<(), ConfigError> {
+    if path.as_os_str().is_empty() || path.to_string_lossy().contains("..") {
+        return Err(ConfigError::UnsafePath(var, path.to_path_buf()));
+    }
+    Ok(())
 }
 
 /// Current process UID; `getuid(2)` takes no arguments and cannot fail.
@@ -323,6 +356,16 @@ mod tests {
             parse_bool("X", "maybe"),
             Err(ConfigError::InvalidValue("X", _, _))
         ));
+    }
+
+    #[test]
+    fn validate_path_rejects_unsafe_and_empty() {
+        assert!(validate_path("X", Path::new("")).is_err());
+        assert!(validate_path("X", Path::new("..")).is_err());
+        assert!(validate_path("X", Path::new("../escape")).is_err());
+        assert!(validate_path("X", Path::new("/var/lib/azihsm/../x")).is_err());
+        assert!(validate_path("X", Path::new("/var/lib/azihsm/resiliency")).is_ok());
+        assert!(validate_path("X", Path::new("./obk.bin")).is_ok());
     }
 
     #[test]

--- a/plugins/ossl_engine/engine-resiliency/src/config.rs
+++ b/plugins/ossl_engine/engine-resiliency/src/config.rs
@@ -21,6 +21,10 @@
 //! | `AZIHSM_POTA_PRIVATE_KEY_PATH`   | none                             | required when `POTA_SOURCE=caller` and resiliency enabled |
 //! | `AZIHSM_POTA_PUBLIC_KEY_PATH`    | none                             | same |
 
+use std::fs;
+use std::os::unix::fs::DirBuilderExt;
+use std::os::unix::fs::MetadataExt;
+use std::path::Path;
 use std::path::PathBuf;
 use std::sync::Arc;
 
@@ -47,6 +51,7 @@ const DEFAULT_OBK_PATH: &str = "./obk.bin";
 const DEFAULT_MOBK_PATH: &str = "./mobk.bin";
 const LOCK_FILE_NAME: &str = ".lock";
 
+/// Error from reading the engine's resiliency environment variables.
 #[derive(Debug, thiserror::Error)]
 pub enum ConfigError {
     #[error("env var {0} contains invalid value {1:?} (expected one of {2})")]
@@ -54,6 +59,9 @@ pub enum ConfigError {
 
     #[error("env var {0} is required but unset")]
     Missing(&'static str),
+
+    #[error("resiliency storage directory {0:?} could not be created or is insecure")]
+    StorageDir(PathBuf),
 }
 
 /// Parsed view of the engine's resiliency-related environment variables.
@@ -136,6 +144,7 @@ impl ResiliencySettings {
             _ => None,
         };
 
+        setup_storage_dir(&self.storage_dir)?;
         let lock_path = self.storage_dir.join(LOCK_FILE_NAME);
 
         Ok(Some(HsmResiliencyConfig {
@@ -183,11 +192,42 @@ fn parse_pota_source(raw: &str) -> Result<HsmPotaEndorsementSource, ConfigError>
     }
 }
 
+/// Current process UID; `getuid(2)` takes no arguments and cannot fail.
+#[allow(unsafe_code)]
+fn current_uid() -> u32 {
+    // SAFETY: getuid() has no preconditions and always succeeds.
+    unsafe { libc::getuid() }
+}
+
+/// Create `dir` with mode `0700`, or, if it already exists, require it to be a
+/// real directory owned by us with no group/other permissions. Mirrors the
+/// provider's storage-directory setup so misconfiguration fails up front
+/// rather than as a generic IO error on the first write.
+fn setup_storage_dir(dir: &Path) -> Result<(), ConfigError> {
+    let err = || ConfigError::StorageDir(dir.to_path_buf());
+    match fs::DirBuilder::new().mode(0o700).create(dir) {
+        Ok(()) => Ok(()),
+        Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
+            // symlink_metadata (lstat) so a symlink at `dir` is rejected here
+            // rather than silently followed.
+            let meta = fs::symlink_metadata(dir).map_err(|_| err())?;
+            if !meta.is_dir() || meta.uid() != current_uid() || meta.mode() & 0o077 != 0 {
+                return Err(err());
+            }
+            Ok(())
+        }
+        Err(_) => Err(err()),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     #![allow(clippy::unwrap_used)]
 
+    use std::os::unix::fs::PermissionsExt;
+
     use super::*;
+    use crate::test_util::Scratch;
 
     fn caller_caller_settings(storage: PathBuf) -> ResiliencySettings {
         ResiliencySettings {
@@ -211,7 +251,8 @@ mod tests {
 
     #[test]
     fn caller_sources_get_both_callbacks() {
-        let s = caller_caller_settings(PathBuf::from("/tmp/x"));
+        let scratch = Scratch::new("cfg-both");
+        let s = caller_caller_settings(scratch.0.join("store"));
         let cfg = s.into_resiliency_config().unwrap().unwrap();
         assert!(cfg.pota_callback.is_some());
         assert!(cfg.mobk_callback.is_some());
@@ -219,7 +260,8 @@ mod tests {
 
     #[test]
     fn tpm_obk_drops_obk_callback() {
-        let mut s = caller_caller_settings(PathBuf::from("/tmp/x"));
+        let scratch = Scratch::new("cfg-tpmobk");
+        let mut s = caller_caller_settings(scratch.0.join("store"));
         s.obk_source = HsmOwnerBackupKeySource::Tpm;
         let cfg = s.into_resiliency_config().unwrap().unwrap();
         assert!(cfg.mobk_callback.is_none());
@@ -228,11 +270,35 @@ mod tests {
 
     #[test]
     fn tpm_pota_drops_pota_callback() {
-        let mut s = caller_caller_settings(PathBuf::from("/tmp/x"));
+        let scratch = Scratch::new("cfg-tpmpota");
+        let mut s = caller_caller_settings(scratch.0.join("store"));
         s.pota_source = HsmPotaEndorsementSource::Tpm;
         let cfg = s.into_resiliency_config().unwrap().unwrap();
         assert!(cfg.pota_callback.is_none());
         assert!(cfg.mobk_callback.is_some());
+    }
+
+    #[test]
+    fn creates_storage_dir_with_owner_only_perms() {
+        let scratch = Scratch::new("cfg-mk");
+        let dir = scratch.0.join("store");
+        let s = caller_caller_settings(dir.clone());
+        assert!(s.into_resiliency_config().is_ok());
+        let mode = fs::symlink_metadata(&dir).unwrap().mode() & 0o777;
+        assert_eq!(mode, 0o700, "created storage dir must be 0700");
+    }
+
+    #[test]
+    fn rejects_group_or_other_accessible_storage_dir() {
+        let scratch = Scratch::new("cfg-perm");
+        let dir = scratch.0.join("store");
+        fs::create_dir(&dir).unwrap();
+        fs::set_permissions(&dir, fs::Permissions::from_mode(0o777)).unwrap();
+        let s = caller_caller_settings(dir);
+        assert!(matches!(
+            s.into_resiliency_config(),
+            Err(ConfigError::StorageDir(_))
+        ));
     }
 
     #[test]

--- a/plugins/ossl_engine/engine-resiliency/src/config.rs
+++ b/plugins/ossl_engine/engine-resiliency/src/config.rs
@@ -1,12 +1,17 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-//! Environment-variable-driven assembly of [`HsmResiliencyConfig`].
+//! Environment-variable-driven resiliency configuration.
 //!
-//! The engine reads its resiliency configuration from `AZIHSM_*` environment
-//! variables, captures them into [`ResiliencySettings`], and turns them into
-//! an SDK [`HsmResiliencyConfig`] for the 6th argument of
-//! `HsmPartition::init`.
+//! The engine reads its resiliency settings from `AZIHSM_*` environment
+//! variables and captures them into [`ResiliencySettings`].
+//! [`ResiliencySettings::into_resiliency_config`] turns the relevant subset
+//! (storage dir, lock, and the POTA / MOBK callbacks) into an SDK
+//! [`HsmResiliencyConfig`] for the 6th argument of `HsmPartition::init`.
+//!
+//! Not every field feeds that config: the plaintext-OBK input (`obk_path`)
+//! is consumed by the engine's init/lifecycle layer to build the
+//! `HsmOwnerBackupKeyConfig` for cold init, not by `into_resiliency_config`.
 //!
 //! # Environment variables
 //!
@@ -266,7 +271,11 @@ fn setup_storage_dir(dir: &Path) -> Result<(), ConfigError> {
             // symlink_metadata (lstat) so a symlink at `dir` is rejected here
             // rather than silently followed.
             let meta = fs::symlink_metadata(dir).map_err(|_| err())?;
-            if !meta.is_dir() || meta.uid() != current_uid() || meta.mode() & 0o077 != 0 {
+            // Require exactly owner-rwx, no group/other (i.e. mode 0700, what
+            // we create above): rejecting too-loose perms protects the key
+            // material, and rejecting too-tight owner perms surfaces the
+            // misconfig here rather than as a generic IO error on first write.
+            if !meta.is_dir() || meta.uid() != current_uid() || meta.mode() & 0o777 != 0o700 {
                 return Err(err());
             }
             Ok(())
@@ -349,6 +358,21 @@ mod tests {
         let dir = scratch.0.join("store");
         fs::create_dir(&dir).unwrap();
         fs::set_permissions(&dir, fs::Permissions::from_mode(0o777)).unwrap();
+        let s = caller_caller_settings(dir);
+        assert!(matches!(
+            s.into_resiliency_config(),
+            Err(ConfigError::StorageDir(_))
+        ));
+    }
+
+    #[test]
+    fn rejects_storage_dir_with_too_tight_owner_perms() {
+        // An existing dir missing owner write/exec passes the group/other
+        // check but would fail later on first write; reject it up front.
+        let scratch = Scratch::new("cfg-tight");
+        let dir = scratch.0.join("store");
+        fs::create_dir(&dir).unwrap();
+        fs::set_permissions(&dir, fs::Permissions::from_mode(0o400)).unwrap();
         let s = caller_caller_settings(dir);
         assert!(matches!(
             s.into_resiliency_config(),

--- a/plugins/ossl_engine/engine-resiliency/src/config.rs
+++ b/plugins/ossl_engine/engine-resiliency/src/config.rs
@@ -49,7 +49,6 @@ const ENV_POTA_PUB: &str = "AZIHSM_POTA_PUBLIC_KEY_PATH";
 const DEFAULT_STORAGE_DIR: &str = "/var/lib/azihsm/resiliency";
 const DEFAULT_OBK_PATH: &str = "./obk.bin";
 const DEFAULT_MOBK_PATH: &str = "./mobk.bin";
-const LOCK_FILE_NAME: &str = ".lock";
 
 /// Error from reading the engine's resiliency environment variables.
 #[derive(Debug, thiserror::Error)]
@@ -107,17 +106,22 @@ impl ResiliencySettings {
         let pota_pub_path = env_nonempty(ENV_POTA_PUB).map(PathBuf::from);
 
         // Reject unsafe paths up front (mirrors the provider's path_is_safe),
-        // but only when resiliency is on: a disabled engine ignores these vars
-        // and must not fail to start over a path it will never use.
+        // but only those that will actually be used: a disabled engine, or a
+        // `tpm` source whose file paths are ignored, must not fail to start
+        // over a path it will never read.
         if enabled {
             validate_path(ENV_STORAGE_DIR, &storage_dir)?;
-            validate_path(ENV_OBK_PATH, &obk_path)?;
-            validate_path(ENV_MOBK_PATH, &mobk_path)?;
-            if let Some(p) = &pota_priv_path {
-                validate_path(ENV_POTA_PRIV, p)?;
+            if matches!(obk_source, HsmOwnerBackupKeySource::Caller) {
+                validate_path(ENV_OBK_PATH, &obk_path)?;
+                validate_path(ENV_MOBK_PATH, &mobk_path)?;
             }
-            if let Some(p) = &pota_pub_path {
-                validate_path(ENV_POTA_PUB, p)?;
+            if matches!(pota_source, HsmPotaEndorsementSource::Caller) {
+                if let Some(p) = &pota_priv_path {
+                    validate_path(ENV_POTA_PRIV, p)?;
+                }
+                if let Some(p) = &pota_pub_path {
+                    validate_path(ENV_POTA_PUB, p)?;
+                }
             }
         }
 
@@ -164,7 +168,7 @@ impl ResiliencySettings {
         };
 
         setup_storage_dir(&self.storage_dir)?;
-        let lock_path = self.storage_dir.join(LOCK_FILE_NAME);
+        let lock_path = self.storage_dir.join(crate::LOCK_FILE_NAME);
 
         Ok(Some(HsmResiliencyConfig {
             storage: Box::new(FileStorage::new(self.storage_dir)),

--- a/plugins/ossl_engine/engine-resiliency/src/config.rs
+++ b/plugins/ossl_engine/engine-resiliency/src/config.rs
@@ -189,6 +189,8 @@ impl ResiliencySettings {
     }
 }
 
+/// Parse a boolean env value (`1`/`true`/`yes`/`on` vs `0`/`false`/`no`/`off`,
+/// case-insensitive); empty parses as `false`.
 fn parse_bool(var: &'static str, raw: &str) -> Result<bool, ConfigError> {
     match raw.trim().to_ascii_lowercase().as_str() {
         "" | "0" | "false" | "no" | "off" => Ok(false),
@@ -201,6 +203,7 @@ fn parse_bool(var: &'static str, raw: &str) -> Result<bool, ConfigError> {
     }
 }
 
+/// Parse the OBK source env value: `caller` (or empty, the default) or `tpm`.
 fn parse_obk_source(raw: &str) -> Result<HsmOwnerBackupKeySource, ConfigError> {
     match raw.trim().to_ascii_lowercase().as_str() {
         "" | "caller" => Ok(HsmOwnerBackupKeySource::Caller),
@@ -213,6 +216,7 @@ fn parse_obk_source(raw: &str) -> Result<HsmOwnerBackupKeySource, ConfigError> {
     }
 }
 
+/// Parse the POTA source env value: `caller` (or empty, the default) or `tpm`.
 fn parse_pota_source(raw: &str) -> Result<HsmPotaEndorsementSource, ConfigError> {
     match raw.trim().to_ascii_lowercase().as_str() {
         "" | "caller" => Ok(HsmPotaEndorsementSource::Caller),

--- a/plugins/ossl_engine/engine-resiliency/src/config.rs
+++ b/plugins/ossl_engine/engine-resiliency/src/config.rs
@@ -106,15 +106,19 @@ impl ResiliencySettings {
         let pota_priv_path = env_nonempty(ENV_POTA_PRIV).map(PathBuf::from);
         let pota_pub_path = env_nonempty(ENV_POTA_PUB).map(PathBuf::from);
 
-        // Reject unsafe paths up front (mirrors the provider's path_is_safe).
-        validate_path(ENV_STORAGE_DIR, &storage_dir)?;
-        validate_path(ENV_OBK_PATH, &obk_path)?;
-        validate_path(ENV_MOBK_PATH, &mobk_path)?;
-        if let Some(p) = &pota_priv_path {
-            validate_path(ENV_POTA_PRIV, p)?;
-        }
-        if let Some(p) = &pota_pub_path {
-            validate_path(ENV_POTA_PUB, p)?;
+        // Reject unsafe paths up front (mirrors the provider's path_is_safe),
+        // but only when resiliency is on: a disabled engine ignores these vars
+        // and must not fail to start over a path it will never use.
+        if enabled {
+            validate_path(ENV_STORAGE_DIR, &storage_dir)?;
+            validate_path(ENV_OBK_PATH, &obk_path)?;
+            validate_path(ENV_MOBK_PATH, &mobk_path)?;
+            if let Some(p) = &pota_priv_path {
+                validate_path(ENV_POTA_PRIV, p)?;
+            }
+            if let Some(p) = &pota_pub_path {
+                validate_path(ENV_POTA_PUB, p)?;
+            }
         }
 
         Ok(Self {

--- a/plugins/ossl_engine/engine-resiliency/src/config.rs
+++ b/plugins/ossl_engine/engine-resiliency/src/config.rs
@@ -1,0 +1,281 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Environment-variable-driven assembly of [`HsmResiliencyConfig`].
+//!
+//! The engine reads its resiliency configuration from `AZIHSM_*` environment
+//! variables, captures them into [`ResiliencySettings`], and turns them into
+//! an SDK [`HsmResiliencyConfig`] for the 6th argument of
+//! `HsmPartition::init`.
+//!
+//! # Environment variables
+//!
+//! | Var                              | Default                          | Notes |
+//! |----------------------------------|----------------------------------|-------|
+//! | `AZIHSM_RESILIENCY_ENABLED`      | unset (off)                      | `1` / `true` → on |
+//! | `AZIHSM_RESILIENCY_STORAGE_DIR`  | `/var/lib/azihsm/resiliency`     | storage dir |
+//! | `AZIHSM_OBK_SOURCE`              | `caller`                         | `caller` or `tpm` |
+//! | `AZIHSM_OBK_PATH`                | `./obk.bin`                      | plaintext OBK, first init; used when `OBK_SOURCE=caller` |
+//! | `AZIHSM_MOBK_PATH`               | `./mobk.bin`                     | cached MOBK, written after init / read to re-init a warm device |
+//! | `AZIHSM_POTA_SOURCE`             | `caller`                         | `caller` or `tpm` |
+//! | `AZIHSM_POTA_PRIVATE_KEY_PATH`   | none                             | required when `POTA_SOURCE=caller` and resiliency enabled |
+//! | `AZIHSM_POTA_PUBLIC_KEY_PATH`    | none                             | same |
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use azihsm_api::HsmOwnerBackupKeySource;
+use azihsm_api::HsmPotaEndorsementSource;
+use azihsm_api::HsmResiliencyConfig;
+
+use crate::FileLock;
+use crate::FileMobkCallback;
+use crate::FilePotaCallback;
+use crate::FileStorage;
+
+const ENV_ENABLED: &str = "AZIHSM_RESILIENCY_ENABLED";
+const ENV_STORAGE_DIR: &str = "AZIHSM_RESILIENCY_STORAGE_DIR";
+const ENV_OBK_SOURCE: &str = "AZIHSM_OBK_SOURCE";
+const ENV_OBK_PATH: &str = "AZIHSM_OBK_PATH";
+const ENV_MOBK_PATH: &str = "AZIHSM_MOBK_PATH";
+const ENV_POTA_SOURCE: &str = "AZIHSM_POTA_SOURCE";
+const ENV_POTA_PRIV: &str = "AZIHSM_POTA_PRIVATE_KEY_PATH";
+const ENV_POTA_PUB: &str = "AZIHSM_POTA_PUBLIC_KEY_PATH";
+
+const DEFAULT_STORAGE_DIR: &str = "/var/lib/azihsm/resiliency";
+const DEFAULT_OBK_PATH: &str = "./obk.bin";
+const DEFAULT_MOBK_PATH: &str = "./mobk.bin";
+const LOCK_FILE_NAME: &str = ".lock";
+
+#[derive(Debug, thiserror::Error)]
+pub enum ConfigError {
+    #[error("env var {0} contains invalid value {1:?} (expected one of {2})")]
+    InvalidValue(&'static str, String, &'static str),
+
+    #[error("env var {0} is required but unset")]
+    Missing(&'static str),
+}
+
+/// Parsed view of the engine's resiliency-related environment variables.
+#[derive(Debug, Clone)]
+pub struct ResiliencySettings {
+    pub enabled: bool,
+    pub storage_dir: PathBuf,
+    pub obk_source: HsmOwnerBackupKeySource,
+    /// Plaintext OBK (BK3) used for the *first* `init` on a power cycle.
+    pub obk_path: PathBuf,
+    /// Caller-persisted MOBK (masked OBK): written after each successful init
+    /// and read back to re-init a warm device, since re-running `init_bk3`
+    /// fails with `Bk3AlreadyInitialized`. Mirrors the provider's
+    /// `azihsm-mobk-path`.
+    pub mobk_path: PathBuf,
+    pub pota_source: HsmPotaEndorsementSource,
+    pub pota_priv_path: Option<PathBuf>,
+    pub pota_pub_path: Option<PathBuf>,
+}
+
+impl ResiliencySettings {
+    /// Read settings from the process environment, applying defaults from
+    /// the module docs. Returns an error for malformed values; missing
+    /// optional vars fall back to their defaults.
+    pub fn from_env() -> Result<Self, ConfigError> {
+        let enabled = parse_bool(ENV_ENABLED, &std::env::var(ENV_ENABLED).unwrap_or_default())?;
+        let storage_dir = std::env::var(ENV_STORAGE_DIR)
+            .map(PathBuf::from)
+            .unwrap_or_else(|_| PathBuf::from(DEFAULT_STORAGE_DIR));
+        let obk_source = parse_obk_source(&std::env::var(ENV_OBK_SOURCE).unwrap_or_default())?;
+        let obk_path = std::env::var(ENV_OBK_PATH)
+            .map(PathBuf::from)
+            .unwrap_or_else(|_| PathBuf::from(DEFAULT_OBK_PATH));
+        let mobk_path = std::env::var(ENV_MOBK_PATH)
+            .map(PathBuf::from)
+            .unwrap_or_else(|_| PathBuf::from(DEFAULT_MOBK_PATH));
+        let pota_source = parse_pota_source(&std::env::var(ENV_POTA_SOURCE).unwrap_or_default())?;
+        let pota_priv_path = std::env::var(ENV_POTA_PRIV).ok().map(PathBuf::from);
+        let pota_pub_path = std::env::var(ENV_POTA_PUB).ok().map(PathBuf::from);
+
+        Ok(Self {
+            enabled,
+            storage_dir,
+            obk_source,
+            obk_path,
+            mobk_path,
+            pota_source,
+            pota_priv_path,
+            pota_pub_path,
+        })
+    }
+
+    /// Assemble an `HsmResiliencyConfig`, or `None` if resiliency is off.
+    ///
+    /// When `pota_source` is `Caller`, both `pota_priv_path` and
+    /// `pota_pub_path` must be set.
+    pub fn into_resiliency_config(self) -> Result<Option<HsmResiliencyConfig>, ConfigError> {
+        if !self.enabled {
+            return Ok(None);
+        }
+
+        let pota_callback = match self.pota_source {
+            HsmPotaEndorsementSource::Caller => {
+                let priv_path = self
+                    .pota_priv_path
+                    .ok_or(ConfigError::Missing(ENV_POTA_PRIV))?;
+                let pub_path = self
+                    .pota_pub_path
+                    .ok_or(ConfigError::Missing(ENV_POTA_PUB))?;
+                Some(Box::new(FilePotaCallback::new(priv_path, pub_path)) as _)
+            }
+            _ => None,
+        };
+
+        // The restore-time MOBK provider reads the caller-persisted MOBK.
+        let mobk_callback = match self.obk_source {
+            HsmOwnerBackupKeySource::Caller => {
+                Some(Box::new(FileMobkCallback::new(self.mobk_path)) as _)
+            }
+            _ => None,
+        };
+
+        let lock_path = self.storage_dir.join(LOCK_FILE_NAME);
+
+        Ok(Some(HsmResiliencyConfig {
+            storage: Box::new(FileStorage::new(self.storage_dir)),
+            lock: Arc::new(FileLock::new(lock_path)),
+            pota_callback,
+            mobk_callback,
+        }))
+    }
+}
+
+fn parse_bool(var: &'static str, raw: &str) -> Result<bool, ConfigError> {
+    match raw.trim().to_ascii_lowercase().as_str() {
+        "" | "0" | "false" | "no" | "off" => Ok(false),
+        "1" | "true" | "yes" | "on" => Ok(true),
+        _ => Err(ConfigError::InvalidValue(
+            var,
+            raw.to_owned(),
+            "1/true/yes/on or 0/false/no/off",
+        )),
+    }
+}
+
+fn parse_obk_source(raw: &str) -> Result<HsmOwnerBackupKeySource, ConfigError> {
+    match raw.trim().to_ascii_lowercase().as_str() {
+        "" | "caller" => Ok(HsmOwnerBackupKeySource::Caller),
+        "tpm" => Ok(HsmOwnerBackupKeySource::Tpm),
+        _ => Err(ConfigError::InvalidValue(
+            ENV_OBK_SOURCE,
+            raw.to_owned(),
+            "caller or tpm",
+        )),
+    }
+}
+
+fn parse_pota_source(raw: &str) -> Result<HsmPotaEndorsementSource, ConfigError> {
+    match raw.trim().to_ascii_lowercase().as_str() {
+        "" | "caller" => Ok(HsmPotaEndorsementSource::Caller),
+        "tpm" => Ok(HsmPotaEndorsementSource::Tpm),
+        _ => Err(ConfigError::InvalidValue(
+            ENV_POTA_SOURCE,
+            raw.to_owned(),
+            "caller or tpm",
+        )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used)]
+
+    use super::*;
+
+    fn caller_caller_settings(storage: PathBuf) -> ResiliencySettings {
+        ResiliencySettings {
+            enabled: true,
+            storage_dir: storage,
+            obk_source: HsmOwnerBackupKeySource::Caller,
+            obk_path: PathBuf::from("./obk.bin"),
+            mobk_path: PathBuf::from("./mobk.bin"),
+            pota_source: HsmPotaEndorsementSource::Caller,
+            pota_priv_path: Some(PathBuf::from("priv.der")),
+            pota_pub_path: Some(PathBuf::from("pub.der")),
+        }
+    }
+
+    #[test]
+    fn disabled_yields_none() {
+        let mut s = caller_caller_settings(PathBuf::from("/tmp/x"));
+        s.enabled = false;
+        assert!(s.into_resiliency_config().unwrap().is_none());
+    }
+
+    #[test]
+    fn caller_sources_get_both_callbacks() {
+        let s = caller_caller_settings(PathBuf::from("/tmp/x"));
+        let cfg = s.into_resiliency_config().unwrap().unwrap();
+        assert!(cfg.pota_callback.is_some());
+        assert!(cfg.mobk_callback.is_some());
+    }
+
+    #[test]
+    fn tpm_obk_drops_obk_callback() {
+        let mut s = caller_caller_settings(PathBuf::from("/tmp/x"));
+        s.obk_source = HsmOwnerBackupKeySource::Tpm;
+        let cfg = s.into_resiliency_config().unwrap().unwrap();
+        assert!(cfg.mobk_callback.is_none());
+        assert!(cfg.pota_callback.is_some());
+    }
+
+    #[test]
+    fn tpm_pota_drops_pota_callback() {
+        let mut s = caller_caller_settings(PathBuf::from("/tmp/x"));
+        s.pota_source = HsmPotaEndorsementSource::Tpm;
+        let cfg = s.into_resiliency_config().unwrap().unwrap();
+        assert!(cfg.pota_callback.is_none());
+        assert!(cfg.mobk_callback.is_some());
+    }
+
+    #[test]
+    fn caller_pota_without_priv_path_errors() {
+        let mut s = caller_caller_settings(PathBuf::from("/tmp/x"));
+        s.pota_priv_path = None;
+        assert!(matches!(
+            s.into_resiliency_config(),
+            Err(ConfigError::Missing(ENV_POTA_PRIV))
+        ));
+    }
+
+    #[test]
+    fn parse_bool_accepts_common_truthy_values() {
+        for v in ["1", "true", "TRUE", "yes", "on"] {
+            assert!(parse_bool("X", v).unwrap(), "expected {v} to parse true");
+        }
+        for v in ["", "0", "false", "no", "off"] {
+            assert!(!parse_bool("X", v).unwrap(), "expected {v} to parse false");
+        }
+        assert!(matches!(
+            parse_bool("X", "maybe"),
+            Err(ConfigError::InvalidValue("X", _, _))
+        ));
+    }
+
+    #[test]
+    fn parse_obk_source_handles_known_values() {
+        assert_eq!(
+            parse_obk_source("").unwrap(),
+            HsmOwnerBackupKeySource::Caller
+        );
+        assert_eq!(
+            parse_obk_source("caller").unwrap(),
+            HsmOwnerBackupKeySource::Caller
+        );
+        assert_eq!(
+            parse_obk_source("TPM").unwrap(),
+            HsmOwnerBackupKeySource::Tpm
+        );
+        assert!(matches!(
+            parse_obk_source("hardware"),
+            Err(ConfigError::InvalidValue(_, _, _))
+        ));
+    }
+}

--- a/plugins/ossl_engine/engine-resiliency/src/lib.rs
+++ b/plugins/ossl_engine/engine-resiliency/src/lib.rs
@@ -23,6 +23,7 @@ use std::io::Write;
 use std::os::unix::fs::OpenOptionsExt;
 use std::path::Path;
 use std::path::PathBuf;
+use std::thread::ThreadId;
 
 use azihsm_api::HsmError;
 use azihsm_api::HsmResult;
@@ -177,14 +178,15 @@ fn rename_atomic(from: &Path, to: &Path) -> std::io::Result<()> {
 /// Cross-process / cross-thread lock backed by `flock(2)` on a lock file.
 ///
 /// Opens a fresh file descriptor per [`lock`](Self::lock) call: `flock(2)`
-/// operates per open-file-description, so a distinct fd is what lets separate
-/// holders contend at the OS level. Two fds to the same file conflict even
-/// within one process, so a reentrant `lock()` would block on its own held
-/// lock; reentrancy is therefore rejected up front via the in-process
-/// `active` slot, before the (potentially blocking) OS lock is attempted.
+/// operates per open-file-description, so distinct fds — even within one
+/// process — contend at the OS level, giving the cross-thread / cross-process
+/// blocking the `ResiliencyLock` contract requires. The in-process `active`
+/// slot records the holding thread so a *reentrant* `lock()` from that same
+/// thread is rejected (it would otherwise deadlock on its own held lock);
+/// other threads simply block on the OS lock until it is released.
 pub struct FileLock {
     path: PathBuf,
-    active: Mutex<Option<fs::File>>,
+    active: Mutex<Option<(fs::File, ThreadId)>>,
 }
 
 impl FileLock {
@@ -198,12 +200,18 @@ impl FileLock {
 
 impl ResiliencyLock for FileLock {
     fn lock(&self) -> HsmResult<()> {
-        let mut guard = self.active.lock();
-        // Reject reentrancy before touching the OS lock: opening a fresh fd and
-        // calling flock again would deadlock against our own held lock, since
-        // flock locks are per open-file-description (see struct docs).
-        if guard.is_some() {
-            return Err(HsmError::InternalError);
+        // Reject only *true* (same-thread) reentrancy: a reentrant flock on a
+        // fresh fd would deadlock against our own held lock (flock is per
+        // open-file-description). Drop the guard before the OS lock so other
+        // threads block on flock rather than erroring.
+        let this = std::thread::current().id();
+        {
+            let guard = self.active.lock();
+            if let Some((_, holder)) = guard.as_ref()
+                && *holder == this
+            {
+                return Err(HsmError::InternalError);
+            }
         }
 
         // O_NOFOLLOW + 0600: refuse a symlinked lock path and keep it
@@ -226,15 +234,16 @@ impl ResiliencyLock for FileLock {
         {
             return Err(HsmError::InternalError);
         }
+        // Blocks until the lock is available (cross-thread / cross-process).
         file.lock_exclusive().map_err(|_| HsmError::InternalError)?;
 
-        *guard = Some(file);
+        *self.active.lock() = Some((file, this));
         Ok(())
     }
 
     fn unlock(&self) -> HsmResult<()> {
         match self.active.lock().take() {
-            Some(file) => file.unlock().map_err(|_| HsmError::InternalError),
+            Some((file, _)) => file.unlock().map_err(|_| HsmError::InternalError),
             None => Err(HsmError::InternalError),
         }
     }
@@ -349,12 +358,44 @@ mod tests {
         let l = FileLock::new(scratch.0.join("lock"));
 
         l.lock().unwrap();
-        // A second lock() on the held instance must be rejected, not deadlock.
+        // A second lock() from the same thread must be rejected, not deadlock.
         assert!(l.lock().is_err(), "reentrant lock must be rejected");
         l.unlock().unwrap();
         // Once released, locking again succeeds.
         l.lock().unwrap();
         l.unlock().unwrap();
+    }
+
+    #[test]
+    fn other_thread_blocks_until_unlock() {
+        use std::sync::Arc;
+        use std::sync::mpsc;
+        use std::time::Duration;
+
+        let scratch = Scratch::new("xthread");
+        let l = Arc::new(FileLock::new(scratch.0.join("lock")));
+        l.lock().unwrap();
+
+        let l2 = Arc::clone(&l);
+        let (tx, rx) = mpsc::channel();
+        let h = std::thread::spawn(move || {
+            // Blocks here until the main thread releases the lock.
+            l2.lock().unwrap();
+            tx.send(()).unwrap();
+            l2.unlock().unwrap();
+        });
+
+        // While we hold the lock the other thread cannot acquire it (it blocks
+        // on flock rather than erroring).
+        assert!(
+            rx.recv_timeout(Duration::from_millis(200)).is_err(),
+            "other thread acquired the lock while it was held"
+        );
+        l.unlock().unwrap();
+        // After release it proceeds.
+        rx.recv_timeout(Duration::from_secs(5))
+            .expect("other thread should acquire after unlock");
+        h.join().unwrap();
     }
 
     #[test]

--- a/plugins/ossl_engine/engine-resiliency/src/lib.rs
+++ b/plugins/ossl_engine/engine-resiliency/src/lib.rs
@@ -1,0 +1,206 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+// The engine is Linux-only; gate the whole crate so non-Linux targets (the
+// workspace `build_windows` clippy) don't pull `openssl-sys`.
+#![cfg(target_os = "linux")]
+
+//! File-backed resiliency primitives for the engine:
+//! [`FileStorage`] / [`FileLock`] for SDK-internal state and
+//! [`FilePotaCallback`] / [`FileMobkCallback`] for caller-side material.
+//!
+//! Writes through `FileStorage` go via temp file + `fsync` + `rename(2)`
+//! + directory fsync, so the on-disk state is crash-consistent.
+
+mod callbacks;
+mod config;
+#[cfg(test)]
+mod test_util;
+
+use std::fs;
+use std::io::Read;
+use std::io::Write;
+use std::path::Path;
+use std::path::PathBuf;
+
+use azihsm_api::HsmError;
+use azihsm_api::HsmResult;
+use azihsm_api::ResiliencyLock;
+use azihsm_api::ResiliencyStorage;
+pub use callbacks::FileMobkCallback;
+pub use callbacks::FilePotaCallback;
+pub use config::ConfigError;
+pub use config::ResiliencySettings;
+use fs2::FileExt;
+use parking_lot::Mutex;
+
+/// File-backed storage: one file per key under `dir`. Writes are durable.
+pub struct FileStorage {
+    dir: PathBuf,
+}
+
+impl FileStorage {
+    pub fn new(dir: PathBuf) -> Self {
+        Self { dir }
+    }
+}
+
+impl ResiliencyStorage for FileStorage {
+    fn read(&self, key: &str) -> HsmResult<Vec<u8>> {
+        let mut file = fs::File::open(self.dir.join(key)).map_err(|e| {
+            if e.kind() == std::io::ErrorKind::NotFound {
+                HsmError::NotFound
+            } else {
+                HsmError::InternalError
+            }
+        })?;
+        let mut buf = Vec::new();
+        file.read_to_end(&mut buf)
+            .map_err(|_| HsmError::InternalError)?;
+        Ok(buf)
+    }
+
+    fn write(&self, key: &str, data: &[u8]) -> HsmResult<()> {
+        let path = self.dir.join(key);
+        let tmp_path = self.dir.join(format!(".{key}.tmp"));
+
+        let result = (|| -> HsmResult<()> {
+            let mut file = fs::File::create(&tmp_path).map_err(|_| HsmError::InternalError)?;
+            file.write_all(data).map_err(|_| HsmError::InternalError)?;
+            file.sync_all().map_err(|_| HsmError::InternalError)?;
+            rename_atomic(&tmp_path, &path).map_err(|_| HsmError::InternalError)?;
+            let dir = fs::File::open(&self.dir).map_err(|_| HsmError::InternalError)?;
+            dir.sync_all().map_err(|_| HsmError::InternalError)
+        })();
+
+        if result.is_err() {
+            let _ = fs::remove_file(&tmp_path);
+        }
+        result
+    }
+
+    fn clear(&self, key: &str) -> HsmResult<()> {
+        let _ = fs::remove_file(self.dir.join(key));
+        Ok(())
+    }
+}
+
+/// Atomically replace `to` with `from`. On Linux `rename(2)` is atomic and
+/// replaces an existing target.
+fn rename_atomic(from: &Path, to: &Path) -> std::io::Result<()> {
+    fs::rename(from, to)
+}
+
+/// Cross-process / cross-thread lock backed by `flock(2)` on a lock file.
+///
+/// Opens a new file descriptor per [`lock`](Self::lock) call: `flock(2)`
+/// operates per open-file-description, so reusing a single descriptor
+/// would let a second thread acquire the same lock immediately. Reentrant
+/// lock() on the same instance is rejected; the OS lock from the second
+/// `open` is released before returning.
+pub struct FileLock {
+    path: PathBuf,
+    active: Mutex<Option<fs::File>>,
+}
+
+impl FileLock {
+    pub fn new(path: PathBuf) -> Self {
+        Self {
+            path,
+            active: Mutex::new(None),
+        }
+    }
+}
+
+impl ResiliencyLock for FileLock {
+    fn lock(&self) -> HsmResult<()> {
+        let file = fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .truncate(false)
+            .open(&self.path)
+            .map_err(|_| HsmError::InternalError)?;
+        file.lock_exclusive().map_err(|_| HsmError::InternalError)?;
+
+        let mut guard = self.active.lock();
+        if guard.is_some() {
+            let _ = file.unlock();
+            return Err(HsmError::InternalError);
+        }
+        *guard = Some(file);
+        Ok(())
+    }
+
+    fn unlock(&self) -> HsmResult<()> {
+        match self.active.lock().take() {
+            Some(file) => file.unlock().map_err(|_| HsmError::InternalError),
+            None => Err(HsmError::InternalError),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used)]
+
+    use super::*;
+    use crate::test_util::Scratch;
+
+    #[test]
+    fn write_then_read_round_trip() {
+        let scratch = Scratch::new("rw");
+        let s = FileStorage::new(scratch.0.clone());
+
+        s.write("k", b"value").unwrap();
+        assert_eq!(s.read("k").unwrap(), b"value");
+    }
+
+    #[test]
+    fn write_overwrites_atomically() {
+        let scratch = Scratch::new("ow");
+        let s = FileStorage::new(scratch.0.clone());
+
+        s.write("k", b"first").unwrap();
+        s.write("k", b"second").unwrap();
+        assert_eq!(s.read("k").unwrap(), b"second");
+    }
+
+    #[test]
+    fn read_missing_returns_not_found() {
+        let scratch = Scratch::new("miss");
+        let s = FileStorage::new(scratch.0.clone());
+
+        assert!(matches!(s.read("absent"), Err(HsmError::NotFound)));
+    }
+
+    #[test]
+    fn clear_is_idempotent() {
+        let scratch = Scratch::new("clr");
+        let s = FileStorage::new(scratch.0.clone());
+
+        s.clear("never-existed").unwrap();
+        s.write("k", b"x").unwrap();
+        s.clear("k").unwrap();
+        assert!(matches!(s.read("k"), Err(HsmError::NotFound)));
+    }
+
+    #[test]
+    fn lock_unlock_round_trip() {
+        let scratch = Scratch::new("lk");
+        let l = FileLock::new(scratch.0.join("lock"));
+
+        l.lock().unwrap();
+        l.unlock().unwrap();
+        l.lock().unwrap();
+        l.unlock().unwrap();
+    }
+
+    #[test]
+    fn unlock_without_lock_errors() {
+        let scratch = Scratch::new("ul");
+        let l = FileLock::new(scratch.0.join("lock"));
+
+        assert!(l.unlock().is_err());
+    }
+}

--- a/plugins/ossl_engine/engine-resiliency/src/lib.rs
+++ b/plugins/ossl_engine/engine-resiliency/src/lib.rs
@@ -43,15 +43,23 @@ const MAX_KEY_NAME_LEN: usize = 256;
 /// allocation on subsequent reads.
 const MAX_STORAGE_FILE_SIZE: u64 = 64 * 1024;
 
-/// Reject empty, over-long, or path-traversal keys, as well as keys with a
-/// separator or interior NUL, so `dir.join(key)` can never escape the storage
-/// directory and an invalid key always maps to `InvalidArgument` (not a later
-/// `InternalError`). Mirrors the provider's `build_storage_path` validation.
+/// Reserved storage-dir filename for the [`FileLock`] lock file. Rejected as a
+/// storage key so storage operations can't clobber the lock.
+pub(crate) const LOCK_FILE_NAME: &str = ".lock";
+
+/// Reject empty, over-long, or path-traversal keys, keys with a separator or
+/// interior NUL, and the reserved lock-file name, so `dir.join(key)` can never
+/// escape the storage directory or clobber the lock file, and an invalid key
+/// always maps to `InvalidArgument` (not a later `InternalError`). Mirrors the
+/// provider's `build_storage_path` validation.
 fn validate_key(key: &str) -> HsmResult<()> {
     if key.is_empty() || key.len() > MAX_KEY_NAME_LEN {
         return Err(HsmError::InvalidArgument);
     }
     if key.contains('/') || key.contains('\0') || key == ".." || key.contains("../") {
+        return Err(HsmError::InvalidArgument);
+    }
+    if key == LOCK_FILE_NAME {
         return Err(HsmError::InvalidArgument);
     }
     Ok(())
@@ -268,7 +276,7 @@ mod tests {
     fn rejects_invalid_keys() {
         let scratch = Scratch::new("trav");
         let s = FileStorage::new(scratch.0.clone());
-        for bad in ["", "..", "../escape", "a/b", "/abs", "a\0b"] {
+        for bad in ["", "..", "../escape", "a/b", "/abs", "a\0b", LOCK_FILE_NAME] {
             assert!(
                 matches!(s.write(bad, b"x"), Err(HsmError::InvalidArgument)),
                 "write {bad:?} should be rejected"

--- a/plugins/ossl_engine/engine-resiliency/src/lib.rs
+++ b/plugins/ossl_engine/engine-resiliency/src/lib.rs
@@ -176,11 +176,12 @@ fn rename_atomic(from: &Path, to: &Path) -> std::io::Result<()> {
 
 /// Cross-process / cross-thread lock backed by `flock(2)` on a lock file.
 ///
-/// Opens a new file descriptor per [`lock`](Self::lock) call: `flock(2)`
-/// operates per open-file-description, so reusing a single descriptor
-/// would let a second thread acquire the same lock immediately. Reentrant
-/// lock() on the same instance is rejected; the OS lock from the second
-/// `open` is released before returning.
+/// Opens a fresh file descriptor per [`lock`](Self::lock) call: `flock(2)`
+/// operates per open-file-description, so a distinct fd is what lets separate
+/// holders contend at the OS level. Two fds to the same file conflict even
+/// within one process, so a reentrant `lock()` would block on its own held
+/// lock; reentrancy is therefore rejected up front via the in-process
+/// `active` slot, before the (potentially blocking) OS lock is attempted.
 pub struct FileLock {
     path: PathBuf,
     active: Mutex<Option<fs::File>>,
@@ -197,6 +198,14 @@ impl FileLock {
 
 impl ResiliencyLock for FileLock {
     fn lock(&self) -> HsmResult<()> {
+        let mut guard = self.active.lock();
+        // Reject reentrancy before touching the OS lock: opening a fresh fd and
+        // calling flock again would deadlock against our own held lock, since
+        // flock locks are per open-file-description (see struct docs).
+        if guard.is_some() {
+            return Err(HsmError::InternalError);
+        }
+
         // O_NOFOLLOW + 0600: refuse a symlinked lock path and keep it
         // owner-only, matching the provider's hardened lock file.
         let file = fs::OpenOptions::new()
@@ -219,13 +228,6 @@ impl ResiliencyLock for FileLock {
         }
         file.lock_exclusive().map_err(|_| HsmError::InternalError)?;
 
-        let mut guard = self.active.lock();
-        if guard.is_some() {
-            // Release the OS lock just acquired before rejecting the reentrant
-            // call; best-effort, since we are already returning an error.
-            let _ = file.unlock();
-            return Err(HsmError::InternalError);
-        }
         *guard = Some(file);
         Ok(())
     }
@@ -339,6 +341,20 @@ mod tests {
 
         let l = FileLock::new(fifo);
         assert!(l.lock().is_err(), "lock on a FIFO must be rejected");
+    }
+
+    #[test]
+    fn reentrant_lock_is_rejected() {
+        let scratch = Scratch::new("reent");
+        let l = FileLock::new(scratch.0.join("lock"));
+
+        l.lock().unwrap();
+        // A second lock() on the held instance must be rejected, not deadlock.
+        assert!(l.lock().is_err(), "reentrant lock must be rejected");
+        l.unlock().unwrap();
+        // Once released, locking again succeeds.
+        l.lock().unwrap();
+        l.unlock().unwrap();
     }
 
     #[test]

--- a/plugins/ossl_engine/engine-resiliency/src/lib.rs
+++ b/plugins/ossl_engine/engine-resiliency/src/lib.rs
@@ -152,10 +152,12 @@ impl ResiliencyStorage for FileStorage {
         let path = self.dir.join(key);
         // Per-write unique staging file so concurrent writes to the same key
         // don't race on a shared temp path: the PID distinguishes processes and
-        // the atomic counter distinguishes writers within a process.
+        // the atomic counter distinguishes writers within a process. The name
+        // is independent of `key` so it stays well under NAME_MAX and doesn't
+        // leak key names into directory listings.
         static TMP_SEQ: AtomicU64 = AtomicU64::new(0);
         let tmp_path = self.dir.join(format!(
-            ".{key}.{}.{}.tmp",
+            ".staging.{}.{}.tmp",
             std::process::id(),
             TMP_SEQ.fetch_add(1, Ordering::Relaxed),
         ));

--- a/plugins/ossl_engine/engine-resiliency/src/lib.rs
+++ b/plugins/ossl_engine/engine-resiliency/src/lib.rs
@@ -114,6 +114,26 @@ impl FileStorage {
     pub fn new(dir: PathBuf) -> Self {
         Self { dir }
     }
+
+    /// Durably write `data` to `tmp_path` (fsync), then atomically rename it
+    /// onto `dest` and fsync the directory. Returns the raw IO error so the
+    /// single caller can map it once.
+    fn write_durable(&self, tmp_path: &Path, dest: &Path, data: &[u8]) -> std::io::Result<()> {
+        // O_NOFOLLOW + 0600: the temp file may hold key material, so refuse a
+        // pre-planted symlink and keep it owner-only.
+        let mut file = fs::OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .custom_flags(libc::O_NOFOLLOW | libc::O_CLOEXEC)
+            .mode(0o600)
+            .open(tmp_path)?;
+        file.write_all(data)?;
+        file.sync_all()?;
+        rename_atomic(tmp_path, dest)?;
+        let dir = fs::File::open(&self.dir)?;
+        dir.sync_all()
+    }
 }
 
 impl ResiliencyStorage for FileStorage {
@@ -130,28 +150,12 @@ impl ResiliencyStorage for FileStorage {
         let path = self.dir.join(key);
         let tmp_path = self.dir.join(format!(".{key}.tmp"));
 
-        // Closure so any step's failure funnels to the temp-file cleanup below.
-        let result = (|| -> HsmResult<()> {
-            // O_NOFOLLOW + 0600: the temp file may hold key material, so refuse
-            // a pre-planted symlink and keep it owner-only.
-            let mut file = fs::OpenOptions::new()
-                .write(true)
-                .create(true)
-                .truncate(true)
-                .custom_flags(libc::O_NOFOLLOW | libc::O_CLOEXEC)
-                .mode(0o600)
-                .open(&tmp_path)
-                .map_err(|_| HsmError::InternalError)?;
-            file.write_all(data).map_err(|_| HsmError::InternalError)?;
-            file.sync_all().map_err(|_| HsmError::InternalError)?;
-            rename_atomic(&tmp_path, &path).map_err(|_| HsmError::InternalError)?;
-            let dir = fs::File::open(&self.dir).map_err(|_| HsmError::InternalError)?;
-            dir.sync_all().map_err(|_| HsmError::InternalError)
-        })();
-
+        let result = self
+            .write_durable(&tmp_path, &path, data)
+            .map_err(|_| HsmError::InternalError);
         if result.is_err() {
-            // Best-effort: the write already failed, so a failed cleanup of
-            // the temp file must not mask the original error.
+            // Best-effort: the write already failed, so a failed cleanup of the
+            // temp file must not mask the original error.
             let _ = fs::remove_file(&tmp_path);
         }
         result

--- a/plugins/ossl_engine/engine-resiliency/src/lib.rs
+++ b/plugins/ossl_engine/engine-resiliency/src/lib.rs
@@ -23,6 +23,8 @@ use std::io::Write;
 use std::os::unix::fs::OpenOptionsExt;
 use std::path::Path;
 use std::path::PathBuf;
+use std::sync::atomic::AtomicU64;
+use std::sync::atomic::Ordering;
 use std::thread::ThreadId;
 
 use azihsm_api::HsmError;
@@ -148,7 +150,15 @@ impl ResiliencyStorage for FileStorage {
             return Err(HsmError::InvalidArgument);
         }
         let path = self.dir.join(key);
-        let tmp_path = self.dir.join(format!(".{key}.tmp"));
+        // Per-write unique staging file so concurrent writes to the same key
+        // don't race on a shared temp path: the PID distinguishes processes and
+        // the atomic counter distinguishes writers within a process.
+        static TMP_SEQ: AtomicU64 = AtomicU64::new(0);
+        let tmp_path = self.dir.join(format!(
+            ".{key}.{}.{}.tmp",
+            std::process::id(),
+            TMP_SEQ.fetch_add(1, Ordering::Relaxed),
+        ));
 
         let result = self
             .write_durable(&tmp_path, &path, data)

--- a/plugins/ossl_engine/engine-resiliency/src/lib.rs
+++ b/plugins/ossl_engine/engine-resiliency/src/lib.rs
@@ -20,6 +20,7 @@ mod test_util;
 use std::fs;
 use std::io::Read;
 use std::io::Write;
+use std::os::unix::fs::OpenOptionsExt;
 use std::path::Path;
 use std::path::PathBuf;
 
@@ -34,6 +35,67 @@ pub use config::ResiliencySettings;
 use fs2::FileExt;
 use parking_lot::Mutex;
 
+/// Max length of a storage key, mirroring the provider's `MAX_KEY_NAME_LEN`.
+const MAX_KEY_NAME_LEN: usize = 256;
+
+/// Cap on a single resiliency file, mirroring the provider's
+/// `MAX_STORAGE_FILE_SIZE`. Bounds reads/writes against disk-fill and runaway
+/// allocation on subsequent reads.
+const MAX_STORAGE_FILE_SIZE: u64 = 64 * 1024;
+
+/// Reject empty, over-long, or path-traversal keys, as well as keys with a
+/// separator or interior NUL, so `dir.join(key)` can never escape the storage
+/// directory and an invalid key always maps to `InvalidArgument` (not a later
+/// `InternalError`). Mirrors the provider's `build_storage_path` validation.
+fn validate_key(key: &str) -> HsmResult<()> {
+    if key.is_empty() || key.len() > MAX_KEY_NAME_LEN {
+        return Err(HsmError::InvalidArgument);
+    }
+    if key.contains('/') || key.contains('\0') || key == ".." || key.contains("../") {
+        return Err(HsmError::InvalidArgument);
+    }
+    Ok(())
+}
+
+/// Map a file IO error to an `HsmError`, preserving "not found".
+pub(crate) fn io_to_hsm(e: std::io::Error) -> HsmError {
+    if e.kind() == std::io::ErrorKind::NotFound {
+        HsmError::NotFound
+    } else {
+        HsmError::InternalError
+    }
+}
+
+/// Open `path` for reading without following a final-component symlink
+/// (`O_NOFOLLOW`) and without blocking on special files (`O_NONBLOCK`),
+/// require it to be a regular file, and read at most [`MAX_STORAGE_FILE_SIZE`]
+/// bytes. Mirrors the provider's hardened secret-material loads.
+pub(crate) fn read_regular_hardened(path: &Path) -> std::io::Result<Vec<u8>> {
+    let file = fs::OpenOptions::new()
+        .read(true)
+        .custom_flags(libc::O_NOFOLLOW | libc::O_NONBLOCK | libc::O_CLOEXEC)
+        .open(path)?;
+    let meta = file.metadata()?;
+    let too_large =
+        || std::io::Error::new(std::io::ErrorKind::InvalidInput, "file exceeds size cap");
+    if !meta.is_file() {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "not a regular file",
+        ));
+    }
+    if meta.len() > MAX_STORAGE_FILE_SIZE {
+        return Err(too_large());
+    }
+    // Bound the read independently of the stat, in case the file grew.
+    let mut buf = Vec::new();
+    file.take(MAX_STORAGE_FILE_SIZE + 1).read_to_end(&mut buf)?;
+    if buf.len() as u64 > MAX_STORAGE_FILE_SIZE {
+        return Err(too_large());
+    }
+    Ok(buf)
+}
+
 /// File-backed storage: one file per key under `dir`. Writes are durable.
 pub struct FileStorage {
     dir: PathBuf,
@@ -47,25 +109,30 @@ impl FileStorage {
 
 impl ResiliencyStorage for FileStorage {
     fn read(&self, key: &str) -> HsmResult<Vec<u8>> {
-        let mut file = fs::File::open(self.dir.join(key)).map_err(|e| {
-            if e.kind() == std::io::ErrorKind::NotFound {
-                HsmError::NotFound
-            } else {
-                HsmError::InternalError
-            }
-        })?;
-        let mut buf = Vec::new();
-        file.read_to_end(&mut buf)
-            .map_err(|_| HsmError::InternalError)?;
-        Ok(buf)
+        validate_key(key)?;
+        read_regular_hardened(&self.dir.join(key)).map_err(io_to_hsm)
     }
 
     fn write(&self, key: &str, data: &[u8]) -> HsmResult<()> {
+        validate_key(key)?;
+        if data.len() as u64 > MAX_STORAGE_FILE_SIZE {
+            return Err(HsmError::InvalidArgument);
+        }
         let path = self.dir.join(key);
         let tmp_path = self.dir.join(format!(".{key}.tmp"));
 
+        // Closure so any step's failure funnels to the temp-file cleanup below.
         let result = (|| -> HsmResult<()> {
-            let mut file = fs::File::create(&tmp_path).map_err(|_| HsmError::InternalError)?;
+            // O_NOFOLLOW + 0600: the temp file may hold key material, so refuse
+            // a pre-planted symlink and keep it owner-only.
+            let mut file = fs::OpenOptions::new()
+                .write(true)
+                .create(true)
+                .truncate(true)
+                .custom_flags(libc::O_NOFOLLOW | libc::O_CLOEXEC)
+                .mode(0o600)
+                .open(&tmp_path)
+                .map_err(|_| HsmError::InternalError)?;
             file.write_all(data).map_err(|_| HsmError::InternalError)?;
             file.sync_all().map_err(|_| HsmError::InternalError)?;
             rename_atomic(&tmp_path, &path).map_err(|_| HsmError::InternalError)?;
@@ -74,14 +141,22 @@ impl ResiliencyStorage for FileStorage {
         })();
 
         if result.is_err() {
+            // Best-effort: the write already failed, so a failed cleanup of
+            // the temp file must not mask the original error.
             let _ = fs::remove_file(&tmp_path);
         }
         result
     }
 
     fn clear(&self, key: &str) -> HsmResult<()> {
-        let _ = fs::remove_file(self.dir.join(key));
-        Ok(())
+        validate_key(key)?;
+        match fs::remove_file(self.dir.join(key)) {
+            Ok(()) => Ok(()),
+            // Already absent counts as cleared (clear is idempotent); any
+            // other error (e.g. permission denied) is surfaced.
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+            Err(_) => Err(HsmError::InternalError),
+        }
     }
 }
 
@@ -114,17 +189,32 @@ impl FileLock {
 
 impl ResiliencyLock for FileLock {
     fn lock(&self) -> HsmResult<()> {
+        // O_NOFOLLOW + 0600: refuse a symlinked lock path and keep it
+        // owner-only, matching the provider's hardened lock file.
         let file = fs::OpenOptions::new()
             .read(true)
             .write(true)
             .create(true)
             .truncate(false)
+            .custom_flags(libc::O_NOFOLLOW | libc::O_CLOEXEC)
+            .mode(0o600)
             .open(&self.path)
             .map_err(|_| HsmError::InternalError)?;
+        // Reject a FIFO/device/etc. at the lock path (O_NOFOLLOW only blocks
+        // symlinks); flock on a special file could hang or misbehave.
+        if !file
+            .metadata()
+            .map_err(|_| HsmError::InternalError)?
+            .is_file()
+        {
+            return Err(HsmError::InternalError);
+        }
         file.lock_exclusive().map_err(|_| HsmError::InternalError)?;
 
         let mut guard = self.active.lock();
         if guard.is_some() {
+            // Release the OS lock just acquired before rejecting the reentrant
+            // call; best-effort, since we are already returning an error.
             let _ = file.unlock();
             return Err(HsmError::InternalError);
         }
@@ -175,6 +265,37 @@ mod tests {
     }
 
     #[test]
+    fn rejects_invalid_keys() {
+        let scratch = Scratch::new("trav");
+        let s = FileStorage::new(scratch.0.clone());
+        for bad in ["", "..", "../escape", "a/b", "/abs", "a\0b"] {
+            assert!(
+                matches!(s.write(bad, b"x"), Err(HsmError::InvalidArgument)),
+                "write {bad:?} should be rejected"
+            );
+            assert!(
+                matches!(s.read(bad), Err(HsmError::InvalidArgument)),
+                "read {bad:?} should be rejected"
+            );
+            assert!(
+                matches!(s.clear(bad), Err(HsmError::InvalidArgument)),
+                "clear {bad:?} should be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn write_rejects_oversize_value() {
+        let scratch = Scratch::new("big");
+        let s = FileStorage::new(scratch.0.clone());
+        let huge = vec![0u8; MAX_STORAGE_FILE_SIZE as usize + 1];
+        assert!(matches!(
+            s.write("k", &huge),
+            Err(HsmError::InvalidArgument)
+        ));
+    }
+
+    #[test]
     fn clear_is_idempotent() {
         let scratch = Scratch::new("clr");
         let s = FileStorage::new(scratch.0.clone());
@@ -194,6 +315,22 @@ mod tests {
         l.unlock().unwrap();
         l.lock().unwrap();
         l.unlock().unwrap();
+    }
+
+    #[test]
+    #[allow(unsafe_code)]
+    fn lock_rejects_non_regular_file() {
+        use std::ffi::CString;
+
+        let scratch = Scratch::new("lkfifo");
+        let fifo = scratch.0.join("fifo");
+        let c = CString::new(fifo.to_str().unwrap()).unwrap();
+        // SAFETY: `c` is a valid NUL-terminated path and 0o600 is a valid mode.
+        let rc = unsafe { libc::mkfifo(c.as_ptr(), 0o600) };
+        assert_eq!(rc, 0, "mkfifo failed");
+
+        let l = FileLock::new(fifo);
+        assert!(l.lock().is_err(), "lock on a FIFO must be rejected");
     }
 
     #[test]

--- a/plugins/ossl_engine/engine-resiliency/src/test_util.rs
+++ b/plugins/ossl_engine/engine-resiliency/src/test_util.rs
@@ -1,0 +1,31 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Shared test fixtures.
+
+#![allow(clippy::unwrap_used)]
+
+use std::fs;
+use std::path::PathBuf;
+use std::sync::atomic::AtomicU64;
+use std::sync::atomic::Ordering;
+
+/// Per-test scratch directory under the system temp dir. Removed on drop.
+pub(crate) struct Scratch(pub PathBuf);
+
+impl Scratch {
+    pub fn new(tag: &str) -> Self {
+        static N: AtomicU64 = AtomicU64::new(0);
+        let n = N.fetch_add(1, Ordering::SeqCst);
+        let pid = std::process::id();
+        let dir = std::env::temp_dir().join(format!("engine-resiliency-{tag}-{pid}-{n}"));
+        fs::create_dir_all(&dir).unwrap();
+        Self(dir)
+    }
+}
+
+impl Drop for Scratch {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.0);
+    }
+}


### PR DESCRIPTION
New engine-resiliency crate: FileStorage + FileLock (file-backed resiliency persistence), FilePotaCallback + FileMobkCallback (POTA endorsement signing and MOBK/OBK file loading with O_NOFOLLOW hardening + zeroization), and ResiliencySettings parsed from AZIHSM_* env vars into an HsmResiliencyConfig.