### PR TITLE
feat(undo): unified lock-free rollback for host commands

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,6 +60,7 @@ members = [
   "fw/core/lib",
   "fw/core/oob",
   "fw/core/tracing",
+  "fw/core/undo",
   "fw/pal/traits",
   "fw/plat/std/lib",
   "fw/plat/std/pal",
@@ -150,6 +151,7 @@ azihsm_fw_hsm_oob = { path = "fw/core/oob" }
 azihsm_fw_hsm_pal_std = { path = "fw/plat/std/pal" }
 azihsm_fw_hsm_pal_traits = { path = "fw/pal/traits" }
 azihsm_fw_hsm_std = { path = "fw/plat/std/lib" }
+azihsm_fw_hsm_undo = { path = "fw/core/undo" }
 
 # Embassy crates
 embassy-executor = "0.10.0"

--- a/ddi/tbor/types/src/status.rs
+++ b/ddi/tbor/types/src/status.rs
@@ -276,6 +276,10 @@ pub enum TborStatus {
     UmsKeyAlreadySet = 0x087000FD,
     UmsKeyNotSet = 0x087000FE,
 
+    /// A per-command undo-log push failed (mirror of
+    /// `HsmError::UndoLogFull`).
+    UndoLogFull = 0x08700101,
+
     /// The SQE's out-of-band descriptor-array length (`oob_len`) is
     /// malformed (mirror of `HsmError::IoChannelInvalidOobLen`).
     IoChannelInvalidOobLen = 0x08700104,

--- a/fw/core/lib/Cargo.toml
+++ b/fw/core/lib/Cargo.toml
@@ -29,6 +29,7 @@ azihsm_fw_hsm_key_decode.workspace = true
 azihsm_fw_hsm_key_unwrap.workspace = true
 azihsm_fw_hsm_oob.workspace = true
 azihsm_fw_hsm_pal_traits.workspace = true
+azihsm_fw_hsm_undo.workspace = true
 
 zerocopy.workspace = true
 

--- a/fw/core/lib/src/ddi/tbor/mod.rs
+++ b/fw/core/lib/src/ddi/tbor/mod.rs
@@ -39,6 +39,7 @@ use azihsm_fw_hsm_pal_traits::DmaBuf;
 use azihsm_fw_hsm_pal_traits::HsmPal;
 use azihsm_fw_hsm_pal_traits::HsmSessId;
 use azihsm_fw_hsm_pal_traits::SessionRole;
+use azihsm_fw_hsm_undo::UndoLog;
 
 use super::*;
 
@@ -123,6 +124,7 @@ pub(crate) async fn dispatch<'p, P: HsmPal>(
     opcode: u8,
     sqe_session_id: u16,
     oob: Option<OobPtr>,
+    undo: &mut UndoLog<'p>,
 ) -> HsmResult<&'p DmaBuf> {
     // Reject unknown opcodes with the canonical error *before*
     // applying any gating logic so the gate cannot leak existence of
@@ -167,12 +169,12 @@ pub(crate) async fn dispatch<'p, P: HsmPal>(
 
     match opcode {
         opcode::API_REV => api_rev::handle(pal, io, req_buf),
-        opcode::SESSION_OPEN_INIT => session_open_init::handle(pal, io, req_buf).await,
-        opcode::SESSION_OPEN_FINISH => session_open_finish::handle(pal, io, req_buf).await,
+        opcode::SESSION_OPEN_INIT => session_open_init::handle(pal, io, req_buf, undo).await,
+        opcode::SESSION_OPEN_FINISH => session_open_finish::handle(pal, io, req_buf, undo).await,
         opcode::SESSION_CLOSE => session_close::handle(pal, io, req_buf).await,
-        opcode::PSK_CHANGE => psk_change::handle(pal, io, req_buf).await,
-        opcode::PART_INIT => part_init::handle(pal, io, req_buf).await,
-        opcode::PART_FINAL => part_final::handle(pal, io, req_buf, oob).await,
+        opcode::PSK_CHANGE => psk_change::handle(pal, io, req_buf, undo).await,
+        opcode::PART_INIT => part_init::handle(pal, io, req_buf, undo).await,
+        opcode::PART_FINAL => part_final::handle(pal, io, req_buf, oob, undo).await,
         opcode::PART_INFO => part_info::handle(pal, io, req_buf),
         _ => Err(HsmError::UnsupportedCmd),
     }

--- a/fw/core/lib/src/ddi/tbor/part_final.rs
+++ b/fw/core/lib/src/ddi/tbor/part_final.rs
@@ -51,6 +51,7 @@ use azihsm_fw_hsm_pal_traits::HsmVaultKeyKind;
 use azihsm_fw_hsm_pal_traits::PartPropId;
 use azihsm_fw_hsm_pal_traits::PartState;
 use azihsm_fw_hsm_pal_traits::SessionRole;
+use azihsm_fw_hsm_undo::UndoLog;
 
 use super::*;
 
@@ -114,6 +115,7 @@ pub(crate) async fn handle<'p, P: HsmPal>(
     io: &impl HsmIo,
     req_buf: &mut DmaBuf,
     oob: Option<OobPtr>,
+    undo: &mut UndoLog<'p>,
 ) -> HsmResult<&'p DmaBuf> {
     let req = parse_request(req_buf)?;
 
@@ -180,7 +182,11 @@ pub(crate) async fn handle<'p, P: HsmPal>(
         pal.rng_fill_bytes(io, &mut ephemeral_mk[..])?;
 
         // ── Commit + respond ──────────────────────────────────────────
-        commit(pal, io, ums_key_id, ups, part_local_mk, ephemeral_mk).await?;
+        // Stage the finalized vault keys (async, independent slots) so the
+        // commit below is a single await-free, atomic guards-first block.
+        let (local_id, ephemeral_id, ups_id) =
+            stage_final_keys(pal, io, ups, part_local_mk, ephemeral_mk, undo).await?;
+        commit_final(pal, io, ums_key_id, local_id, ephemeral_id, ups_id, undo)?;
         encode_response(pal, io, curr_backup)
     })
     .await
@@ -475,20 +481,22 @@ fn peek_backup_svn_owner(blob: &DmaBuf) -> HsmResult<(u64, u16)> {
     Ok((meta.svn.get(), meta.owner_seed_id.get()))
 }
 
-/// Commit the finalized partition state: vault the live masking keys and
-/// record their ids, replace UMS with UPS in the root slot, and advance
-/// the lifecycle to [`PartState::Initialized`].
-async fn commit<P: HsmPal>(
+/// Stage the three finalized vault keys — partition-local MK, ephemeral MK,
+/// and the UPS that replaces UMS in the root slot — recording each key's
+/// delete-inverse on the undo log.
+///
+/// Done **before** [`commit_final`] so that block can be a single await-free
+/// (atomic) commit; concurrent `PartFinal`s stage their own keys
+/// independently and only race in the atomic commit, where the loser
+/// fails-fast and its just-staged keys are reaped by the recorded inverses.
+async fn stage_final_keys<'p, P: HsmPal>(
     pal: &P,
     io: &impl HsmIo,
-    ums_key_id: HsmKeyId,
     ups: &DmaBuf,
     part_local_mk: &DmaBuf,
     ephemeral_mk: &DmaBuf,
-) -> HsmResult<()> {
-    use super::super::part_state;
-
-    // Vault the partition-local + ephemeral masking keys; record ids.
+    undo: &mut UndoLog<'p>,
+) -> HsmResult<(HsmKeyId, HsmKeyId, HsmKeyId)> {
     let local_id = pal
         .vault_key_create(
             io,
@@ -498,7 +506,7 @@ async fn commit<P: HsmPal>(
             PART_LOCAL_MK_ATTRS,
         )
         .await?;
-    part_state::part_set_local_mk_key_id(pal, io, local_id)?;
+    undo.push_vault_create(local_id)?;
 
     let ephemeral_id = pal
         .vault_key_create(
@@ -509,11 +517,8 @@ async fn commit<P: HsmPal>(
             EPHEMERAL_MK_ATTRS,
         )
         .await?;
-    part_state::part_set_ephemeral_mk_key_id(pal, io, ephemeral_id)?;
+    undo.push_vault_create(ephemeral_id)?;
 
-    // Replace UMS → UPS in the partition root slot.  The id slot is
-    // write-once, so clear it before re-pointing; then free the old UMS
-    // vault key.
     let ups_id = pal
         .vault_key_create(
             io,
@@ -523,11 +528,67 @@ async fn commit<P: HsmPal>(
             PART_ROOT_ATTRS,
         )
         .await?;
+    undo.push_vault_create(ups_id)?;
+
+    Ok((local_id, ephemeral_id, ups_id))
+}
+
+/// Commit the finalized partition state in a single **await-free**
+/// guards-first block: record the masking-key ids, replace UMS → UPS in the
+/// root slot (soft-deleting the old UMS key), and advance the lifecycle to
+/// [`PartState::Initialized`].
+///
+/// The three vault keys are already staged by [`stage_final_keys`]; only
+/// their `key_id`s flow in here.  Each mutation's inverse is recorded
+/// *before* applying, so a partial failure (or a later response/completion
+/// failure) is rolled back by the dispatcher's walk.  The UMS key is
+/// **soft-deleted** ([`UndoLog::push_vault_disable`]) so the undo walk
+/// re-enables it and the commit walk zeroizes it.
+///
+/// Being await-free, this block is **atomic** on the cooperative executor: a
+/// racing `PartFinal` that reaches the guard after this one committed sees
+/// `STATE != Initializing` and **fails-fast without mutating** — so no
+/// partition lock is needed, and its empty field-undo cannot clobber this
+/// commit.
+fn commit_final<P: HsmPal>(
+    pal: &P,
+    io: &impl HsmIo,
+    ums_key_id: HsmKeyId,
+    local_id: HsmKeyId,
+    ephemeral_id: HsmKeyId,
+    ups_id: HsmKeyId,
+    undo: &mut UndoLog<'_>,
+) -> HsmResult<()> {
+    use super::super::part_state;
+
+    // Guards-first: bail before recording or applying any inverse if the
+    // partition is no longer `Initializing` (e.g. a racing PartFinal already
+    // finalized).  Recording the inverses and then failing would otherwise
+    // clobber the winner's just-committed state.
+    if part_state::part_state(pal, io)? != PartState::Initializing {
+        return Err(HsmError::InvalidArg);
+    }
+
+    // Record every inverse *before* applying, in commit order (the undo walk
+    // reverses them): clear the two new masking-key ids, restore UPS_KEY_ID
+    // to the prior UMS id, re-enable the soft-deleted UMS key, and restore
+    // STATE to `Initializing`.
+    undo.push_prop_restore_absent(PartPropId::LOCAL_MK_KEY_ID)?;
+    undo.push_prop_restore_absent(PartPropId::EPHEMERAL_MK_KEY_ID)?;
+    undo.push_prop_restore_scalar(PartPropId::UPS_KEY_ID, u32::from(u16::from(ums_key_id)))?;
+    undo.push_vault_disable(ums_key_id)?;
+    undo.push_prop_restore_scalar(PartPropId::STATE, PartState::Initializing as u32)?;
+
+    // Apply the mutations in the same order as the inverses above.
+    part_state::part_set_local_mk_key_id(pal, io, local_id)?;
+    part_state::part_set_ephemeral_mk_key_id(pal, io, ephemeral_id)?;
+    // The UPS_KEY_ID slot is write-once, so clear it before re-pointing.
     pal.part_prop_clear(io, PartPropId::UPS_KEY_ID)?;
     part_state::part_set_ups_key_id(pal, io, ups_id)?;
-    pal.vault_key_delete(io, ums_key_id).await?;
+    // Soft-delete the old UMS key: the commit walk zeroizes it, the undo
+    // walk re-enables it (see the recorded `push_vault_disable`).
+    pal.vault_key_disable(io, ums_key_id)?;
 
-    // Finalize the lifecycle.
     part_state::part_set_state(pal, io, PartState::Initialized)
 }
 

--- a/fw/core/lib/src/ddi/tbor/part_init.rs
+++ b/fw/core/lib/src/ddi/tbor/part_init.rs
@@ -68,11 +68,14 @@ use azihsm_fw_ddi_tbor_types::PTA_REPORT_MAX_LEN;
 use azihsm_fw_ddi_tbor_types::SAPOTA_THUMBPRINT_LEN;
 use azihsm_fw_hsm_pal_traits::DmaBuf;
 use azihsm_fw_hsm_pal_traits::HsmHashAlgo;
+use azihsm_fw_hsm_pal_traits::HsmKeyId;
 use azihsm_fw_hsm_pal_traits::HsmSessId;
 use azihsm_fw_hsm_pal_traits::HsmVaultKeyAttrs;
 use azihsm_fw_hsm_pal_traits::HsmVaultKeyKind;
+use azihsm_fw_hsm_pal_traits::PartPropId;
 use azihsm_fw_hsm_pal_traits::PartState;
 use azihsm_fw_hsm_pal_traits::SessionRole;
+use azihsm_fw_hsm_undo::UndoLog;
 
 use super::*;
 
@@ -139,6 +142,7 @@ pub(crate) async fn handle<'p, P: HsmPal>(
     pal: &'p P,
     io: &impl HsmIo,
     req_buf: &mut DmaBuf,
+    undo: &mut UndoLog<'p>,
 ) -> HsmResult<&'p DmaBuf> {
     let req = parse_request(req_buf)?;
 
@@ -197,21 +201,29 @@ pub(crate) async fn handle<'p, P: HsmPal>(
         pal.hash(io, HsmHashAlgo::Sha384, policy_dma, policy_hash_dma, true)
             .await?;
 
-        // Commit partition state, then encode the response.
+        // Stage the partition's vault keys (async; independent slots) so the
+        // commit below is a single await-free, atomic block.  Their
+        // delete-inverses are recorded now, so a fail-fast in the commit
+        // guard still reaps the just-created keys.
+        let (root_key_id, pta_key_id) =
+            stage_part_keys(pal, io, root_dma, pta.priv_scalar, undo).await?;
+
+        // Commit partition state (guards-first, atomic), then encode the
+        // response.
         commit_partition_state(
             pal,
             io,
             CommitInputs {
-                root: root_dma,
-                pta_priv: pta.priv_scalar,
                 pta_pub_sec1: pta.pub_sec1,
                 policy_hash: policy_hash_dma,
                 pota_thumb: pota_thumb_dma,
                 sata_thumb: sata_thumb_dma,
                 sapota_thumb: sapota_thumb_dma,
             },
-        )
-        .await?;
+            root_key_id,
+            pta_key_id,
+            undo,
+        )?;
         encode_response(pal, io, &csr_dma[..csr_len], &report_dma[..report_len])
     })
     .await
@@ -574,8 +586,6 @@ async fn build_report_data<'a, P: HsmPal>(
 
 /// Write-once inputs committed by [`commit_partition_state`].
 struct CommitInputs<'a> {
-    root: &'a DmaBuf,
-    pta_priv: &'a DmaBuf,
     pta_pub_sec1: &'a DmaBuf,
     policy_hash: &'a DmaBuf,
     pota_thumb: &'a DmaBuf,
@@ -583,43 +593,85 @@ struct CommitInputs<'a> {
     sapota_thumb: Option<&'a DmaBuf>,
 }
 
-/// Vault the PartRoot and PTA private keys, register the partition
-/// write-once fields (including the security-domain thumbprints), and
-/// publish the `Enabled → Initializing` transition.
+/// Create the partition's two vault keys — the PartRoot UPS secret and the
+/// PTA private key — in independent vault slots, recording each key's
+/// delete-inverse on the undo log.
 ///
