### PR TITLE
feat(tbor): add out-of-session PartInfo command

### DIFF
--- a/ddi/tbor/types/src/lib.rs
+++ b/ddi/tbor/types/src/lib.rs
@@ -64,6 +64,7 @@ mod close_session;
 mod get_api_rev;
 mod open_session_finish;
 mod open_session_init;
+mod part_info;
 mod part_init;
 mod status;
 pub use change_psk::*;
@@ -71,6 +72,7 @@ pub use close_session::*;
 pub use get_api_rev::*;
 pub use open_session_finish::*;
 pub use open_session_init::*;
+pub use part_info::*;
 pub use part_init::*;
 pub use status::*;
 

--- a/ddi/tbor/types/src/part_info.rs
+++ b/ddi/tbor/types/src/part_info.rs
@@ -26,8 +26,8 @@ pub const TBOR_OP_PART_INFO: u8 = 0x31;
 /// Length of the opaque partition identity blob (PID).
 pub const PID_LEN: usize = 16;
 
-/// Length of the raw ECC-P384 identity public key (`x ‖ y`, big-endian
-/// coordinates with the SEC1 `0x04` prefix stripped).
+/// Length of the raw ECC-P384 identity public key (`x ‖ y`), with each
+/// 48-byte coordinate in little-endian (HSM wire format; SEC1 `0x04` prefix stripped).
 pub const PID_PUB_KEY_LEN: usize = 96;
 
 /// Host-facing TBOR `PartInfo` request. Carries no per-call data.

--- a/ddi/tbor/types/src/part_info.rs
+++ b/ddi/tbor/types/src/part_info.rs
@@ -1,0 +1,81 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Host-side wrapper for the TBOR `PartInfo` command.
+//!
+//! `PartInfo` is an **out-of-session** info command. It combines the
+//! device-level fields of the MBOR `GetDeviceInfo` command with the
+//! partition identity (Partition ID + identity public key). A single
+//! round-trip lets a host learn both what device it is talking to and
+//! the identity and lifecycle posture of the partition it is bound to,
+//! without first establishing a session.
+//!
+//! Both the request and response wire schemas are shared with the
+//! firmware handler via `azihsm_fw_ddi_tbor_types::part_info`
+//! (`fw/core/ddi/tbor/types/src/part_info.rs`); this module adds the
+//! host-facing value types so [`exec_op_tbor`] returns owned response
+//! values rather than borrowing `View<'a>` accessors.
+//!
+//! [`exec_op_tbor`]: ../../azihsm_ddi_interface/trait.DdiDev.html#method.exec_op_tbor
+
+use crate::tbor;
+
+/// TBOR opcode for `PartInfo`.
+pub const TBOR_OP_PART_INFO: u8 = 0x31;
+
+/// Length of the opaque partition identity blob (PID).
+pub const PID_LEN: usize = 16;
+
+/// Length of the raw ECC-P384 identity public key (`x ‖ y`, big-endian
+/// coordinates with the SEC1 `0x04` prefix stripped).
+pub const PID_PUB_KEY_LEN: usize = 96;
+
+/// Host-facing TBOR `PartInfo` request. Carries no per-call data.
+#[tbor(opcode = TBOR_OP_PART_INFO, session_ctrl = no_session)]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub struct TborPartInfoReq;
+
+impl TborPartInfoReq {
+    /// Construct a `PartInfo` request.
+    #[inline]
+    pub const fn new() -> Self {
+        Self
+    }
+}
+
+/// Host-facing TBOR `PartInfo` response.
+///
+/// Field order mirrors the firmware schema in
+/// `azihsm_fw_ddi_tbor_types::part_info`; the two MUST stay in sync so
+/// the TOC layouts match.
+///
+/// The module-wide FIPS approval status is carried in the standard TBOR
+/// response header flag, not as a body field, so it is not declared
+/// here.
+#[tbor(response)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct TborPartInfoResp {
+    /// Device kind, matching MBOR `DdiDeviceKind` (`2` = Physical).
+    pub device_kind: u8,
+
+    /// Partition lifecycle state, matching the firmware `PartState`
+    /// discriminant (`0` = Unallocated, `1` = Allocated, `2` = Enabled,
+    /// …).
+    pub part_state: u8,
+
+    /// Monotonic partition generation counter, incremented on every
+    /// allocate/free cycle.
+    pub generation: u32,
+
+    /// Owner-seed (BKS2) selector currently in effect.
+    pub owner_svn: u64,
+
+    /// Manufacturer-seed (BKS1) selector — the current firmware SVN.
+    pub mfgr_svn: u64,
+
+    /// Opaque 16-byte partition identity (PID).
+    pub pid: [u8; PID_LEN],
+
+    /// Raw ECC-P384 identity public-key coordinates (`x ‖ y`, 96 B).
+    pub pid_pub_key: [u8; PID_PUB_KEY_LEN],
+}

