### PR TITLE
feat(uno/session): session store + vault-backed TBOR handshake

### DIFF
--- a/fw/core/lib/src/ddi/mbor/close_session.rs
+++ b/fw/core/lib/src/ddi/mbor/close_session.rs
@@ -19,12 +19,11 @@ use super::*;
 /// validates it before calling the handler.  We re-check defensively so
 /// the partition state never sees `session_destroy` with a `None` id.
 ///
-/// No `partition_lock` is needed: the only state mutation is the single
-/// synchronous [`HsmSessionManager::session_destroy`] call, which is
-/// atomic on the partition entry (no yield points), so there is no
-/// read-then-mutate window that could race against a concurrent
-/// handler on the same partition.
-pub(crate) fn close_session<'p, P: HsmPal>(
+/// No `partition_lock` is needed.  Although `session_destroy` is now
+/// awaited (it can yield on Uno during vault GDMA cleanup), DDI commands
+/// run on a single-threaded cooperative executor with one command in
+/// flight per partition, so no concurrent handler can interleave.
+pub(crate) async fn close_session<'p, P: HsmPal>(
     pal: &'p P,
     io: &impl HsmIo,
     decoder: &mut DdiDecoder<'_>,
@@ -33,7 +32,7 @@ pub(crate) fn close_session<'p, P: HsmPal>(
     let _body: DdiCloseSessionReq = decoder.decode_data()?;
 
     let sess_id = hdr.sess_id.ok_or(HsmError::SessionExpected)?;
-    pal.session_destroy(io, HsmSessId::from(sess_id))?;
+    pal.session_destroy(io, HsmSessId::from(sess_id)).await?;
 
     // Echo the closed session id back in the response header so the
     // host can confirm which session was torn down.

--- a/fw/core/lib/src/ddi/mbor/mod.rs
+++ b/fw/core/lib/src/ddi/mbor/mod.rs
@@ -129,7 +129,7 @@ pub(crate) async fn dispatch<'p, P: HsmPal>(
         DdiOp::InitBk3 => init_bk3(pal, io, decoder, hdr).await,
         DdiOp::EstablishCredential => establish_credential(pal, io, decoder, hdr).await,
         DdiOp::OpenSession => open_session(pal, io, decoder, hdr).await,
-        DdiOp::CloseSession => close_session(pal, io, decoder, hdr),
+        DdiOp::CloseSession => close_session(pal, io, decoder, hdr).await,
         DdiOp::DeleteKey => delete_key(pal, io, decoder, hdr).await,
         DdiOp::AesGenerateKey => aes_generate_key(pal, io, decoder, hdr).await,
         DdiOp::AesEncryptDecrypt => aes_encrypt_decrypt(pal, io, decoder, hdr).await,

--- a/fw/core/lib/src/ddi/mbor/open_session.rs
+++ b/fw/core/lib/src/ddi/mbor/open_session.rs
@@ -128,7 +128,9 @@ pub(crate) async fn open_session<'p, P: HsmPal>(
 
     // ── Step 8: Allocate the session table entry ─────────────────────
     let api_rev_bytes = pack_api_rev(api_rev);
-    let sess_id = pal.session_create(io, &api_rev_bytes, mk_session, None)?;
+    let sess_id = pal
+        .session_create(io, &api_rev_bytes, mk_session, None)
+        .await?;
 
     // ── Step 9: Encode response + envelope MK_SESSION under BK_SESSION
     let resp = encode_response(

--- a/fw/core/lib/src/ddi/tbor/close_session.rs
+++ b/fw/core/lib/src/ddi/tbor/close_session.rs
@@ -53,7 +53,7 @@ pub(crate) async fn handle<'p, P: HsmPal>(
     // request in the outer AEAD-authenticated framing layer once it
     // lands; until then this is vulnerable to same-partition DoS by
     // a caller who guesses an active slot id.
-    pal.session_destroy(io, id)?;
+    pal.session_destroy(io, id).await?;
     let resp = pal.dma_alloc_var(io, |buf| {
         let frame = TborCloseSessionResp::encode(buf, 0, false)?.finish();
         Ok(frame.as_bytes().len())

--- a/fw/core/lib/src/ddi/tbor/open_session_finish.rs
+++ b/fw/core/lib/src/ddi/tbor/open_session_finish.rs
@@ -174,7 +174,7 @@ pub(crate) async fn handle<'p, P: HsmPal>(
         let bmk_session = build_bmk_session(pal, io, alloc, seed, derived.masking_key).await?;
 
         // ── Promote Pending → Active ──────────────────────────────
-        promote_to_active(pal, io, alloc, sess_id, derived)?;
+        promote_to_active(pal, io, alloc, sess_id, derived).await?;
 
         encode_response(pal, io, bmk_session)
     })
@@ -298,7 +298,7 @@ async fn verify_mac<P: HsmPal>(
     }
     let mac_verified = pal.hmac_finish_verify(io, hmac_ctx, mac_fin).await?;
     if !mac_verified {
-        let _ = pal.session_destroy(io, id);
+        let _ = pal.session_destroy(io, id).await;
         return Err(HsmError::SessionAuthFailure);
     }
     Ok(())
@@ -329,13 +329,13 @@ async fn open_seed_envelope<'a, P: HsmPal>(
         Err(_) => {
             // Destroy the Pending slot before returning so the
             // tampered envelope is not retry-probeable.
-            let _ = pal.session_destroy(io, id);
+            let _ = pal.session_destroy(io, id).await;
             return Err(HsmError::SessionAuthFailure);
         }
     };
 
     if view.payload.len() != SEED_LEN {
-        let _ = pal.session_destroy(io, id);
+        let _ = pal.session_destroy(io, id).await;
         return Err(HsmError::SessionAuthFailure);
     }
     // Hand the caller the AEAD plaintext view directly: it borrows
@@ -502,7 +502,7 @@ fn encode_response<'p, P: HsmPal>(
 
 /// Materialise the api-rev tag in a scoped DmaBuf and call
 /// `session_promote` to flip the slot from Pending to Active.
-fn promote_to_active<P: HsmPal>(
+async fn promote_to_active<P: HsmPal>(
     pal: &P,
     io: &impl HsmIo,
     alloc: &impl HsmScopedAlloc,
@@ -520,4 +520,5 @@ fn promote_to_active<P: HsmPal>(
         derived.mac_tx_key.as_deref().map(|b| &**b),
         derived.mac_rx_key.as_deref().map(|b| &**b),
     )
+    .await
 }

--- a/fw/core/lib/src/ddi/tbor/open_session_init.rs
+++ b/fw/core/lib/src/ddi/tbor/open_session_init.rs
@@ -137,7 +137,8 @@ pub(crate) async fn handle<'p, P: HsmPal>(
             exported,
             pk_init,
             pk_resp,
-        )?;
+        )
+        .await?;
         let session_id = u16::from(slot);
 
         // ── Phase-1 confirm MAC ────────────────────────────────────
@@ -300,7 +301,7 @@ async fn hpke_auth_psk_export<'a, P: HsmPal>(
 /// Pack `exported ‖ pk_init ‖ pk_resp ‖ session_type ‖ suite_id`
 /// into a Pending blob and hand it to `session_create_pending`.
 #[allow(clippy::too_many_arguments)]