-/// Setter order is fixed by [`HsmPartitionManager::part_mark_initializing`]
-/// (the write-once fields must be set first).  Vault entries are
-/// committed as soon as they are created (`vault_key_create` is
-/// awaited), and the returned `key_id`s then flow into the partition
-/// setters.  There is no provisional / `dismiss()` rollback stage;
-/// undoing a partially-applied `PartInit` is a future undo-log TODO.
-async fn commit_partition_state<P: HsmPal>(
+/// Done **before** [`commit_partition_state`] so that block can be a single
+/// await-free (atomic) commit.  Concurrent `PartInit`s stage their own keys
+/// independently and only race in the atomic commit, where the loser
+/// fails-fast; its just-staged keys are reaped by the recorded inverses.
+async fn stage_part_keys<'p, P: HsmPal>(
     pal: &P,
     io: &impl HsmIo,
-    inputs: CommitInputs<'_>,
-) -> HsmResult<()> {
-    // The keys are committed as they are created; the partition-state
-    // setters below run afterwards (a future undo log will handle
-    // rollback of a partially-applied PartInit).
+    root: &DmaBuf,
+    pta_priv: &DmaBuf,
+    undo: &mut UndoLog<'p>,
+) -> HsmResult<(HsmKeyId, HsmKeyId)> {
     let root_key_id = pal
         .vault_key_create(
             io,
-            inputs.root,
+            root,
             HsmVaultKeyKind::UniquePartitionSecret,
             None,
             PART_ROOT_VAULT_ATTRS,
         )
         .await?;
+    undo.push_vault_create(root_key_id)?;
 
     let pta_key_id = pal
         .vault_key_create(
             io,
-            inputs.pta_priv,
+            pta_priv,
             HsmVaultKeyKind::PartitionTrustAnchor,
             None,
             PTA_VAULT_ATTRS,
         )
         .await?;
+    undo.push_vault_create(pta_key_id)?;
+
+    Ok((root_key_id, pta_key_id))
+}
+
+/// Register the partition write-once fields (including the security-domain
+/// thumbprints) and publish the `Enabled → Initializing` transition, in a
+/// single **await-free** guards-first block.
+///
+/// The two vault keys are already staged by [`stage_part_keys`]; only their
+/// `key_id`s flow in here.  Setter order is fixed (the write-once fields
+/// must be set before the STATE transition).  Each mutation records its
+/// inverse on the per-command undo log, so a partial failure (or a later
+/// response/completion failure) is rolled back by the dispatcher's walk.
+///
+/// Being await-free, this block is **atomic** on the cooperative executor:
+/// a racing `PartInit` that reaches the guard after this one committed finds
+/// the partition already provisioned and **fails-fast without mutating** — so
+/// no partition lock is needed, and its empty field-undo cannot clobber this
+/// commit.
+fn commit_partition_state<P: HsmPal>(
+    pal: &P,
+    io: &impl HsmIo,
+    inputs: CommitInputs<'_>,
+    root_key_id: HsmKeyId,
+    pta_key_id: HsmKeyId,
+    undo: &mut UndoLog<'_>,
+) -> HsmResult<()> {
+    // Guards-first: reject a racing PartInit (or a re-init) that already
+    // published this partition's write-once provisioning, *before* any field
+    // inverse is recorded — otherwise its restore-to-absent undo would clear
+    // the winner's just-set fields.  Mirrors `part_set_pta_key`'s one-shot
+    // `PtaKeyAlreadySet` guard, hoisted ahead of the undo bookkeeping so the
+    // whole commit stays atomic (await-free) and the loser mutates nothing.
+    // Only a genuinely absent slot (`PartPropNotFound`) means "not set yet";
+    // any other read error is propagated rather than masked as unset.
+    if crate::part_state::prop_present(crate::part_state::part_pta_key_id(pal, io))? {
+        return Err(HsmError::PtaKeyAlreadySet);
+    }
+
+    // Record the write-once / STATE inverses *before* applying them: the
+    // fields are absent now, so "restore to absent" is valid even if a
+    // setter below fails partway (the clear is then a benign no-op).
+    record_field_undo(undo, inputs.sapota_thumb.is_some())?;
 
     crate::part_state::part_set_pta_key(pal, io, pta_key_id, inputs.pta_pub_sec1)?;
     crate::part_state::part_set_ups_key_id(pal, io, root_key_id)?;
@@ -631,6 +683,24 @@ async fn commit_partition_state<P: HsmPal>(
     }
     crate::part_state::part_set_state(pal, io, PartState::Initializing)?;
     Ok(())
+}
+
+/// Push the write-once / STATE undo actions for [`commit_partition_state`]
+/// in commit order (the dispatcher walks them LIFO).  Each write-once
+/// field restores to **absent** (it was unset before PartInit); STATE
+/// restores to its prior `Enabled`.  The two `part_set_pta_key` fields
+/// (`PTA_KEY_ID` + `PTA_PUB_KEY`) are recorded together.
+fn record_field_undo(undo: &mut UndoLog<'_>, has_sapota: bool) -> HsmResult<()> {
+    undo.push_prop_restore_absent(PartPropId::PTA_KEY_ID)?;
+    undo.push_prop_restore_absent(PartPropId::PTA_PUB_KEY)?;
+    undo.push_prop_restore_absent(PartPropId::UPS_KEY_ID)?;
+    undo.push_prop_restore_absent(PartPropId::POLICY_HASH)?;
+    undo.push_prop_restore_absent(PartPropId::POTA_THUMBPRINT)?;
+    undo.push_prop_restore_absent(PartPropId::SATA_THUMBPRINT)?;
+    if has_sapota {
+        undo.push_prop_restore_absent(PartPropId::SAPOTA_THUMBPRINT)?;
+    }
+    undo.push_prop_restore_scalar(PartPropId::STATE, PartState::Enabled as u32)
 }
 
 /// Encode the `TborPartInitResp` into a fresh IO-scoped DmaBuf.

--- a/fw/core/lib/src/ddi/tbor/psk_change.rs
+++ b/fw/core/lib/src/ddi/tbor/psk_change.rs
@@ -34,6 +34,7 @@ use azihsm_fw_hsm_pal_traits::HsmResult;
 use azihsm_fw_hsm_pal_traits::HsmSessId;
 use azihsm_fw_hsm_pal_traits::SessionRole;
 use azihsm_fw_hsm_pal_traits::PSK_LEN;
+use azihsm_fw_hsm_undo::UndoLog;
 
 /// PSK slot id written when the active session is the Crypto Officer.
 const PSK_ID_CO: u8 = 0;
@@ -45,6 +46,7 @@ pub(crate) async fn handle<'p, P: HsmPal>(
     pal: &'p P,
     io: &impl HsmIo,
     req_buf: &mut DmaBuf,
+    undo: &mut UndoLog<'p>,
 ) -> HsmResult<&'p DmaBuf> {
     // `decode_mut` validates the wire frame and hands back a
     // destructured view: scalar `session_id` by value, plus
@@ -72,6 +74,15 @@ pub(crate) async fn handle<'p, P: HsmPal>(
     // renegotiate to retry.  Cross-session replay is already
     // structurally impossible (HPKE-derived per-session `param_key`).
     pal.session_try_consume_psk_change(io, sess_id)?;
+
+    // Record the prior PSK *before* overwriting it, so any later failure
+    // — the crypto below, the response DMA, or the CQE post — restores it
+    // via the dispatcher's undo walk.  The rotation is therefore
+    // all-or-nothing as the host observes it.  (The budget burn above is
+    // intentionally *not* reverted: one attempt per session.)
+    let prior = crate::part_state::part_psk(pal, io, target_psk_id)?;
+    let psk_prop = crate::part_state::part_psk_prop_id(target_psk_id)?;
+    undo.push_prop_restore_bytes(psk_prop, prior)?;
 
     pal.alloc_scoped_async(io, async |_alloc| {
         // Fetch the session's `param_key` schedule (the PAL hides the

--- a/fw/core/lib/src/ddi/tbor/session_open_finish.rs
+++ b/fw/core/lib/src/ddi/tbor/session_open_finish.rs
@@ -29,6 +29,7 @@ use azihsm_fw_core_crypto_key_masking::aead::masked_blob_len;
 use azihsm_fw_core_crypto_key_masking::aead::MaskParams;
 use azihsm_fw_ddi_tbor_types::*;
 use azihsm_fw_hsm_pal_traits::*;
+use azihsm_fw_hsm_undo::UndoLog;
 
 /// Map a [`SessionSuite`] to the concrete [`HpkeSuite`] used by the
 /// session-establishment handshake.  Mirrors the function of the same
@@ -116,6 +117,7 @@ pub(crate) async fn handle<'p, P: HsmPal>(
     pal: &'p P,
     io: &impl HsmIo,
     req_buf: &mut DmaBuf,
+    undo: &mut UndoLog<'p>,
 ) -> HsmResult<&'p DmaBuf> {
     let ParsedRequest {
         sess_id,
@@ -133,6 +135,12 @@ pub(crate) async fn handle<'p, P: HsmPal>(
             session_type,
             suite,
         } = load_pending_state(pal, io, alloc, sess_id)?;
+
+        // Record the session's teardown inverse up front: any failure below
+        // (MAC/envelope auth, key derivation, promote, response, or the CQE
+        // post) reverts the session via the dispatcher's undo walk — the
+        // same "destroy on failure" the bespoke rollback did, now uniform.
+        undo.push_session_destroy(sess_id)?;
         let pk_hsm = load_pk_hsm(pal, io, alloc)?;
 
         // The `mac_fin` length is dictated by the suite recorded in
@@ -145,10 +153,20 @@ pub(crate) async fn handle<'p, P: HsmPal>(
         }
 
         // ── Verify Phase-2 confirm MAC ────────────────────────────
-        verify_mac(
+        // On any failure here (MAC mismatch → `SessionAuthFailure`, or an
+        // internal HMAC error) eagerly destroy the still-Pending slot: IOs
+        // run in a concurrent task pool, so a delayed teardown would let a
+        // racing `SessionOpenFinish` re-probe the same slot in the window
+        // before the dispatcher's undo walk runs.  The pushed
+        // `session_destroy` undo entry stays as the backstop.
+        if let Err(e) = verify_mac(
             pal, io, alloc, sess_id, mac_fin, exported, pk_init, pk_hsm, pk_resp,
         )
-        .await?;
+        .await
+        {
+            destroy_pending_on_auth_failure(pal, io, sess_id).await;
+            return Err(e);
+        }
 
         // ── Derive param_key once, use it to open the seed envelope
         let param_key = hkdf_expand_labeled(
@@ -161,16 +179,24 @@ pub(crate) async fn handle<'p, P: HsmPal>(
         )
         .await?;
 
-        let seed = open_seed_envelope(pal, io, sess_id, param_key, seed_envelope).await?;
+        // Same eager-teardown rationale as the MAC check above: a tampered
+        // envelope must not be re-probable against a lingering Pending slot.
+        let seed = match open_seed_envelope(pal, io, param_key, seed_envelope).await {
+            Ok(seed) => seed,
+            Err(e) => {
+                destroy_pending_on_auth_failure(pal, io, sess_id).await;
+                return Err(e);
+            }
+        };
 
         // ── Derive remaining per-session keys ─────────────────────
         let derived =
             derive_remaining_keys(pal, io, alloc, exported, session_type, param_key).await?;
 
         // ── Build bmk_session (BK_SESSION-wrapped masking-key blob)
-        //    BEFORE promote, so a wrap failure leaves the slot Pending
-        //    (caller may retry; eviction reclaims it eventually) and
-        //    no active session is created without a recovery blob.
+        //    BEFORE promote, so no active session is ever created without a
+        //    recovery blob.  A failure at this step (or any later one) tears
+        //    the still-Pending session down via the dispatcher's undo walk.
         let bmk_session = build_bmk_session(pal, io, alloc, seed, derived.masking_key).await?;
 
         // ── Promote Pending → Active ──────────────────────────────
@@ -179,6 +205,22 @@ pub(crate) async fn handle<'p, P: HsmPal>(
         encode_response(pal, io, bmk_session)
     })
     .await
+}
+
+/// Eagerly tear down the still-Pending session after an authentication
+/// failure, closing the window in which a tampered MAC or seed envelope
+/// could be re-probed against the same slot.
+///
+/// `SessionOpenFinish` IOs run in a concurrent task pool, so relying only
+/// on the dispatcher's post-command undo walk would leave the Pending slot
+/// observable to a racing finish until that walk completes.  Destroying
+/// here shrinks that window to nothing.
+///
+/// Best-effort: the [`UndoLog`] `session_destroy` entry pushed up front is
+/// the authoritative backstop (its walk step is best-effort), so a failure
+/// here — or the walk's later redundant destroy — is harmless.
+async fn destroy_pending_on_auth_failure<P: HsmPal>(pal: &P, io: &impl HsmIo, id: HsmSessId) {
+    let _ = pal.session_destroy(io, id).await;
 }
 
 /// Decode and validate the wire request.
@@ -270,8 +312,8 @@ fn load_pk_hsm<'a, P: HsmPal>(
 /// Recompute and constant-time-verify the Phase-2 confirm MAC:
 /// `HMAC-SHA384(exported, (label ‖ session_id_be) ‖ pk_init ‖ pk_hsm ‖ pk_resp)`.
 ///
-/// On failure the Pending slot is destroyed and
-/// `HsmError::SessionAuthFailure` is returned.
+/// On failure `HsmError::SessionAuthFailure` is returned; the caller's
+/// undo log tears the session down.
 #[allow(clippy::too_many_arguments)]
 async fn verify_mac<P: HsmPal>(
     pal: &P,
@@ -298,7 +340,6 @@ async fn verify_mac<P: HsmPal>(
     }
     let mac_verified = pal.hmac_finish_verify(io, hmac_ctx, mac_fin).await?;
     if !mac_verified {
-        let _ = pal.session_destroy(io, id).await;
         return Err(HsmError::SessionAuthFailure);
     }
     Ok(())
@@ -308,14 +349,15 @@ async fn verify_mac<P: HsmPal>(
 /// `param_key`.  Returns the 32-byte plaintext seed as a `&DmaBuf`
 /// sub-view of the envelope buffer (which was decrypted in place).
 ///
-/// Any AEAD failure (bad magic, unsupported alg, tag mismatch) is
-/// treated as a session-establishment authentication failure: the
-/// Pending slot is destroyed before returning so a tampered envelope
-/// cannot be probed repeatedly.
+/// Any AEAD failure (bad magic, unsupported alg, tag mismatch) or a
+/// wrong-length plaintext is treated as a session-establishment
+/// authentication failure ([`HsmError::SessionAuthFailure`]).  The caller
+/// eagerly destroys the Pending session on this error (with the undo log
+/// as backstop), so a tampered envelope cannot be re-probed against the
+/// same slot.
 async fn open_seed_envelope<'a, P: HsmPal>(
     pal: &P,
     io: &impl HsmIo,
-    id: HsmSessId,
     param_key: &DmaBuf,
     seed_envelope: &'a mut DmaBuf,
 ) -> HsmResult<&'a DmaBuf> {
@@ -326,16 +368,10 @@ async fn open_seed_envelope<'a, P: HsmPal>(
     let result = aead_open(pal, io, param_key, seed_envelope).await;
     let view = match result {
         Ok(v) => v,
-        Err(_) => {
-            // Destroy the Pending slot before returning so the
-            // tampered envelope is not retry-probeable.
-            let _ = pal.session_destroy(io, id).await;
-            return Err(HsmError::SessionAuthFailure);
-        }
+        Err(_) => return Err(HsmError::SessionAuthFailure),
     };
 
     if view.payload.len() != SEED_LEN {
-        let _ = pal.session_destroy(io, id).await;
         return Err(HsmError::SessionAuthFailure);
     }
     // Hand the caller the AEAD plaintext view directly: it borrows

--- a/fw/core/lib/src/ddi/tbor/session_open_init.rs
+++ b/fw/core/lib/src/ddi/tbor/session_open_init.rs
@@ -23,6 +23,7 @@
 use azihsm_fw_core_crypto_hpke::*;
 use azihsm_fw_ddi_tbor_types::*;
 use azihsm_fw_hsm_pal_traits::*;
+use azihsm_fw_hsm_undo::UndoLog;
 
 /// Validated `SessionOpenInit` request fields.
 struct ParsedRequest<'a> {
@@ -82,6 +83,7 @@ pub(crate) async fn handle<'p, P: HsmPal>(
     pal: &'p P,
     io: &impl HsmIo,
     req_buf: &DmaBuf,
+    undo: &mut UndoLog<'p>,
 ) -> HsmResult<&'p DmaBuf> {
     let ParsedRequest {
         role,
@@ -139,6 +141,10 @@ pub(crate) async fn handle<'p, P: HsmPal>(
             pk_resp,
         )
         .await?;
+        // Record the just-created Pending session's teardown inverse, so a
+        // failure below (MAC, response encode, or the CQE post) reverts it
+        // via the dispatcher's undo walk rather than leaking the slot.
+        undo.push_session_destroy(slot)?;
         let session_id = u16::from(slot);
 
         // ── Phase-1 confirm MAC ────────────────────────────────────

--- a/fw/core/lib/src/io.rs
+++ b/fw/core/lib/src/io.rs
@@ -46,6 +46,9 @@ use azihsm_fw_ddi_mbor_api::DdiDecoder;
 use azihsm_fw_ddi_mbor_types::DdiReqHdr;
 use azihsm_fw_ddi_tbor::RequestView as TborRequestView;
 use azihsm_fw_hsm_oob::OobPtr;