--- a/ddi/tbor/types/src/part_info.rs
+++ b/ddi/tbor/types/src/part_info.rs
@@ -21,7 +21,7 @@
 use crate::tbor;
 
 /// TBOR opcode for `PartInfo`.
-pub const TBOR_OP_PART_INFO: u8 = 0x31;
+pub const TBOR_OP_PART_INFO: u8 = 0x32;
 
 /// Length of the opaque partition identity blob (PID).
 pub const PID_LEN: usize = 16;

--- a/ddi/tbor/types/tests/commands/mod.rs
+++ b/ddi/tbor/types/tests/commands/mod.rs
@@ -12,5 +12,6 @@ pub mod forward_compat;
 pub mod fw_error_decode;
 pub mod get_api_rev;
 pub mod open_session;
+pub mod part_info;
 pub mod part_init;
 pub mod unexpected_toc_type;

--- a/ddi/tbor/types/tests/commands/part_info.rs
+++ b/ddi/tbor/types/tests/commands/part_info.rs
@@ -1,0 +1,208 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Integration tests for the out-of-session TBOR `PartInfo` command.
+//!
+//! `round_trip` exercises the full host → backend (`emu` or `sock`) →
+//! fw `handle_tbor_op` → response path and asserts the device/partition
+//! fields the firmware reports for the default provisioned partition.
+//! `part_info_independent_of_session_state_emu` proves the dispatcher
+//! never lets session-machine state leak into the out-of-session
+//! handler.  `unsupported_on_mock` asserts the design contract that
+//! backends opt in to TBOR.
+
+#![cfg(any(feature = "emu", feature = "mock", feature = "sock"))]
+
+use azihsm_ddi_tbor_types::TborPartInfoReq;
+
+use crate::harness::TestCtx;
+
+/// `DdiDeviceKind::Physical` discriminant — uno is a physical device.
+#[cfg(any(feature = "emu", feature = "sock"))]
+const DEVICE_KIND_PHYSICAL: u8 = 2;
+
+/// `PartState::Enabled` discriminant — the default provisioned state of
+/// the emulator partition before any `PartInit`.
+#[cfg(any(feature = "emu", feature = "sock"))]
+const PART_STATE_ENABLED: u8 = 2;
+
+/// `PartState::Initializing` discriminant — the state a partition enters
+/// after a successful `PartInit` binds its PTA / policy / POTA thumb.
+#[cfg(feature = "emu")]
+const PART_STATE_INITIALIZING: u8 = 4;
+
+/// Assert the invariant device-level fields PartInfo reports for the
+/// default provisioned partition, plus that the identity public key is
+/// materialized (not all-zero).
+#[cfg(any(feature = "emu", feature = "sock"))]
+fn assert_default_part_info(resp: &azihsm_ddi_tbor_types::TborPartInfoResp) {
+    assert_eq!(
+        resp.device_kind, DEVICE_KIND_PHYSICAL,
+        "uno firmware must report a physical device kind",
+    );
+    assert_eq!(
+        resp.part_state, PART_STATE_ENABLED,
+        "default provisioned partition must be Enabled",
+    );
+    assert!(
+        resp.pid_pub_key.iter().any(|&b| b != 0),
+        "identity public key must be materialized (non-zero)",
+    );
+}
+
+#[cfg(any(feature = "emu", feature = "sock"))]
+#[test]
+fn round_trip() {
+    let ctx = TestCtx::new();
+    let resp = ctx
+        .tbor(&TborPartInfoReq::new())
+        .expect("TBOR PartInfo round-trip");
+    assert_default_part_info(&resp);
+}
+
+/// `PartInfo` is stateless with respect to repeated invocation — on a
+/// quiescent partition (no intervening lifecycle command) every call
+/// returns a byte-identical response. Catches any regression that would
+/// silently introduce per-call state (e.g. a counter, a cached
+/// allocation) into the out-of-session handler.
+#[cfg(feature = "emu")]
+#[test]
+fn part_info_repeated_stable_emu() {
+    let ctx = TestCtx::new();
+    let baseline = ctx
+        .tbor(&TborPartInfoReq::new())
+        .expect("baseline PartInfo");
+    assert_default_part_info(&baseline);
+    for i in 1..16 {
+        let resp = ctx
+            .tbor(&TborPartInfoReq::new())
+            .expect("repeated PartInfo");
+        assert_eq!(resp, baseline, "PartInfo response changed on iteration {i}",);
+    }
+}
+
+/// `PartInfo` is independent of session-machine state — it returns a
+/// byte-identical response while a Pending (init-only) handshake
+/// occupies a session slot, after that slot transitions to Active, and
+/// again once it is closed.  Catches any regression that would let
+/// session state leak into the out-of-session handler.
+#[cfg(feature = "emu")]
+#[test]
+fn part_info_independent_of_session_state_emu() {
+    use azihsm_ddi_tbor_types::SessionType;
+
+    let ctx = TestCtx::new();
+
+    // No sessions outstanding.
+    let pre = ctx
+        .tbor(&TborPartInfoReq::new())
+        .expect("PartInfo before any session");
+    assert_default_part_info(&pre);
+
+    // CO Pending: init only, do not finish yet.
+    let pending = ctx
+        .open_session_init(0, SessionType::Authenticated)
+        .expect("OpenSessionInit (CO/Authenticated) for pending-state probe");
+    let during_pending = ctx
+        .tbor(&TborPartInfoReq::new())
+        .expect("PartInfo with one Pending session slot");
+    assert_eq!(
+        during_pending, pre,
+        "PartInfo changed while a session was Pending",
+    );
+
+    // CO Active: finish the same handshake.
+    let session = ctx
+        .open_session_finish(pending)
+        .expect("OpenSessionFinish for probe");
+    let during_active = ctx
+        .tbor(&TborPartInfoReq::new())
+        .expect("PartInfo with one Active session slot");
+    assert_eq!(
+        during_active, pre,
+        "PartInfo changed while a session was Active",
+    );
+
+    // Cleanup.
+    ctx.close_session(session.session_id)
+        .expect("close probe session");
+    let post = ctx
+        .tbor(&TborPartInfoReq::new())
+        .expect("PartInfo after close");
+    assert_eq!(post, pre, "PartInfo changed after the session closed");
+}
+
+/// `PartInfo` reflects partition lifecycle transitions. A successful
+/// `PartInit` moves the partition from `Enabled` to `Initializing`;
+/// `PartInfo` must report the new `part_state` afterwards, while the
+/// stable identity fields (PID, identity public key, owner/manufacturer
+/// SVN) are unchanged across the transition. This is the property that
+/// makes `PartInfo` more than a static device probe — it is the live
+/// view of the bound partition's posture.
+#[cfg(feature = "emu")]
+#[test]
+fn part_info_reflects_part_init_transition_emu() {
+    use crate::commands::part_init::bootstrap_rotated_co;
+    use crate::commands::part_init::known_good_part_policy;
+    use crate::commands::part_init::mach_seed;
+    use crate::commands::part_init::pota_thumbprint;
+    use crate::commands::part_init::ROTATED_CO_PSK;
+
+    let ctx = TestCtx::new();
+
+    // Before PartInit: default Enabled posture with a materialized
+    // identity.
+    let before = ctx
+        .tbor(&TborPartInfoReq::new())
+        .expect("PartInfo before PartInit");
+    assert_default_part_info(&before);
+
+    // Drive PartInit — rotate the CO PSK first to clear the default-PSK
+    // gate, then bind PTA / policy / POTA thumb on the rotated session.
+    let session = bootstrap_rotated_co(&ctx, &ROTATED_CO_PSK);
+    ctx.part_init(
+        &session,
+        &mach_seed(),
+        &known_good_part_policy(),
+        &pota_thumbprint(),
+    )
+    .expect("PartInit");
+
+    // After PartInit: the lifecycle state advances to Initializing while
+    // the identity and SVN lineage are unchanged.
+    let after = ctx
+        .tbor(&TborPartInfoReq::new())
+        .expect("PartInfo after PartInit");
+    assert_eq!(
+        after.part_state, PART_STATE_INITIALIZING,
+        "PartInfo must report Initializing after PartInit",
+    );
+    assert_eq!(after.pid, before.pid, "PID must be stable across PartInit",);
+    assert_eq!(
+        after.pid_pub_key, before.pid_pub_key,
+        "identity public key must be stable across PartInit",
+    );
+    assert_eq!(
+        after.owner_svn, before.owner_svn,
+        "owner SVN must be stable across PartInit",
+    );
+    assert_eq!(
+        after.mfgr_svn, before.mfgr_svn,
+        "manufacturer SVN must be stable across PartInit",
+    );
+
+    ctx.close_session(session.session_id)
+        .expect("close CO session");
+}
+
+#[cfg(all(feature = "mock", not(feature = "emu")))]
+#[test]
+fn unsupported_on_mock() {
+    use crate::harness::assertions::assert_unsupported_encoding;
+
+    let ctx = TestCtx::new();
+    let err = ctx
+        .tbor(&TborPartInfoReq::new())
+        .expect_err("mock backend must not implement exec_op_tbor");
+    assert_unsupported_encoding(&err);
+}

