### PR TITLE
fix(fw/pal): emit establish-cred/session-enc ECC pub keys in LE wire form

### DIFF
--- a/fw/plat/std/pal/src/cert.rs
+++ b/fw/plat/std/pal/src/cert.rs
@@ -24,7 +24,6 @@
 //! bottom of this file is the only path the core uses.
 
 use azihsm_crypto::EccCurve;
-use azihsm_crypto::EccKeyOp;
 use azihsm_crypto::EccPrivateKey;
 use azihsm_crypto::ExportableHsmKey;
 use azihsm_crypto::HashAlgo;
@@ -320,19 +319,14 @@ impl StdHsmPal {
     /// drives the [`StdEcc`] driver directly, mirroring what the trait
     /// impl in `crate::ecc` would do.
     async fn gen_cert_keypair(&self) -> HsmResult<CertKeyPair> {
-        let (pk, pubk) = self.ecc.gen_keypair(EccCurve::P384).await?;
-
-        // Export private key as raw HSM scalar bytes (48 B for P-384).
+        // Generate the keypair, then serialize: the public key as raw
+        // big-endian `x ∥ y`, the private key as raw HSM scalar bytes.
+        let (pk, pub_key) = self.ecc.gen_keypair(EccCurve::P384).await?;
+        let mut pub_raw = [0u8; P384_PUB_KEY_LEN];
+        self.ecc.pub_coords(&pub_key, true, &mut pub_raw).await?;
         let priv_len = pk.hsm_bytes_len();
         let mut priv_key = vec![0u8; priv_len];
         pk.to_hsm_bytes(&mut priv_key[..priv_len])
-            .map_err(|_| HsmError::EccExportError)?;
-
-        // Export raw P-384 public key (x ∥ y).
-        let mut pub_raw = [0u8; P384_PUB_KEY_LEN];
-        let half = P384_PUB_KEY_LEN / 2;
-        let (x_buf, y_buf) = pub_raw.split_at_mut(half);
-        pubk.coord(Some((x_buf, y_buf)))
             .map_err(|_| HsmError::EccExportError)?;
 
         let uncompressed = to_uncompressed(&pub_raw);

--- a/fw/plat/std/pal/src/drivers/ecc.rs
+++ b/fw/plat/std/pal/src/drivers/ecc.rs
@@ -14,6 +14,7 @@
 //! | Method | Operation | Input | Output |
 //! |--------|-----------|-------|--------|
 //! | [`gen_keypair`] | Key generation | `EccCurve` | `(EccPrivateKey, EccPublicKey)` |
+//! | [`pub_coords`] | Serialize pub key | `&EccPublicKey`, `big_endian`, `&mut [u8]` out | `x ∥ y` bytes |
 //! | [`ecc_sign`] | Raw EC sign | `&EccPrivateKey`, `&[u8]` hash | `Vec<u8>` (r∥s) |
 //! | [`ecc_verify`] | Raw EC verify | `&EccPublicKey`, `&[u8]` hash, `&[u8]` sig | `bool` |
 //! | [`ecdh_derive`] | ECDH agreement | `&EccPrivateKey`, `&EccPublicKey` | writes `&mut [u8]` |
@@ -76,13 +77,13 @@ impl StdEcc {
         Self { pool }
     }
 
-    /// Generate an ECC key pair asynchronously.
+    /// Generate an ECC key pair asynchronously, returning the
+    /// `(EccPrivateKey, EccPublicKey)` handle pair.
     ///
-    /// Returns the `(EccPrivateKey, EccPublicKey)` handle pair.
-    /// Used by internal-firmware callers (`cert.rs`, `part.rs`)
-    /// that work directly in OpenSSL handles and BE coordinates;
-    /// PAL-trait callers should use [`Self::gen_keypair_le`]
-    /// instead.
+    /// Serialization is a separate concern: turn the public-key handle
+    /// into raw `x ∥ y` bytes (in a chosen byte order) with
+    /// [`Self::pub_coords`], and the private-key handle into raw HSM
+    /// scalar bytes with its `to_hsm_bytes`.
     pub async fn gen_keypair(&self, curve: EccCurve) -> HsmResult<(EccPrivateKey, EccPublicKey)> {
         self.pool
             .submit_with_result(async move {
@@ -96,35 +97,56 @@ impl StdEcc {
             .await
     }
 
-    /// Generate an ECC key pair, returning the private-key handle
-    /// and writing the public key in wire-LE `x_le || y_le` form
-    /// (with P-521 padded to 68 bytes per coordinate) into
-    /// `pub_le_out`.
+    /// Serialize a public-key handle's coordinates to raw `x ∥ y` bytes
+    /// in the requested byte order.  The curve is taken from the handle.
     ///
-    /// `pub_le_out.len()` must be `wire_pub_key_len(curve)`
+    /// `big_endian = true` yields the OpenSSL/NIST big-endian form used
+    /// by internal consumers (cert generation, POTA hashing); `false`
+    /// yields the little-endian DDI wire form (matching real PKA
+    /// hardware).  The BE↔LE flip lives here in the driver.  P-521
+    /// coordinates are padded to `wire_coord_len`.
+    ///
+    /// `out.len()` must be `wire_pub_key_len` for the key's curve
     /// (64 / 96 / 136 for P-256 / P-384 / P-521).
-    pub async fn gen_keypair_le(
+    pub async fn pub_coords(
         &self,
-        curve: EccCurve,
-        pub_le_out: &mut [u8],
-    ) -> HsmResult<EccPrivateKey> {
-        let (priv_key, pub_key) = self.gen_keypair(curve).await?;
+        pub_key: &EccPublicKey,
+        big_endian: bool,
+        out: &mut [u8],
+    ) -> HsmResult<()> {
+        let curve = pub_key.curve();
         let coord_len = priv_key_len(curve);
         let wire_coord = wire_coord_len(curve);
-        if pub_le_out.len() != wire_coord * 2 {
+        if out.len() != wire_coord * 2 {
             return Err(HsmError::EccGetCoordinatesError);
         }
-        let mut x_be = [0u8; 66];
-        let mut y_be = [0u8; 66];
-        pub_key
-            .coord(Some((&mut x_be[..coord_len], &mut y_be[..coord_len])))
-            .map_err(|_| HsmError::EccGetCoordinatesError)?;
 
-        pub_le_out.fill(0);
-        let (x_dst, y_dst) = pub_le_out.split_at_mut(wire_coord);
-        reverse_copy(x_dst, &x_be[..coord_len]);
-        reverse_copy(y_dst, &y_be[..coord_len]);
-        Ok(priv_key)
+        // Read the big-endian coordinates on the worker pool.
+        let pub_key = pub_key.clone();
+        let (x_be, y_be) = self
+            .pool
+            .submit_with_result(async move {
+                let mut x_be = [0u8; 66];
+                let mut y_be = [0u8; 66];
+                pub_key
+                    .coord(Some((&mut x_be[..coord_len], &mut y_be[..coord_len])))
+                    .map_err(|_| HsmError::EccGetCoordinatesError)?;
+                Ok::<_, HsmError>((x_be, y_be))
+            })
+            .await?;
+
+        // Lay the coordinates out in the requested byte order — the
+        // BE↔LE flip is the driver's responsibility.
+        out.fill(0);
+        let (x_dst, y_dst) = out.split_at_mut(wire_coord);
+        if big_endian {
+            x_dst[..coord_len].copy_from_slice(&x_be[..coord_len]);
+            y_dst[..coord_len].copy_from_slice(&y_be[..coord_len]);
+        } else {
+            reverse_copy(x_dst, &x_be[..coord_len]);
+            reverse_copy(y_dst, &y_be[..coord_len]);
+        }
+        Ok(())
     }
 
     /// Raw EC sign over a pre-computed hash digest.
@@ -407,6 +429,27 @@ mod tests {
         let (priv_key, pub_key) = driver.gen_keypair(EccCurve::P521).await.unwrap();
         assert_eq!(EccKeyOp::curve(&priv_key), EccCurve::P521);
         assert_eq!(pub_key.curve(), EccCurve::P521);
+    }
+
+    // ── Public-key coordinate serialization ─────────────────────
+
+    #[tokio::test]
+    async fn pub_coords_le_is_byte_reverse_of_be() {
+        let driver = make_driver();
+        let (_priv_key, pub_key) = driver.gen_keypair(EccCurve::P384).await.unwrap();
+        let mut be = [0u8; 96];
+        let mut le = [0u8; 96];
+        driver.pub_coords(&pub_key, true, &mut be).await.unwrap();
+        driver.pub_coords(&pub_key, false, &mut le).await.unwrap();
+        // Each 48-byte coordinate in LE is the byte-reverse of BE.
+        let mut expected = [0u8; 96];
+        for (d, s) in expected[..48].iter_mut().zip(be[..48].iter().rev()) {
+            *d = *s;
+        }
+        for (d, s) in expected[48..].iter_mut().zip(be[48..].iter().rev()) {
+            *d = *s;
+        }
+        assert_eq!(le, expected);
     }
 
     // ── Sign / verify roundtrip ─────────────────────────────────

--- a/fw/plat/std/pal/src/ecc.rs
+++ b/fw/plat/std/pal/src/ecc.rs
@@ -36,7 +36,6 @@
 //! mode returns the same deterministic sizes.
 
 use azihsm_crypto::EccCurve;
-use azihsm_crypto::EccKeyOp;
 use azihsm_crypto::EccPrivateKey;
 use azihsm_crypto::ExportableHsmKey;
 use azihsm_crypto::PrivateKey;
@@ -45,12 +44,6 @@ use super::*;
 
 /// Map the PAL-level [`HsmEccCurve`] to the crypto library's
 /// [`azihsm_crypto::EccCurve`].
-fn reverse_copy(dst: &mut [u8], src: &[u8]) {
-    for (d, s) in dst[..src.len()].iter_mut().zip(src.iter().rev()) {
-        *d = *s;
-    }
-}
-
 fn to_ecc_curve(curve: HsmEccCurve) -> EccCurve {
     match curve {
         HsmEccCurve::P256 => EccCurve::P256,
@@ -100,10 +93,8 @@ impl HsmEcc for StdHsmPal {
         let scratch = alloc.dma_alloc(priv_len + wire_pub_len)?;
         let (scratch_priv, scratch_pub) = scratch.split_at_mut(priv_len);
 
-        let pk = self
-            .ecc
-            .gen_keypair_le(to_ecc_curve(curve), scratch_pub)
-            .await?;
+        let (pk, pub_key) = self.ecc.gen_keypair(to_ecc_curve(curve)).await?;
+        self.ecc.pub_coords(&pub_key, false, scratch_pub).await?;
         pk.to_hsm_bytes(&mut scratch_priv[..priv_len])
             .map_err(|_| HsmError::EccExportError)?;
 
@@ -149,18 +140,7 @@ impl HsmEcc for StdHsmPal {
         let pub_key = pk
             .public_key()
             .map_err(|_| HsmError::EccGetCoordinatesError)?;
-        let coord_len = curve.priv_key_len();
-        let wire_coord = curve.wire_coord_len();
-        let mut x_be = [0u8; 66];
-        let mut y_be = [0u8; 66];
-        pub_key
-            .coord(Some((&mut x_be[..coord_len], &mut y_be[..coord_len])))
-            .map_err(|_| HsmError::EccGetCoordinatesError)?;
-
-        scratch_pub.fill(0);
-        let (x_dst, y_dst) = scratch_pub.split_at_mut(wire_coord);
-        reverse_copy(x_dst, &x_be[..coord_len]);
-        reverse_copy(y_dst, &y_be[..coord_len]);
+        self.ecc.pub_coords(&pub_key, false, scratch_pub).await?;
 
         priv_out[..priv_len].copy_from_slice(&scratch_priv[..priv_len]);
         pub_out[..wire_pub_len].copy_from_slice(scratch_pub);

--- a/fw/plat/std/pal/src/part.rs
+++ b/fw/plat/std/pal/src/part.rs
@@ -164,14 +164,21 @@ pub(crate) struct PartitionEntry {
     /// `None` before enable or after one-time clear.
     establish_cred_key_id: Option<HsmKeyId>,
 
-    /// DER-encoded public key for establish-credential encryption.
+    /// Raw establish-credential encryption public key, stored as
+    /// little-endian `x ∥ y` (the DDI wire format).  This key is
+    /// wire-only — it is returned verbatim by
+    /// `GetEstablishCredEncryptionKey` and never consumed internally,
+    /// so it is kept in wire (LE) form rather than the big-endian form
+    /// used for internally-consumed keys (e.g. the identity key).
     establish_cred_pub_key: [u8; P384_PUB_KEY_LEN],
 
     /// Vault key ID for the session encryption ECC-384 key.
     /// `None` before enable.
     session_enc_key_id: Option<HsmKeyId>,
 
-    /// Raw public key coordinates (x ∥ y) for session encryption.
+    /// Raw session-encryption public key, stored as little-endian
+    /// `x ∥ y` (the DDI wire format).  Wire-only — returned verbatim by
+    /// `GetSessionEncryptionKey` and never consumed internally.
     session_enc_pub_key: [u8; P384_PUB_KEY_LEN],
 
     /// 32-byte random nonce, generated on enable and refreshable.
@@ -582,6 +589,7 @@ impl StdHsmPal {
                 HsmVaultKeyKind::Ecc384Private,
                 id_attrs,
                 HsmEccPct::SignVerify,
+                true,
                 &mut id_pub,
             )
             .await;
@@ -693,6 +701,7 @@ impl StdHsmPal {
                     HsmVaultKeyKind::Ecc384Private,
                     id_attrs,
                     HsmEccPct::SignVerify,
+                    true,
                     &mut id_pub,
                 )
                 .await?;
@@ -709,6 +718,7 @@ impl StdHsmPal {
         }
 
         // Generate establish-credential encryption ECC-384 key pair.
+        // Wire-only key: exported in little-endian DDI wire order.
         let mut ec_pub = [0u8; P384_PUB_KEY_LEN];
         let ec_kid = self
             .create_internal_ecc384_key(
@@ -716,6 +726,7 @@ impl StdHsmPal {
                 HsmVaultKeyKind::EstablishCred,
                 attrs,
                 HsmEccPct::KeyAgreement,
+                false,
                 &mut ec_pub,
             )
             .await?;
@@ -726,6 +737,7 @@ impl StdHsmPal {
         entry.establish_cred_pub_key = ec_pub;
 
         // Generate session encryption ECC-384 key pair.
+        // Wire-only key: exported in little-endian DDI wire order.
         let mut se_pub = [0u8; P384_PUB_KEY_LEN];
         let se_result = self
             .create_internal_ecc384_key(
@@ -733,6 +745,7 @@ impl StdHsmPal {
                 HsmVaultKeyKind::SessionEncryption,
                 attrs,
                 HsmEccPct::KeyAgreement,
+                false,
                 &mut se_pub,
             )
             .await;
@@ -840,8 +853,14 @@ impl StdHsmPal {
     // -----------------------------------------------------------------------
 
     /// Generate an ECC P-384 key pair, store the raw HSM-format private
-    /// key (scalar `d`, 48 bytes) in the vault, and write raw public key
-    /// coordinates (x ∥ y) into `pub_key_out`.
+    /// key (scalar `d`, 48 bytes) in the vault, and write the raw public
+    /// key coordinates (x ∥ y) into `pub_key_out`.
+    ///
+    /// `big_endian` selects the public-key byte order (the BE↔LE flip is
+    /// the driver's responsibility): `true` yields OpenSSL big-endian
+    /// coordinates for internally-consumed keys (cert generation / POTA
+    /// hashing); `false` yields the little-endian DDI wire form (matching
+    /// real PKA hardware) for wire-only keys.
     ///
     /// Bypasses [`HsmEcc::ecc_gen_keypair`] (which now requires an
     /// `HsmIo` and a scoped allocator) and drives the
@@ -856,27 +875,23 @@ impl StdHsmPal {
         kind: HsmVaultKeyKind,
         attrs: HsmVaultKeyAttrs,
         _pct: HsmEccPct,
+        big_endian: bool,
         pub_key_out: &mut [u8; P384_PUB_KEY_LEN],
     ) -> HsmResult<HsmKeyId> {
-        let (pk, pubk) = self.ecc.gen_keypair(EccCurve::P384).await?;
+        // Generate the keypair; the driver owns the public-key byte
+        // order, so this layer stays free of byte-shuffling boilerplate.
+        let (pk, pub_key) = self.ecc.gen_keypair(EccCurve::P384).await?;
+        self.ecc
+            .pub_coords(&pub_key, big_endian, pub_key_out)
+            .await?;
 
-        // Export private key as raw HSM scalar bytes (48 B for P-384).
+        // Export private key as raw HSM scalar bytes (48 B for P-384)
+        // and store them in the vault.
         let priv_len = pk.hsm_bytes_len();
         let mut priv_buf = vec![0u8; priv_len];
         pk.to_hsm_bytes(&mut priv_buf[..priv_len])
             .map_err(|_| HsmError::EccExportError)?;
 
-        // Export raw P-384 public key coordinates (x ∥ y) in big-endian
-        // form — matches OpenSSL conventions and is the form expected by
-        // internal consumers (cert generation, POTA hash).  Wire-facing
-        // PAL accessors (e.g. [`part_establish_cred_pub_key`]) handle
-        // BE→LE conversion at the response boundary.
-        let half = P384_PUB_KEY_LEN / 2;
-        let (x_buf, y_buf) = pub_key_out.split_at_mut(half);
-        pubk.coord(Some((x_buf, y_buf)))
-            .map_err(|_| HsmError::EccExportError)?;
-
-        // Store raw HSM private-key bytes in vault.
         let table = self.table_mut();
         let entry = &mut table.entries[pid as usize];
         entry.vault.create(&priv_buf[..priv_len], kind, None, attrs)


### PR DESCRIPTION
The std PAL stores ECC-384 public keys big-endian (OpenSSL convention), while the DDI wire format is little-endian `x ∥ y` (matching real PKA hardware); the host `post_decode` on `DdiDerPublicKey` reverses each coord LE->BE before DER-encoding. PR #454 (property-based partition API) replaced the typed wire accessors that performed the BE->LE reversal (`copy_out_pub_key_le`) with a generic `part_prop_get_bytes` that returns the stored big-endian bytes verbatim, so the establish-credential and session-encryption public keys went out big-endian. The host then reversed them into off-curve points, failing `EccPublicKey::from_bytes` with `EccKeyImportError` during GetEstablishCredEncryptionKey / GetSessionEncryptionKey -- breaking the credential/session setup that nearly every emu integration test depends on.

Restore the wire-LE serialization, with byte order owned by the ECC driver:

- `StdEcc::gen_keypair` is now pure generation, returning the `(EccPrivateKey, EccPublicKey)` handle pair with no endianness notion.
- New `StdEcc::pub_coords(&pub, big_endian, out)` serializes a public-key handle to raw `x ∥ y`: it derives the curve from the handle, reads the big-endian coordinates via `coord()` on the worker pool, then lays them out big-endian or little-endian (the BE<->LE flip stays in the driver).
- `create_internal_ecc384_key` takes a `big_endian` flag: the identity key stays big-endian (consumed internally for cert generation / POTA hashing), while the wire-only establish-cred and session-enc keys are serialized little-endian.
- `cert.rs` and the `HsmEcc` trait impl (`ecc_gen_keypair`, `ecc_gen_keypair_from_okm`) route through the same two methods, removing a duplicated inline coord+reverse block and a now-dead `reverse_copy` helper / unused `EccKeyOp` imports.

Validation (emu):
- Smoke: `cargo nextest run --no-fail-fast -p azihsm_ddi_mbor_types --features emu --test azihsm_ddi_tests smoke` -> 50/50 passed (was 12/50).
- Full DDI integration: same command without `smoke` -> 337 passed / 272 failed, matching the pre-regression June-9 baseline. Every test passing pre-regression passes again; the remaining failures are pre-existing unimplemented-feature tests (the sole non-baseline failure, `reopen_session::test_reopen_session_after_lm_with_max`, is a newer live-migration test unrelated to this change).
- std PAL unit tests: `cargo nextest run -p azihsm_fw_hsm_pal_std` ->
  157/157 passed (incl. new `pub_coords_le_is_byte_reverse_of_be`).
- Build warning-free; `cargo +nightly xtask fmt --fix` and `cargo xtask copyright --fix` clean.