+use azihsm_fw_hsm_undo::UndoLog;
+use azihsm_fw_hsm_undo::WalkOutcome;
+use azihsm_fw_hsm_undo::UNDO_LOG_SIZE;
 
 use super::*;
 
@@ -68,11 +71,20 @@ impl<P: HsmPal> Hsm<P> {
         // and dispatch.
         let (op, validated) = Self::init_cqe_from_sqe(&mut io);
 
+        // The per-command undo log (TBOR only), owned here so it outlives
+        // `complete_io` and the post-completion walk.  Stays `None` for
+        // MBOR / flush / invalid SQEs; a TBOR command binds it on entry and
+        // **fails before mutating** if its DMA buffer can't be carved.
+        let mut undo: Option<UndoLog<'_>> = None;
+
         let op_result = match validated {
             Err(e) => Err(e),
             Ok(()) => match op {
                 OP_MBOR => self.handle_mbor_op(&mut io).await,
-                OP_TBOR => self.handle_tbor_op(&mut io).await,
+                OP_TBOR => match self.bind_undo(&io) {
+                    Ok(log) => self.handle_tbor_op(&mut io, undo.insert(log)).await,
+                    Err(e) => Err(e),
+                },
                 OP_FLUSH => self.handle_flush_op(&mut io).await,
                 _ => Err(OpError::new(
                     HsmError::UnsupportedCmd,
@@ -80,16 +92,77 @@ impl<P: HsmPal> Hsm<P> {
                 )),
             },
         };
+        let handler_ok = op_result.is_ok();
         Self::finalize_cqe(&mut io, op_result);
 
-        if let Err(_e) = self.pal().complete_io(io).await {
-            error!(
-                "core",
-                HsmError::CompleteIoFailure,
-                "complete_io failed: {:?}",
-                _e
-            );
+        // Post the completion (CQE) to the host, then run the undo/commit
+        // walk, then free the slot.  Splitting `complete_io` from
+        // `drop_io` lets the walk run over `io` *after* the CQE post, so a
+        // failed post reverts too.
+        let cqe_ok = match self.pal().complete_io(&mut io).await {
+            Ok(()) => true,
+            Err(_e) => {
+                error!(
+                    "core",
+                    HsmError::CompleteIoFailure,
+                    "complete_io failed: {:?}",
+                    _e
+                );
+                false
+            }
+        };
+
+        // Walk the undo log (TBOR only): commit iff the handler succeeded
+        // *and* the CQE posted; otherwise revert unconditionally.  Safe
+        // without a lock or generation check — admin teardown can't race an
+        // in-flight IO, and this walk runs before `drop_io` frees the slot.
+        if let Some(log) = undo {
+            let outcome = if handler_ok && cqe_ok {
+                log.apply_commit(self.pal(), &io).await
+            } else {
+                log.apply_undo(self.pal(), &io).await
+            };
+            if outcome == WalkOutcome::Poisoned {
+                // A consistency-critical restore failed: the partition's
+                // in-memory state is incoherent.  Quarantine it (Faulted) so
+                // the enable gate drops all further host IO until a
+                // free/realloc (or reboot) clears the fault.
+                error!(
+                    "core",
+                    HsmError::InternalError,
+                    "undo walk poisoned partition {:?}",
+                    io.pid()
+                );
+                if crate::part_state::part_set_faulted(self.pal(), &io).is_err() {
+                    error!(
+                        "core",
+                        HsmError::InternalError,
+                        "failed to fault poisoned partition {:?}",
+                        io.pid()
+                    );
+                }
+            }
         }
+
+        if let Err(_e) = self.pal().drop_io(io).await {
+            error!("core", HsmError::DropIoFailure, "drop_io failed: {:?}", _e);
+        }
+    }
+
+    /// Bind the per-command undo log for a TBOR command, carved from `io`'s
+    /// DMA heap.
+    ///
+    /// [`UNDO_LOG_SIZE`] bytes are taken from `io`'s DMA heap so the byte
+    /// pre-images the undo walk restores are DMA-accessible.  The undo log
+    /// is **mandatory**: if the buffer can't be carved, the command fails
+    /// here (`ALLOC_ERR`) *before* mutating any partition state, rather than
+    /// running with no rollback.
+    fn bind_undo<'s>(&'s self, io: &P::Io) -> Result<UndoLog<'s>, OpError> {
+        let buf = self
+            .pal()
+            .dma_alloc(io, UNDO_LOG_SIZE)
+            .op_status(HostStatus::ALLOC_ERR)?;
+        Ok(UndoLog::new(buf))
     }
 
     /// Returns `true` if the partition for this IO can accept host traffic.