-fn create_pending_slot<P: HsmPal>(
+async fn create_pending_slot<P: HsmPal>(
     pal: &P,
     io: &impl HsmIo,
     alloc: &impl HsmScopedAlloc,
@@ -324,7 +325,7 @@ fn create_pending_slot<P: HsmPal>(
     off += npk;
     pending_blob[off] = session_type.to_u8();
     pending_blob[off + 1] = suite.to_u8();
-    pal.session_create_pending(io, role, pending_blob)
+    pal.session_create_pending(io, role, pending_blob).await
 }
 
 /// Compute the Phase-1 confirm MAC:

--- a/fw/pal/traits/src/session.rs
+++ b/fw/pal/traits/src/session.rs
@@ -270,7 +270,7 @@ pub trait HsmSessionManager {
     ///   is free, or `api_rev`/`masking_key` is the wrong length.
     /// - `Err(HsmError::NotEnoughSpace)` — vault is full and cannot
     ///   store the masking blob.
-    fn session_create(
+    async fn session_create(
         &self,
         io: &impl HsmIo,
         api_rev: &[u8],
@@ -302,7 +302,7 @@ pub trait HsmSessionManager {
     /// - `Ok(())` on success.
     /// - `Err(HsmError::InvalidArg)` — `id` does not refer to a live
     ///   session in the caller's partition.
-    fn session_destroy(&self, io: &impl HsmIo, id: HsmSessId) -> HsmResult<()>;
+    async fn session_destroy(&self, io: &impl HsmIo, id: HsmSessId) -> HsmResult<()>;
 
     /// Queries the lifecycle state of a session slot.
     ///
@@ -368,11 +368,11 @@ pub trait HsmSessionManager {
     ///   `handshake_state.len() > SESSION_PENDING_BLOB_MAX`.
     /// - `Err(HsmError::VaultSessionLimitReached)` — no eligible slot
     ///   available for `role`.
-    fn session_create_pending(
+    async fn session_create_pending(
         &self,
         io: &impl HsmIo,
         role: SessionRole,
-        handshake_state: &[u8],
+        handshake_state: &DmaBuf,
     ) -> HsmResult<HsmSessId>;
 
     /// Borrows the opaque handshake state of a
@@ -453,7 +453,7 @@ pub trait HsmSessionManager {
     /// - `Err(HsmError::SessionNotPending)` — slot exists but is not
     ///   in [`Pending`](HsmSessionState::Pending) state.
     #[allow(clippy::too_many_arguments)]
-    fn session_promote(
+    async fn session_promote(
         &self,
         io: &impl HsmIo,
         id: HsmSessId,

--- a/fw/pal/traits/src/vault.rs
+++ b/fw/pal/traits/src/vault.rs
@@ -131,20 +131,37 @@ pub enum HsmVaultKeyKind {
     VarLenHmacSha384 = 33,
     VarLenHmacSha512 = 34,
 
+    /// In-flight TBOR session-handshake (Pending) state blob.
+    ///
+    /// Holds the opaque Pending blob (`exported ‖ pk_init ‖ pk_resp ‖
+    /// session_type ‖ suite_id`, up to
+    /// [`SESSION_PENDING_BLOB_MAX`](crate::SESSION_PENDING_BLOB_MAX) =
+    /// 256 B) produced by the TBOR `OpenSessionInit` phase and consumed
+    /// by `OpenSessionFinish`.
+    ///
+    /// Written by
+    /// [`HsmSessionManager::session_create_pending`](crate::HsmSessionManager::session_create_pending)
+    /// as a session-scoped key (auto-deleted on session close); replaced
+    /// by a [`SessionEx`](Self::SessionEx) key on
+    /// [`session_promote`](crate::HsmSessionManager::session_promote).
+    /// Used only by PALs that back Pending state in the key vault (e.g.
+    /// the Uno PAL); the std PAL keeps Pending state in RAM.
+    SessionExPending = 35,
+
     /// Session-establishment-protocol blob for TBOR sessions (both CO
     /// and CU).
     ///
     /// Length-discriminated by session type:
-    /// * **PlainText (CU):** `[api_rev(8) ‖ param_key(80) ‖ masking_key(80)]`
-    ///   = 168 B.
+    /// * **PlainText (CU):** `[api_rev(8) ‖ param_key(32) ‖ masking_key(80)]`
+    ///   = 120 B.
     /// * **Authenticated (CO):** the above ‖ `mac_tx(48) ‖ mac_rx(48)`
-    ///   = 264 B.
+    ///   = 216 B.
     ///
     /// Written by
     /// [`HsmSessionManager::session_promote`](crate::HsmSessionManager::session_promote)
     /// when any TBOR session completes its handshake; never produced
     /// by the existing [`Session`](Self::Session) path.
-    SessionCu = 35,
+    SessionEx = 36,
 
     /// Partition Trust Anchor (PTA) ECC-P384 private key.
     ///
@@ -153,7 +170,7 @@ pub enum HsmVaultKeyKind {
     /// rebinding is rejected with [`HsmError::PtaKeyAlreadySet`].
     ///
     /// [`HsmError::PtaKeyAlreadySet`]: crate::HsmError::PtaKeyAlreadySet
-    PartitionTrustAnchor = 36,
+    PartitionTrustAnchor = 37,
 
     /// Partition Unique Machine Secret (UMS) — 48 B HMAC-SHA-384-sized
     /// secret derived in `PartInit` from `UDS` plus the request-side
@@ -166,7 +183,7 @@ pub enum HsmVaultKeyKind {
     /// rejected with [`HsmError::UmsKeyAlreadySet`].
     ///
     /// [`HsmError::UmsKeyAlreadySet`]: crate::HsmError::UmsKeyAlreadySet
-    PartitionUniqueMachineSecret = 37,
+    PartitionUniqueMachineSecret = 38,
 }
 
 /// Key attribute bitfield for vault-stored keys.

--- a/fw/plat/std/pal/src/drivers/vault.rs
+++ b/fw/plat/std/pal/src/drivers/vault.rs
@@ -99,10 +99,10 @@ pub fn fw_key_size(kind: HsmVaultKeyKind) -> Option<usize> {
         HsmVaultKeyKind::MaskingKey => 80,
         HsmVaultKeyKind::PartitionTrustAnchor => 48,
         HsmVaultKeyKind::PartitionUniqueMachineSecret => 48,
-        // SessionCu is length-discriminated by session type
+        // SessionEx is length-discriminated by session type
         // (PlainText=168, Authenticated=264); reported as variable
         // length, same handling as VarLenHmac*.
-        HsmVaultKeyKind::SessionCu => return None,
+        HsmVaultKeyKind::SessionEx => return None,
         // Variable-length HMAC — size depends on actual key.
         HsmVaultKeyKind::VarLenHmacSha256
         | HsmVaultKeyKind::VarLenHmacSha384
@@ -127,7 +127,7 @@ fn fw_storage_cost(kind: HsmVaultKeyKind, actual_len: usize) -> Option<usize> {
             HsmVaultKeyKind::VarLenHmacSha256
                 | HsmVaultKeyKind::VarLenHmacSha384
                 | HsmVaultKeyKind::VarLenHmacSha512
-                | HsmVaultKeyKind::SessionCu
+                | HsmVaultKeyKind::SessionEx
         ) =>
         {
             actual_len

--- a/fw/plat/std/pal/src/drivers/vault.rs
+++ b/fw/plat/std/pal/src/drivers/vault.rs
@@ -100,7 +100,7 @@ pub fn fw_key_size(kind: HsmVaultKeyKind) -> Option<usize> {
         HsmVaultKeyKind::PartitionTrustAnchor => 48,
         HsmVaultKeyKind::PartitionUniqueMachineSecret => 48,
         // SessionEx is length-discriminated by session type
-        // (PlainText=168, Authenticated=264); reported as variable
+        // (PlainText=120, Authenticated=216); reported as variable
         // length, same handling as VarLenHmac*.
         HsmVaultKeyKind::SessionEx => return None,
         // Variable-length HMAC — size depends on actual key.

--- a/fw/plat/std/pal/src/session.rs
+++ b/fw/plat/std/pal/src/session.rs
@@ -33,12 +33,12 @@ const SESSION_MASKING_KEY_SIZE: usize = 80;
 /// MBOR masking-key flow: `[api_rev(8) || masking_key(80)]` = 88 B.
 const SESSION_BLOB_SIZE: usize = SESSION_API_REV_SIZE + SESSION_MASKING_KEY_SIZE;
 
-/// `SessionCu`-kind blob size for **PlainText (CU)** sessions:
+/// `SessionEx`-kind blob size for **PlainText (CU)** sessions:
 /// `api_rev(8) || param_key(32) || masking_key(80)` = 120 B.
 const SESSION_CU_BLOB_SIZE: usize =
     SESSION_API_REV_SIZE + SESSION_PARAM_KEY_LEN + SESSION_MASKING_KEY_LEN;
 
-/// `SessionCu`-kind blob size for **Authenticated (CO)** sessions:
+/// `SessionEx`-kind blob size for **Authenticated (CO)** sessions:
 /// PlainText blob ‖ `mac_tx(48) ‖ mac_rx(48)` = 216 B.
 const SESSION_CU_AUTH_BLOB_SIZE: usize = SESSION_CU_BLOB_SIZE + 2 * SESSION_MAC_DIR_KEY_LEN;
 
@@ -58,7 +58,7 @@ impl HsmSessionManager for StdHsmPal {
     /// 3. Allocates (or re-maps) a logical session slot.
     ///
     /// The session is committed immediately.
-    fn session_create(
+    async fn session_create(
         &self,
         io: &impl HsmIo,
         api_rev: &[u8],
@@ -117,7 +117,7 @@ impl HsmSessionManager for StdHsmPal {
     ///
     /// For [`Pending`](HsmSessionState::Pending) slots no vault entry
     /// exists yet, so steps 1–3 are skipped and only step 4 runs.
-    fn session_destroy(&self, io: &impl HsmIo, id: HsmSessId) -> HsmResult<()> {
+    async fn session_destroy(&self, io: &impl HsmIo, id: HsmSessId) -> HsmResult<()> {
         let entry = self.active_part_mut(io.pid())?;
 
         // Pending slots: no vault state to clean up.
@@ -148,11 +148,11 @@ impl HsmSessionManager for StdHsmPal {
         entry.session_table.state(id)
     }
 
-    fn session_create_pending(
+    async fn session_create_pending(
         &self,
         io: &impl HsmIo,
         role: SessionRole,
-        handshake_state: &[u8],
+        handshake_state: &DmaBuf,
     ) -> HsmResult<HsmSessId> {
         let entry = self.active_part_mut(io.pid())?;
         entry.session_table.create_pending(role, handshake_state)
@@ -178,7 +178,7 @@ impl HsmSessionManager for StdHsmPal {
         }
     }
 
-    fn session_promote(
+    async fn session_promote(
         &self,
         io: &impl HsmIo,
         id: HsmSessId,
@@ -242,7 +242,7 @@ impl HsmSessionManager for StdHsmPal {
         let physical_id =
             entry
                 .vault
-                .create(&blob[..blob_len], HsmVaultKeyKind::SessionCu, None, attrs)?;
+                .create(&blob[..blob_len], HsmVaultKeyKind::SessionEx, None, attrs)?;
 
         // Promote the slot to Active and bind to the new vault entry.
         if let Err(e) = entry.session_table.promote(id, physical_id) {

--- a/fw/plat/uno/fw/Cargo.toml
+++ b/fw/plat/uno/fw/Cargo.toml
@@ -25,6 +25,7 @@ members = [
   "drivers/profile",
   "drivers/rng",
   "drivers/semihosting",
+  "drivers/session_store",
   "drivers/sha",
   "drivers/systick",
   "drivers/uart",
@@ -56,6 +57,7 @@ azihsm_fw_uno_drivers_part_store = { path = "drivers/part_store" }
 azihsm_fw_uno_drivers_profile = { default-features = false, path = "drivers/profile" }
 azihsm_fw_uno_drivers_rng = { path = "drivers/rng" }
 azihsm_fw_uno_drivers_semihosting = { path = "drivers/semihosting" }
+azihsm_fw_uno_drivers_session_store = { path = "drivers/session_store" }
 azihsm_fw_uno_drivers_sha = { path = "drivers/sha" }
 azihsm_fw_uno_drivers_systick = { path = "drivers/systick" }
 azihsm_fw_uno_drivers_uart = { path = "drivers/uart" }

--- a/fw/plat/uno/fw/crates/key_vault/src/kind.rs
+++ b/fw/plat/uno/fw/crates/key_vault/src/kind.rs
@@ -79,9 +79,10 @@ impl KeyLen {
 /// Per-kind length table, indexed by `HsmVaultKeyKind` discriminant.
 ///
 /// Mirrors the reference firmware's `raw_key_blob_size()` (fixed kinds)
-/// and var-HMAC min/max. `SessionCu` is length-discriminated by session
-/// type (PlainText=168, Authenticated=264) and modelled as variable.
-static KIND_LEN: [KeyLen; 38] = [
+/// and var-HMAC min/max. `SessionEx` is length-discriminated by session
+/// type (PlainText=120, Authenticated=216) and modelled as variable;
+/// `SessionExPending` holds the in-flight TBOR Pending blob (up to 256).
+static KIND_LEN: [KeyLen; 39] = [
     /* 0  Free                         */ KeyLen::Invalid,
     /* 1  Rsa2kPublic                  */ KeyLen::Fixed(260),
     /* 2  Rsa3kPublic                  */ KeyLen::Fixed(388),
@@ -117,9 +118,10 @@ static KIND_LEN: [KeyLen; 38] = [
     /* 32 VarLenHmacSha256             */ KeyLen::Variable { min: 32, max: 64 },
     /* 33 VarLenHmacSha384             */ KeyLen::Variable { min: 48, max: 128 },
     /* 34 VarLenHmacSha512             */ KeyLen::Variable { min: 64, max: 128 },
-    /* 35 SessionCu                    */ KeyLen::Variable { min: 168, max: 264 },
-    /* 36 PartitionTrustAnchor         */ KeyLen::Fixed(48),
-    /* 37 PartitionUniqueMachineSecret */ KeyLen::Fixed(48),
+    /* 35 SessionExPending           */ KeyLen::Variable { min: 32, max: 256 },
+    /* 36 SessionEx                    */ KeyLen::Variable { min: 120, max: 216 },
+    /* 37 PartitionTrustAnchor         */ KeyLen::Fixed(48),
+    /* 38 PartitionUniqueMachineSecret */ KeyLen::Fixed(48),
 ];
 
 /// Resolves the length contract for `kind` in O(1).
@@ -195,7 +197,7 @@ mod tests {
 
     #[test]
     fn unknown_discriminant_is_invalid_key_type() {
-        // 200 is well outside the named 0..=37 range.
+        // 200 is well outside the named 0..=38 range.
         assert_eq!(key_len(HsmVaultKeyKind(200)), Err(HsmError::InvalidKeyType));
     }
 
@@ -238,8 +240,12 @@ mod tests {
             Ok(KeyLen::Variable { min: 64, max: 128 })
         );
         assert_eq!(
-            key_len(HsmVaultKeyKind::SessionCu),
-            Ok(KeyLen::Variable { min: 168, max: 264 })
+            key_len(HsmVaultKeyKind::SessionEx),
+            Ok(KeyLen::Variable { min: 120, max: 216 })
+        );
+        assert_eq!(
+            key_len(HsmVaultKeyKind::SessionExPending),
+            Ok(KeyLen::Variable { min: 32, max: 256 })
         );
     }
 

--- a/fw/plat/uno/fw/drivers/part_store/src/part_store.rs
+++ b/fw/plat/uno/fw/drivers/part_store/src/part_store.rs
@@ -59,7 +59,9 @@ const RESERVED3_LEN: usize = 626
     - PUB_KEY_LEN  // pta_pub_key
     - 1  // pta_pub_key_valid
     - 1  // policy_hash_valid
-    - 1; // bk3_initialized
+    - 1  // policy_hash_valid
+    - 1  // bk3_initialized
+    - 2; // session_meta (pending_mask + psk_change_mask)
 
 /// Total per-partition slot size (matches the reference layout).
 const STORE_SIZE: usize = 3072;
@@ -227,6 +229,11 @@ struct Storage {
     // which tracks presence of the BK3 *session key*; this flag records
     // that InitBk3 has run and must not run again.
     bk3_initialized: bool,
+    // Volatile TBOR session slot metadata: byte 0 = pending_mask
+    // (bit N set while slot N's handshake is in flight), byte 1 =
+    // psk_change_mask (bit N set once slot N has consumed its one
+    // allowed PSK change). Owned by the session_store driver.
+    session_meta: [u8; 2],
     reserved3: [u8; RESERVED3_LEN],
 }
 
@@ -406,6 +413,7 @@ impl Partition {
         slot.nonce = [0u8; NONCE_LEN];
         slot.vm_launch_guid = [0u8; GUID_LEN];
         slot.session_table = [0u8; SESSION_TABLE_LEN];
+        slot.session_meta = [0u8; 2];
     }
 
     /// Borrows the partition's 16-byte identity.
@@ -1145,6 +1153,19 @@ impl Partition {
     #[inline(never)]
     pub fn session_table_mut(&mut self) -> &mut [u8; SESSION_TABLE_LEN] {
         &mut self.slot_mut().session_table
+    }
+
+    /// Borrows the 2-byte volatile session metadata (`pending_mask`,
+    /// `psk_change_mask`) for the TBOR session slots.
+    #[inline(never)]
+    pub fn session_meta(self) -> &'static [u8; 2] {
+        &self.slot().session_meta
+    }
+
+    /// Mutably borrows the session metadata region.
+    #[inline(never)]
+    pub fn session_meta_mut(&mut self) -> &mut [u8; 2] {
+        &mut self.slot_mut().session_meta
     }
 }
 

--- a/fw/plat/uno/fw/drivers/part_store/src/part_store.rs
+++ b/fw/plat/uno/fw/drivers/part_store/src/part_store.rs
@@ -59,7 +59,6 @@ const RESERVED3_LEN: usize = 626
     - PUB_KEY_LEN  // pta_pub_key
     - 1  // pta_pub_key_valid
     - 1  // policy_hash_valid
-    - 1  // policy_hash_valid
     - 1  // bk3_initialized
     - 2; // session_meta (pending_mask + psk_change_mask)
 

--- a/fw/plat/uno/fw/drivers/session_store/Cargo.toml
+++ b/fw/plat/uno/fw/drivers/session_store/Cargo.toml
@@ -1,0 +1,16 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+[package]
+edition = "2021"
+name = "azihsm_fw_uno_drivers_session_store"
+version = "0.1.0"
+
+[lib]
+bench = false
+doctest = false
+test = false
+
+[dependencies]
+azihsm_fw_hsm_pal_traits = { workspace = true }
+azihsm_fw_uno_drivers_part_store = { workspace = true }

--- a/fw/plat/uno/fw/drivers/session_store/src/lib.rs
+++ b/fw/plat/uno/fw/drivers/session_store/src/lib.rs
@@ -1,0 +1,30 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Persistent session indirection table for the Uno platform.
+//!
+//! Maps logical session IDs (the stable IDs handed to the host) to
+//! physical vault key IDs (where the session masking key lives). The
+//! indirection keeps customer-visible session IDs stable across physical
+//! remaps (live migration / disaster recovery), so it is the *persistent*
+//! subset of the session manager's state.
+//!
+//! This driver owns only that persistent subset — `alloc_mask`,
+//! `renego_mask`, and the logical→physical map — which is exactly the
+//! 18-byte `session_table` region carried in each partition's persistent
+//! store. It reaches that region through the partition-store driver's
+//! [`Partition`](azihsm_fw_uno_drivers_part_store::Partition) handle, so the
+//! GSRAM addressing lives in one place.
+//!
+//! The volatile session state (in-flight handshake / Pending slots, the
+//! one-shot PSK-change budget, eviction sequencing) is NOT here — it lives
+//! in the PAL's DTCM partition struct and is managed separately.
+
+#![no_std]
+
+mod session_store;
+
+pub use session_store::SessionStore;
+pub use session_store::SessionTable;
+pub use session_store::MAX_SESSIONS;
+pub use session_store::SESSION_STORE_LEN;

--- a/fw/plat/uno/fw/drivers/session_store/src/lib.rs
+++ b/fw/plat/uno/fw/drivers/session_store/src/lib.rs
@@ -9,16 +9,19 @@
 //! remaps (live migration / disaster recovery), so it is the *persistent*
 //! subset of the session manager's state.
 //!
-//! This driver owns only that persistent subset — `alloc_mask`,
-//! `renego_mask`, and the logical→physical map — which is exactly the
-//! 18-byte `session_table` region carried in each partition's persistent
-//! store. It reaches that region through the partition-store driver's
+//! This driver owns the persistent indirection state — `alloc_mask`,
+//! `renego_mask`, and the logical→physical map — which is the 18-byte
+//! `session_table` region carried in each partition's persistent store. It
+//! also tracks two volatile, single-byte bitmasks — the in-flight Pending
+//! set and the one-shot PSK-change budget — in the partition store's 2-byte
+//! `session_meta` region (cleared on reset, not migrated). Both regions are
+//! reached through the partition-store driver's
 //! [`Partition`](azihsm_fw_uno_drivers_part_store::Partition) handle, so the
 //! GSRAM addressing lives in one place.
 //!
-//! The volatile session state (in-flight handshake / Pending slots, the
-//! one-shot PSK-change budget, eviction sequencing) is NOT here — it lives
-//! in the PAL's DTCM partition struct and is managed separately.
+//! The remaining volatile session state (handshake key material, eviction
+//! policy beyond the Pending bit) is NOT here — it lives in the PAL's DTCM
+//! partition struct and is managed separately.
 
 #![no_std]
 

--- a/fw/plat/uno/fw/drivers/session_store/src/session_store.rs
+++ b/fw/plat/uno/fw/drivers/session_store/src/session_store.rs
@@ -1,8 +1,10 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-//! [`SessionStore`]: the persistent session indirection table, operating on
-//! the raw 18-byte session-table region of a partition's persistent store.
+//! [`SessionStore`]: the session indirection table. Its persistent state
+//! lives in the raw 18-byte `session_table` region of a partition's
+//! persistent store; the volatile Pending and PSK-change bitmasks live in
+//! the adjacent 2-byte `session_meta` region (cleared on reset).
 
 use azihsm_fw_hsm_pal_traits::HsmError;
 use azihsm_fw_hsm_pal_traits::HsmKeyId;

--- a/fw/plat/uno/fw/drivers/session_store/src/session_store.rs
+++ b/fw/plat/uno/fw/drivers/session_store/src/session_store.rs
@@ -1,0 +1,379 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! [`SessionStore`]: the persistent session indirection table, operating on
+//! the raw 18-byte session-table region of a partition's persistent store.
+
+use azihsm_fw_hsm_pal_traits::HsmError;
+use azihsm_fw_hsm_pal_traits::HsmKeyId;
+use azihsm_fw_hsm_pal_traits::HsmPartId;
+use azihsm_fw_hsm_pal_traits::HsmResult;
+use azihsm_fw_hsm_pal_traits::HsmSessId;
+use azihsm_fw_hsm_pal_traits::HsmSessionState;
+use azihsm_fw_hsm_pal_traits::SessionRole;
+use azihsm_fw_uno_drivers_part_store::PartStore;
+use azihsm_fw_uno_drivers_part_store::Partition;
+
+/// Maximum concurrent sessions per partition (one bit per slot in the
+/// allocation / renegotiation masks).
+pub const MAX_SESSIONS: usize = 8;
+
+/// Size of the persistent session-store region, in bytes:
+/// `alloc_mask` (1) + `renego_mask` (1) + `phys_ids` (8 × u16 = 16).
+pub const SESSION_STORE_LEN: usize = 2 + MAX_SESSIONS * 2;
+
+// Byte offsets within the region.
+const ALLOC_MASK: usize = 0;
+const RENEGO_MASK: usize = 1;
+const PHYS_IDS: usize = 2;
+
+/// Persistent session indirection table.
+///
+/// Stateless entry point: [`SessionStore::partition`] validates a raw
+/// partition id and returns a [`SessionTable`] handle through which the
+/// partition's session slots are managed. Mirrors
+/// [`PartStore`](azihsm_fw_uno_drivers_part_store::PartStore).
+#[derive(Debug)]
+pub struct SessionStore;
+
+impl SessionStore {
+    /// Validates a raw partition id and returns a handle to its session
+    /// table.
+    ///
+    /// # Errors
+    ///
+    /// - [`HsmError::InvalidArg`] — `pid` is out of range.
+    #[inline]
+    pub fn partition(pid: HsmPartId) -> HsmResult<SessionTable> {
+        Ok(SessionTable(PartStore::partition(pid)?))
+    }
+}
+
+/// A partition's persistent session indirection table.
+///
+/// Obtained only via [`SessionStore::partition`], so holding one is proof
+/// that the partition index is in range. Logical session IDs are slot
+/// indices (`0..MAX_SESSIONS`); each occupied slot maps to a physical
+/// vault key ID. Only the persistent fields live here — see the crate docs
+/// for the volatile state that is managed elsewhere. Mirrors the
+/// [`Partition`](azihsm_fw_uno_drivers_part_store::Partition) handle.
+#[derive(Debug, Clone, Copy)]
+pub struct SessionTable(Partition);
+
+impl SessionTable {
+    // ── raw field helpers ────────────────────────────────────────────────
+
+    #[inline]
+    fn region(&self) -> &[u8; SESSION_STORE_LEN] {
+        self.0.session_table()
+    }
+
+    #[inline]
+    fn region_mut(&mut self) -> &mut [u8; SESSION_STORE_LEN] {
+        self.0.session_table_mut()
+    }
+
+    #[inline]
+    fn alloc_mask(&self) -> u8 {
+        self.region()[ALLOC_MASK]
+    }
+
+    #[inline]
+    fn renego_mask(&self) -> u8 {
+        self.region()[RENEGO_MASK]
+    }
+
+    #[inline]
+    fn phys_id(&self, slot: usize) -> u16 {
+        let off = PHYS_IDS + slot * 2;
+        let r = self.region();
+        u16::from_le_bytes([r[off], r[off + 1]])
+    }
+
+    #[inline]
+    fn set_phys_id(&mut self, slot: usize, value: u16) {
+        let off = PHYS_IDS + slot * 2;
+        self.region_mut()[off..off + 2].copy_from_slice(&value.to_le_bytes());
+    }
+
+    // ── volatile pending / psk-change masks (uno session_meta region) ────
+
+    #[inline]
+    fn pending_mask(&self) -> u8 {
+        self.0.session_meta()[0]
+    }
+
+    #[inline]
+    fn set_pending_mask(&mut self, v: u8) {
+        self.0.session_meta_mut()[0] = v;
+    }
+
+    #[inline]
+    fn psk_change_mask(&self) -> u8 {
+        self.0.session_meta()[1]
+    }
+
+    #[inline]
+    fn set_psk_change_mask(&mut self, v: u8) {
+        self.0.session_meta_mut()[1] = v;
+    }
+
+    /// Slot range eligible for a Pending session of `role`:
+    /// CryptoOfficer → slot 0 only; CryptoUser → slots `1..=MAX_SESSIONS-1`.
+    #[inline]
+    fn role_slot_range(role: SessionRole) -> (usize, usize) {
+        match role {
+            SessionRole::CryptoOfficer => (0, 0),
+            SessionRole::CryptoUser => (1, MAX_SESSIONS - 1),
+        }
+    }
+
+    /// Validates that `id` refers to an allocated slot, returning its index.
+    fn active_slot(&self, id: HsmSessId) -> HsmResult<usize> {
+        let slot = u16::from(id) as usize;
+        if slot >= MAX_SESSIONS || (self.alloc_mask() & (1 << slot)) == 0 {
+            return Err(HsmError::SessionNotFound);
+        }
+        Ok(slot)
+    }
+
+    // ── operations ───────────────────────────────────────────────────────
+
+    /// Allocates a session in the lowest free slot, mapping it to
+    /// `physical_id`.
+    ///
+    /// # Errors
+    ///
+    /// - [`HsmError::VaultSessionLimitReached`] — all slots are occupied.
+    #[inline(never)]
+    pub fn create(&mut self, physical_id: HsmKeyId) -> HsmResult<HsmSessId> {
+        let slot = self.alloc_mask().trailing_ones() as usize;
+        if slot >= MAX_SESSIONS {
+            return Err(HsmError::VaultSessionLimitReached);
+        }
+        self.region_mut()[ALLOC_MASK] |= 1 << slot;
+        self.set_phys_id(slot, u16::from(physical_id));
+        Ok(HsmSessId::from(slot as u16))
+    }
+
+    /// Closes a session, freeing its slot and returning the physical vault
+    /// key ID it mapped to (so the caller can clean up the vault entry).
+    ///
+    /// # Errors
+    ///
+    /// - [`HsmError::SessionNotFound`] — `id` is not an allocated slot.
+    #[inline(never)]
+    pub fn delete(&mut self, id: HsmSessId) -> HsmResult<HsmKeyId> {
+        let slot = self.active_slot(id)?;
+        let phys = HsmKeyId::from(self.phys_id(slot));
+        let clear = !(1u8 << slot);
+        self.region_mut()[ALLOC_MASK] &= clear;
+        self.region_mut()[RENEGO_MASK] &= clear;
+        self.set_pending_mask(self.pending_mask() & clear);
+        self.set_psk_change_mask(self.psk_change_mask() & clear);
+        self.set_phys_id(slot, 0);
+        Ok(phys)
+    }
+
+    /// Looks up the physical vault key ID for a logical session.
+    ///
+    /// # Errors
+    ///
+    /// - [`HsmError::SessionNotFound`] — `id` is not an allocated slot.
+    #[inline(never)]
+    pub fn physical_id(&self, id: HsmSessId) -> HsmResult<HsmKeyId> {
+        let slot = self.active_slot(id)?;
+        Ok(HsmKeyId::from(self.phys_id(slot)))
+    }
+
+    /// Re-keys a session that needs renegotiation with a new physical vault
+    /// key ID, clearing its renegotiation flag.
+    ///
+    /// # Errors
+    ///
+    /// - [`HsmError::SessionNotFound`] — `id` is not an allocated slot.
+    /// - [`HsmError::InvalidArg`] — the session is not in the
+    ///   [`NeedsRenegotiation`](HsmSessionState::NeedsRenegotiation) state.
+    #[inline(never)]
+    pub fn recreate(&mut self, id: HsmSessId, new_physical: HsmKeyId) -> HsmResult<HsmSessId> {
+        let slot = self.active_slot(id)?;
+        if (self.renego_mask() & (1 << slot)) == 0 {
+            return Err(HsmError::InvalidArg);
+        }
+        self.region_mut()[RENEGO_MASK] &= !(1u8 << slot);
+        self.set_phys_id(slot, u16::from(new_physical));
+        Ok(id)
+    }
+
+    /// Returns the persistent state of a session slot.
+    ///
+    /// A slot whose handshake is still in flight reports
+    /// [`Pending`](HsmSessionState::Pending); a renegotiation-flagged
+    /// slot reports [`NeedsRenegotiation`](HsmSessionState::NeedsRenegotiation);
+    /// otherwise [`Active`](HsmSessionState::Active).
+    #[inline(never)]
+    pub fn state(&self, id: HsmSessId) -> HsmSessionState {
+        let Ok(slot) = self.active_slot(id) else {
+            return HsmSessionState::Invalid;
+        };
+        if (self.pending_mask() & (1 << slot)) != 0 {
+            return HsmSessionState::Pending;
+        }
+        if (self.renego_mask() & (1 << slot)) != 0 {
+            return HsmSessionState::NeedsRenegotiation;
+        }
+        HsmSessionState::Active
+    }
+
+    /// Returns `true` when every slot is occupied.
+    #[inline(never)]
+    pub fn limit_reached(&self) -> bool {
+        self.alloc_mask().count_ones() >= MAX_SESSIONS as u32
+    }
+
+    /// Marks an allocated session as needing renegotiation. No-op for
+    /// unallocated slots.
+    #[inline(never)]
+    pub fn set_needs_renego(&mut self, id: HsmSessId) {
+        let slot = u16::from(id) as usize;
+        if slot < MAX_SESSIONS && (self.alloc_mask() & (1 << slot)) != 0 {
+            self.region_mut()[RENEGO_MASK] |= 1 << slot;
+        }
+    }
+
+    /// Returns the physical vault key id of every occupied slot (Active,
+    /// NeedsRenegotiation, or Pending), so a caller tearing the partition
+    /// down can delete the backing session-blob vault keys before the
+    /// table is zeroized — otherwise they would be orphaned in the vault.
+    ///
+    /// Read-only: the table is left unchanged (the caller clears it
+    /// separately, e.g. via the partition store's `clear_enabled_state`).
+    #[inline(never)]
+    pub fn occupied_physical_ids(&self) -> [Option<HsmKeyId>; MAX_SESSIONS] {
+        let mut out = [None; MAX_SESSIONS];
+        let mask = self.alloc_mask();
+        for (slot, entry) in out.iter_mut().enumerate() {
+            if (mask & (1 << slot)) != 0 {
+                *entry = Some(HsmKeyId::from(self.phys_id(slot)));
+            }
+        }
+        out
+    }
+
+    // ── TBOR in-flight handshake (Pending) slots ─────────────────────────
+
+    /// Reserves a [`Pending`](HsmSessionState::Pending) slot in `role`'s
+    /// eligible range, mapping it to the handshake-blob vault key
+    /// `physical_id`.
+    ///
+    /// Prefers the lowest free slot in range; if the range is full, evicts
+    /// the lowest-index Pending slot and returns its physical vault key id
+    /// so the caller can delete the abandoned handshake key. Active /
+    /// renegotiating slots are never evicted.
+    ///
+    /// # Errors
+    ///
+    /// - [`HsmError::VaultSessionLimitReached`] — every slot in range is
+    ///   Active or NeedsRenegotiation (nothing evictable).
+    #[inline(never)]
+    pub fn create_pending(
+        &mut self,
+        role: SessionRole,
+        physical_id: HsmKeyId,
+    ) -> HsmResult<(HsmSessId, Option<HsmKeyId>)> {
+        let (start, end) = Self::role_slot_range(role);
+
+        // 1. Lowest free slot in range.
+        for slot in start..=end {
+            if (self.alloc_mask() & (1 << slot)) == 0 {
+                self.install_pending(slot, physical_id);
+                return Ok((HsmSessId::from(slot as u16), None));
+            }
+        }
+
+        // 2. Evict the lowest-index Pending slot in range.
+        for slot in start..=end {
+            if (self.pending_mask() & (1 << slot)) != 0 {
+                let evicted = HsmKeyId::from(self.phys_id(slot));
+                self.install_pending(slot, physical_id);
+                return Ok((HsmSessId::from(slot as u16), Some(evicted)));
+            }
+        }
+
+        // 3. All slots in range are Active or NeedsRenegotiation.
+        Err(HsmError::VaultSessionLimitReached)
+    }
+
+    /// Occupies `slot` as a fresh Pending session mapped to `physical_id`,
+    /// clearing any stale renegotiation / psk-change flags.
+    fn install_pending(&mut self, slot: usize, physical_id: HsmKeyId) {
+        let bit = 1u8 << slot;
+        self.region_mut()[ALLOC_MASK] |= bit;
+        self.region_mut()[RENEGO_MASK] &= !bit;
+        self.set_pending_mask(self.pending_mask() | bit);
+        self.set_psk_change_mask(self.psk_change_mask() & !bit);
+        self.set_phys_id(slot, u16::from(physical_id));
+    }
+
+    /// Returns the handshake-blob vault key id for a Pending session.
+    ///
+    /// # Errors
+    ///
+    /// - [`HsmError::SessionNotFound`] — `id` is not an allocated slot.
+    /// - [`HsmError::SessionNotPending`] — the slot exists but is not
+    ///   Pending.
+    #[inline(never)]
+    pub fn pending_phys(&self, id: HsmSessId) -> HsmResult<HsmKeyId> {
+        let slot = self.active_slot(id)?;
+        if (self.pending_mask() & (1 << slot)) == 0 {
+            return Err(HsmError::SessionNotPending);
+        }
+        Ok(HsmKeyId::from(self.phys_id(slot)))
+    }
+
+    /// Promotes a [`Pending`](HsmSessionState::Pending) slot to
+    /// [`Active`](HsmSessionState::Active), rebinding it to the committed
+    /// session vault key `new_physical`. Returns the old handshake vault
+    /// key id so the caller can delete it.
+    ///
+    /// # Errors
+    ///
+    /// - [`HsmError::SessionNotFound`] — `id` is not an allocated slot.
+    /// - [`HsmError::SessionNotPending`] — the slot exists but is not
+    ///   Pending.
+    #[inline(never)]
+    pub fn promote(&mut self, id: HsmSessId, new_physical: HsmKeyId) -> HsmResult<HsmKeyId> {
+        let slot = self.active_slot(id)?;
+        let bit = 1u8 << slot;
+        if (self.pending_mask() & bit) == 0 {
+            return Err(HsmError::SessionNotPending);
+        }
+        let old = HsmKeyId::from(self.phys_id(slot));
+        self.set_pending_mask(self.pending_mask() & !bit);
+        self.set_psk_change_mask(self.psk_change_mask() & !bit);
+        self.set_phys_id(slot, u16::from(new_physical));
+        Ok(old)
+    }
+
+    /// Consumes the one PSK change permitted for an Active session.
+    ///
+    /// # Errors
+    ///
+    /// - [`HsmError::SessionNotFound`] — `id` is not an allocated slot, or
+    ///   is still Pending.
+    /// - [`HsmError::InvalidPermissions`] — the session has already
+    ///   consumed its PSK change (the flag remains set).
+    #[inline(never)]
+    pub fn try_consume_psk_change(&mut self, id: HsmSessId) -> HsmResult<()> {
+        let slot = self.active_slot(id)?;
+        let bit = 1u8 << slot;
+        if (self.pending_mask() & bit) != 0 {
+            return Err(HsmError::SessionNotFound);
+        }
+        if (self.psk_change_mask() & bit) != 0 {
+            return Err(HsmError::InvalidPermissions);
+        }
+        self.set_psk_change_mask(self.psk_change_mask() | bit);
+        Ok(())
+    }
+}

--- a/fw/plat/uno/fw/pal/Cargo.toml
+++ b/fw/plat/uno/fw/pal/Cargo.toml
@@ -28,6 +28,7 @@ azihsm_fw_uno_drivers_oic = { workspace = true }
 azihsm_fw_uno_drivers_part_store = { workspace = true }
 azihsm_fw_uno_drivers_rng = { workspace = true }
 azihsm_fw_uno_drivers_semihosting = { optional = true, workspace = true }
+azihsm_fw_uno_drivers_session_store = { workspace = true }
 azihsm_fw_uno_drivers_sha = { workspace = true }
 azihsm_fw_uno_drivers_systick = { workspace = true }
 azihsm_fw_uno_drivers_upka = { workspace = true }

--- a/fw/plat/uno/fw/pal/src/part.rs
+++ b/fw/plat/uno/fw/pal/src/part.rs
@@ -31,6 +31,7 @@ use azihsm_fw_hsm_pal_traits::HsmVaultKeyKind;
 use azihsm_fw_hsm_pal_traits::PartPropId;
 use azihsm_fw_hsm_pal_traits::PartState;
 use azihsm_fw_uno_drivers_part_store::PartStore;
+use azihsm_fw_uno_drivers_session_store::SessionStore;
 
 use crate::UnoHsmPal;
 use crate::alloc::UnoScopedAlloc;
@@ -322,10 +323,11 @@ impl UnoHsmPal {
     }
 
     /// Clears partition `pid`'s per-tenant state — deletes every
-    /// enable-time and provisioning vault key, then zeroizes all cached
-    /// public keys, caller-presented secrets, write-once provisioning
-    /// fields, the nonce, VM launch GUID, BK3 incarnation flag, and the
-    /// session table (see [`PartStore`]'s `clear_enabled_state`).
+    /// enable-time and provisioning vault key plus every session-blob
+    /// vault key, then zeroizes all cached public keys, caller-presented
+    /// secrets, write-once provisioning fields, the nonce, VM launch GUID,
+    /// BK3 incarnation flag, and the session table (see [`PartStore`]'s
+    /// `clear_enabled_state`).
     ///
     /// The partition identity and `Masked_BK_BOOT` are preserved — they
     /// are torn down only on free. Best-effort and idempotent: keys are
@@ -349,6 +351,14 @@ impl UnoHsmPal {
         .flatten()
         {
             self.delete_key(pid, key_id).await;
+        }
+        // Delete every session-blob vault key (Active, NeedsRenegotiation,
+        // or Pending) mapped by the session table, so none are orphaned in
+        // the vault when the table is zeroized below.
+        if let Ok(sessions) = SessionStore::partition(pid) {
+            for key_id in sessions.occupied_physical_ids().into_iter().flatten() {
+                self.delete_key(pid, key_id).await;
+            }
         }
         part.clear_enabled_state();
     }

--- a/fw/plat/uno/fw/pal/src/session.rs
+++ b/fw/plat/uno/fw/pal/src/session.rs
@@ -313,8 +313,12 @@ impl HsmSessionManager for UnoHsmPal {
         // The param_key is the 32-byte field following the 8-byte api_rev
         // in the committed SessionEx blob.
         let blob = self.vault_key(io, physical_id)?;
+        // A committed SessionEx blob is always long enough to carry the
+        // param_key; a short blob indicates vault corruption, not a caller
+        // error — surface it as `InternalError` (matches the trait contract
+        // and the std PAL).
         if blob.len() < SESSION_API_REV_SIZE + SESSION_PARAM_KEY_LEN {
-            return Err(HsmError::InvalidArg);
+            return Err(HsmError::InternalError);
         }
         Ok(blob
             .split_at(SESSION_API_REV_SIZE)

--- a/fw/plat/uno/fw/pal/src/session.rs
+++ b/fw/plat/uno/fw/pal/src/session.rs
@@ -1,78 +1,330 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-//! [`HsmSessionManager`] stub for the Uno PAL.
+//! [`HsmSessionManager`] for the Uno PAL.
+//!
+//! Mirrors the standard PAL's session model: a committed session is
+//! stored as a vault key (`Session` for MBOR, `SessionEx` for promoted
+//! TBOR sessions); a logical session slot in the partition's persistent
+//! [`SessionStore`] maps to that vault key's physical [`HsmKeyId`].
+//!
+//! In-flight TBOR handshake (Pending) state is **also** held in the key
+//! vault — `session_create_pending` stores the opaque handshake blob as
+//! a session-scoped [`HsmVaultKeyKind::SessionExPending`] key, and
+//! `session_promote` replaces it with the committed
+//! [`HsmVaultKeyKind::SessionEx`] key. The session store's `pending_mask`
+//! / `psk_change_mask` (the Uno `session_meta` region) track slot state;
+//! Pending eviction within a role's slot range is lowest-index-first.
+//!
+//! The vault-touching methods are `async` (the Uno vault drives GDMA);
+//! the read-only probes (`session_pending_state`, `session_param_key`,
+//! `session_try_consume_psk_change`) are synchronous.
 
 use azihsm_fw_hsm_pal_traits::DmaBuf;
+use azihsm_fw_hsm_pal_traits::HsmAlloc;
 use azihsm_fw_hsm_pal_traits::HsmError;
 use azihsm_fw_hsm_pal_traits::HsmIo;
 use azihsm_fw_hsm_pal_traits::HsmResult;
 use azihsm_fw_hsm_pal_traits::HsmSessId;
 use azihsm_fw_hsm_pal_traits::HsmSessionManager;
 use azihsm_fw_hsm_pal_traits::HsmSessionState;
+use azihsm_fw_hsm_pal_traits::HsmVault;
+use azihsm_fw_hsm_pal_traits::HsmVaultKeyAttrs;
+use azihsm_fw_hsm_pal_traits::HsmVaultKeyKind;
+use azihsm_fw_hsm_pal_traits::SESSION_MAC_DIR_KEY_LEN;
+use azihsm_fw_hsm_pal_traits::SESSION_PARAM_KEY_LEN;
+use azihsm_fw_hsm_pal_traits::SESSION_PENDING_BLOB_MAX;
 use azihsm_fw_hsm_pal_traits::SessionRole;
+use azihsm_fw_uno_drivers_session_store::SessionStore;
 
 use crate::UnoHsmPal;
 
+/// API-revision portion of the session blob (bytes).
+const SESSION_API_REV_SIZE: usize = 8;
+
+/// Masking-key portion of the session blob: AES-CBC-256 (32) + HMAC-SHA-384
+/// (48) = 80 bytes.
+const SESSION_MASKING_KEY_SIZE: usize = 80;
+
+/// `Session`-kind blob: `[api_rev(8) || masking_key(80)]` = 88 bytes.
+const SESSION_BLOB_SIZE: usize = SESSION_API_REV_SIZE + SESSION_MASKING_KEY_SIZE;
+
+/// `SessionEx` plaintext (CU) blob:
+/// `[api_rev(8) || param_key(32) || masking_key(80)]` = 120 bytes.
+const SESSION_CU_BLOB_SIZE: usize =
+    SESSION_API_REV_SIZE + SESSION_PARAM_KEY_LEN + SESSION_MASKING_KEY_SIZE;
+
+/// `SessionEx` authenticated (CO) blob: the plaintext blob followed by
+/// `mac_tx(48) || mac_rx(48)` = 216 bytes.
+const SESSION_CU_AUTH_BLOB_SIZE: usize = SESSION_CU_BLOB_SIZE + 2 * SESSION_MAC_DIR_KEY_LEN;
+
 impl HsmSessionManager for UnoHsmPal {
-    fn session_limit_reached(&self, _io: &impl HsmIo) -> bool {
-        true
+    fn session_limit_reached(&self, io: &impl HsmIo) -> bool {
+        let Ok(table) = SessionStore::partition(io.pid()) else {
+            return true;
+        };
+        table.limit_reached()
     }
 
-    fn session_create(
+    async fn session_create(
         &self,
-        _io: &impl HsmIo,
-        _api_rev: &[u8],
-        _masking_key: &[u8],
-        _id: Option<HsmSessId>,
+        io: &impl HsmIo,
+        api_rev: &[u8],
+        masking_key: &[u8],
+        id: Option<HsmSessId>,
     ) -> HsmResult<HsmSessId> {
-        Err(HsmError::UnsupportedCmd)
+        if api_rev.len() != SESSION_API_REV_SIZE || masking_key.len() != SESSION_MASKING_KEY_SIZE {
+            return Err(HsmError::InvalidArg);
+        }
+        let table = SessionStore::partition(io.pid())?;
+
+        // On re-key: tear down the old session-scoped keys and the old
+        // session key before creating the replacement.
+        if let Some(reopen_id) = id {
+            let old_phys = table.physical_id(reopen_id)?;
+            let mut v = crate::vault::vault(io);
+            v.delete_by_session(self, io, u16::from(reopen_id)).await?;
+            v.delete(self, io, old_phys).await?;
+        }
+
+        // Build the 88-byte session blob in a DMA buffer:
+        // [api_rev(8) || masking_key(80)].
+        let blob = self.dma_alloc(io, SESSION_BLOB_SIZE)?;
+        blob[..SESSION_API_REV_SIZE].copy_from_slice(api_rev);
+        blob[SESSION_API_REV_SIZE..].copy_from_slice(masking_key);
+
+        // Store as an internal session key.
+        let attrs = HsmVaultKeyAttrs::new().with_internal(true);
+        let physical_id = {
+            let mut v = crate::vault::vault(io);
+            v.create(
+                self,
+                io,
+                u8::from(io.pid()),
+                blob,
+                HsmVaultKeyKind::Session,
+                None,
+                attrs,
+            )
+            .await?
+        };
+
+        // Allocate (or re-map, on re-key) the logical session slot.
+        let result = {
+            let mut store = table;
+            match id {
+                None => store.create(physical_id),
+                Some(reopen_id) => store.recreate(reopen_id, physical_id),
+            }
+        };
+
+        // If the slot allocation fails, remove the just-stored vault key so
+        // it does not leak.
+        match result {
+            Ok(sess_id) => Ok(sess_id),
+            Err(e) => {
+                let mut v = crate::vault::vault(io);
+                let _ = v.delete(self, io, physical_id).await;
+                Err(e)
+            }
+        }
     }
 
-    fn session_destroy(&self, _io: &impl HsmIo, _id: HsmSessId) -> HsmResult<()> {
-        Err(HsmError::UnsupportedCmd)
+    async fn session_destroy(&self, io: &impl HsmIo, id: HsmSessId) -> HsmResult<()> {
+        let mut table = SessionStore::partition(io.pid())?;
+
+        // Resolve the physical vault key id before any async work (drops the
+        // session-store borrow before the awaits).
+        let physical_id = table.physical_id(id)?;
+
+        // Delete every session-scoped key bound to this logical session,
+        // then the session key itself.
+        let mut v = crate::vault::vault(io);
+        v.delete_by_session(self, io, u16::from(id)).await?;
+        v.delete(self, io, physical_id).await?;
+
+        // Free the logical session slot.
+        table.delete(id)?;
+        Ok(())
     }
 
-    fn session_state(&self, _io: &impl HsmIo, _id: HsmSessId) -> HsmSessionState {
-        HsmSessionState::Invalid
+    fn session_state(&self, io: &impl HsmIo, id: HsmSessId) -> HsmSessionState {
+        let Ok(table) = SessionStore::partition(io.pid()) else {
+            return HsmSessionState::Invalid;
+        };
+        table.state(id)
     }
 
-    fn session_create_pending(
+    async fn session_create_pending(
         &self,
-        _io: &impl HsmIo,
-        _role: SessionRole,
-        _handshake_state: &[u8],
+        io: &impl HsmIo,
+        role: SessionRole,
+        handshake_state: &DmaBuf,
     ) -> HsmResult<HsmSessId> {
-        Err(HsmError::UnsupportedCmd)
+        if handshake_state.is_empty() || handshake_state.len() > SESSION_PENDING_BLOB_MAX {
+            return Err(HsmError::InvalidArg);
+        }
+
+        // Stash the opaque handshake blob as a session-scoped vault key.
+        // The caller already owns it in a DMA buffer, so it is handed to
+        // the vault directly — no intermediate copy.
+        let attrs = HsmVaultKeyAttrs::new().with_internal(true);
+        let physical_id = {
+            let mut v = crate::vault::vault(io);
+            v.create(
+                self,
+                io,
+                u8::from(io.pid()),
+                handshake_state,
+                HsmVaultKeyKind::SessionExPending,
+                None,
+                attrs,
+            )
+            .await?
+        };
+
+        // Reserve the logical Pending slot; on eviction, delete the
+        // abandoned handshake key. If slot reservation fails, remove the
+        // just-stored key so it does not leak.
+        let mut store = SessionStore::partition(io.pid())?;
+        match store.create_pending(role, physical_id) {
+            Ok((sess_id, evicted)) => {
+                if let Some(old) = evicted {
+                    let mut v = crate::vault::vault(io);
+                    let _ = v.delete(self, io, old).await;
+                }
+                Ok(sess_id)
+            }
+            Err(e) => {
+                let mut v = crate::vault::vault(io);
+                let _ = v.delete(self, io, physical_id).await;
+                Err(e)
+            }
+        }
     }
 
     fn session_pending_state(
         &self,
-        _io: &impl HsmIo,
-        _id: HsmSessId,
-        _out: Option<&mut [u8]>,
+        io: &impl HsmIo,
+        id: HsmSessId,
+        out: Option<&mut [u8]>,
     ) -> HsmResult<usize> {
-        Err(HsmError::UnsupportedCmd)
+        let table = SessionStore::partition(io.pid())?;
+        let physical_id = table.pending_phys(id)?;
+        let blob = self.vault_key(io, physical_id)?;
+        let len = blob.len();
+        match out {
+            None => Ok(len),
+            Some(buf) => {
+                if buf.len() < len {
+                    return Err(HsmError::InvalidArg);
+                }
+                buf[..len].copy_from_slice(blob);
+                Ok(len)
+            }
+        }
     }
 
-    fn session_promote(
+    async fn session_promote(
         &self,
-        _io: &impl HsmIo,
-        _id: HsmSessId,
-        _api_rev: &[u8],
-        _param_key: &[u8],
-        _masking_key: &[u8],
-        _mac_tx_key: Option<&[u8]>,
-        _mac_rx_key: Option<&[u8]>,
+        io: &impl HsmIo,
+        id: HsmSessId,
+        api_rev: &[u8],
+        param_key: &[u8],
+        masking_key: &[u8],
+        mac_tx_key: Option<&[u8]>,
+        mac_rx_key: Option<&[u8]>,
     ) -> HsmResult<()> {
-        Err(HsmError::UnsupportedCmd)
+        if api_rev.len() != SESSION_API_REV_SIZE
+            || param_key.len() != SESSION_PARAM_KEY_LEN
+            || masking_key.len() != SESSION_MASKING_KEY_SIZE
+        {
+            return Err(HsmError::InvalidArg);
+        }
+        // CO (authenticated) supplies both MAC keys; CU (plaintext)
+        // supplies neither — anything else is malformed.
+        let mac_pair = match (mac_tx_key, mac_rx_key) {
+            (None, None) => None,
+            (Some(tx), Some(rx)) => {
+                if tx.len() != SESSION_MAC_DIR_KEY_LEN || rx.len() != SESSION_MAC_DIR_KEY_LEN {
+                    return Err(HsmError::InvalidArg);
+                }
+                Some((tx, rx))
+            }
+            _ => return Err(HsmError::InvalidArg),
+        };
+
+        // Confirm the slot is Pending before doing any work.
+        let mut store = SessionStore::partition(io.pid())?;
+        if !matches!(store.state(id), HsmSessionState::Pending) {
+            return Err(HsmError::SessionNotPending);
+        }
+
+        // Build the length-discriminated SessionEx blob:
+        //   PlainText:     api_rev(8) ‖ param_key(32) ‖ masking_key(80)        = 120 B
+        //   Authenticated: above ‖ mac_tx(48) ‖ mac_rx(48)                     = 216 B
+        let blob_len = match mac_pair {
+            None => SESSION_CU_BLOB_SIZE,
+            Some(_) => SESSION_CU_AUTH_BLOB_SIZE,
+        };
+        let blob = self.dma_alloc(io, blob_len)?;
+        blob[..SESSION_API_REV_SIZE].copy_from_slice(api_rev);
+        blob[SESSION_API_REV_SIZE..SESSION_API_REV_SIZE + SESSION_PARAM_KEY_LEN]
+            .copy_from_slice(param_key);
+        blob[SESSION_API_REV_SIZE + SESSION_PARAM_KEY_LEN..SESSION_CU_BLOB_SIZE]
+            .copy_from_slice(masking_key);
+        if let Some((tx, rx)) = mac_pair {
+            blob[SESSION_CU_BLOB_SIZE..SESSION_CU_BLOB_SIZE + SESSION_MAC_DIR_KEY_LEN]
+                .copy_from_slice(tx);
+            blob[SESSION_CU_BLOB_SIZE + SESSION_MAC_DIR_KEY_LEN..SESSION_CU_AUTH_BLOB_SIZE]
+                .copy_from_slice(rx);
+        }
+
+        let attrs = HsmVaultKeyAttrs::new().with_internal(true);
+        let physical_id = {
+            let mut v = crate::vault::vault(io);
+            v.create(
+                self,
+                io,
+                u8::from(io.pid()),
+                blob,
+                HsmVaultKeyKind::SessionEx,
+                None,
+                attrs,
+            )
+            .await?
+        };
+
+        // Bind the slot to the committed SessionEx key. `promote` returns
+        // the now-obsolete SessionExPending handshake key, which must be
+        // deleted once SessionEx is established. Rollback of a
+        // partially-applied promote is deferred to a future undo-log
+        // framework.
+        let old_pending = store.promote(id, physical_id)?;
+        crate::vault::vault(io)
+            .delete(self, io, old_pending)
+            .await?;
+        Ok(())
     }
 
-    fn session_param_key(&self, _io: &impl HsmIo, _id: HsmSessId) -> HsmResult<&DmaBuf> {
-        Err(HsmError::UnsupportedCmd)
+    fn session_param_key(&self, io: &impl HsmIo, id: HsmSessId) -> HsmResult<&DmaBuf> {
+        let table = SessionStore::partition(io.pid())?;
+        let physical_id = table.physical_id(id)?;
+        // The param_key is the 32-byte field following the 8-byte api_rev
+        // in the committed SessionEx blob.
+        let blob = self.vault_key(io, physical_id)?;
+        if blob.len() < SESSION_API_REV_SIZE + SESSION_PARAM_KEY_LEN {
+            return Err(HsmError::InvalidArg);
+        }
+        Ok(blob
+            .split_at(SESSION_API_REV_SIZE)
+            .1
+            .split_at(SESSION_PARAM_KEY_LEN)
+            .0)
     }
 
-    fn session_try_consume_psk_change(&self, _io: &impl HsmIo, _id: HsmSessId) -> HsmResult<()> {
-        Err(HsmError::UnsupportedCmd)
+    fn session_try_consume_psk_change(&self, io: &impl HsmIo, id: HsmSessId) -> HsmResult<()> {
+        let mut table = SessionStore::partition(io.pid())?;
+        table.try_consume_psk_change(id)
     }
 }


### PR DESCRIPTION
Implement the Uno session manager on a dedicated persistent session store and the TBOR two-phase session-establishment handshake (OpenSessionInit -> OpenSessionFinish), previously stubbed with UnsupportedCmd.

Session store + manager
- drivers/session_store: SessionStore, a borrow-wrapper over the per-partition session-table region in the persistent store. 8 logical slots mapping to physical vault key ids (alloc_mask + renego_mask + phys_ids); create/delete/physical_id/recreate/state/limit_reached.
- HsmSessionManager: session_create / session_destroy / session_promote are async (the Uno vault drives GDMA); std PAL impl updated; DDI handlers (mbor/tbor close_session, open_session, open_session_finish) await accordingly.
- pal/session.rs: a committed session is an [api_rev || masking_key] vault key (Session for MBOR; SessionEx for promoted TBOR sessions); the SessionStore slot maps to it.

Vault-backed Pending handshake state
- Add vault key kinds SessionExPending (in-flight Pending handshake blob) and SessionEx (committed/promoted session key, renamed from the former SessionCu since it serves both CO and CU); key_vault KIND_LEN updated. Fix a latent SessionEx length bug: api_rev(8)+param_key(32)+ masking_key(80)=120 B (plaintext) / +mac_tx(48)+mac_rx(48)=216 B (authenticated), not the previous {168,264}.
- Implement session_create_pending / session_pending_state / session_promote / session_param_key / session_try_consume_psk_change against the vault + session_store. The Pending blob is stored as a session-scoped SessionExPending key; promote builds the SessionEx key, rebinds the slot, then deletes the SessionExPending key (rollback deferred to a future undo-log framework).
- session_store: create_pending (lowest-index Pending eviction per role range -- CO=slot 0, CU=slots 1..7), pending_phys, promote, try_consume_psk_change, occupied_physical_ids, Pending-aware state/delete. Volatile pending_mask + psk_change_mask live in a new 2-byte session_meta field carved from part_store's reserved region (Storage stays exactly 3072 B).
- Teardown: clear_enabled_state also deletes every session-blob vault key (Active/Pending) before zeroing the session table, so they are not orphaned on disable/free.

Trait change
- session_create_pending becomes async and takes the handshake blob as &DmaBuf (it already arrives in a DMA buffer), letting the Uno PAL hand it straight to the vault -- eliding a redundant DMA allocation and ~244 B copy per OpenSessionInit.

Code size
- #[inline(never)] on the session_store accessors (matching the part_store/bks_store convention).