--- a/ddi/tbor/types/tests/commands/part_init/mod.rs
+++ b/ddi/tbor/types/tests/commands/part_init/mod.rs
@@ -41,12 +41,12 @@ mod crypto_rejects;
 mod fw_rejects;
 mod happy_path;
 
-pub(super) const CO: u8 = 0;
+pub(crate) const CO: u8 = 0;
 
 /// Non-default 32-byte CO PSK used so PartInit clears the
 /// default-PSK-gate.  Pinned to a fixed value so the smoke test is
 /// fully deterministic.
-pub(super) const ROTATED_CO_PSK: [u8; PSK_LEN] = [
+pub(crate) const ROTATED_CO_PSK: [u8; PSK_LEN] = [
     0xA1, 0xA2, 0xA3, 0xA4, 0xA5, 0xA6, 0xA7, 0xA8, 0xA9, 0xAA, 0xAB, 0xAC, 0xAD, 0xAE, 0xAF, 0xB0,
     0xB1, 0xB2, 0xB3, 0xB4, 0xB5, 0xB6, 0xB7, 0xB8, 0xB9, 0xBA, 0xBB, 0xBC, 0xBD, 0xBE, 0xBF, 0xC0,
 ];
@@ -55,7 +55,7 @@ pub(super) const ROTATED_CO_PSK: [u8; PSK_LEN] = [
 /// `azihsm_fw_hsm_core::ddi::tbor::policy::from_bytes`.  Layout mirrors
 /// the canonical wire format defined in
 /// `fw/core/ddi/tbor/types/src/policy.rs`.
-pub(super) fn known_good_part_policy() -> [u8; PART_POLICY_LEN] {
+pub(crate) fn known_good_part_policy() -> [u8; PART_POLICY_LEN] {
     const OFF_VERSION_MAJOR: usize = 0;
     const OFF_VERSION_MINOR: usize = 1;
     const OFF_KIND: usize = 2;
@@ -78,7 +78,7 @@ pub(super) fn known_good_part_policy() -> [u8; PART_POLICY_LEN] {
     bytes
 }
 
-pub(super) fn mach_seed() -> [u8; MACH_SEED_LEN] {
+pub(crate) fn mach_seed() -> [u8; MACH_SEED_LEN] {
     let mut v = [0u8; MACH_SEED_LEN];
     for (i, b) in v.iter_mut().enumerate() {
         *b = 0x40 + i as u8;
@@ -86,7 +86,7 @@ pub(super) fn mach_seed() -> [u8; MACH_SEED_LEN] {
     v
 }
 
-pub(super) fn pota_thumbprint() -> [u8; POTA_THUMBPRINT_LEN] {
+pub(crate) fn pota_thumbprint() -> [u8; POTA_THUMBPRINT_LEN] {
     let mut v = [0u8; POTA_THUMBPRINT_LEN];
     for (i, b) in v.iter_mut().enumerate() {
         *b = 0x80 ^ i as u8;
@@ -140,7 +140,7 @@ pub(super) fn open_co_with(ctx: &TestCtx, psk: &[u8; PSK_LEN]) -> SessionHandsha
 /// drop the bootstrap session, and return a fresh CO session opened
 /// under the rotated PSK — ready for the in-session command under
 /// test.
-pub(super) fn bootstrap_rotated_co(ctx: &TestCtx, target_psk: &[u8; PSK_LEN]) -> SessionHandshake {
+pub(crate) fn bootstrap_rotated_co(ctx: &TestCtx, target_psk: &[u8; PSK_LEN]) -> SessionHandshake {
     let bootstrap = ctx.open_session(CO, SessionType::Authenticated);
     ctx.change_psk(bootstrap.handshake(), target_psk)
         .expect("rotate CO PSK");

--- a/fw/core/ddi/tbor/types/src/lib.rs
+++ b/fw/core/ddi/tbor/types/src/lib.rs
@@ -20,6 +20,7 @@ pub mod close_session;
 pub mod get_api_rev;
 pub mod open_session_finish;
 pub mod open_session_init;
+pub mod part_info;
 pub mod part_init;
 pub mod policy;
 
@@ -28,5 +29,6 @@ pub use close_session::*;
 pub use get_api_rev::*;
 pub use open_session_finish::*;
 pub use open_session_init::*;
+pub use part_info::*;
 pub use part_init::*;
 pub use policy::*;

--- a/fw/core/ddi/tbor/types/src/part_info.rs
+++ b/fw/core/ddi/tbor/types/src/part_info.rs
@@ -32,7 +32,7 @@ pub const PID_PUB_KEY_LEN: usize = 96;
 /// single `none` TOC placeholder to satisfy the TBOR codec's
 /// `toc_count >= 1` requirement; the decoder verifies that placeholder
 /// is present and the opcode matches.
-#[tbor(opcode = 0x32)]
+#[tbor(opcode = TBOR_OP_PART_INFO)]
 pub struct TborPartInfoReq;
 
 /// `PartInfo` response schema.

--- a/fw/core/ddi/tbor/types/src/part_info.rs
+++ b/fw/core/ddi/tbor/types/src/part_info.rs
@@ -1,0 +1,70 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! TBOR `PartInfo` wire schema.
+//!
+//! `PartInfo` is an out-of-session info command. The host sends an
+//! empty request; the firmware responds with device-level fields (kind,
+//! FIPS status) plus the partition's lifecycle and identity: state,
+//! generation counter, owner/manufacturer SVN selectors, the opaque
+//! Partition ID (PID), and the raw ECC-P384 identity public key. It is
+//! the TBOR analogue of the MBOR `GetDeviceInfo` command combined with
+//! the partition identity (Partition ID + identity public key).
+//!
+//! The byte fields are declared as `&[u8]` slices with `len`
+//! constraints so handler code can pass borrows from the partition
+//! store straight to the encoder.
+
+use azihsm_fw_ddi_tbor_api::tbor;
+
+/// TBOR opcode for `PartInfo`.
+pub const TBOR_OP_PART_INFO: u8 = 0x31;
+
+/// Length of the opaque partition identity blob (PID).
+pub const PID_LEN: usize = 16;
+
+/// Length of the raw ECC-P384 identity public key (`x ‖ y`).
+pub const PID_PUB_KEY_LEN: usize = 96;
+
+/// `PartInfo` request schema.
+///
+/// The body carries no semantic data. On the wire the derive emits a
+/// single `none` TOC placeholder to satisfy the TBOR codec's
+/// `toc_count >= 1` requirement; the decoder verifies that placeholder
+/// is present and the opcode matches.
+#[tbor(opcode = 0x31)]
+pub struct TborPartInfoReq;
+
+/// `PartInfo` response schema.
+///
+/// Field order MUST stay in sync with the host value type in
+/// `azihsm_ddi_tbor_types::part_info` so the TOC layouts match.
+///
+/// The module-wide FIPS approval status is carried in the standard TBOR
+/// response header flag (set via the `encode` builder), not as a body
+/// field, so it is not declared here.
+#[tbor(response)]
+pub struct TborPartInfoResp<'a> {
+    /// Device kind, matching MBOR `DdiDeviceKind` (`2` = Physical).
+    pub device_kind: u8,
+
+    /// Partition lifecycle state (`PartState` discriminant).
+    pub part_state: u8,
+
+    /// Monotonic partition generation counter.
+    pub generation: u32,
+
+    /// Owner-seed (BKS2) selector currently in effect.
+    pub owner_svn: u64,
+
+    /// Manufacturer-seed (BKS1) selector — the current firmware SVN.
+    pub mfgr_svn: u64,
+
+    /// Opaque 16-byte partition identity (PID).
+    #[tbor(len = 16)]
+    pub pid: &'a [u8],
+
+    /// Raw ECC-P384 identity public-key coordinates (`x ‖ y`, 96 B).
+    #[tbor(len = 96)]
+    pub pid_pub_key: &'a [u8],
+}

--- a/fw/core/ddi/tbor/types/src/part_info.rs
+++ b/fw/core/ddi/tbor/types/src/part_info.rs
@@ -18,7 +18,7 @@
 use azihsm_fw_ddi_tbor_api::tbor;
 
 /// TBOR opcode for `PartInfo`.
-pub const TBOR_OP_PART_INFO: u8 = 0x31;
+pub const TBOR_OP_PART_INFO: u8 = 0x32;
 
 /// Length of the opaque partition identity blob (PID).
 pub const PID_LEN: usize = 16;
@@ -32,7 +32,7 @@ pub const PID_PUB_KEY_LEN: usize = 96;
 /// single `none` TOC placeholder to satisfy the TBOR codec's
 /// `toc_count >= 1` requirement; the decoder verifies that placeholder
 /// is present and the opcode matches.
-#[tbor(opcode = 0x31)]
+#[tbor(opcode = 0x32)]
 pub struct TborPartInfoReq;
 
 /// `PartInfo` response schema.

--- a/fw/core/ddi/tbor/types/src/part_info.rs
+++ b/fw/core/ddi/tbor/types/src/part_info.rs
@@ -23,7 +23,9 @@ pub const TBOR_OP_PART_INFO: u8 = 0x32;
 /// Length of the opaque partition identity blob (PID).
 pub const PID_LEN: usize = 16;
 
-/// Length of the raw ECC-P384 identity public key (`x ‖ y`).
+/// Length of the raw ECC-P384 identity public key (`x ‖ y`), with each
+/// 48-byte coordinate in little-endian (HSM wire format; SEC1 `0x04`
+/// prefix stripped).
 pub const PID_PUB_KEY_LEN: usize = 96;
 
 /// `PartInfo` request schema.
@@ -32,7 +34,11 @@ pub const PID_PUB_KEY_LEN: usize = 96;
 /// single `none` TOC placeholder to satisfy the TBOR codec's
 /// `toc_count >= 1` requirement; the decoder verifies that placeholder
 /// is present and the opcode matches.
-#[tbor(opcode = TBOR_OP_PART_INFO)]
+///
+/// The `tbor` derive requires an integer literal here, so the opcode is
+/// spelled out rather than referencing [`TBOR_OP_PART_INFO`]; the two
+/// MUST stay in sync (both `0x32`).
+#[tbor(opcode = 0x32)]
 pub struct TborPartInfoReq;
 
 /// `PartInfo` response schema.

--- a/fw/core/lib/src/ddi/tbor/mod.rs
+++ b/fw/core/lib/src/ddi/tbor/mod.rs
@@ -84,7 +84,7 @@ pub(crate) mod opcode {
     /// (state, generation, owner/manufacturer SVN, PID, identity public
     /// key).  TBOR analogue of MBOR `GetDeviceInfo` + the Manticore
     /// `GetPartID` primitive.
-    pub(crate) const PART_INFO: u8 = 0x31;
+    pub(crate) const PART_INFO: u8 = 0x32;
 }
 
 /// Dispatch a parsed TBOR request to its handler.

--- a/fw/core/lib/src/ddi/tbor/mod.rs
+++ b/fw/core/lib/src/ddi/tbor/mod.rs
@@ -25,6 +25,7 @@ pub(crate) mod close_session;
 pub(crate) mod get_api_rev;
 pub(crate) mod open_session_finish;
 pub(crate) mod open_session_init;
+pub mod part_info;
 pub mod part_init;
 pub mod policy;
 
@@ -77,6 +78,13 @@ pub(crate) mod opcode {
 
     /// `PartInit` — bind PTA, policy, and POTA thumbprint.
     pub(crate) const PART_INIT: u8 = 0x30;
+
+    /// `PartInfo` — out-of-session info command reporting device kind /
+    /// FIPS status plus the bound partition's lifecycle and identity
+    /// (state, generation, owner/manufacturer SVN, PID, identity public
+    /// key).  TBOR analogue of MBOR `GetDeviceInfo` + the Manticore
+    /// `GetPartID` primitive.
+    pub(crate) const PART_INFO: u8 = 0x31;
 }
 
 /// Dispatch a parsed TBOR request to its handler.
@@ -156,6 +164,7 @@ pub(crate) async fn dispatch<'p, P: HsmPal>(
         opcode::CLOSE_SESSION => close_session::handle(pal, io, req_buf).await,
         opcode::CHANGE_PSK => change_psk::handle(pal, io, req_buf).await,
         opcode::PART_INIT => part_init::handle(pal, io, req_buf).await,
+        opcode::PART_INFO => part_info::handle(pal, io, req_buf),
         _ => Err(HsmError::UnsupportedCmd),
     }
 }
@@ -173,6 +182,7 @@ fn is_known_opcode(opcode: u8) -> bool {
             | opcode::CLOSE_SESSION
             | opcode::CHANGE_PSK
             | opcode::PART_INIT
+            | opcode::PART_INFO
     )
 }
 
@@ -191,7 +201,10 @@ fn is_known_opcode(opcode: u8) -> bool {
 /// default-PSK gate via [`allowed_with_default_psk`].
 fn is_in_session(opcode: u8) -> bool {
     match opcode {
-        opcode::GET_API_REV | opcode::OPEN_SESSION_INIT | opcode::OPEN_SESSION_FINISH => false,
+        opcode::GET_API_REV
+        | opcode::OPEN_SESSION_INIT
+        | opcode::OPEN_SESSION_FINISH
+        | opcode::PART_INFO => false,
         opcode::CLOSE_SESSION | opcode::CHANGE_PSK | opcode::PART_INIT => true,
         // Default-deny: any future opcode is treated as in-session
         // until classified, so the default-PSK gate applies to it.
@@ -221,7 +234,7 @@ fn is_in_session(opcode: u8) -> bool {
 /// same change that wires it into `dispatch`.
 fn needs_session_id_cross_check(opcode: u8) -> bool {
     match opcode {
-        opcode::GET_API_REV | opcode::OPEN_SESSION_INIT => false,
+        opcode::GET_API_REV | opcode::OPEN_SESSION_INIT | opcode::PART_INFO => false,
         opcode::OPEN_SESSION_FINISH
         | opcode::CLOSE_SESSION
         | opcode::CHANGE_PSK

--- a/fw/core/lib/src/ddi/tbor/part_info.rs
+++ b/fw/core/lib/src/ddi/tbor/part_info.rs
@@ -38,22 +38,14 @@ const FIPS_APPROVED: bool = false;
 ///
 /// The caller (`dispatch`) has already structurally validated the
 /// buffer via [`RequestView::parse`] and confirmed the opcode is
-/// `PART_INFO`. This handler gathers the device/partition fields and
-/// encodes the response.
+/// `PART_INFO`, so the request body is not re-inspected here. This
+/// handler gathers the device/partition fields and encodes the
+/// response.
 pub(crate) fn handle<'p, P: HsmPal>(
     pal: &'p P,
     io: &impl HsmIo,
-    req_buf: &DmaBuf,
+    _req_buf: &DmaBuf,
 ) -> HsmResult<&'p DmaBuf> {
-    // Defense-in-depth: verify the opcode matches without a full
-    // re-parse.  The header structure was already validated by the
-    // upstream `RequestView::parse` in `handle_tbor_op`.
-    debug_assert_eq!(
-        req_buf[3],
-        super::opcode::PART_INFO,
-        "opcode mismatch in part_info"
-    );
-
     let part_state_val = part_state::part_state(pal, io)? as u8;
     let generation = part_state::part_gen(pal, io)?;
     let owner_svn = part_state::part_owner_svn(pal);

--- a/fw/core/lib/src/ddi/tbor/part_info.rs
+++ b/fw/core/lib/src/ddi/tbor/part_info.rs
@@ -48,7 +48,11 @@ pub(crate) fn handle<'p, P: HsmPal>(
     // Defense-in-depth: verify the opcode matches without a full
     // re-parse.  The header structure was already validated by the
     // upstream `RequestView::parse` in `handle_tbor_op`.
-    debug_assert_eq!(req_buf[3], super::opcode::PART_INFO, "opcode mismatch in part_info");
+    debug_assert_eq!(
+        req_buf[3],
+        super::opcode::PART_INFO,
+        "opcode mismatch in part_info"
+    );
 
     let part_state_val = part_state::part_state(pal, io)? as u8;
     let generation = part_state::part_gen(pal, io)?;

--- a/fw/core/lib/src/ddi/tbor/part_info.rs
+++ b/fw/core/lib/src/ddi/tbor/part_info.rs
@@ -1,0 +1,73 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! TBOR `PartInfo` command handler.
+//!
+//! `PartInfo` is an out-of-session info command: it reports device-level
+//! fields (kind, FIPS status) together with the bound partition's
+//! lifecycle and identity (state, generation counter, owner/manufacturer
+//! SVN, the Partition ID, and the raw ECC-P384 identity public key). It
+//! is the TBOR analogue of the MBOR `GetDeviceInfo` command combined
+//! with the partition identity (Partition ID + identity public key).
+//!
+//! No session is required. `handle_io` already drops every IO whose
+//! partition is not `Enabled`/`Initializing`, so by the time this
+//! handler runs the identity key pair (and therefore the PID and its
+//! public key) is always present; the identity reads use `?` purely as
+//! defense-in-depth.
+
+use azihsm_fw_ddi_tbor_types::TborPartInfoResp;
+use azihsm_fw_hsm_pal_traits::DmaBuf;
+use azihsm_fw_hsm_pal_traits::HsmIo;
+use azihsm_fw_hsm_pal_traits::HsmPal;
+use azihsm_fw_hsm_pal_traits::HsmResult;
+
+use crate::part_state;
+
+/// Device kind reported by uno firmware — a physical device.  Matches
+/// the MBOR `DdiDeviceKind::Physical` discriminant returned by
+/// `get_device_info`.
+const DEVICE_KIND_PHYSICAL: u8 = 2;
+
+/// Module FIPS approval status carried in the TBOR response header flag.
+/// `false` matches the MBOR `get_device_info` handler — uno firmware is
+/// not yet FIPS-approved.
+const FIPS_APPROVED: bool = false;
+
+/// Handle a TBOR `PartInfo` request.
+///
+/// The caller (`dispatch`) has already structurally validated the
+/// buffer via [`RequestView::parse`] and confirmed the opcode is
+/// `PART_INFO`. This handler gathers the device/partition fields and
+/// encodes the response.
+pub(crate) fn handle<'p, P: HsmPal>(
+    pal: &'p P,
+    io: &impl HsmIo,
+    req_buf: &DmaBuf,
+) -> HsmResult<&'p DmaBuf> {
+    // Defense-in-depth: verify the opcode matches without a full
+    // re-parse.  The header structure was already validated by the
+    // upstream `RequestView::parse` in `handle_tbor_op`.
+    debug_assert_eq!(req_buf[3], 0x31, "opcode mismatch in part_info");
+
+    let part_state_val = part_state::part_state(pal, io)? as u8;
+    let generation = part_state::part_gen(pal, io)?;
+    let owner_svn = part_state::part_owner_svn(pal);
+    let mfgr_svn = part_state::part_mfgr_svn(pal);
+    let pid = part_state::part_id(pal, io)?;
+    let pid_pub_key = part_state::part_id_pub_key(pal, io)?;
+
+    let resp = pal.dma_alloc_var(io, |buf| {
+        let frame = TborPartInfoResp::encode(buf, 0, FIPS_APPROVED)?
+            .device_kind(DEVICE_KIND_PHYSICAL)?
+            .part_state(part_state_val)?
+            .generation(generation)?
+            .owner_svn(owner_svn)?
+            .mfgr_svn(mfgr_svn)?
+            .pid(pid)?
+            .pid_pub_key(pid_pub_key)?
+            .finish();
+        Ok(frame.as_bytes().len())
+    })?;
+    Ok(resp)
+}

--- a/fw/core/lib/src/ddi/tbor/part_info.rs
+++ b/fw/core/lib/src/ddi/tbor/part_info.rs
@@ -48,7 +48,7 @@ pub(crate) fn handle<'p, P: HsmPal>(
     // Defense-in-depth: verify the opcode matches without a full
     // re-parse.  The header structure was already validated by the
     // upstream `RequestView::parse` in `handle_tbor_op`.
-    debug_assert_eq!(req_buf[3], 0x31, "opcode mismatch in part_info");
+    debug_assert_eq!(req_buf[3], super::opcode::PART_INFO, "opcode mismatch in part_info");
 
     let part_state_val = part_state::part_state(pal, io)? as u8;
     let generation = part_state::part_gen(pal, io)?;


### PR DESCRIPTION
Add the TBOR `PartInfo` command (opcode 0x32): an out-of-session info command that reports device-level fields plus the bound partition's lifecycle and identity in a single round-trip. It combines the device-level fields of the MBOR `GetDeviceInfo` command with the partition identity (Partition ID and identity public key).

The response carries:
  - device_kind   (DdiDeviceKind; physical device)
  - part_state    (PartState discriminant)
  - generation    (partition generation counter)
  - owner_svn     (BKS2 selector)
  - mfgr_svn      (BKS1 selector / firmware SVN)
  - pid           (16-byte Partition ID)
  - pid_pub_key   (96-byte raw ECC-P384 identity public key)

The module-wide FIPS approval status is conveyed through the standard TBOR response header flag (set via the encode builder), not a body field, matching the existing `get_device_info` handler.

No new PAL trait methods are required — the handler reuses the existing `part_state` helpers. `PartInfo` needs no session: it is classified out-of-session in the dispatcher (not in-session, no session-id cross-check), so the default-PSK gate never applies. `handle_io` already drops IOs for non-Enabled/Initializing partitions, so the identity reads always succeed; they use `?` purely as defense-in-depth.

Wire schema is shared between firmware and host via azihsm_fw_ddi_tbor_types::part_info; the host value types live in azihsm_ddi_tbor_types::part_info and the two field orders are kept in sync so the TOC layouts match.

Tests (mirroring get_api_rev, plus a state-transition test):
  - round_trip (emu/sock)
  - part_info_repeated_stable_emu — 16-iteration stateless probe
  - part_info_independent_of_session_state_emu — stable across Pending/Active/Closed
  - part_info_reflects_part_init_transition_emu — part_state advances Enabled -> Initializing after PartInit while PID, identity public key, and SVN lineage remain stable
  - unsupported_on_mock

Promote the part_init test helpers (bootstrap_rotated_co, known_good_part_policy, mach_seed, pota_thumbprint, ROTATED_CO_PSK, CO) from pub(super) to pub(crate) so the PartInfo transition test can reuse the rotate-CO-PSK + PartInit bootstrap.