@@ -245,7 +318,11 @@ impl<P: HsmPal> Hsm<P> {
     /// (built by the per-opcode handlers via the encoder API). For now,
     /// dispatch errors that cannot construct a typed error response
     /// surface as CQE-level host status codes.
-    async fn handle_tbor_op(&self, io: &mut P::Io) -> Result<HsmOpStatus, OpError> {
+    async fn handle_tbor_op<'s>(
+        &'s self,
+        io: &mut P::Io,
+        undo: &mut UndoLog<'s>,
+    ) -> Result<HsmOpStatus, OpError> {
         let params = Self::decode_io_sqe(io)?;
         let split = params.src_len.next_multiple_of(4);
         let req_buf = self
@@ -303,6 +380,7 @@ impl<P: HsmPal> Hsm<P> {
                     opcode,
                     params.sqe_session_id,
                     params.oob,
+                    undo,
                 )
                 .await;
                 let resp: &DmaBuf = dispatch_result.or_else(|err| {

--- a/fw/core/lib/src/part_state.rs
+++ b/fw/core/lib/src/part_state.rs
@@ -137,17 +137,54 @@ pub fn part_state(pal: &impl HsmPartitionManager, io: &impl HsmIo) -> HsmResult<
     PartState::from_u8(raw).ok_or(HsmError::InternalError)
 }
 
+/// Presence probe for an `AbsentUntilSet` property slot.
+///
+/// Maps a getter result to a presence flag: `Ok(true)` when the getter
+/// succeeds, `Ok(false)` **only** for [`HsmError::PartPropNotFound`]
+/// (the slot is genuinely absent), and propagates every other read error
+/// so a real fault (e.g. internal corruption / IO failure) is never
+/// silently misread as "absent".  Mirrors the pattern used by
+/// [`part_is_provisioned`].
+#[inline]
+pub(crate) fn prop_present<T>(result: HsmResult<T>) -> HsmResult<bool> {
+    match result {
+        Ok(_) => Ok(true),
+        Err(HsmError::PartPropNotFound) => Ok(false),
+        Err(e) => Err(e),
+    }
+}
+
 /// Set the partition lifecycle state.
 ///
-/// Wraps [`PartPropId::STATE`].  The PAL impl is responsible for
-/// rejecting any state byte that violates the partition's allowed
-/// transition graph — this wrapper performs no validation of its
-/// own and serialises the discriminant directly.
+/// Wraps [`PartPropId::STATE`].  **Transition policy lives here, in the
+/// upper layer:** the generic PAL `part_prop_set_u8(STATE)` is a raw
+/// mechanism (it writes the discriminant directly), so the undo log can
+/// restore any prior state through it.  This wrapper accepts only the two
+/// caller-facing transitions — `Enabled → Initializing` (`PartInit`,
+/// which additionally requires the four write-once provisioning fields —
+/// PTA key, UPS key, policy hash, POTA thumbprint — to be present) and
+/// `Initializing → Initialized` (`PartFinal`).  A same-state write is a
+/// no-op; any other pair is rejected with [`HsmError::InvalidArg`].
 pub fn part_set_state(
     pal: &impl HsmPartitionManager,
     io: &impl HsmIo,
     s: PartState,
 ) -> HsmResult<()> {
+    let current = part_state(pal, io)?;
+    match (current, s) {
+        (PartState::Enabled, PartState::Initializing) => {
+            let provisioned = prop_present(part_pta_key_id(pal, io))?
+                && prop_present(part_ups_key_id(pal, io))?
+                && prop_present(part_policy_hash(pal, io))?
+                && prop_present(part_pota_thumbprint(pal, io))?;
+            if !provisioned {
+                return Err(HsmError::InvalidArg);
+            }
+        }
+        (PartState::Initializing, PartState::Initialized) => {}
+        (cur, tgt) if cur == tgt => return Ok(()),
+        _ => return Err(HsmError::InvalidArg),
+    }
     pal.part_prop_set_u8(io, PartPropId::STATE, s as u8)
 }
 
@@ -155,6 +192,19 @@ pub fn part_set_state(
 #[inline]
 pub const fn part_state_prop_id() -> PartPropId {
     PartPropId::STATE
+}
+
+/// Quarantine the partition by forcing it to [`PartState::Faulted`].
+///
+/// Called by the dispatcher when an undo walk reports a poisoned
+/// (consistency-critical) failure: the partition's in-memory state is
+/// incoherent, so it is fenced off — the `partition_enabled` gate then drops
+/// all further host IO, and neither `PartInit`/`PartFinal` nor an admin
+/// `PfnEnable` can transition out of `Faulted`.  Only a free/realloc cycle
+/// (or reboot) clears it.  Uses the raw STATE setter because this is an
+/// out-of-band fault transition, not a normal lifecycle step.
+pub fn part_set_faulted(pal: &impl HsmPartitionManager, io: &impl HsmIo) -> HsmResult<()> {
+    pal.part_prop_set_u8(io, PartPropId::STATE, PartState::Faulted as u8)
 }
 
 /// Monotonic partition generation counter.
@@ -276,6 +326,25 @@ fn key_id_set(
     pal.part_prop_set_u16(io, id, u16::from(key_id))
 }
 
+/// Enforce write-once for an `AbsentUntilSet` key-id property.
+///
+/// Write-once is **upper-layer policy**: the generic PAL
+/// `part_prop_set_u16` is a raw mechanism (so the undo log can restore a
+/// prior id), so the typed setters that must be write-once gate on the
+/// current presence here.  Returns `err` if the slot is already
+/// populated, and propagates any non-absent read error.
+fn ensure_key_id_unset(
+    pal: &impl HsmPartitionManager,
+    io: &impl HsmIo,
+    id: PartPropId,
+    err: HsmError,
+) -> HsmResult<()> {
+    if prop_present(key_id_get(pal, io, id))? {
+        return Err(err);
+    }
+    Ok(())
+}
+
 /// Vault id of the partition identity (ECC-P384) key.
 ///
 /// Wraps [`PartPropId::ID_KEY_ID`] (`U16 → HsmKeyId`,
@@ -344,6 +413,7 @@ pub fn part_set_ups_key_id(
     io: &impl HsmIo,
     key_id: HsmKeyId,
 ) -> HsmResult<()> {
+    ensure_key_id_unset(pal, io, PartPropId::UPS_KEY_ID, HsmError::UpsKeyAlreadySet)?;
     key_id_set(pal, io, PartPropId::UPS_KEY_ID, key_id)
 }
 
@@ -367,6 +437,7 @@ pub fn part_set_pta_key_id(
     io: &impl HsmIo,
     key_id: HsmKeyId,
 ) -> HsmResult<()> {
+    ensure_key_id_unset(pal, io, PartPropId::PTA_KEY_ID, HsmError::PtaKeyAlreadySet)?;
     key_id_set(pal, io, PartPropId::PTA_KEY_ID, key_id)
 }
 
@@ -1046,7 +1117,7 @@ pub fn part_set_pta_key(
     pub_sec1: &DmaBuf,
 ) -> HsmResult<()> {
     let raw = pta_sec1_to_raw(pub_sec1)?;
-    key_id_set(pal, io, PartPropId::PTA_KEY_ID, key_id)?;
+    part_set_pta_key_id(pal, io, key_id)?;
     pal.part_prop_set_bytes(io, PartPropId::PTA_PUB_KEY, raw)
 }
 

--- a/fw/core/undo/Cargo.toml
+++ b/fw/core/undo/Cargo.toml
@@ -1,0 +1,16 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+[package]
+edition = "2021"
+name = "azihsm_fw_hsm_undo"
+version = "0.1.0"
+
+[lib]
+doctest = false
+
+[dependencies]
+azihsm_fw_hsm_pal_traits = { workspace = true }
+
+[lints]
+workspace = true

--- a/fw/core/undo/src/lib.rs
+++ b/fw/core/undo/src/lib.rs
@@ -1,0 +1,981 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Unified undo log — the dual-semantics rollback engine.
+//!
+//! A command (host-IO or Admin-IPC) drives state changes *optimistically*
+//! through plain PAL verbs and records, next to each mutation, an
+//! [`UndoLog`] entry describing how to **reverse** it on failure and how
+//! to **finalise** it on success.  The dispatcher walks the log once at
+//! command completion:
+//!
+//! - success → [`UndoLog::apply_commit`] (FIFO): finalise (e.g. zeroise a
+//!   soft-deleted key);
+//! - failure → [`UndoLog::apply_undo`] (LIFO): reverse every mutation.
+//!
+//! The PAL stays **undo-unaware**: the walk drives the same id-keyed verbs
+//! handlers use, via the narrow [`UndoVerbs`] adapter (blanket-implemented
+//! for any [`HsmVault`] + [`HsmPartitionManager`]).  The log lives in a
+//! leaf crate so both core (host) and a platform PAL (admin) can own one.
+//!
+//! # Backing buffer
+//!
+//! Entry slots (a fixed [`ENTRY_SIZE`] bytes each: `tag`/`aux`/`id`/`data`)
+//! and variable byte pre-images share **one** buffer, packed from opposite
+//! ends — slots up from the front, pre-images down from the back.  An
+//! entry's `data` holds an inline scalar or a packed `{offset, len}` handle
+//! into the back arena.
+//!
+//! # Failure policy
+//!
+//! See [`FailurePolicy`].  Reversing a *logical* change (re-enable a key,
+//! restore a property) must succeed → a failure **poisons** the partition;
+//! finalising *physical cleanup* (zeroise) that fails leaves only a benign
+//! orphan → **best-effort** + reclaim by the recovery sweep.
+
+#![no_std]
+// The narrow `UndoVerbs` adapter mirrors the PAL's own `async fn` vault
+// methods; an explicit future type buys nothing here.
+#![allow(async_fn_in_trait)]
+
+use azihsm_fw_hsm_pal_traits::DmaBuf;
+use azihsm_fw_hsm_pal_traits::HsmError;
+use azihsm_fw_hsm_pal_traits::HsmIo;
+use azihsm_fw_hsm_pal_traits::HsmKeyId;
+use azihsm_fw_hsm_pal_traits::HsmPartitionManager;
+use azihsm_fw_hsm_pal_traits::HsmResult;
+use azihsm_fw_hsm_pal_traits::HsmSessId;
+use azihsm_fw_hsm_pal_traits::HsmSessionManager;
+use azihsm_fw_hsm_pal_traits::HsmVault;
+use azihsm_fw_hsm_pal_traits::PartPropId;
+use azihsm_fw_hsm_pal_traits::PartPropKind;
+
+/// Serialized size of one undo entry slot in the backing buffer (bytes).
+pub const ENTRY_SIZE: usize = 8;
+
+/// Recommended per-command entry budget.
+///
+/// The busiest command (`PartInit`) needs ~10 entries, so 16 leaves
+/// headroom.  Entry slots and the byte arena share one buffer
+/// (double-ended), so this is a sizing guide, not a hard cap.
+pub const MAX_UNDO_ACTIONS: usize = 16;
+
+/// Recommended byte-arena allowance (bytes) for property pre-images.
+///
+/// Most undos carry no payload (id-only or inline scalar); only an
+/// overwrite of an already-set byte property (e.g. a 32-byte PSK) spends
+/// arena, so 128 bytes comfortably covers the partition/vault commands.
+pub const UNDO_ARENA: usize = 128;
+
+/// Recommended single-buffer size (bytes) for [`UndoLog::new`].
+///
+/// The dispatcher allocates this much from the per-io heap (or a per-opcode
+/// amount) and hands the slice to [`UndoLog::new`], which packs
+/// [`ENTRY_SIZE`]-byte entry slots up from the front and byte pre-images
+/// down from the back: `16 × 8 + 128 = 256`.
+pub const UNDO_LOG_SIZE: usize = MAX_UNDO_ACTIONS * ENTRY_SIZE + UNDO_ARENA;
+
+// ── `tag` byte encoding ──────────────────────────────────────────────
+//
+//   bits[2:0] kind   bits[4:3] mode (PropRestore only)   bits[7:5] spare
+const KIND_MASK: u8 = 0b0000_0111;
+const KIND_VAULT_CREATE: u8 = 0;
+const KIND_VAULT_DISABLE: u8 = 1;
+const KIND_PROP_RESTORE: u8 = 2;
+const KIND_SESSION_DESTROY: u8 = 3;
+
+const MODE_SHIFT: u8 = 3;
+const MODE_MASK: u8 = 0b0000_0011;
+const MODE_ABSENT: u8 = 0;
+const MODE_SCALAR: u8 = 1;
+const MODE_BYTES: u8 = 2;
+
+/// One undo record, serialized to [`ENTRY_SIZE`] little-endian bytes.
+///
+/// | field  | bytes | meaning                                            |
+/// |--------|-------|----------------------------------------------------|
+/// | `tag`  | 1     | action kind + (for `PropRestore`) the `data` mode  |
+/// | `aux`  | 1     | reserved (0 today)                                 |
+/// | `id`   | 2     | [`HsmKeyId`] or [`PartPropId`] raw value           |
+/// | `data` | 4     | inline scalar, or packed `{offset:u16, len:u16}`   |
+#[derive(Clone, Copy)]
+struct UndoEntry {
+    tag: u8,
+    /// Reserved (used by the session actions added in P3, e.g. a
+    /// `SessionPropId`); written as 0 today.
+    aux: u8,
+    id: u16,
+    data: u32,
+}
+
+impl UndoEntry {
+    #[inline]
+    fn kind(&self) -> u8 {
+        self.tag & KIND_MASK
+    }
+
+    #[inline]
+    fn mode(&self) -> u8 {
+        (self.tag >> MODE_SHIFT) & MODE_MASK
+    }
+
+    #[inline]
+    fn vault_create(id: HsmKeyId) -> Self {
+        Self {
+            tag: KIND_VAULT_CREATE,
+            aux: 0,
+            id: u16::from(id),
+            data: 0,
+        }
+    }
+
+    #[inline]
+    fn vault_disable(id: HsmKeyId) -> Self {
+        Self {
+            tag: KIND_VAULT_DISABLE,
+            aux: 0,
+            id: u16::from(id),
+            data: 0,
+        }
+    }
+
+    #[inline]
+    fn session_destroy(id: HsmSessId) -> Self {
+        Self {
+            tag: KIND_SESSION_DESTROY,
+            aux: 0,
+            id: u16::from(id),
+            data: 0,
+        }
+    }
+
+    #[inline]
+    fn prop_restore_absent(id: PartPropId) -> Self {
+        Self {
+            tag: KIND_PROP_RESTORE | (MODE_ABSENT << MODE_SHIFT),
+            aux: 0,
+            id: id.raw(),
+            data: 0,
+        }
+    }
+
+    #[inline]
+    fn prop_restore_scalar(id: PartPropId, prior: u32) -> Self {
+        Self {
+            tag: KIND_PROP_RESTORE | (MODE_SCALAR << MODE_SHIFT),
+            aux: 0,
+            id: id.raw(),
+            data: prior,
+        }
+    }
+
+    #[inline]
+    fn prop_restore_bytes(id: PartPropId, handle: u32) -> Self {
+        Self {
+            tag: KIND_PROP_RESTORE | (MODE_BYTES << MODE_SHIFT),
+            aux: 0,
+            id: id.raw(),
+            data: handle,
+        }
+    }
+
+    /// Serialize into an [`ENTRY_SIZE`]-byte slot (little-endian).
+    #[inline]
+    fn write(&self, slot: &mut [u8]) {
+        slot[0] = self.tag;
+        slot[1] = self.aux;
+        slot[2..4].copy_from_slice(&self.id.to_le_bytes());
+        slot[4..8].copy_from_slice(&self.data.to_le_bytes());
+    }
+
+    /// Deserialize from an [`ENTRY_SIZE`]-byte slot (little-endian).
+    #[inline]
+    fn read(slot: &[u8]) -> Self {
+        Self {
+            tag: slot[0],
+            aux: slot[1],
+            id: u16::from_le_bytes([slot[2], slot[3]]),
+            data: u32::from_le_bytes([slot[4], slot[5], slot[6], slot[7]]),
+        }
+    }
+}
+
+#[inline]
+fn pack_bytes_handle(offset: usize, len: usize) -> HsmResult<u32> {
+    if offset > usize::from(u16::MAX) || len > usize::from(u16::MAX) {
+        return Err(HsmError::UndoLogFull);
+    }
+    Ok(((offset as u32) << 16) | (len as u32))
+}
+
+#[inline]
+fn unpack_bytes_handle(handle: u32) -> (usize, usize) {
+    ((handle >> 16) as usize, (handle & 0xFFFF) as usize)
+}
+
+/// What to do when an [`UndoLog`] walk step's verb fails mid-walk.
+///
+/// One rule decides it: failures of operations that *restore logical
+/// consistency* (re-enable, prop restore) poison; failures of *physical
+/// cleanup* (zeroise/delete of already-removed material) are best-effort.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum FailurePolicy {
+    /// Benign orphan → log and continue; reclaimed by the recovery sweep.
+    BestEffort,
+    /// In-memory state is now incoherent → fail closed (poison).
+    Poison,
+}
+
+/// Result of an [`UndoLog`] walk.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+#[must_use]
+pub enum WalkOutcome {
+    /// Every step succeeded (or failed best-effort).
+    Ok,
+    /// A `Poison`-class step failed; the dispatcher must quarantine the
+    /// partition (set `Faulted`) and reject further commands until reset.
+    Poisoned,
+}
+
+/// Per-command undo log — the inverse actions to roll a command back.
+///
+/// Borrows a **single** backing buffer from the per-command io heap
+/// (`io.alloc`) and packs it **double-ended**: fixed [`ENTRY_SIZE`]-byte
+/// entry slots grow up from the front, variable byte pre-images grow down
+/// from the back, meeting in the middle.  The log therefore costs **no
+/// fixed memory** and is sized per-opcode ([`UNDO_LOG_SIZE`] by default, 0
+/// for read-only commands).  Lifetime `'a` ties the buffer to the command
+/// scope.
+///
+/// The command runs **lock-free** (see the crate's concurrency model):
+/// rollback safety comes from structural invariants, not a lock or a
+/// generation counter.  Admin teardown cannot race an in-flight host IO
+/// (a partition can't be disabled/freed while host IOs are outstanding,
+/// and the undo walk runs before the io is dropped), and host↔host
+/// overlap is resolved by the handlers' guards-first sync commit — so the
+/// log carries no partition lock guard.
+pub struct UndoLog<'a> {
+    /// Double-ended backing: entry slots front, byte arena back.
+    buf: &'a mut DmaBuf,
+    /// Entry slots used (each [`ENTRY_SIZE`] bytes, from the front).
+    nentries: usize,
+    /// Bytes used by the pre-image arena (from the back).
+    arena_used: usize,
+}
+
+impl<'a> UndoLog<'a> {
+    /// Create an empty log over a single caller-provided [`DmaBuf`].
+    ///
+    /// `buf.len()` bounds the combined cost of entry slots ([`ENTRY_SIZE`]
+    /// bytes each, from the front) and byte pre-images (from the back).
+    /// The dispatcher carves `buf` from the per-io DMA heap (sized from
+    /// [`UNDO_LOG_SIZE`] / a per-opcode table); tests pass a fixed array
+    /// branded as a `DmaBuf`. A `DmaBuf` is required (not a plain slice)
+    /// so the log's internal `zeroize` on walk completion can securely
+    /// scrub captured secret pre-images with volatile writes.
+    pub fn new(buf: &'a mut DmaBuf) -> Self {
+        Self {
+            buf,
+            nentries: 0,
+            arena_used: 0,
+        }
+    }
+
+    /// `true` if no entries have been pushed.
+    pub fn is_empty(&self) -> bool {
+        self.nentries == 0
+    }
+
+    /// Number of entries pushed.
+    pub fn len(&self) -> usize {
+        self.nentries
+    }
+
+    /// Reset the log (success path discards it after the commit walk; the
+    /// dispatcher calls this once per command regardless of outcome).
+    pub fn discard(&mut self) {
+        self.nentries = 0;
+        self.arena_used = 0;
+    }
+
+    /// Deserialize the `i`th entry slot from the front of the buffer.
+    fn entry_at(&self, i: usize) -> UndoEntry {
+        let o = i * ENTRY_SIZE;
+        UndoEntry::read(&self.buf[o..o + ENTRY_SIZE])
+    }
+
+    /// Append an entry slot, given `extra` further arena bytes must also
+    /// fit (the byte-payload pushes reserve their bytes here).  Fails with
+    /// [`HsmError::UndoLogFull`] if the slots (front) would overrun the
+    /// arena (back).
+    fn push_entry_reserving(&mut self, entry: UndoEntry, extra: usize) -> HsmResult<()> {
+        let slots_end = self
+            .nentries
+            .checked_add(1)
+            .and_then(|n| n.checked_mul(ENTRY_SIZE))
+            .ok_or(HsmError::UndoLogFull)?;
+        let back = self
+            .arena_used
+            .checked_add(extra)
+            .ok_or(HsmError::UndoLogFull)?;
+        if slots_end.checked_add(back).ok_or(HsmError::UndoLogFull)? > self.buf.len() {
+            return Err(HsmError::UndoLogFull);
+        }
+        let o = self.nentries * ENTRY_SIZE;
+        entry.write(&mut self.buf[o..o + ENTRY_SIZE]);
+        self.nentries += 1;
+        Ok(())
+    }
+
+    fn push_entry(&mut self, entry: UndoEntry) -> HsmResult<()> {
+        self.push_entry_reserving(entry, 0)
+    }
+
+    /// Record that a vault key was **created**.
+    ///
+    /// undo → delete (zeroise) the new key; commit → keep.
+    pub fn push_vault_create(&mut self, id: HsmKeyId) -> HsmResult<()> {
+        self.push_entry(UndoEntry::vault_create(id))
+    }
+
+    /// Record that a vault key was **disabled** (soft-deleted).
+    ///
+    /// undo → re-enable; commit → delete (zeroise).
+    pub fn push_vault_disable(&mut self, id: HsmKeyId) -> HsmResult<()> {
+        self.push_entry(UndoEntry::vault_disable(id))
+    }
+
+    /// Record that a session was **created** (or promoted from Pending).
+    ///
+    /// undo → destroy the session (its slot + backing vault keys); commit →
+    /// keep.  The inverse is the coarse [`HsmSessionManager::session_destroy`]
+    /// (the PAL session ops manage slot + vault together), which is exactly
+    /// what the handlers' bespoke rollback used before conversion.
+    pub fn push_session_destroy(&mut self, id: HsmSessId) -> HsmResult<()> {
+        self.push_entry(UndoEntry::session_destroy(id))
+    }
+
+    /// Record that a property was set while previously **absent**.
+    ///
+    /// undo → clear the slot; commit → keep.
+    pub fn push_prop_restore_absent(&mut self, id: PartPropId) -> HsmResult<()> {
+        self.push_entry(UndoEntry::prop_restore_absent(id))
+    }
+
+    /// Record a scalar property's **prior value** (`U8`/`U16`/`U32`/`Bool`,
+    /// widened to `u32`).
+    ///
+    /// undo → write `prior` back (raw, overwriting); commit → keep.
+    pub fn push_prop_restore_scalar(&mut self, id: PartPropId, prior: u32) -> HsmResult<()> {
+        self.push_entry(UndoEntry::prop_restore_scalar(id, prior))
+    }
+
+    /// Record a byte property's **prior bytes** (copied into the arena).
+    ///
+    /// undo → write the bytes back; commit → keep.  Fails with
+    /// [`HsmError::UndoLogFull`] if the buffer cannot hold the slot plus
+    /// `prior`.
+    pub fn push_prop_restore_bytes(&mut self, id: PartPropId, prior: &[u8]) -> HsmResult<()> {
+        let len = prior.len();
+        // Pre-images sit at the back; this one's offset is from the start.
+        let new_arena_used = self
+            .arena_used
+            .checked_add(len)
+            .ok_or(HsmError::UndoLogFull)?;
+        let off = self
+            .buf
+            .len()
+            .checked_sub(new_arena_used)
+            .ok_or(HsmError::UndoLogFull)?;
+        let handle = pack_bytes_handle(off, len)?;
+        // Reserve the slot AND the arena bytes in one overflow check; only
+        // then copy the payload, so a full log never leaks arena.
+        self.push_entry_reserving(UndoEntry::prop_restore_bytes(id, handle), len)?;
+        self.buf[off..off + len].copy_from_slice(prior);
+        self.arena_used = new_arena_used;
+        Ok(())
+    }
+
+    fn bytes_from_handle(&self, handle: u32) -> HsmResult<&DmaBuf> {
+        let (off, len) = unpack_bytes_handle(handle);
+        let end = off.checked_add(len).ok_or(HsmError::InvalidArg)?;
+        if end > self.buf.len() {
+            return Err(HsmError::InvalidArg);
+        }
+        // `self.buf` is a `&mut DmaBuf`; indexing a `DmaBuf` by range yields
+        // a `DmaBuf` sub-view, so this stays DMA-typed with no re-branding.
+        Ok(&self.buf[off..end])
+    }
+
+    /// Reverse every recorded mutation, **LIFO** (failure path).
+    ///
+    /// Consumes the log.  Returns [`WalkOutcome::Poisoned`] if any
+    /// `Poison`-class step failed; the walk always runs to completion
+    /// (best-effort for the rest).  Zeroizes the backing buffer last, so
+    /// any captured secret pre-image (e.g. a prior PSK) does not linger.
+    pub async fn apply_undo<V: UndoVerbs>(mut self, verbs: &V, io: &impl HsmIo) -> WalkOutcome {
+        let mut outcome = WalkOutcome::Ok;
+        let mut i = self.nentries;
+        while i > 0 {
+            i -= 1;
+            let entry = self.entry_at(i);
+            if self.undo_one(&entry, verbs, io).await.is_err()
+                && undo_policy(entry.kind()) == FailurePolicy::Poison
+            {
+                outcome = WalkOutcome::Poisoned;
+            }
+        }
+        self.zeroize();
+        outcome
+    }
+
+    /// Finalise every recorded mutation, **FIFO** (success path).
+    ///
+    /// Consumes the log.  All commit-side failures are best-effort
+    /// (benign orphans), so this always returns [`WalkOutcome::Ok`]; the
+    /// return type mirrors [`apply_undo`](Self::apply_undo) for a uniform
+    /// dispatcher.  Zeroizes the backing buffer last, so any captured
+    /// secret pre-image (e.g. a prior PSK) does not linger.
+    pub async fn apply_commit<V: UndoVerbs>(mut self, verbs: &V, io: &impl HsmIo) -> WalkOutcome {
+        for i in 0..self.nentries {
+            let entry = self.entry_at(i);
+            // Best-effort: a failed zeroise leaves a benign orphan.
+            let _ = self.commit_one(&entry, verbs, io).await;
+        }
+        self.zeroize();
+        WalkOutcome::Ok
+    }
+
+    /// Scrub the backing buffer (entries + arena) before the borrow ends,
+    /// so captured secret pre-images do not linger in the per-IO DMA heap
+    /// (which is only watermark-reset, not cleared, on the next IO).
+    fn zeroize(&mut self) {
+        // Delegate to `DmaBuf::zeroize`, which uses per-byte volatile
+        // writes + a compiler fence so the wipe cannot be elided even
+        // though these bytes are never read again through this reference.
+        self.buf.zeroize();
+        self.nentries = 0;
+        self.arena_used = 0;
+    }
+
+    async fn undo_one<V: UndoVerbs>(
+        &self,
+        entry: &UndoEntry,
+        verbs: &V,
+        io: &impl HsmIo,
+    ) -> HsmResult<()> {
+        match entry.kind() {
+            KIND_VAULT_CREATE => verbs.vault_delete(io, HsmKeyId::from(entry.id)).await,
+            KIND_VAULT_DISABLE => verbs.vault_enable(io, HsmKeyId::from(entry.id)),
+            KIND_PROP_RESTORE => {
+                let id = PartPropId::from_raw(entry.id);
+                match entry.mode() {
+                    MODE_ABSENT => verbs.prop_clear(io, id),
+                    MODE_SCALAR => {
+                        let meta = id.meta().ok_or(HsmError::InvalidArg)?;
+                        match meta.kind {
+                            PartPropKind::U8 => verbs.prop_set_u8(io, id, entry.data as u8),
+                            PartPropKind::U16 => verbs.prop_set_u16(io, id, entry.data as u16),
+                            PartPropKind::U32 => verbs.prop_set_u32(io, id, entry.data),
+                            PartPropKind::Bool => verbs.prop_set_bool(io, id, entry.data != 0),
+                            _ => Err(HsmError::InvalidArg),
+                        }
+                    }
+                    MODE_BYTES => {
+                        let bytes = self.bytes_from_handle(entry.data)?;
+                        verbs.prop_set_bytes(io, id, bytes)
+                    }
+                    _ => Err(HsmError::InvalidArg),
+                }
+            }
+            KIND_SESSION_DESTROY => verbs.session_destroy(io, HsmSessId::from(entry.id)).await,
+            _ => Err(HsmError::InvalidArg),
+        }
+    }
+
+    async fn commit_one<V: UndoVerbs>(
+        &self,
+        entry: &UndoEntry,
+        verbs: &V,
+        io: &impl HsmIo,
+    ) -> HsmResult<()> {
+        match entry.kind() {
+            // Finalise a soft-delete: zeroise the retired key.
+            KIND_VAULT_DISABLE => verbs.vault_delete(io, HsmKeyId::from(entry.id)).await,
+            // VaultCreate / PropRestore: the live writes already stand.
+            _ => Ok(()),
+        }
+    }
+}
+
+/// Failure policy for the **undo** (failure-path) side of an action.
+///
+/// Commit-side failures are uniformly [`FailurePolicy::BestEffort`].
+fn undo_policy(kind: u8) -> FailurePolicy {
+    match kind {
+        // undo = delete the freshly-created key; a failure orphans a key
+        // that was never observable → benign.
+        KIND_VAULT_CREATE => FailurePolicy::BestEffort,
+        // undo = destroy the freshly-created session; a failure leaks a
+        // never-established session slot → benign (reclaimed on teardown).
+        KIND_SESSION_DESTROY => FailurePolicy::BestEffort,
+        // undo = re-enable / restore: must succeed for consistency.
+        _ => FailurePolicy::Poison,
+    }
+}
+
+/// The narrow set of PAL verbs the undo walk drives.
+///
+/// Blanket-implemented for any [`HsmVault`] + [`HsmPartitionManager`], so
+/// the engine never names the full `HsmPal` super-trait and tests can
+/// supply a tiny mock.  The PAL stays undo-unaware — these map onto the
+/// same id-keyed verbs handlers already use.
+pub trait UndoVerbs {
+    /// Delete (zeroise) a vault key.
+    async fn vault_delete(&self, io: &impl HsmIo, id: HsmKeyId) -> HsmResult<()>;
+    /// Re-enable a soft-deleted (disabled) vault key.
+    fn vault_enable(&self, io: &impl HsmIo, id: HsmKeyId) -> HsmResult<()>;
+    /// Clear a property slot (restore-to-absent).
+    fn prop_clear(&self, io: &impl HsmIo, id: PartPropId) -> HsmResult<()>;
+    /// Restore a `U8` property.
+    fn prop_set_u8(&self, io: &impl HsmIo, id: PartPropId, value: u8) -> HsmResult<()>;
+    /// Restore a `U16` property.
+    fn prop_set_u16(&self, io: &impl HsmIo, id: PartPropId, value: u16) -> HsmResult<()>;
+    /// Restore a `U32` property.
+    fn prop_set_u32(&self, io: &impl HsmIo, id: PartPropId, value: u32) -> HsmResult<()>;
+    /// Restore a `Bool` property.
+    fn prop_set_bool(&self, io: &impl HsmIo, id: PartPropId, value: bool) -> HsmResult<()>;
+    /// Restore a byte property from arena bytes.
+    fn prop_set_bytes(&self, io: &impl HsmIo, id: PartPropId, data: &DmaBuf) -> HsmResult<()>;
+    /// Destroy a session (its slot + backing vault keys) — the coarse
+    /// inverse of session create/promote.
+    async fn session_destroy(&self, io: &impl HsmIo, id: HsmSessId) -> HsmResult<()>;
+}
+
+impl<P> UndoVerbs for P
+where
+    P: HsmVault + HsmPartitionManager + HsmSessionManager,
+{
+    async fn vault_delete(&self, io: &impl HsmIo, id: HsmKeyId) -> HsmResult<()> {
+        HsmVault::vault_key_delete(self, io, id).await
+    }
+
+    fn vault_enable(&self, io: &impl HsmIo, id: HsmKeyId) -> HsmResult<()> {
+        HsmVault::vault_key_enable(self, io, id)
+    }
+
+    fn prop_clear(&self, io: &impl HsmIo, id: PartPropId) -> HsmResult<()> {
+        HsmPartitionManager::part_prop_clear(self, io, id)
+    }
+
+    fn prop_set_u8(&self, io: &impl HsmIo, id: PartPropId, value: u8) -> HsmResult<()> {
+        HsmPartitionManager::part_prop_set_u8(self, io, id, value)
+    }
+
+    fn prop_set_u16(&self, io: &impl HsmIo, id: PartPropId, value: u16) -> HsmResult<()> {
+        HsmPartitionManager::part_prop_set_u16(self, io, id, value)
+    }
+
+    fn prop_set_u32(&self, io: &impl HsmIo, id: PartPropId, value: u32) -> HsmResult<()> {
+        HsmPartitionManager::part_prop_set_u32(self, io, id, value)
+    }
+
+    fn prop_set_bool(&self, io: &impl HsmIo, id: PartPropId, value: bool) -> HsmResult<()> {
+        HsmPartitionManager::part_prop_set_bool(self, io, id, value)
+    }
+
+    fn prop_set_bytes(&self, io: &impl HsmIo, id: PartPropId, data: &DmaBuf) -> HsmResult<()> {
+        // `data` is already a `&DmaBuf` sub-view of the per-IO undo arena
+        // (itself carved from the DMA heap), so no re-branding is needed.
+        HsmPartitionManager::part_prop_set_bytes(self, io, id, data)
+    }
+
+    async fn session_destroy(&self, io: &impl HsmIo, id: HsmSessId) -> HsmResult<()> {
+        HsmSessionManager::session_destroy(self, io, id).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    // `.unwrap()` is the idiomatic assertion in unit tests (repo-wide
+    // convention; `unwrap_used` is denied only in production code).
+    #![allow(clippy::unwrap_used)]
+
+    use core::cell::Cell;
+    use core::cell::RefCell;
+    use core::future::Future;
+    use core::pin::pin;
+    use core::task::Context;
+    use core::task::Poll;
+    use core::task::RawWaker;
+    use core::task::RawWakerVTable;
+    use core::task::Waker;
+
+    use azihsm_fw_hsm_pal_traits::HsmCqe;
+    use azihsm_fw_hsm_pal_traits::HsmPartId;
+    use azihsm_fw_hsm_pal_traits::HsmSqe;
+    use azihsm_fw_hsm_pal_traits::PartState;
+
+    use super::*;
+
+    // ── Poll-once executor (mock verbs complete immediately) ──────────
+    #[allow(unsafe_code)]
+    fn block_on<F: Future>(fut: F) -> F::Output {
+        fn noop(_: *const ()) {}
+        fn clone(_: *const ()) -> RawWaker {
+            RawWaker::new(core::ptr::null(), &VTABLE)
+        }
+        static VTABLE: RawWakerVTable = RawWakerVTable::new(clone, noop, noop, noop);
+        // SAFETY: all vtable ops are no-ops over a null data pointer.
+        let waker = unsafe { Waker::from_raw(RawWaker::new(core::ptr::null(), &VTABLE)) };
+        let mut cx = Context::from_waker(&waker);
+        let mut fut = pin!(fut);
+        loop {
+            if let Poll::Ready(v) = fut.as_mut().poll(&mut cx) {
+                return v;
+            }
+        }
+    }
+
+    #[derive(Default)]
+    struct FakeIo {
+        sqe: HsmSqe,
+        cqe: HsmCqe,
+    }
+
+    impl HsmIo for FakeIo {
+        fn index(&self) -> u16 {
+            0
+        }
+        fn pid(&self) -> HsmPartId {
+            HsmPartId::from(0u8)
+        }
+        fn queue_id(&self) -> u16 {
+            0
+        }
+        fn queue_idx(&self) -> u16 {
+            0
+        }
+        fn sqe(&self) -> &HsmSqe {
+            &self.sqe
+        }
+        fn cqe(&mut self) -> &mut HsmCqe {
+            &mut self.cqe
+        }
+    }
+
+    // Op codes recorded by the mock, in call order.
+    const OP_DELETE: u8 = 1;
+    const OP_ENABLE: u8 = 2;
+    const OP_CLEAR: u8 = 3;
+    const OP_SET_U8: u8 = 4;
+    const OP_SET_U16: u8 = 5;
+    const OP_SET_U32: u8 = 6;
+    const OP_SET_BOOL: u8 = 7;
+    const OP_SET_BYTES: u8 = 8;
+    const OP_SESSION_DESTROY: u8 = 9;
+
+    #[derive(Clone, Copy, Default)]
+    struct Rec {
+        op: u8,
+        id: u16,
+        val: u32,
+    }
+
+    struct MockVerbs {
+        recs: RefCell<[Rec; 32]>,
+        n: Cell<usize>,
+        fail_enable: Cell<bool>,
+        fail_delete: Cell<bool>,
+        fail_session_destroy: Cell<bool>,
+        last_bytes: RefCell<[u8; 64]>,
+        last_bytes_len: Cell<usize>,
+    }
+
+    impl MockVerbs {
+        fn new() -> Self {
+            Self {
+                recs: RefCell::new([Rec::default(); 32]),
+                n: Cell::new(0),
+                fail_enable: Cell::new(false),
+                fail_delete: Cell::new(false),
+                fail_session_destroy: Cell::new(false),
+                last_bytes: RefCell::new([0u8; 64]),
+                last_bytes_len: Cell::new(0),
+            }
+        }
+        fn record(&self, op: u8, id: u16, val: u32) {
+            let i = self.n.get();
+            self.recs.borrow_mut()[i] = Rec { op, id, val };
+            self.n.set(i + 1);
+        }
+        fn rec(&self, i: usize) -> Rec {
+            self.recs.borrow()[i]
+        }
+        fn count(&self) -> usize {
+            self.n.get()
+        }
+
+        fn assert_rec(&self, index: usize, op: u8, id: u16, val: u32) {
+            let rec = self.rec(index);
+            assert_eq!(rec.op, op);
+            assert_eq!(rec.id, id);
+            assert_eq!(rec.val, val);
+        }
+
+        fn assert_last_bytes(&self, expected: &[u8]) {
+            assert_eq!(self.last_bytes_len.get(), expected.len());
+            assert_eq!(&self.last_bytes.borrow()[..expected.len()], expected);
+        }
+    }
+
+    fn run_undo(log: UndoLog<'_>, verbs: &MockVerbs, io: &FakeIo) -> WalkOutcome {
+        block_on(log.apply_undo(verbs, io))
+    }
+
+    fn run_commit(log: UndoLog<'_>, verbs: &MockVerbs, io: &FakeIo) -> WalkOutcome {
+        block_on(log.apply_commit(verbs, io))
+    }
+
+    impl UndoVerbs for MockVerbs {
+        async fn vault_delete(&self, _io: &impl HsmIo, id: HsmKeyId) -> HsmResult<()> {
+            self.record(OP_DELETE, u16::from(id), 0);
+            if self.fail_delete.get() {
+                Err(HsmError::KeyNotFound)
+            } else {
+                Ok(())
+            }
+        }
+        fn vault_enable(&self, _io: &impl HsmIo, id: HsmKeyId) -> HsmResult<()> {
+            self.record(OP_ENABLE, u16::from(id), 0);
+            if self.fail_enable.get() {
+                Err(HsmError::KeyNotFound)
+            } else {
+                Ok(())
+            }
+        }
+        fn prop_clear(&self, _io: &impl HsmIo, id: PartPropId) -> HsmResult<()> {
+            self.record(OP_CLEAR, id.raw(), 0);
+            Ok(())
+        }
+        fn prop_set_u8(&self, _io: &impl HsmIo, id: PartPropId, value: u8) -> HsmResult<()> {
+            self.record(OP_SET_U8, id.raw(), u32::from(value));
+            Ok(())
+        }
+        fn prop_set_u16(&self, _io: &impl HsmIo, id: PartPropId, value: u16) -> HsmResult<()> {
+            self.record(OP_SET_U16, id.raw(), u32::from(value));
+            Ok(())
+        }
+        fn prop_set_u32(&self, _io: &impl HsmIo, id: PartPropId, value: u32) -> HsmResult<()> {
+            self.record(OP_SET_U32, id.raw(), value);
+            Ok(())
+        }
+        fn prop_set_bool(&self, _io: &impl HsmIo, id: PartPropId, value: bool) -> HsmResult<()> {
+            self.record(OP_SET_BOOL, id.raw(), u32::from(value));
+            Ok(())
+        }
+        fn prop_set_bytes(&self, _io: &impl HsmIo, id: PartPropId, data: &DmaBuf) -> HsmResult<()> {
+            self.record(OP_SET_BYTES, id.raw(), data.len() as u32);
+            self.last_bytes.borrow_mut()[..data.len()].copy_from_slice(data);
+            self.last_bytes_len.set(data.len());
+            Ok(())
+        }
+        async fn session_destroy(&self, _io: &impl HsmIo, id: HsmSessId) -> HsmResult<()> {
+            self.record(OP_SESSION_DESTROY, u16::from(id), 0);
+            if self.fail_session_destroy.get() {
+                Err(HsmError::InvalidArg)
+            } else {
+                Ok(())
+            }
+        }
+    }
+
+    // Declares a stack-local backing buffer and a log borrowing it —
+    // mirrors what the dispatcher's `bind_undo` does from the per-io heap.
+    macro_rules! log {
+        ($name:ident) => {
+            let mut buf = [0u8; UNDO_LOG_SIZE];
+            // SAFETY: in-process test heap buffer; branding as a DmaBuf is sound.
+            #[allow(unsafe_code)]
+            let dma = unsafe { DmaBuf::from_raw_mut(&mut buf) };
+            let mut $name: UndoLog<'_> = UndoLog::new(dma);
+        };
+    }
+
+    fn key(v: u16) -> HsmKeyId {
+        HsmKeyId::from(v)
+    }
+
+    #[test]
+    fn undo_walk_is_lifo_and_dispatches() {
+        log!(log);
+        log.push_vault_create(key(11)).unwrap();
+        log.push_prop_restore_scalar(PartPropId::UPS_KEY_ID, 0x42)
+            .unwrap();
+        log.push_vault_disable(key(22)).unwrap();
+
+        let m = MockVerbs::new();
+        let io = FakeIo::default();
+        assert_eq!(run_undo(log, &m, &io), WalkOutcome::Ok);
+
+        // LIFO: disable→enable(22), then prop→set_u16(UPS, 0x42), then create→delete(11).
+        assert_eq!(m.count(), 3);
+        m.assert_rec(0, OP_ENABLE, 22, 0);
+        m.assert_rec(1, OP_SET_U16, PartPropId::UPS_KEY_ID.raw(), 0x42);
+        m.assert_rec(2, OP_DELETE, 11, 0);
+    }
+
+    #[test]
+    fn commit_walk_finalizes_disable_only() {
+        log!(log);
+        log.push_vault_create(key(11)).unwrap();
+        log.push_vault_disable(key(22)).unwrap();
+        log.push_prop_restore_scalar(PartPropId::UPS_KEY_ID, 7)
+            .unwrap();
+
+        let m = MockVerbs::new();
+        let io = FakeIo::default();
+        assert_eq!(run_commit(log, &m, &io), WalkOutcome::Ok);
+
+        // Only the disable finalises (zeroise the retired key); the rest noop.
+        assert_eq!(m.count(), 1);
+        m.assert_rec(0, OP_DELETE, 22, 0);
+    }
+
+    #[test]
+    fn prop_restore_absent_clears_on_undo() {
+        log!(log);
+        log.push_prop_restore_absent(PartPropId::UPS_KEY_ID)
+            .unwrap();
+        let m = MockVerbs::new();
+        let io = FakeIo::default();
+        assert_eq!(run_undo(log, &m, &io), WalkOutcome::Ok);
+        assert_eq!(m.count(), 1);
+        m.assert_rec(0, OP_CLEAR, PartPropId::UPS_KEY_ID.raw(), 0);
+    }
+
+    #[test]
+    fn scalar_restore_picks_kind_width() {
+        log!(log);
+        // STATE is U8, UPS_KEY_ID is U16.
+        log.push_prop_restore_scalar(PartPropId::STATE, PartState::Enabled as u32)
+            .unwrap();
+        log.push_prop_restore_scalar(PartPropId::UPS_KEY_ID, 0x1234)
+            .unwrap();
+        let m = MockVerbs::new();
+        let io = FakeIo::default();
+        assert_eq!(run_undo(log, &m, &io), WalkOutcome::Ok);
+        // LIFO: UPS first (U16), then STATE (U8).
+        m.assert_rec(0, OP_SET_U16, PartPropId::UPS_KEY_ID.raw(), 0x1234);
+        m.assert_rec(
+            1,
+            OP_SET_U8,
+            PartPropId::STATE.raw(),
+            PartState::Enabled as u32,
+        );
+    }
+
+    #[test]
+    fn bytes_restore_round_trips_through_arena() {
+        log!(log);
+        let prior = [0xABu8; 32];
+        log.push_prop_restore_bytes(PartPropId::PSK_CU, &prior)
+            .unwrap();
+        let m = MockVerbs::new();
+        let io = FakeIo::default();
+        assert_eq!(run_undo(log, &m, &io), WalkOutcome::Ok);
+        m.assert_rec(0, OP_SET_BYTES, PartPropId::PSK_CU.raw(), 32);
+        m.assert_last_bytes(&prior);
+    }
+
+    #[test]
+    fn poison_when_restore_verb_fails() {
+        log!(log);
+        log.push_vault_disable(key(5)).unwrap(); // undo = enable (Poison-class)
+        let m = MockVerbs::new();
+        m.fail_enable.set(true);
+        let io = FakeIo::default();
+        assert_eq!(run_undo(log, &m, &io), WalkOutcome::Poisoned);
+    }
+
+    #[test]
+    fn best_effort_when_create_undo_fails() {
+        log!(log);
+        log.push_vault_create(key(5)).unwrap(); // undo = delete (BestEffort)
+        let m = MockVerbs::new();
+        m.fail_delete.set(true);
+        let io = FakeIo::default();
+        // Delete fails, but a never-observable new key is a benign orphan.
+        assert_eq!(run_undo(log, &m, &io), WalkOutcome::Ok);
+    }
+
+    #[test]
+    fn session_destroy_undoes_and_commit_noops() {
+        let m = MockVerbs::new();
+        let io = FakeIo::default();
+
+        // commit → keep the session (no verb calls).
+        log!(commit_log);
+        commit_log.push_session_destroy(HsmSessId::from(7)).unwrap();
+        assert_eq!(run_commit(commit_log, &m, &io), WalkOutcome::Ok);
+        assert_eq!(m.count(), 0, "commit must not tear down a live session");
+
+        // undo → session_destroy(id).
+        log!(undo_log);
+        undo_log.push_session_destroy(HsmSessId::from(7)).unwrap();
+        assert_eq!(run_undo(undo_log, &m, &io), WalkOutcome::Ok);
+        m.assert_rec(0, OP_SESSION_DESTROY, 7, 0);
+    }
+
+    #[test]
+    fn session_destroy_undo_is_best_effort() {
+        // A failed teardown leaks a never-established session → benign.
+        log!(log);
+        log.push_session_destroy(HsmSessId::from(3)).unwrap();
+        let m = MockVerbs::new();
+        m.fail_session_destroy.set(true);
+        let io = FakeIo::default();
+        assert_eq!(run_undo(log, &m, &io), WalkOutcome::Ok);
+    }
+
+    #[test]
+    fn push_overflows_when_buffer_full() {
+        log!(log);
+        // With no arena bytes spent, the whole buffer holds entry slots.
+        let cap = UNDO_LOG_SIZE / ENTRY_SIZE;
+        for _ in 0..cap {
+            log.push_vault_create(key(1)).unwrap();
+        }
+        assert_eq!(log.len(), cap);
+        assert_eq!(log.push_vault_create(key(1)), Err(HsmError::UndoLogFull));
+    }
+
+    #[test]
+    fn discard_resets_buffer() {
+        log!(log);
+        // Two arena-sized payloads cannot coexist (their slots + bytes
+        // exceed the buffer), but one fits; discard resets the back
+        // pointer so the second still fits afterwards.
+        log.push_prop_restore_bytes(PartPropId::PSK_CU, &[1u8; UNDO_ARENA])
+            .unwrap();
+        assert!(!log.is_empty());
+        log.discard();
+        assert!(log.is_empty());
+        log.push_prop_restore_bytes(PartPropId::PSK_CU, &[2u8; UNDO_ARENA])
+            .unwrap();
+        assert_eq!(log.len(), 1);
+    }
+
+    #[test]
+    fn bytes_push_overflows_when_buffer_full() {
+        log!(log);
+        // One payload that, with its slot, exactly fills the buffer.
+        log.push_prop_restore_bytes(PartPropId::PSK_CU, &[1u8; UNDO_LOG_SIZE - ENTRY_SIZE])
+            .unwrap();
+        // Even a single further byte now overflows.
+        assert_eq!(
+            log.push_prop_restore_bytes(PartPropId::PSK_CU, &[2u8; 1]),
+            Err(HsmError::UndoLogFull)
+        );
+    }
+}

--- a/fw/pal/traits/src/error.rs
+++ b/fw/pal/traits/src/error.rs
@@ -350,6 +350,16 @@ pub enum HsmError {
     /// carries the requested selector (SVN / owner id).
     SeedNotFound = 0x08700100,
 
+    /// A per-command undo-log push failed because the fixed
+    /// per-command log buffer is full (its entry slots would overrun
+    /// the byte-pre-image arena).  Distinct from
+    /// [`NotEnoughSpace`](Self::NotEnoughSpace), which signals genuine
+    /// vault/resource exhaustion: an `UndoLogFull` instead indicates a
+    /// firmware sizing bug — the handler records more inverse actions
+    /// than its opcode's `UNDO_LOG_SIZE` budget allows — and should
+    /// never occur in a correctly-sized handler.
+    UndoLogFull = 0x08700101,
+
     /// The SQE's out-of-band descriptor-array length (`oob_len`) is
     /// malformed: not a whole number of 16-byte SGL descriptors, or
     /// larger than a single descriptor page.

--- a/fw/pal/traits/src/io.rs
+++ b/fw/pal/traits/src/io.rs
@@ -178,12 +178,14 @@ pub trait HsmIoController {
     ///   unrecoverable).
     async fn poll_io(&self) -> HsmResult<Self::Io>;
 
-    /// Posts the completion entry for `io` and frees its queue slot.
+    /// Posts the completion entry (CQE) for `io` to the host.
     ///
-    /// Consumes the [`Self::Io`] handle.  Callers must have written
-    /// the desired CQE contents via [`HsmIo::cqe`] before invoking
-    /// this method; the contents are flushed to the host as part of
-    /// completion.
+    /// Borrows `io` by `&mut` and leaves its queue slot **allocated**, so
+    /// the caller can run post-completion work — e.g. an undo/commit walk
+    /// that DMAs through `io` — before releasing the slot with
+    /// [`drop_io`](Self::drop_io).  Callers must have written the desired
+    /// CQE contents via [`HsmIo::cqe`] before invoking this method; the
+    /// contents are flushed to the host as part of the post.
     ///
     /// # Parameters
     ///
@@ -193,16 +195,19 @@ pub trait HsmIoController {
     /// # Returns
     ///
     /// - `Ok(())` — completion was successfully posted.
-    /// - `Err(HsmError)` — failed to enqueue the CQE; the slot is
-    ///   still freed, but the host will not see this completion.
-    async fn complete_io(&self, io: Self::Io) -> HsmResult<()>;
+    /// - `Err(HsmError)` — failed to enqueue the CQE; the host will not
+    ///   see this completion.  The slot is still owned and must be freed
+    ///   via [`drop_io`](Self::drop_io).
+    async fn complete_io(&self, io: &mut Self::Io) -> HsmResult<()>;
 
-    /// Frees the queue slot **without** posting a CQE.
+    /// Frees the queue slot, releasing `io`.
     ///
-    /// Used when the IO must be silently discarded — for example
-    /// when it arrived for a non-[`PartState::Enabled`](crate::PartState::Enabled)
-    /// partition and core wants to drop it without surfacing
-    /// anything to the host.
+    /// Posts no CQE of its own.  Called either to silently discard an IO
+    /// — for example one that arrived for a
+    /// non-[`PartState::Enabled`](crate::PartState::Enabled) partition and
+    /// core wants to drop without surfacing anything to the host — or to
+    /// release the slot after [`complete_io`](Self::complete_io) has
+    /// already posted the completion.
     ///
     /// # Parameters
     ///

--- a/fw/pal/traits/src/part.rs
+++ b/fw/pal/traits/src/part.rs
@@ -159,6 +159,13 @@ pub enum PartState {
     /// [`Initializing`](Self::Initializing) (one-shot per alloc/free
     /// cycle); the partition continues to serve DDI traffic.
     Initialized = 5,
+
+    /// The partition is **quarantined**: an undo-log rollback failed a
+    /// consistency-critical restore, so the in-memory state is incoherent.
+    /// Host IO is dropped (the dispatcher's enable gate excludes this state)
+    /// and the partition cannot be re-enabled — only a free/realloc cycle
+    /// (or reboot) clears the fault.
+    Faulted = 6,
 }
 
 impl PartState {
@@ -186,6 +193,7 @@ impl PartState {
             3 => Some(Self::Disabled),
             4 => Some(Self::Initializing),
             5 => Some(Self::Initialized),
+            6 => Some(Self::Faulted),
             _ => None,
         }
     }

--- a/fw/pal/traits/src/vault.rs
+++ b/fw/pal/traits/src/vault.rs
@@ -443,6 +443,39 @@ pub trait HsmVault {
     ///   is unset (e.g. internal device keys).
     async fn vault_key_delete(&self, io: &impl HsmIo, key_id: HsmKeyId) -> HsmResult<()>;
 
+    /// Marks a key as **disabled** without freeing its slot or zeroizing
+    /// its material — the staging half of a reversible delete.
+    ///
+    /// A disabled key is invisible to all lookups
+    /// ([`vault_key`](Self::vault_key), [`vault_key_kind`](Self::vault_key_kind),
+    /// …) which return [`HsmError::KeyNotFound`], but its slot and bytes
+    /// remain reserved.  It can be re-enabled with
+    /// [`vault_key_enable`](Self::vault_key_enable) or finalized (zeroized)
+    /// with [`vault_key_delete`](Self::vault_key_delete).
+    ///
+    /// This is the vault primitive the upper-layer undo log drives for a
+    /// reversible delete: `disable` at mutation time, `enable` to roll
+    /// back on failure, `delete` to commit on success.  The PAL itself
+    /// stays undo-unaware.  Unlike `vault_key_delete` it performs no
+    /// zeroize, so it is synchronous and cannot fail beyond the liveness
+    /// check.
+    ///
+    /// # Errors
+    ///
+    /// - [`HsmError::KeyNotFound`] — `key_id` does not refer to a live
+    ///   (present, not-already-disabled) key in the caller's partition.
+    fn vault_key_disable(&self, io: &impl HsmIo, key_id: HsmKeyId) -> HsmResult<()>;
+
+    /// Re-enables a [`vault_key_disable`](Self::vault_key_disable)d key,
+    /// making it visible to lookups again.  The inverse of
+    /// `vault_key_disable`.
+    ///
+    /// # Errors
+    ///
+    /// - [`HsmError::KeyNotFound`] — `key_id` does not refer to a present
+    ///   slot in the caller's partition.
+    fn vault_key_enable(&self, io: &impl HsmIo, key_id: HsmKeyId) -> HsmResult<()>;
+
     /// Deletes every key whose `session_id` matches `session_id`.
     ///
     /// Used during session teardown to reap session-scoped keys in

--- a/fw/plat/std/pal/src/drivers/oic.rs
+++ b/fw/plat/std/pal/src/drivers/oic.rs
@@ -6,6 +6,8 @@
 //! Sends the response through the per-IO reply channel.
 
 use azihsm_fw_hsm_core_tracing::*;
+use azihsm_fw_hsm_pal_traits::HsmError;
+use azihsm_fw_hsm_pal_traits::HsmResult;
 
 use crate::io::StdHsmIo;
 
@@ -20,17 +22,31 @@ impl StdOic {
         Self
     }
 
-    /// Send a completion response.
+    /// Send a completion response by posting the CQE to the submitter.
     ///
-    /// Takes ownership of the IO work item, consuming the reply channel
-    /// and CQE.
-    pub async fn send(&self, io: StdHsmIo) {
+    /// Borrows the IO work item by `&mut` and `take()`s its oneshot reply
+    /// sender (consumed on send) so the slot stays alive for the caller's
+    /// post-completion work; the CQE is a `Copy` value.
+    ///
+    /// Synchronous — posting to the oneshot channel does not suspend.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`HsmError::CompleteIoFailure`] if the CQE could not be
+    /// posted — either the oneshot receiver was dropped (the submitter is
+    /// gone) or `io.tx` was already taken (a double-complete). Core treats
+    /// this as `cqe_ok = false` and rolls the command back, matching the
+    /// Uno OIC driver's failure semantics.
+    pub fn send(&self, io: &mut StdHsmIo) -> HsmResult<()> {
         debug!(
             "oic",
             "send part={:?} qid={} qidx={}", io.pid, io.qid, io.qidx
         );
 
-        // Reply to submitter with just the CQE.
-        let _ = io.tx.send(io.cqe);
+        // Reply to submitter with just the CQE (oneshot — fires at most once).
+        match io.tx.take() {
+            Some(tx) => tx.send(io.cqe).map_err(|_| HsmError::CompleteIoFailure),
+            None => Err(HsmError::CompleteIoFailure),
+        }
     }
 }

--- a/fw/plat/std/pal/src/drivers/vault.rs
+++ b/fw/plat/std/pal/src/drivers/vault.rs
@@ -159,6 +159,11 @@ struct VaultEntry {
     session_key_id: Option<HsmKeyId>,
     /// Firmware-equivalent storage cost (for capacity tracking).
     cost: usize,
+    /// Soft-delete flag: a disabled entry is present (slot + bytes
+    /// reserved) but hidden from lookups.  The staging state for the undo
+    /// log's reversible delete (disable → enable rolls back, delete
+    /// commits).  Mirrors the Uno key-vault `Entry.disabled` bit.
+    disabled: bool,
 }
 
 /// One vault sub-table emulating a single firmware table.
@@ -226,6 +231,7 @@ impl KeyVault {
                 attrs,
                 session_key_id,
                 cost,
+                disabled: false,
             });
             table.used_bytes += cost;
 
@@ -251,6 +257,29 @@ impl KeyVault {
         table.used_bytes -= entry.cost;
         // Key material in entry.key is dropped (Vec deallocated).
         // In a real zeroize implementation we'd use zeroize crate.
+        Ok(())
+    }
+
+    /// Mark a live key as disabled (soft-delete): hidden from lookups but
+    /// slot and material retained.  The undo log's reversible-delete
+    /// staging step — `enable` rolls it back, `delete` commits (frees) it.
+    ///
+    /// Returns [`HsmError::KeyNotFound`] for a free or already-disabled
+    /// slot (disable is once-only).
+    pub fn disable(&mut self, key_id: HsmKeyId) -> HsmResult<()> {
+        let entry = self.entry_mut_present(key_id)?;
+        if entry.disabled {
+            return Err(HsmError::KeyNotFound);
+        }
+        entry.disabled = true;
+        Ok(())
+    }
+
+    /// Re-enable a disabled key — the inverse of [`disable`](Self::disable).
+    ///
+    /// Returns [`HsmError::KeyNotFound`] for a free slot.
+    pub fn enable(&mut self, key_id: HsmKeyId) -> HsmResult<()> {
+        self.entry_mut_present(key_id)?.disabled = false;
         Ok(())
     }
 
@@ -316,10 +345,31 @@ impl KeyVault {
     fn get_entry(&self, key_id: HsmKeyId) -> HsmResult<&VaultEntry> {
         let (table_idx, entry_idx) = split_key_id(key_id);
         let table = self.tables.get(table_idx).ok_or(HsmError::KeyNotFound)?;
-        table
+        let entry = table
             .entries
             .get(entry_idx)
             .and_then(|s| s.as_ref())
+            .ok_or(HsmError::KeyNotFound)?;
+        // A disabled (soft-deleted) entry is present but hidden from lookups.
+        if entry.disabled {
+            return Err(HsmError::KeyNotFound);
+        }
+        Ok(entry)
+    }
+
+    /// Mutable access to a *present* entry (live or disabled), ignoring the
+    /// disabled flag — only a free slot is rejected.  Backs
+    /// [`disable`](Self::disable) / [`enable`](Self::enable).
+    fn entry_mut_present(&mut self, key_id: HsmKeyId) -> HsmResult<&mut VaultEntry> {
+        let (table_idx, entry_idx) = split_key_id(key_id);
+        let table = self
+            .tables
+            .get_mut(table_idx)
+            .ok_or(HsmError::KeyNotFound)?;
+        table
+            .entries
+            .get_mut(entry_idx)
+            .and_then(|s| s.as_mut())
             .ok_or(HsmError::KeyNotFound)
     }
 }
@@ -367,6 +417,61 @@ mod tests {
         // Both in table 0, entries 0 and 1.
         assert_eq!(u16::from(k0), 0x0000);
         assert_eq!(u16::from(k1), 0x0001);
+    }
+
+    #[test]
+    fn disable_hides_then_enable_restores() {
+        let mut vault = KeyVault::new(1);
+        let key_data = [0xCD; 32];
+        let kid = vault
+            .create(&key_data, HsmVaultKeyKind::Aes256, None, aes256_attrs())
+            .unwrap();
+        assert!(vault.key(kid).is_ok());
+        // Disable hides it from lookups without freeing.
+        vault.disable(kid).unwrap();
+        assert_eq!(vault.key(kid).unwrap_err(), HsmError::KeyNotFound);
+        // Enable (the undo side) restores it with material intact.
+        vault.enable(kid).unwrap();
+        assert_eq!(vault.key(kid).unwrap(), &key_data);
+    }
+
+    #[test]
+    fn disable_then_delete_commits() {
+        let mut vault = KeyVault::new(1);
+        let kid = vault
+            .create(&[0x11; 32], HsmVaultKeyKind::Aes256, None, aes256_attrs())
+            .unwrap();
+        vault.disable(kid).unwrap();
+        // The commit side: delete frees even a disabled key; slot reusable.
+        vault.delete(kid).unwrap();
+        assert_eq!(vault.key(kid).unwrap_err(), HsmError::KeyNotFound);
+        let kid2 = vault
+            .create(&[0x22; 32], HsmVaultKeyKind::Aes256, None, aes256_attrs())
+            .unwrap();
+        assert_eq!(u16::from(kid2), u16::from(kid));
+    }
+
+    #[test]
+    fn disable_enable_reject_non_present() {
+        let mut vault = KeyVault::new(1);
+        // A free slot can be neither disabled nor enabled.
+        assert_eq!(
+            vault.disable(HsmKeyId::from(0u16)).unwrap_err(),
+            HsmError::KeyNotFound
+        );
+        assert_eq!(
+            vault.enable(HsmKeyId::from(0u16)).unwrap_err(),
+            HsmError::KeyNotFound
+        );
+        let kid = vault
+            .create(&[0x33; 32], HsmVaultKeyKind::Aes256, None, aes256_attrs())
+            .unwrap();
+        vault.disable(kid).unwrap();
+        // Disable is once-only — an already-disabled key is not "live".
+        assert_eq!(vault.disable(kid).unwrap_err(), HsmError::KeyNotFound);
+        // Enable is disabled-aware and still finds it.
+        vault.enable(kid).unwrap();
+        assert!(vault.key(kid).is_ok());
     }
 
     #[test]

--- a/fw/plat/std/pal/src/io.rs
+++ b/fw/plat/std/pal/src/io.rs
@@ -65,7 +65,12 @@ pub struct StdHsmIo {
     pub(crate) slot: u16,
 
     /// Oneshot channel for the CQE reply.
-    pub(crate) tx: ReplySender<HsmCqe>,
+    ///
+    /// `Option` so [`complete_io`](HsmIoController::complete_io) can
+    /// `take()` the oneshot sender (which is consumed on send) through a
+    /// `&mut` borrow, leaving the rest of `io` intact for the
+    /// post-completion walk.
+    pub(crate) tx: Option<ReplySender<HsmCqe>>,
 
     /// The 64-byte submission queue entry.
     pub(crate) sqe: HsmSqe,
@@ -86,7 +91,7 @@ impl StdHsmIo {
             qidx: req.qidx,
             sqe: req.sqe,
             slot,
-            tx: req.tx,
+            tx: Some(req.tx),
             cqe: [0; CQE_DWORDS],
         }
     }
@@ -102,7 +107,7 @@ impl StdHsmIo {
             qidx: 0,
             sqe: [0; SQE_DWORDS],
             slot,
-            tx,
+            tx: Some(tx),
             cqe: [0; CQE_DWORDS],
         }
     }
@@ -161,17 +166,17 @@ impl HsmIoController for StdHsmPal {
         Ok(StdHsmIo::new(req, slot))
     }
 
-    /// Complete an IO: send response via OIC driver, then free the buffer.
+    /// Complete an IO: post the response CQE via the OIC driver.
     ///
-    /// 1. Delegates to [`StdOic::send`](crate::drivers::oic::StdOic::send)
-    ///    which simulates the OIC delay and sends the response.
-    /// 2. Frees the buffer slot back to the pool via
-    ///    [`StdIic::free`](crate::drivers::iic::StdIic::free).
-    async fn complete_io(&self, io: Self::Io) -> HsmResult<()> {
-        let slot = io.slot;
-        self.oic.send(io).await;
-        self.iic.free(slot);
-        Ok(())
+    /// Posts the CQE only; the buffer slot is freed separately by
+    /// [`drop_io`](HsmIoController::drop_io) so the caller can run
+    /// post-completion work over `io` first.
+    ///
+    /// Propagates [`HsmError::CompleteIoFailure`] from the OIC driver when
+    /// the CQE cannot be posted (dropped receiver or double-complete) so
+    /// core can treat it as `cqe_ok = false` and roll back.
+    async fn complete_io(&self, io: &mut Self::Io) -> HsmResult<()> {
+        self.oic.send(io)
     }
 
     /// Drop an IO without sending a CQE — frees the buffer slot only.

--- a/fw/plat/std/pal/src/part.rs
+++ b/fw/plat/std/pal/src/part.rs
@@ -1190,44 +1190,6 @@ fn dma(buf: &[u8]) -> &DmaBuf {
 // ─── PartitionEntry property dispatch ────────────────────────────────────
 
 impl PartitionEntry {
-    /// Apply a caller-driven STATE transition through the property API.
-    ///
-    /// The internal device-command lifecycle (`part_alloc_internal`,
-    /// `part_enable_internal`, `part_disable_internal`,
-    /// `part_free_internal`) drives all other transitions; the prop
-    /// API exposes the two caller-facing ones: `Enabled → Initializing`
-    /// (`PartInit`, which additionally requires the four write-once
-    /// provisioning fields — PTA key, UMS key, policy, POTA thumbprint —
-    /// to be present) and `Initializing → Initialized` (`PartFinal`).
-    /// Any other source/target pair is rejected with
-    /// [`HsmError::InvalidArg`].
-    fn transition_state_via_prop(&mut self, target: PartState) -> HsmResult<()> {
-        match (self.state, target) {
-            (PartState::Enabled, PartState::Initializing) => {
-                if self.pta_key_id.is_none()
-                    || self.ups_key_id.is_none()
-                    || self.policy_hash.is_none()
-                    || self.pota_thumbprint.is_none()
-                {
-                    return Err(HsmError::InvalidArg);
-                }
-                self.state = PartState::Initializing;
-                Ok(())
-            }
-            // `PartFinal` finalizes the partition: the one caller-facing
-            // transition out of `Initializing`.
-            (PartState::Initializing, PartState::Initialized) => {
-                self.state = PartState::Initialized;
-                Ok(())
-            }
-            // No-op writes (same state) are accepted as a convenience.
-            (cur, tgt) if cur == tgt => Ok(()),
-            // All other transitions are PAL-internal — reject from the
-            // prop API.
-            _ => Err(HsmError::InvalidArg),
-        }
-    }
-
     /// Translate `id` to the matching scalar field on this entry.
     /// All values are widened to `u32` for a uniform return type;
     /// the trait wrapper narrows back to the requested kind.
@@ -1255,24 +1217,26 @@ impl PartitionEntry {
     fn prop_set_scalar(&mut self, id: PartPropId, value: u32) -> HsmResult<()> {
         match id {
             PartPropId::STATE => {
-                let target = PartState::from_u8(value as u8).ok_or(HsmError::InvalidArg)?;
-                self.transition_state_via_prop(target)
+                // Raw mechanism: write the discriminant directly. Transition
+                // validation + the `PartInit` provisioning gate are upper-layer
+                // policy (`part_state::part_set_state`); the undo log restores
+                // prior states through this raw path.
+                self.state = PartState::from_u8(value as u8).ok_or(HsmError::InvalidArg)?;
+                Ok(())
             }
             PartPropId::MK_KEY_ID => {
                 self.mk_key_id = Some(HsmKeyId::from(value as u16));
                 Ok(())
             }
             PartPropId::UPS_KEY_ID => {
-                if self.ups_key_id.is_some() {
-                    return Err(HsmError::UpsKeyAlreadySet);
-                }
+                // Raw mechanism; write-once is upper-layer policy
+                // (`part_state::part_set_ups_key_id`).
                 self.ups_key_id = Some(HsmKeyId::from(value as u16));
                 Ok(())
             }
             PartPropId::PTA_KEY_ID => {
-                if self.pta_key_id.is_some() {
-                    return Err(HsmError::PtaKeyAlreadySet);
-                }
+                // Raw mechanism; write-once is upper-layer policy
+                // (`part_state::part_set_pta_key_id`).
                 self.pta_key_id = Some(HsmKeyId::from(value as u16));
                 Ok(())
             }
@@ -1852,36 +1816,29 @@ mod tests {
     fn scalar_state_round_trip() {
         let mut e = fresh_entry();
         assert_eq!(e.prop_get_scalar(PartPropId::STATE).unwrap(), 0); // Unallocated
-                                                                      // No-op writes (same → same) are accepted.
-        e.prop_set_scalar(PartPropId::STATE, PartState::Unallocated as u32)
+                                                                      // The generic prop setter is a raw mechanism: any valid state byte
+                                                                      // is written directly (transition policy lives in
+                                                                      // `part_state::part_set_state`, exercised by the PartInit emu tests).
+        e.prop_set_scalar(PartPropId::STATE, PartState::Enabled as u32)
             .unwrap();
-        // Invalid state byte rejected.
+        assert_eq!(
+            e.prop_get_scalar(PartPropId::STATE).unwrap(),
+            PartState::Enabled as u32
+        );
+        // An invalid state byte is still rejected.
         assert!(matches!(
             e.prop_set_scalar(PartPropId::STATE, 250),
-            Err(HsmError::InvalidArg)
-        ));
-        // Caller-facing transition Unallocated → Enabled is rejected
-        // (must go through PAL-internal lifecycle methods).
-        assert!(matches!(
-            e.prop_set_scalar(PartPropId::STATE, PartState::Enabled as u32),
             Err(HsmError::InvalidArg)
         ));
     }
 
     #[test]
-    fn scalar_state_enabled_to_initializing_requires_provisioning_fields() {
+    fn scalar_state_set_is_raw_no_transition_gate() {
         let mut e = fresh_entry();
         e.state = PartState::Enabled;
-        // Missing all four write-once fields → reject.
-        assert!(matches!(
-            e.prop_set_scalar(PartPropId::STATE, PartState::Initializing as u32),
-            Err(HsmError::InvalidArg)
-        ));
-        // Set the four required fields then transition.
-        e.pta_key_id = Some(HsmKeyId::from(1u16));
-        e.ups_key_id = Some(HsmKeyId::from(2u16));
-        e.policy_hash = Some([0u8; POLICY_HASH_LEN]);
-        e.pota_thumbprint = Some([0u8; 48]);
+        // Raw mechanism: `Enabled → Initializing` is accepted WITHOUT the
+        // four provisioning fields — the gate moved to the upper-layer
+        // `part_state::part_set_state` (covered by the PartInit emu tests).
         e.prop_set_scalar(PartPropId::STATE, PartState::Initializing as u32)
             .unwrap();
         assert_eq!(
@@ -1891,19 +1848,20 @@ mod tests {
     }
 
     #[test]
-    fn scalar_state_other_transitions_rejected_via_prop() {
+    fn scalar_state_arbitrary_transitions_accepted_raw() {
         let mut e = fresh_entry();
         e.state = PartState::Enabled;
-        // Enabled → Disabled must go through part_disable_internal.
-        assert!(matches!(
-            e.prop_set_scalar(PartPropId::STATE, PartState::Disabled as u32),
-            Err(HsmError::InvalidArg)
-        ));
-        // Enabled → Allocated is nonsense.
-        assert!(matches!(
-            e.prop_set_scalar(PartPropId::STATE, PartState::Allocated as u32),
-            Err(HsmError::InvalidArg)
-        ));
+        // The raw setter accepts any valid state (transition policy is
+        // enforced above the PAL); the undo log relies on this to restore a
+        // prior state on rollback.
+        e.prop_set_scalar(PartPropId::STATE, PartState::Disabled as u32)
+            .unwrap();
+        assert_eq!(
+            e.prop_get_scalar(PartPropId::STATE).unwrap(),
+            PartState::Disabled as u32
+        );
+        e.prop_set_scalar(PartPropId::STATE, PartState::Allocated as u32)
+            .unwrap();
     }
 
     #[test]

--- a/fw/plat/std/pal/src/vault.rs
+++ b/fw/plat/std/pal/src/vault.rs
@@ -47,6 +47,20 @@ impl HsmVault for StdHsmPal {
         entry.vault.delete(key_id)
     }
 
+    /// Disable (soft-delete) a key — the undo log's reversible-delete
+    /// staging step.  Hidden from lookups; `enable` rolls back, `delete`
+    /// commits.
+    fn vault_key_disable(&self, io: &impl HsmIo, key_id: HsmKeyId) -> HsmResult<()> {
+        let entry = self.active_part_mut(io.pid())?;
+        entry.vault.disable(key_id)
+    }
+
+    /// Re-enable a disabled key — the undo side of a reversible delete.
+    fn vault_key_enable(&self, io: &impl HsmIo, key_id: HsmKeyId) -> HsmResult<()> {
+        let entry = self.active_part_mut(io.pid())?;
+        entry.vault.enable(key_id)
+    }
+
     /// Delete all session-scoped keys for the given logical session.
     ///
     /// Maps the logical session ID to the physical vault key ID, then

--- a/fw/plat/uno/fw/crates/key_vault/src/tests.rs
+++ b/fw/plat/uno/fw/crates/key_vault/src/tests.rs
@@ -307,6 +307,65 @@ fn delete_zeroizes_and_frees() {
 }
 
 #[test]
+fn disable_hides_then_enable_restores() {
+    let (mut v, g, io) = vault::<1>();
+    let id = with_key(&[0xCDu8; 32], |k| {
+        block_on(v.create(&g, &io, 0, k, HsmVaultKeyKind::Aes256, None, aes_attrs())).unwrap()
+    });
+    assert!(v.key(id).is_ok(), "freshly created key is live");
+
+    // Disable hides the key from lookups without zeroizing or freeing.
+    v.disable(id).unwrap();
+    assert_eq!(v.key(id).unwrap_err(), HsmError::KeyNotFound);
+    assert_eq!(g.zeroizes.get(), 0, "disable must not zeroize");
+
+    // Enable (the undo side) restores it with material intact.
+    v.enable(id).unwrap();
+    assert_eq!(&**v.key(id).unwrap(), &[0xCDu8; 32][..]);
+}
+
+#[test]
+fn disable_then_delete_commits() {
+    let (mut v, g, io) = vault::<1>();
+    let id = with_key(&[0x11u8; 32], |k| {
+        block_on(v.create(&g, &io, 0, k, HsmVaultKeyKind::Aes256, None, aes_attrs())).unwrap()
+    });
+    v.disable(id).unwrap();
+    // The commit side: delete zeroizes + frees even a disabled key.
+    block_on(v.delete(&g, &io, id)).unwrap();
+    assert_eq!(v.key(id).unwrap_err(), HsmError::KeyNotFound);
+    // Slot is reusable.
+    let id2 = with_key(&[2u8; 32], |k| {
+        block_on(v.create(&g, &io, 0, k, HsmVaultKeyKind::Aes256, None, aes_attrs())).unwrap()
+    });
+    assert_eq!(u16::from(id2), u16::from(id));
+}
+
+#[test]
+fn disable_enable_reject_non_present() {
+    let (mut v, g, io) = vault::<1>();
+    // Free slots can be neither disabled nor enabled.
+    assert_eq!(
+        v.disable(HsmKeyId::from(0)).unwrap_err(),
+        HsmError::KeyNotFound
+    );
+    assert_eq!(
+        v.enable(HsmKeyId::from(0)).unwrap_err(),
+        HsmError::KeyNotFound
+    );
+
+    let id = with_key(&[0x22u8; 32], |k| {
+        block_on(v.create(&g, &io, 0, k, HsmVaultKeyKind::Aes256, None, aes_attrs())).unwrap()
+    });
+    v.disable(id).unwrap();
+    // Disable is once-only — an already-disabled key is not "live".
+    assert_eq!(v.disable(id).unwrap_err(), HsmError::KeyNotFound);
+    // Enable is disabled-aware and still finds it.
+    v.enable(id).unwrap();
+    assert!(v.key(id).is_ok());
+}
+
+#[test]
 fn large_key_delete_uses_dma_zeroize() {
     let (mut v, g, io) = vault::<1>();
     let id = with_key(&[7u8; 516], |k| {

--- a/fw/plat/uno/fw/crates/key_vault/src/vault.rs
+++ b/fw/plat/uno/fw/crates/key_vault/src/vault.rs
@@ -163,8 +163,61 @@ impl<S: TableStorage> KeyVault<S> {
         key_id: HsmKeyId,
     ) -> HsmResult<()> {
         let (table, slot) = split_key_id(key_id);
-        let entry = self.entry(table, slot)?;
+        // Delete operates on any *present* key — live or disabled — so the
+        // undo-log commit path can zeroize a soft-deleted (disabled) key.
+        // Only a genuinely free slot is rejected (matches `delete_by_session`
+        // / `clear`, which already evict on a bare `!is_free()` check).
+        let entry = *self.storage.entry(table, slot)?;
+        if entry.is_free() {
+            return Err(HsmError::KeyNotFound);
+        }
         self.evict(gdma, io, table, slot, entry).await
+    }
+
+    /// Marks a live key as **disabled** without freeing its slot or
+    /// zeroizing its material.
+    ///
+    /// A disabled key is invisible to lookups ([`key`](Self::key),
+    /// [`key_kind`](Self::key_kind), [`key_location`](Self::key_location)
+    /// all return [`HsmError::KeyNotFound`]) but its slot and bytes
+    /// remain reserved.  It can be re-enabled via [`enable`](Self::enable)
+    /// or finalized (zeroized) via [`delete`](Self::delete).
+    ///
+    /// This is the staging half of a reversible delete used by the
+    /// upper-layer undo log: `disable` at mutation time, `enable` to roll
+    /// back on failure, `delete` to commit (zeroize) on success.  Unlike
+    /// `delete` it performs no GDMA, so it is synchronous and infallible
+    /// beyond the liveness check.
+    ///
+    /// # Errors
+    ///
+    /// - [`HsmError::KeyNotFound`] — `key_id` does not refer to a live
+    ///   (present, not-already-disabled) key in this vault.
+    pub fn disable(&mut self, key_id: HsmKeyId) -> HsmResult<()> {
+        let (table, slot) = split_key_id(key_id);
+        // Must currently be live: `entry` rejects free or already-disabled
+        // slots, so this enforces disable-once semantics.
+        let _ = self.entry(table, slot)?;
+        self.storage.entry_mut(table, slot)?.set_disabled(true);
+        Ok(())
+    }
+
+    /// Re-enables a [`disable`](Self::disable)d key, making it visible to
+    /// lookups again.  The inverse of `disable`.
+    ///
+    /// # Errors
+    ///
+    /// - [`HsmError::KeyNotFound`] — `key_id` does not refer to a present
+    ///   slot (a free slot cannot be enabled).
+    pub fn enable(&mut self, key_id: HsmKeyId) -> HsmResult<()> {
+        let (table, slot) = split_key_id(key_id);
+        // Disabled-aware lookup: a disabled entry is hidden from `entry`,
+        // so read it raw and reject only a genuinely free slot.
+        if self.storage.entry(table, slot)?.is_free() {
+            return Err(HsmError::KeyNotFound);
+        }
+        self.storage.entry_mut(table, slot)?.set_disabled(false);
+        Ok(())
     }
 
     /// Deletes every session-scoped key bound to `session`.

--- a/fw/plat/uno/fw/pal/src/io.rs
+++ b/fw/plat/uno/fw/pal/src/io.rs
@@ -156,13 +156,13 @@ impl HsmIoController for UnoHsmPal {
         Ok(UnoHsmIo { index })
     }
 
-    /// Sends the completed IO back to the host via OIC, then returns
-    /// the IO_SQ slot to the ISQ for reuse.
-    async fn complete_io(&self, io: Self::Io) -> HsmResult<()> {
-        let queue_id = io.queue_id();
-        let result = self.oic.send(io.index)?.await;
-        self.iic.free_io(io.index, queue_id);
-        result
+    /// Posts the completion (CQE) to the host via OIC.
+    ///
+    /// Posts the CQE only; the IO_SQ slot is returned to the ISQ
+    /// separately by [`drop_io`](HsmIoController::drop_io) so the caller
+    /// can run post-completion work over `io` first.
+    async fn complete_io(&self, io: &mut Self::Io) -> HsmResult<()> {
+        self.oic.send(io.index)?.await
     }
 
     /// Drops an IO without sending a completion (e.g. for disabled

--- a/fw/plat/uno/fw/pal/src/lock.rs
+++ b/fw/plat/uno/fw/pal/src/lock.rs
@@ -1,14 +1,14 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-//! [`HsmPartitionLock`] no-op implementation for the Uno PAL.
+//! [`HsmPartitionLock`] implementation for the Uno PAL.
 //!
-//! The Uno firmware is single-threaded with cooperative async
-//! scheduling, so partition-level mutual exclusion is not required.
-//! [`partition_lock`](HsmPartitionLock::partition_lock) returns a
-//! unit-typed guard that performs no action on drop.
-
-#![allow(clippy::unused_async)]
+//! The Uno PAL is **lock-free**: per-partition serialization is unnecessary.
+//! Admin teardown cannot race in-flight host IOs (a partition can't be
+//! disabled/freed while host IOs are outstanding), and host↔host overlap is
+//! resolved by the handlers' guards-first sync commit.  Legacy MBOR handlers
+//! still call [`partition_lock`](HsmPartitionLock::partition_lock), so the
+//! trait is implemented as a no-op guard.
 
 use azihsm_fw_hsm_pal_traits::HsmIo;
 use azihsm_fw_hsm_pal_traits::HsmPartitionLock;
@@ -17,20 +17,9 @@ use azihsm_fw_hsm_pal_traits::HsmResult;
 use crate::UnoHsmPal;
 
 impl HsmPartitionLock for UnoHsmPal {
-    /// No-op guard. The unit type carries no state and its `Drop` impl
-    /// is also a no-op.
-    type PartitionGuard<'a>
-        = ()
-    where
-        Self: 'a;
+    type PartitionGuard<'a> = ();
 
-    /// Acquire the (logical) lock for the given partition.
-    ///
-    /// # Parameters
-    /// * `_io` — IO context associated with the request (ignored).
-    ///
-    /// # Returns
-    /// * `Ok(())` — the unit guard, which holds no resources.
+    /// No-op: the Uno PAL needs no partition lock (see module docs).
     async fn partition_lock(&self, _io: &impl HsmIo) -> HsmResult<Self::PartitionGuard<'_>> {
         Ok(())
     }

--- a/fw/plat/uno/fw/pal/src/pal.rs
+++ b/fw/plat/uno/fw/pal/src/pal.rs
@@ -282,8 +282,10 @@ pub struct UnoHsmPal {
 }
 
 // SAFETY: UnoHsmPal is only accessed from a single-threaded Embassy
-// executor on a single-core Cortex-M7 with no preemptive ISRs.
-// The Cell<BootPhase> field is never accessed from interrupt context.
+// executor on a single-core Cortex-M7 with no preemptive ISRs.  The
+// interior-mutable field (Cell<BootPhase>) is never accessed from
+// interrupt context, so concurrent access is impossible despite the
+// asserted Sync.
 unsafe impl Sync for UnoHsmPal {}
 
 impl Default for UnoHsmPal {
@@ -601,7 +603,10 @@ impl UnoHsmPal {
         // assigned; a VF is enabled after. `part_enable` needs to know which.
         let is_pf = msg.info.pfn == 64;
         // Map the IPC action onto a partition-lifecycle primitive; Migrate
-        // and any unknown action are not supported.
+        // and any unknown action are not supported.  No partition lock: a
+        // partition cannot be disabled/freed while host IOs are in flight,
+        // and admin-IPC is strictly serial, so this cannot race a host
+        // command (see lock.rs).
         let result = match PfnEnableDisableAction(msg.info.action) {
             PfnEnableDisableAction::Enable => self.part_enable(pid, is_pf).await,
             PfnEnableDisableAction::Disable => self.part_disable(pid).await,
@@ -660,6 +665,8 @@ impl UnoHsmPal {
         // A zero mask frees the partition; any other mask (re)allocates it.
         // The ACK's owned-table count is a pure function of the mask — an
         // IPC-reply concern, computed here rather than in the partition layer.
+        // No partition lock: a partition cannot be freed/allocated while host
+        // IOs are in flight, and admin-IPC is strictly serial (see lock.rs).
         let result = if mask == 0 {
             self.part_free(pid).await
         } else {

--- a/fw/plat/uno/fw/pal/src/part.rs
+++ b/fw/plat/uno/fw/pal/src/part.rs
@@ -472,37 +472,13 @@ impl HsmPartitionManager for UnoHsmPal {
         let part = PartStore::partition(io.pid())?;
         match id {
             PartPropId::STATE => {
+                // Raw mechanism: write the discriminant directly. Transition
+                // validation + the `PartInit` provisioning gate are upper-layer
+                // policy (`part_state::part_set_state`); the undo log restores
+                // prior states through this raw path.
                 let target = PartState::from_u8(value).ok_or(HsmError::InvalidArg)?;
-                let current = part.state()?;
-                match (current, target) {
-                    // The single caller-facing transition: `Enabled →
-                    // Initializing`, which additionally requires the four
-                    // write-once provisioning fields (PTA key, UPS key,
-                    // policy hash, POTA thumbprint) to be present. Mirrors
-                    // the std PAL property-API contract.
-                    (PartState::Enabled, PartState::Initializing) => {
-                        if part.pta_key_id().is_none()
-                            || part.ups_key_id().is_none()
-                            || !part.policy_hash_valid()
-                            || !part.pota_thumbprint_valid()
-                        {
-                            return Err(HsmError::InvalidArg);
-                        }
-                        part.set_state(PartState::Initializing);
-                        Ok(())
-                    }
-                    // `PartFinal` finalizes the partition: the one
-                    // caller-facing transition out of `Initializing`.
-                    (PartState::Initializing, PartState::Initialized) => {
-                        part.set_state(PartState::Initialized);
-                        Ok(())
-                    }
-                    // No-op writes (same state) are accepted as a convenience.
-                    (cur, tgt) if cur == tgt => Ok(()),
-                    // All other transitions are PAL-internal (driven by the
-                    // device-command lifecycle) — reject from the prop API.
-                    _ => Err(HsmError::InvalidArg),
-                }
+                part.set_state(target);
+                Ok(())
             }
             // RES_COUNT is read-only; it is derived from the resource mask.
             _ => Err(HsmError::UnsupportedCmd),
@@ -535,19 +511,11 @@ impl HsmPartitionManager for UnoHsmPal {
             PartPropId::ESTABLISH_CRED_KEY_ID => part.set_ec_key_id(Some(key)),
             PartPropId::LOCAL_MK_KEY_ID => part.set_local_mk_key_id(Some(key)),
             PartPropId::EPHEMERAL_MK_KEY_ID => part.set_ephemeral_mk_key_id(Some(key)),
-            // UPS / PTA key ids are write-once provisioning fields.
-            PartPropId::UPS_KEY_ID => {
-                if part.ups_key_id().is_some() {
-                    return Err(HsmError::UpsKeyAlreadySet);
-                }
-                part.set_ups_key_id(Some(key));
-            }
-            PartPropId::PTA_KEY_ID => {
-                if part.pta_key_id().is_some() {
-                    return Err(HsmError::PtaKeyAlreadySet);
-                }
-                part.set_pta_key_id(Some(key));
-            }
+            // Raw mechanism: UPS / PTA write-once is upper-layer policy
+            // (`part_state::part_set_ups_key_id` / `part_set_pta_key_id`); the
+            // undo log restores a prior id through this raw path.
+            PartPropId::UPS_KEY_ID => part.set_ups_key_id(Some(key)),
+            PartPropId::PTA_KEY_ID => part.set_pta_key_id(Some(key)),
             // ID_KEY_ID / RSA_UNWRAPPING_KEY_ID are read-only.
             _ => return Err(HsmError::UnsupportedCmd),
         }

--- a/fw/plat/uno/fw/pal/src/vault.rs
+++ b/fw/plat/uno/fw/pal/src/vault.rs
@@ -62,6 +62,16 @@ impl HsmVault for UnoHsmPal {
         v.delete(self, io, key_id).await
     }
 
+    fn vault_key_disable(&self, io: &impl HsmIo, key_id: HsmKeyId) -> HsmResult<()> {
+        let mut v = vault(io);
+        v.disable(key_id)
+    }
+
+    fn vault_key_enable(&self, io: &impl HsmIo, key_id: HsmKeyId) -> HsmResult<()> {
+        let mut v = vault(io);
+        v.enable(key_id)
+    }
+
     async fn vault_key_delete_by_session(
         &self,
         io: &impl HsmIo,


### PR DESCRIPTION
## Summary
Replaces the scattered, bespoke error-path rollback across the host (TBOR) command handlers with a single **undo-log** mechanism. Each state-modifying command records the inverse of every partition/vault/session mutation as it applies it; the dispatcher walks the log after the command completes — finalizing on success, reverting on failure (a handler error **or** a failed CQE post).

## Safety model (lock-free)
The undo walk is **unconditional** — no partition lock, no generation counter, no state re-check. Safety rests on two structural invariants:
1. **Admin can't race an in-flight host IO** — host IO only flows on an enabled partition, a partition can't be disabled/freed while IOs are in flight, and the walk runs after `complete_io` posts the CQE but **before** `drop_io` frees the slot.
2. **host↔host** same-partition overlap is resolved by a **guards-first sync commit** — handlers stage all async work first, then apply every partition mutation in one **await-free** block that fails-fast, so the loser mutates nothing.

The log is **mandatory**: carved from the io DMA heap; if that allocation fails the command fails *before* mutating anything (it never runs without rollback).

## What's included
- New `azihsm_fw_hsm_undo` leaf crate — per-command double-ended log over one DMA buffer; LIFO undo / FIFO commit walks over a narrow `UndoVerbs` adapter; Poison/BestEffort failure policy. The backing buffer (which can capture secret pre-images such as a prior PSK) is zeroized after every walk.
- Reversible vault **soft-delete** (`vault_key_disable`/`enable`) on std + uno.
- Converted handlers: `part_init`, `part_final`, `psk_change`, `session_open_init`, `session_open_finish` (`session_close` is a terminal destroy with nothing to roll back).
- **Poisoned ⇒ Faulted** quarantine (new `PartState::Faulted`).
- STATE / write-once transition policy relocated to `part_state.rs` wrappers; the uno partition lock (and `embassy-sync`) removed.

## Out of scope
Admin-IPC rollback stays a PAL implementation detail; legacy MBOR keeps its own lock + bespoke rollback; crash recovery is unnecessary (partition state resets on crash).

## Validation
12 undo unit + 38 std-PAL + 79 TBOR emu tests; core / std / uno clippy clean; uno firmware builds (**+4.7 KiB `.text` / +2.2%**, no new dependencies). A code review pass surfaced one stale comment (corrected).

## Follow-up (not in this PR)
**P6** — fault-injection tests that drive the undo-**walk** (rollback) path end to end; the emu suite currently exercises push + the commit walk only.
