### PR TITLE
[fix] uno/sha,aes: stop writing the read-only engine STATUS register

### DIFF
--- a/fw/plat/uno/fw/drivers/aes/src/api.rs
+++ b/fw/plat/uno/fw/drivers/aes/src/api.rs
@@ -28,6 +28,9 @@ const AES: StaticRef<AesRegs> = unsafe { StaticRef::new(AES_BASE as *const AesRe
 const AES_Q: StaticRef<IoGsramRegs> =
     unsafe { StaticRef::new(IO_GSRAM_BASE as *const IoGsramRegs) };
 
+/// W1C status flag mask: COMPLETE, ERROR_CMD, ERROR_BUS, ERROR_FAULT.
+const STATUS_FLAGS_MASK: u32 = 0x1E;
+
 /// AES block size in bytes.
 pub const AES_BLOCK_SIZE: usize = 16;
 
@@ -291,7 +294,8 @@ impl<const DEPTH: usize> AesDriver<DEPTH> {
     /// main poll loop (polling mode).
     pub fn wake(&self) {
         let status = AES.status.get();
-        if (status & 0x1E) == 0 {
+        let flags = status & STATUS_FLAGS_MASK;
+        if flags == 0 {
             // No flag set — spurious wake.
             return;
         }
@@ -471,11 +475,12 @@ impl<const DEPTH: usize> AesExclusive<'_, DEPTH> {
 
         loop {
             let status = AES.status.get();
-            if (status & 0x1E) != 0 {
+            let flags = status & STATUS_FLAGS_MASK;
+            if flags != 0 {
                 // STATUS is read-only; do not write it (bus-faults). It
                 // auto-clears on the next command doorbell.
                 Nvic::unpend(Interrupt::AES_DONE);
-                return Ok((status & 0x1E) as u8);
+                return Ok(flags as u8);
             }
         }
     }

--- a/fw/plat/uno/fw/drivers/aes/src/api.rs
+++ b/fw/plat/uno/fw/drivers/aes/src/api.rs
@@ -12,7 +12,6 @@ use azihsm_fw_uno_error::HsmResult;
 use azihsm_fw_uno_pac::interrupt::Interrupt;
 use azihsm_fw_uno_reg_soc::aes::regs::AesRegs;
 use azihsm_fw_uno_reg_soc::aes::AES_BASE;
-use azihsm_fw_uno_reg_soc::aes::STATUS_OFFSET;
 use azihsm_fw_uno_reg_soc::io_gsram::regs::IoGsramRegs;
 use azihsm_fw_uno_reg_soc::io_gsram::*;
 use bitfield_struct::bitfield;
@@ -28,21 +27,6 @@ const AES: StaticRef<AesRegs> = unsafe { StaticRef::new(AES_BASE as *const AesRe
 /// DTCM overlay for AES command descriptors.
 const AES_Q: StaticRef<IoGsramRegs> =
     unsafe { StaticRef::new(IO_GSRAM_BASE as *const IoGsramRegs) };
-
-/// W1C status flag mask: COMPLETE, ERROR_CMD, ERROR_BUS, ERROR_FAULT.
-const STATUS_FLAGS_MASK: u32 = 0x1E;
-
-fn clear_status(flags: u32) {
-    // SAFETY: STATUS is a W1C MMIO register at AES_BASE + STATUS_OFFSET.
-    // The mask guarantees we only attempt to clear documented flag bits,
-    // protecting against accidental writes to reserved bits or BUSY.
-    unsafe {
-        core::ptr::write_volatile(
-            (AES_BASE + STATUS_OFFSET) as *mut u32,
-            flags & STATUS_FLAGS_MASK,
-        );
-    }
-}
 
 /// AES block size in bytes.
 pub const AES_BLOCK_SIZE: usize = 16;
@@ -312,8 +296,9 @@ impl<const DEPTH: usize> AesDriver<DEPTH> {
             return;
         }
 
-        // Clear the flag bits (W1C).
-        clear_status(status & 0x1E);
+        // STATUS (AES_BASE + 0x4) is read-only (RO32): the flag bits auto-clear
+        // when the next command doorbell sets BUSY. Writing it bus-faults the
+        // engine and hard-faults the CPU, so only clear the NVIC pending bit.
         Nvic::unpend(Interrupt::AES_DONE);
 
         self.state.with(|s| {
@@ -487,7 +472,8 @@ impl<const DEPTH: usize> AesExclusive<'_, DEPTH> {
         loop {
             let status = AES.status.get();
             if (status & 0x1E) != 0 {
-                clear_status(status & 0x1E);
+                // STATUS is read-only; do not write it (bus-faults). It
+                // auto-clears on the next command doorbell.
                 Nvic::unpend(Interrupt::AES_DONE);
                 return Ok((status & 0x1E) as u8);
             }

--- a/fw/plat/uno/fw/drivers/aes/src/api.rs
+++ b/fw/plat/uno/fw/drivers/aes/src/api.rs
@@ -28,7 +28,7 @@ const AES: StaticRef<AesRegs> = unsafe { StaticRef::new(AES_BASE as *const AesRe
 const AES_Q: StaticRef<IoGsramRegs> =
     unsafe { StaticRef::new(IO_GSRAM_BASE as *const IoGsramRegs) };
 
-/// W1C status flag mask: COMPLETE, ERROR_CMD, ERROR_BUS, ERROR_FAULT.
+/// Status flag mask (read-side decode): COMPLETE, ERROR_CMD, ERROR_BUS, ERROR_FAULT.
 const STATUS_FLAGS_MASK: u32 = 0x1E;
 
 /// AES block size in bytes.
@@ -310,7 +310,7 @@ impl<const DEPTH: usize> AesDriver<DEPTH> {
             if s.active != s.tail {
                 let idx = (s.active & Self::MASK) as usize;
                 let slot = &mut s.slots[idx];
-                slot.status = status as u8;
+                slot.status = flags as u8;
                 slot.waker.wake();
 
                 // Advance past the completed slot and submit the next

--- a/fw/plat/uno/fw/drivers/sha/src/api.rs
+++ b/fw/plat/uno/fw/drivers/sha/src/api.rs
@@ -15,7 +15,6 @@ use azihsm_fw_uno_reg_soc::io_gsram::ShaCmdEntry;
 use azihsm_fw_uno_reg_soc::io_gsram::*;
 use azihsm_fw_uno_reg_soc::sha::regs::ShaRegs;
 use azihsm_fw_uno_reg_soc::sha::SHA_BASE;
-use azihsm_fw_uno_reg_soc::sha::STATUS_OFFSET;
 use bitfield_struct::bitfield;
 use embassy_sync::waitqueue::WakerRegistration;
 use tock_registers::interfaces::Readable;
@@ -30,20 +29,8 @@ const SHA: StaticRef<ShaRegs> = unsafe { StaticRef::new(SHA_BASE as *const ShaRe
 const SHA_Q: StaticRef<IoGsramRegs> =
     unsafe { StaticRef::new(IO_GSRAM_BASE as *const IoGsramRegs) };
 
-/// W1C status flag mask: COMPLETE, ERROR_*, DIGEST_MATCH.
+/// Status flag mask (read-side decode): COMPLETE, ERROR_*, DIGEST_MATCH.
 const STATUS_FLAGS_MASK: u32 = 0x5E;
-
-fn clear_status(flags: u32) {
-    // SAFETY: STATUS is a W1C MMIO register at SHA_BASE + STATUS_OFFSET.
-    // The mask guarantees we only attempt to clear documented flag bits,
-    // protecting against accidental writes to reserved bits or BUSY.
-    unsafe {
-        core::ptr::write_volatile(
-            (SHA_BASE + STATUS_OFFSET) as *mut u32,
-            flags & STATUS_FLAGS_MASK,
-        );
-    }
-}
 
 #[bitfield(u32)]
 struct ShaCmdCode {
@@ -414,7 +401,10 @@ impl<const DEPTH: usize> ShaDriver<DEPTH> {
             return;
         }
 
-        clear_status(flags);
+        // STATUS (SHA_BASE + 0x4) is read-only (RO32): the COMPLETE/ERROR bits
+        // auto-clear when the next command doorbell sets BUSY. Writing it
+        // bus-faults the engine and hard-faults the CPU, so only clear the
+        // NVIC pending bit here.
         Nvic::unpend(Interrupt::SHA_DONE);
 
         self.state.with(|s| {
@@ -586,7 +576,8 @@ impl<const DEPTH: usize> ShaExclusive<'_, DEPTH> {
             let status = SHA.status.get();
             let flags = status & STATUS_FLAGS_MASK;
             if flags != 0 {
-                clear_status(flags);
+                // STATUS is read-only; do not write it (bus-faults). It
+                // auto-clears on the next command doorbell.
                 Nvic::unpend(Interrupt::SHA_DONE);
                 return Ok(flags as u8);
             }

--- a/fw/plat/uno/fw/reg/soc/src/sha.rs
+++ b/fw/plat/uno/fw/reg/soc/src/sha.rs
@@ -20,7 +20,7 @@ tock_registers::register_bitfields! [u32,
     pub STATUS [
         /// 'Engine is currently processing a command. Cleared on completion (success or error). Firmware must NOT write the COMMAND register while BUSY is set.'
         BUSY OFFSET(0) NUMBITS(1) [],
-        /// 'Engine successfully finished the most recent command. Mutually exclusive with the ERROR_* bits. Cleared by firmware via write-1-to-clear before submitting the next command.'
+        /// 'Engine successfully finished the most recent command. Mutually exclusive with the ERROR_* bits. STATUS is read-only; this bit is cleared by hardware when the next command's doorbell sets BUSY (firmware must NOT write STATUS).'
         COMPLETE OFFSET(1) NUMBITS(1) [],
         /// 'Engine could not decode the command structure successfully (invalid opcode, bad descriptor layout).'
         ERROR_CMD OFFSET(2) NUMBITS(1) [],

--- a/fw/plat/uno/rdl/soc/sha.rdl
+++ b/fw/plat/uno/rdl/soc/sha.rdl
@@ -63,9 +63,10 @@ reg sha_status_t {                                          // SHA: status
         sw = r;
         hw = w;
         desc = "Engine successfully finished the most recent command.
-                Mutually exclusive with the ERROR_* bits. Cleared by
-                firmware via write-1-to-clear before submitting the
-                next command.";
+                Mutually exclusive with the ERROR_* bits. STATUS is
+                read-only; this bit is cleared by hardware when the next
+                command's doorbell sets BUSY (firmware must NOT write
+                STATUS).";
     } COMPLETE[1:1] = 0x0;                              // SHA: complete
 
     field {


### PR DESCRIPTION
The SHA (0xA0400004) and AES (0xA0200004) STATUS registers are read-only (RO32 per the SoC RDL; cp/azihsm and mcr-hsm only ever read them). The drivers' clear_status() did a raw W1C write to them, which bus-faults the engine and hard-faults the CPU on the first completion -- silently hanging the whole core (e.g. during partition provisioning's HMAC-SHA384 KDF and AES-CBC key masking).

The COMPLETE/ERROR flags are hardware-managed and auto-clear when the next command doorbell sets BUSY, so no firmware clear is needed. Remove the clear_status() writes; keep only the NVIC pending-bit clear.