### PR TITLE
Enable tbor DDI tests on the hardware

### DIFF
--- a/ddi/nix/Cargo.toml
+++ b/ddi/nix/Cargo.toml
@@ -13,6 +13,7 @@ doctest = false
 azihsm_ddi_interface.workspace = true
 azihsm_ddi_mbor_codec.workspace = true
 azihsm_ddi_mbor_types.workspace = true
+azihsm_ddi_tbor_types.workspace = true
 bitfield-struct.workspace = true
 glob.workspace = true
 nix.workspace = true

--- a/ddi/nix/src/dev.rs
+++ b/ddi/nix/src/dev.rs
@@ -24,6 +24,8 @@ use azihsm_ddi_mbor_types::DdiRespHdr;
 use azihsm_ddi_mbor_types::DdiStatus;
 use azihsm_ddi_mbor_types::MborError;
 use azihsm_ddi_mbor_types::SessionControlKind;
+use azihsm_ddi_tbor_types::TborOpReq;
+use azihsm_ddi_tbor_types::TborResp;
 use bitfield_struct::bitfield;
 use nix::ioctl_readwrite;
 use parking_lot::RwLock;
@@ -845,6 +847,101 @@ impl DdiDev for DdiNixDev {
         let resp = <T::OpResp>::mbor_decode(&mut decoder)
             .map_err(|_| DdiError::MborError(MborError::DecodeError))?;
         Ok(resp)
+    }
+
+    /// Execute a DDI command whose body is TBOR-encoded.
+    ///
+    /// Mirrors [`Self::exec_op_mbor`] but:
+    ///   * encodes the request via [`TborOpReq::encode_request`];
+    ///   * sets the SQE opcode to `OP_TBOR` (= 2) so that the firmware
+    ///     dispatches the request through its TBOR handler instead of
+    ///     the legacy MBOR handler;
+    ///   * decodes the response via [`TborResp::decode_response`],
+    ///     which already maps embedded fw-error status into
+    ///     [`DdiError::DdiError`] / [`DdiError::TborDecodeError`].
+    ///
+    /// The Linux kernel driver is wire-agnostic — it forwards the
+    /// `opc` and `cmdset` ioctl fields verbatim into the SQE — so
+    /// no driver change is required to route TBOR.
+    fn exec_op_tbor<T: TborOpReq>(
+        &self,
+        req: &T,
+        _cookie: &mut Option<DdiCookie>,
+    ) -> DdiResult<T::OpResp> {
+        /// SQE opcode that routes the command through the firmware's
+        /// TBOR dispatcher (see `fw/core/lib/src/op.rs::OP_TBOR`).
+        const OP_TBOR: u16 = 2;
+
+        const REQ_BUF_LEN: usize = 8192;
+        const RESP_BUF_LEN: usize = 8192;
+
+        // ── 1. Encode the TBOR request ───────────────────────────
+        let mut req_buf = [0u8; REQ_BUF_LEN];
+        let req_bytes = req.encode_request(&mut req_buf)?;
+        let req_len = req_bytes.len();
+
+        tracing::debug!(
+            opcode = T::OPCODE,
+            "TBOR Request Buffer (in hex): {:02x?}",
+            &req_buf[..req_len]
+        );
+
+        let mut resp_buf = Box::<[u8; RESP_BUF_LEN]>::new([0u8; RESP_BUF_LEN]);
+
+        // ── 2. Build the ioctl command ───────────────────────────
+        let mut cmd = McrCpGenericCmd::default();
+        cmd.hdr.ioctl_data_size = mem::size_of::<McrCpGenericCmd>() as u32;
+        cmd.hdr.app_cmd_id = 0xCD1DDEAD;
+        cmd.hdr.timeout = 100; // ms
+
+        // The Rust field `rsvd1` aliases the C UAPI `__u16 opc` field
+        // (see drivers/linux/drvsrc/azihsm_hsm_dev_ioctl.h). Writing
+        // OP_TBOR here is THE flag the firmware uses to route the
+        // request through `handle_tbor_op` instead of `handle_mbor_op`.
+        cmd.in_data.rsvd1 = OP_TBOR;
+        cmd.in_data.command_set = McrCpCmdSet::Generic;
+
+        // Session control flags come from the TBOR request type.
+        let session_ctrl = req.session_ctrl();
+        cmd.in_data
+            .session_control_flags
+            .set_kind(u8::from(session_ctrl));
+        if let Some(sid) = req.get_session_id() {
+            cmd.in_data.session_id = sid;
+            cmd.in_data
+                .session_control_flags
+                .set_session_id_is_valid(true);
+        }
+
+        cmd.in_data.src_length = req_len as u32;
+        cmd.in_data.src_buf = req_buf.as_ptr();
+        cmd.in_data.dst_length = resp_buf.len() as u32;
+        cmd.in_data.dst_buf = resp_buf.as_mut_ptr();
+
+        // ── 3. Issue the ioctl ───────────────────────────────────
+        // SAFETY: src/dst pointers above are valid for the duration
+        // of the ioctl call; the buffers outlive `cmd`.
+        let res = unsafe {
+            mcr_ctrl_cmd_generic_ioctl(self.file.read().as_raw_fd(), &mut cmd)
+        };
+        if res.is_err() {
+            self.map_ioctl_status(cmd.out_data.ioctl_status)?;
+            res.map_err(DdiError::NixError)?;
+        }
+        if cmd.out_data.status != 0 {
+            return Err(DdiError::DdiError(cmd.out_data.status));
+        }
+
+        // ── 4. Decode the typed response ─────────────────────────
+        let resp_len = cmd.out_data.byte_count as usize;
+        let resp_bytes = &resp_buf[..resp_len];
+        tracing::debug!(
+            opcode = T::OPCODE,
+            "TBOR Response Buffer (in hex): {:02x?}",
+            resp_bytes
+        );
+
+        Ok(<T::OpResp>::decode_response(resp_bytes)?)
     }
 
     /// Execute AES GCM operation (encryption/decryption) with slice-based buffers

--- a/ddi/nix/src/dev.rs
+++ b/ddi/nix/src/dev.rs
@@ -921,9 +921,7 @@ impl DdiDev for DdiNixDev {
         // ── 3. Issue the ioctl ───────────────────────────────────
         // SAFETY: src/dst pointers above are valid for the duration
         // of the ioctl call; the buffers outlive `cmd`.
-        let res = unsafe {
-            mcr_ctrl_cmd_generic_ioctl(self.file.read().as_raw_fd(), &mut cmd)
-        };
+        let res = unsafe { mcr_ctrl_cmd_generic_ioctl(self.file.read().as_raw_fd(), &mut cmd) };
         if res.is_err() {
             self.map_ioctl_status(cmd.out_data.ioctl_status)?;
             res.map_err(DdiError::NixError)?;

--- a/ddi/nix/src/dev.rs
+++ b/ddi/nix/src/dev.rs
@@ -866,6 +866,7 @@ impl DdiDev for DdiNixDev {
     fn exec_op_tbor<T: TborOpReq>(
         &self,
         req: &T,
+        _oob_items: Option<&[&[u8]]>,
         _cookie: &mut Option<DdiCookie>,
     ) -> DdiResult<T::OpResp> {
         /// SQE opcode that routes the command through the firmware's

--- a/ddi/nix/src/dev.rs
+++ b/ddi/nix/src/dev.rs
@@ -866,12 +866,21 @@ impl DdiDev for DdiNixDev {
     fn exec_op_tbor<T: TborOpReq>(
         &self,
         req: &T,
-        _oob_items: Option<&[&[u8]]>,
+        oob_items: Option<&[&[u8]]>,
         _cookie: &mut Option<DdiCookie>,
     ) -> DdiResult<T::OpResp> {
         /// SQE opcode that routes the command through the firmware's
         /// TBOR dispatcher (see `fw/core/lib/src/op.rs::OP_TBOR`).
         const OP_TBOR: u16 = 2;
+
+        // The nix backend does not (yet) forward out-of-band items as
+        // SGL Data Block descriptors. Reject non-empty `oob_items`
+        // loudly rather than silently dropping payloads — any TBOR
+        // opcode that needs OOB data would otherwise misbehave in a
+        // hard-to-diagnose way.
+        if oob_items.is_some_and(|items| !items.is_empty()) {
+            return Err(DdiError::InvalidParameter);
+        }
 
         const REQ_BUF_LEN: usize = 8192;
         const RESP_BUF_LEN: usize = 8192;
@@ -881,11 +890,10 @@ impl DdiDev for DdiNixDev {
         let req_bytes = req.encode_request(&mut req_buf)?;
         let req_len = req_bytes.len();
 
-        tracing::debug!(
-            opcode = T::OPCODE,
-            "TBOR Request Buffer (in hex): {:02x?}",
-            &req_buf[..req_len]
-        );
+        // Do not log raw request bytes: TBOR requests can carry
+        // sensitive material (e.g. `TborPskChangeReq.psk_envelope`).
+        // Opcode + length is enough to trace the transport path.
+        tracing::debug!(opcode = T::OPCODE, req_len, "TBOR request encoded");
 
         let mut resp_buf = Box::<[u8; RESP_BUF_LEN]>::new([0u8; RESP_BUF_LEN]);
 
@@ -932,13 +940,18 @@ impl DdiDev for DdiNixDev {
         }
 
         // ── 4. Decode the typed response ─────────────────────────
+        // `byte_count` comes from the driver / firmware and is
+        // therefore across a trust boundary — clamp it against the
+        // allocated response buffer before indexing to avoid a
+        // host-side panic on a bogus device value.
         let resp_len = cmd.out_data.byte_count as usize;
+        if resp_len > RESP_BUF_LEN {
+            return Err(DdiError::InvalidParameter);
+        }
         let resp_bytes = &resp_buf[..resp_len];
-        tracing::debug!(
-            opcode = T::OPCODE,
-            "TBOR Response Buffer (in hex): {:02x?}",
-            resp_bytes
-        );
+        // Do not log raw response bytes: responses can carry
+        // sensitive data depending on opcode.
+        tracing::debug!(opcode = T::OPCODE, resp_len, "TBOR response received");
 
         Ok(<T::OpResp>::decode_response(resp_bytes)?)
     }

--- a/ddi/tbor/types/Cargo.toml
+++ b/ddi/tbor/types/Cargo.toml
@@ -39,6 +39,11 @@ path = "tests/azihsm_ddi_tbor_tests.rs"
 emu = ["azihsm_ddi/emu"]
 mock = ["azihsm_ddi/mock"]
 sock = ["azihsm_ddi/sock"]
+# Opt-in feature for the `hw::` smoke tests. These tests drive real
+# silicon via the native OS backend and require a physical device;
+# excluded from the default `cargo test` build so contributor / CI
+# runs on machines without a board don't panic in `open_hw_dev`.
+hw-tests = []
 table-4 = ["azihsm_ddi/table-4"]
 table-64 = ["azihsm_ddi/table-64"]
 

--- a/ddi/tbor/types/tests/azihsm_ddi_tbor_tests.rs
+++ b/ddi/tbor/types/tests/azihsm_ddi_tbor_tests.rs
@@ -7,8 +7,15 @@
 //! transport. Run with `--features emu` (in-process firmware),
 //! `--features sock` (firmware behind a socket server), or
 //! `--features mock` (transport-contract probes).
+//!
+//! With **no** feature enabled the crate falls through to the native
+//! OS backend (`nix` on Linux / `win` on Windows), which drives real
+//! silicon. Hardware-only smoke tests live under [`hw`].
 
 #[cfg(any(feature = "emu", feature = "mock", feature = "sock"))]
 pub mod harness;
 
 pub mod commands;
+
+#[cfg(not(any(feature = "emu", feature = "mock", feature = "sock")))]
+pub mod hw;

--- a/ddi/tbor/types/tests/azihsm_ddi_tbor_tests.rs
+++ b/ddi/tbor/types/tests/azihsm_ddi_tbor_tests.rs
@@ -17,5 +17,5 @@ pub mod harness;
 
 pub mod commands;
 
-#[cfg(not(any(feature = "emu", feature = "mock", feature = "sock")))]
+#[cfg(feature = "hw-tests")]
 pub mod hw;

--- a/ddi/tbor/types/tests/harness/session/crypto.rs
+++ b/ddi/tbor/types/tests/harness/session/crypto.rs
@@ -13,8 +13,8 @@
 //!
 //! * `pk_hsm` retrieval via the MBOR cert-chain (`GetCertChainInfo`
 //!   + `GetCertificate`) — the production attestation path that reads
-//!   the partition-ID cert (its SubjectPublicKeyInfo carries the P-384
-//!   key the FW uses as `pk_s` in HPKE `auth_psk`).
+//!     the partition-ID cert (its SubjectPublicKeyInfo carries the P-384
+//!     key the FW uses as `pk_s` in HPKE `auth_psk`).
 
 use azihsm_crypto::*;
 use azihsm_ddi::AzihsmDdi;

--- a/ddi/tbor/types/tests/hw/api_rev.rs
+++ b/ddi/tbor/types/tests/hw/api_rev.rs
@@ -1,0 +1,38 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Hardware smoke test for TBOR `ApiRev`.
+//!
+//! Exercises the full host -> nix/win backend -> silicon fw
+//! `handle_tbor_op` -> response path. `ApiRev` is sessionless and
+//! stateless, so it is safe to run against a live board without
+//! any pre-/post-test cleanup.
+
+use azihsm_ddi_interface::DdiDev;
+use azihsm_ddi_tbor_types::TborApiRevReq;
+use azihsm_ddi_tbor_types::TborApiRevResp;
+
+use crate::hw::open_hw_dev;
+
+/// Expected response for the bootstrap TBOR protocol version.
+///
+/// Mirrors the emu-harness constant in
+/// `commands::api_rev::EXPECTED` so both paths pin the same wire
+/// contract.
+const EXPECTED: TborApiRevResp = TborApiRevResp {
+    min_ver: 1,
+    max_ver: 1,
+};
+
+#[test]
+fn round_trip() {
+    let dev = open_hw_dev();
+    let mut cookie = None;
+    let resp = dev
+        .exec_op_tbor(&TborApiRevReq::new(), &mut cookie)
+        .expect("TBOR ApiRev round-trip on hardware");
+    assert_eq!(
+        resp, EXPECTED,
+        "firmware should report min=max=1 for the bootstrap TBOR protocol version",
+    );
+}

--- a/ddi/tbor/types/tests/hw/api_rev.rs
+++ b/ddi/tbor/types/tests/hw/api_rev.rs
@@ -29,7 +29,7 @@ fn round_trip() {
     let dev = open_hw_dev();
     let mut cookie = None;
     let resp = dev
-        .exec_op_tbor(&TborApiRevReq::new(), &mut cookie)
+        .exec_op_tbor(&TborApiRevReq::new(), None, &mut cookie)
         .expect("TBOR ApiRev round-trip on hardware");
     assert_eq!(
         resp, EXPECTED,

--- a/ddi/tbor/types/tests/hw/assertions.rs
+++ b/ddi/tbor/types/tests/hw/assertions.rs
@@ -1,0 +1,14 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Re-export of `harness/assertions.rs` for hardware tests.
+//!
+//! The `harness` module tree is `#[cfg]`'d off in the hardware build,
+//! so we pull the file in directly via `#[path]` and re-export its
+//! public surface. This keeps hw and emu tests using the same
+//! `assert_fw_rejects` predicate so a wire-contract change touches
+//! one file.
+
+#[path = "../harness/assertions.rs"]
+mod _inner;
+pub use _inner::*;

--- a/ddi/tbor/types/tests/hw/default_psk_gate.rs
+++ b/ddi/tbor/types/tests/hw/default_psk_gate.rs
@@ -1,0 +1,138 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Hardware end-to-end tests for the TBOR dispatcher's default-PSK
+//! gate (see `fw/core/lib/src/ddi/tbor/mod.rs::dispatch`).
+//!
+//! Mirrors the emu suite in `commands::default_psk_gate` and adds
+//! the E4 case (in-session, non-allow-listed opcode rejected with
+//! `DefaultPskMustRotate`) using `PartInit`.
+//!
+//! Cross-test isolation comes from
+//! [`hw_test_reset`](crate::hw::harness::hw_test_reset) — NSSR
+//! before + after each test body so every test starts and ends with
+//! the partition at pristine defaults.
+
+use azihsm_ddi_interface::DdiDev;
+use azihsm_ddi_tbor_types::PolicyKeyKind;
+use azihsm_ddi_tbor_types::SessionType;
+use azihsm_ddi_tbor_types::TborApiRevReq;
+use azihsm_ddi_tbor_types::TborStatus;
+use azihsm_ddi_tbor_types::DEFAULT_PSK_CO;
+use azihsm_ddi_tbor_types::DEFAULT_PSK_CU;
+use azihsm_ddi_tbor_types::MACH_SEED_LEN;
+use azihsm_ddi_tbor_types::PART_POLICY_LEN;
+use azihsm_ddi_tbor_types::POTA_THUMBPRINT_LEN;
+use azihsm_ddi_tbor_types::SATA_THUMBPRINT_LEN;
+
+use crate::hw::assertions::assert_fw_rejects;
+use crate::hw::harness::hw_test_reset;
+use crate::hw::session_helper::open_session;
+use crate::hw::session_helper::part_init;
+use crate::hw::session_helper::session_close;
+use crate::hw::session_helper::session_open_finish;
+use crate::hw::session_helper::session_open_init_with_options;
+use crate::hw::session_helper::SessionOpenInitOptions;
+
+const CO: u8 = 0;
+const CU: u8 = 1;
+
+/// Build a 484-byte `PartPolicy` blob that passes wire decode so
+/// the request reaches the dispatcher's gate. Mirrors
+/// `commands::part_init::known_good_part_policy`.
+fn known_good_part_policy() -> [u8; PART_POLICY_LEN] {
+    const OFF_POTA: usize = 2;
+    const OFF_SATA: usize = 102;
+    const OFF_FLAGS: usize = 418;
+    const OFF_INFO: usize = 419;
+
+    fn write_pubkey(bytes: &mut [u8], off: usize, fill: u8) {
+        bytes[off..off + 2].copy_from_slice(&PolicyKeyKind::Ecc384.0.to_le_bytes());
+        bytes[off + 2..off + 4].copy_from_slice(&96u16.to_le_bytes());
+        for (i, b) in bytes[off + 4..off + 4 + 96].iter_mut().enumerate() {
+            *b = (fill.wrapping_add(i as u8)) | 0x80;
+        }
+    }
+
+    let mut bytes = [0u8; PART_POLICY_LEN];
+    bytes[0] = 1;
+    bytes[1] = 0;
+    write_pubkey(&mut bytes, OFF_POTA, 0x10);
+    write_pubkey(&mut bytes, OFF_SATA, 0x20);
+    bytes[OFF_FLAGS] = 0;
+    for b in bytes[OFF_INFO..OFF_INFO + 64].iter_mut() {
+        *b = 0xAB;
+    }
+    bytes
+}
+
+fn mach_seed() -> [u8; MACH_SEED_LEN] {
+    let mut v = [0u8; MACH_SEED_LEN];
+    for (i, b) in v.iter_mut().enumerate() {
+        *b = 0x40 + i as u8;
+    }
+    v
+}
+
+fn pota_thumbprint() -> [u8; POTA_THUMBPRINT_LEN] {
+    [0x5Au8; POTA_THUMBPRINT_LEN]
+}
+
+fn sata_thumbprint() -> [u8; SATA_THUMBPRINT_LEN] {
+    [0x6Au8; SATA_THUMBPRINT_LEN]
+}
+
+/// E5: out-of-session `ApiRev` is never gated.
+#[test]
+fn api_rev_bypass() {
+    hw_test_reset(|dev| {
+        let mut cookie = None;
+        let _ = dev
+            .exec_op_tbor(&TborApiRevReq::new(), None, &mut cookie)
+            .expect("ApiRev bypasses the gate on any PSK state");
+    });
+}
+
+/// E2 + E3: SessionOpenInit / SessionOpenFinish / SessionClose all
+/// bypass the gate under the default PSK.
+#[test]
+fn session_open_and_close_bypass() {
+    hw_test_reset(|dev| {
+        let opts_co =
+            SessionOpenInitOptions::new(CO, SessionType::Authenticated).with_psk(&DEFAULT_PSK_CO);
+        let pending_co = session_open_init_with_options(dev, opts_co).expect("CO init");
+        let session_co = session_open_finish(dev, pending_co).expect("CO finish");
+        session_close(dev, session_co.session_id).expect("CO close");
+
+        let opts_cu =
+            SessionOpenInitOptions::new(CU, SessionType::PlainText).with_psk(&DEFAULT_PSK_CU);
+        let pending_cu = session_open_init_with_options(dev, opts_cu).expect("CU init");
+        let session_cu = session_open_finish(dev, pending_cu).expect("CU finish");
+        session_close(dev, session_cu.session_id).expect("CU close");
+    });
+}
+
+/// E4: in-session non-allow-listed opcode (`PartInit`) is rejected
+/// with `DefaultPskMustRotate`. Gate rejects at dispatch, before
+/// any handler runs.
+#[test]
+fn part_init_rejected_under_default_psk() {
+    hw_test_reset(|dev| {
+        let session = open_session(dev, CO, SessionType::Authenticated).expect("open CO");
+        let session_id = session.session_id;
+
+        let err = part_init(
+            dev,
+            &session,
+            &mach_seed(),
+            &known_good_part_policy(),
+            &pota_thumbprint(),
+            &sata_thumbprint(),
+            None,
+        )
+        .expect_err("PartInit under default PSK must be gated");
+        assert_fw_rejects(&err, TborStatus::DefaultPskMustRotate);
+
+        session_close(dev, session_id).expect("close CO");
+    });
+}

--- a/ddi/tbor/types/tests/hw/harness.rs
+++ b/ddi/tbor/types/tests/hw/harness.rs
@@ -1,0 +1,71 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Setup / execute / cleanup harness for hardware tests.
+//!
+//! Modelled on the mbor integration-test `ddi_dev_test` helper
+//! (`ddi/mbor/types/tests/integration/common.rs`) but panic-safe:
+//! cleanup runs even if `execute` panics, and any panic is
+//! re-raised after cleanup so the failure is still reported.
+//!
+//! The default cleanup is [`cleanup_nssr`], which issues NSSR /
+//! factory-reset via [`DdiDev::erase`]. Combined with
+//! [`setup_nssr`] on entry, each test starts and ends with the
+//! partition at pristine defaults (PSKs at `DEFAULT_PSK_*`,
+//! partition `Enabled`, session table empty) so tests are
+//! idempotent and order-independent.
+
+use std::panic::AssertUnwindSafe;
+
+use azihsm_ddi::AzihsmDdi;
+use azihsm_ddi_interface::Ddi;
+use azihsm_ddi_interface::DdiDev;
+
+use crate::hw::open_hw_dev;
+
+/// Backend device type shared across all hw tests.
+pub type HwDevInner = <AzihsmDdi as Ddi>::Dev;
+
+/// Run `setup` -> `execute` -> `cleanup` against a locked hw device.
+///
+/// The value returned by `setup` is passed by reference to `execute`
+/// and moved into `cleanup`, mirroring the mbor pattern of
+/// `setup -> u16 -> test -> cleanup(Some(u16))`.
+///
+/// `cleanup` runs even if `execute` panics; the panic is re-raised
+/// after cleanup so the test still fails.
+pub fn hw_test<S, T, C, U>(setup: S, execute: T, cleanup: C)
+where
+    S: FnOnce(&HwDevInner) -> U,
+    T: FnOnce(&HwDevInner, &U),
+    C: FnOnce(&HwDevInner, U),
+{
+    let dev = open_hw_dev();
+    let state = setup(&dev);
+    let result = std::panic::catch_unwind(AssertUnwindSafe(|| execute(&dev, &state)));
+    cleanup(&dev, state);
+    if let Err(p) = result {
+        std::panic::resume_unwind(p);
+    }
+}
+
+/// Default setup: NSSR / factory-reset before the test runs so the
+/// partition is guaranteed at pristine defaults regardless of any
+/// prior test's state.
+pub fn setup_nssr(dev: &HwDevInner) {
+    dev.erase().expect("NSSR setup: dev.erase() must succeed");
+}
+
+/// Default cleanup: NSSR / factory-reset after the test. Best-effort
+/// (ignores errors) so a panic in `execute` still propagates cleanly
+/// even if the device is in a state that rejects `erase`.
+pub fn cleanup_nssr<U>(dev: &HwDevInner, _state: U) {
+    let _ = dev.erase();
+}
+
+/// Convenience wrapper: NSSR on entry, run `execute`, NSSR on exit.
+/// Use for tests that don't need to thread state from setup to
+/// cleanup (i.e. sessions are opened and closed inside `execute`).
+pub fn hw_test_reset<T: FnOnce(&HwDevInner)>(execute: T) {
+    hw_test(setup_nssr, |dev, _| execute(dev), cleanup_nssr);
+}

--- a/ddi/tbor/types/tests/hw/mod.rs
+++ b/ddi/tbor/types/tests/hw/mod.rs
@@ -1,0 +1,97 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Hardware-only TBOR smoke tests.
+//!
+//! Runs against the native OS backend (`azihsm_ddi_nix::DdiNix` on
+//! Linux, `azihsm_ddi_win::DdiWin` on Windows) selected by
+//! [`azihsm_ddi::AzihsmDdi`] when no `emu` / `mock` / `sock` feature
+//! is enabled. Invoke with:
+//!
+//! ```text
+//! cargo test --no-default-features \
+//!     -p azihsm_ddi_tbor_types \
+//!     --test azihsm_ddi_tbor_tests hw::
+//! ```
+//!
+//! # Why a separate module (vs. the `commands/` harness)
+//!
+//! * The `commands/*` tests are file-gated on
+//!   `any(feature = "emu", feature = "mock", feature = "sock")` and
+//!   drive the [`TestCtx`](crate::harness::TestCtx) which itself is
+//!   only compiled under those features. `TestCtx::new` also relies
+//!   on `dev.erase()` (an emu-only factory-reset) for cross-test
+//!   isolation — real silicon cannot be reset from a test binary.
+//! * Hardware tests therefore need their own thin fixture: a
+//!   process-global serialisation lock so parallel `cargo test`
+//!   workers don''t stomp on the single physical device, plus an
+//!   open-and-return helper that does **no** state-mutating setup.
+//! * Keeping these under `hw::` also documents which tests are
+//!   safe to run against a live board (sessionless / read-only, or
+//!   with explicit end-of-test cleanup) — everything else stays
+//!   confined to the emu-backed harness.
+//!
+//! # What belongs here
+//!
+//! Sessionless / read-only TBOR commands, e.g. `ApiRev`, `PartInfo`
+//! before any `PartInit`. Anything that opens a session slot,
+//! rotates a PSK, or mutates persistent state should either land in
+//! the emu harness (with factory reset) or ship with its own
+//! explicit cleanup path.
+
+use std::ops::Deref;
+
+use azihsm_ddi::AzihsmDdi;
+use azihsm_ddi_interface::Ddi;
+use parking_lot::Mutex;
+use parking_lot::MutexGuard;
+
+pub mod api_rev;
+pub mod part_info;
+
+/// Process-global serialisation lock for hardware tests.
+///
+/// The single physical HSM is shared across the whole test binary, so
+/// concurrent `cargo test` workers must not issue overlapping TBOR
+/// commands. `parking_lot::Mutex` matches the workspace convention
+/// (std''s variant is disallowed by `clippy.toml`) and does not
+/// poison, so a panicking test cannot wedge subsequent runs.
+static HW_TEST_LOCK: Mutex<()> = Mutex::new(());
+
+/// Owned wrapper around an opened native-backend device that holds
+/// [`HW_TEST_LOCK`] for its lifetime.
+///
+/// `Deref`s to `<AzihsmDdi as Ddi>::Dev` so test bodies can call
+/// [`DdiDev`](azihsm_ddi_interface::DdiDev) methods
+/// (`exec_op_tbor`, ...) directly on the guard.
+pub(crate) struct HwDev {
+    dev: <AzihsmDdi as Ddi>::Dev,
+    _guard: MutexGuard<'static, ()>,
+}
+
+impl Deref for HwDev {
+    type Target = <AzihsmDdi as Ddi>::Dev;
+    fn deref(&self) -> &Self::Target {
+        &self.dev
+    }
+}
+
+/// Acquire [`HW_TEST_LOCK`] and open the first device advertised by
+/// the native backend.
+///
+/// Panics if the backend lists no devices or if `open_dev` fails —
+/// both are environmental (driver not loaded, board not present),
+/// not test bugs, and surfacing them immediately gives a clearer
+/// signal than downstream `exec_op_tbor` failures.
+pub(crate) fn open_hw_dev() -> HwDev {
+    let guard = HW_TEST_LOCK.lock();
+    let ddi = AzihsmDdi::default();
+    let infos = ddi.dev_info_list();
+    let info = infos
+        .first()
+        .expect("hw test: backend advertised no device (driver loaded? board present?)");
+    let dev = ddi
+        .open_dev(&info.path)
+        .expect("hw test: failed to open backend device");
+    HwDev { dev, _guard: guard }
+}

--- a/ddi/tbor/types/tests/hw/mod.rs
+++ b/ddi/tbor/types/tests/hw/mod.rs
@@ -47,7 +47,10 @@ use parking_lot::Mutex;
 use parking_lot::MutexGuard;
 
 pub mod api_rev;
+pub mod assertions;
+pub mod open_session;
 pub mod part_info;
+pub mod session_helper;
 
 /// Process-global serialisation lock for hardware tests.
 ///
@@ -85,13 +88,29 @@ impl Deref for HwDev {
 /// signal than downstream `exec_op_tbor` failures.
 pub(crate) fn open_hw_dev() -> HwDev {
     let guard = HW_TEST_LOCK.lock();
+    let dev = open_backend_dev();
+    HwDev { dev, _guard: guard }
+}
+
+/// Open an *additional* fd on the same physical device without
+/// re-acquiring [`HW_TEST_LOCK`]. Intended for tests that need two
+/// concurrent file descriptors on the same board (the Linux kernel
+/// driver enforces `AZIHSM_MAX_SESSIONS_PER_FD = 1`, so multi-session
+/// tests must span multiple fds).
+///
+/// The caller must already hold the lock via a live [`HwDev`], which
+/// is why this helper takes `&HwDev` — it borrows the guard's
+/// lifetime to statically prevent lock-free use.
+pub(crate) fn open_additional_hw_dev_fd(_lock_holder: &HwDev) -> <AzihsmDdi as Ddi>::Dev {
+    open_backend_dev()
+}
+
+fn open_backend_dev() -> <AzihsmDdi as Ddi>::Dev {
     let ddi = AzihsmDdi::default();
     let infos = ddi.dev_info_list();
     let info = infos
         .first()
         .expect("hw test: backend advertised no device (driver loaded? board present?)");
-    let dev = ddi
-        .open_dev(&info.path)
-        .expect("hw test: failed to open backend device");
-    HwDev { dev, _guard: guard }
+    ddi.open_dev(&info.path)
+        .expect("hw test: failed to open backend device")
 }

--- a/ddi/tbor/types/tests/hw/mod.rs
+++ b/ddi/tbor/types/tests/hw/mod.rs
@@ -5,11 +5,12 @@
 //!
 //! Runs against the native OS backend (`azihsm_ddi_nix::DdiNix` on
 //! Linux, `azihsm_ddi_win::DdiWin` on Windows) selected by
-//! [`azihsm_ddi::AzihsmDdi`] when no `emu` / `mock` / `sock` feature
-//! is enabled. Invoke with:
+//! [`azihsm_ddi::AzihsmDdi`]. Gated behind the `hw-tests` cargo
+//! feature so a plain `cargo test` on machines without a physical
+//! device does not attempt to open the backend. Invoke with:
 //!
 //! ```text
-//! cargo test --no-default-features \
+//! cargo test --no-default-features --features hw-tests \
 //!     -p azihsm_ddi_tbor_types \
 //!     --test azihsm_ddi_tbor_tests hw::
 //! ```
@@ -24,7 +25,7 @@
 //!   isolation — real silicon cannot be reset from a test binary.
 //! * Hardware tests therefore need their own thin fixture: a
 //!   process-global serialisation lock so parallel `cargo test`
-//!   workers don''t stomp on the single physical device, plus an
+//!   workers don't stomp on the single physical device, plus an
 //!   open-and-return helper that does **no** state-mutating setup.
 //! * Keeping these under `hw::` also documents which tests are
 //!   safe to run against a live board (sessionless / read-only, or
@@ -60,7 +61,7 @@ pub mod session_helper;
 /// The single physical HSM is shared across the whole test binary, so
 /// concurrent `cargo test` workers must not issue overlapping TBOR
 /// commands. `parking_lot::Mutex` matches the workspace convention
-/// (std''s variant is disallowed by `clippy.toml`) and does not
+/// (std's variant is disallowed by `clippy.toml`) and does not
 /// poison, so a panicking test cannot wedge subsequent runs.
 static HW_TEST_LOCK: Mutex<()> = Mutex::new(());
 

--- a/ddi/tbor/types/tests/hw/mod.rs
+++ b/ddi/tbor/types/tests/hw/mod.rs
@@ -48,8 +48,11 @@ use parking_lot::MutexGuard;
 
 pub mod api_rev;
 pub mod assertions;
+pub mod default_psk_gate;
+pub mod harness;
 pub mod open_session;
 pub mod part_info;
+pub mod psk_change;
 pub mod session_helper;
 
 /// Process-global serialisation lock for hardware tests.

--- a/ddi/tbor/types/tests/hw/open_session.rs
+++ b/ddi/tbor/types/tests/hw/open_session.rs
@@ -274,3 +274,309 @@ fn multiple_concurrent_sessions_have_distinct_ids() {
     close_b.expect("close session B");
     assert_ne!(id_a, id_b, "concurrent sessions must have distinct ids");
 }
+
+// ---------------------------------------------------------------------------
+// Finish-side error paths not already covered above.
+// Ported from the emu suite (`commands::open_session`) so both suites
+// stay wire-identical.
+// ---------------------------------------------------------------------------
+
+/// `SessionOpenFinish` against a session id that does not match
+/// the pending slot on this fd must be rejected. The Linux kernel
+/// driver enforces fd-scoping (`FileHandleNoExistingSession`) so we
+/// establish a real pending slot first, then send the finish with
+/// a mismatched id. Either the driver (id mismatch) or the FW
+/// (pending-blob load fails) is a valid rejection surface — accept
+/// both.
+#[test]
+fn finish_unknown_session_id_rejected() {
+    let dev = open_hw_dev();
+    let pending = session_open_init(&dev, CU, SessionType::PlainText)
+        .expect("phase-1 to establish a real pending slot must succeed");
+    let real_id = pending.session_id;
+    // Consume `pending` so it isn't reused. The FW pending blob
+    // remains until we either finish it or `SessionClose` it.
+    drop(pending);
+
+    // Mismatched id: flip the high bit so the value can never
+    // collide with `real_id` on any realistic slot count.
+    let bogus_id = real_id ^ 0x8000;
+
+    let req = TborSessionOpenFinishReq {
+        session_id: bogus_id,
+        mac_fin: [0u8; 48],
+        seed_envelope: [0u8; SEED_ENVELOPE_LEN],
+    };
+    let mut cookie = None;
+    let err = dev
+        .exec_op_tbor::<TborSessionOpenFinishReq>(&req, None, &mut cookie)
+        .expect_err("finish against mismatched session_id must fail");
+    assert!(
+        matches!(
+            err,
+            azihsm_ddi_interface::DdiError::DdiError(_)
+                | azihsm_ddi_interface::DdiError::DdiStatus(_)
+        ),
+        "expected FW or driver rejection, got {err:?}",
+    );
+
+    // Clean up the real pending slot we established up front.
+    let _ = session_close(&dev, real_id);
+}
+
+/// Replaying `SessionOpenFinish` after a successful handshake must
+/// fail: the pending blob has been consumed and the slot is Active,
+/// so the finish-side pre-check refuses to load it as pending. This
+/// is the regression for the "pending blob consumed on success"
+/// wiring.
+#[test]
+fn double_finish_rejected() {
+    let dev = open_hw_dev();
+    let handshake = open_session(&dev, CU, SessionType::PlainText)
+        .expect("hw handshake CU+PlainText must succeed");
+    let session_id = handshake.session_id;
+    drop(handshake);
+
+    let req = TborSessionOpenFinishReq {
+        session_id,
+        mac_fin: [0u8; 48],
+        seed_envelope: [0u8; SEED_ENVELOPE_LEN],
+    };
+    let mut cookie = None;
+    let err = dev
+        .exec_op_tbor::<TborSessionOpenFinishReq>(&req, None, &mut cookie)
+        .expect_err("second finish against the same slot must fail");
+    assert!(
+        matches!(err, azihsm_ddi_interface::DdiError::DdiError(_)),
+        "expected FW-side rejection on double-finish, got {err:?}",
+    );
+    // Close the Active slot we established up front so this test
+    // does not leak on the physical board.
+    session_close(&dev, session_id).expect("SessionClose must succeed on hw");
+}
+
+// ---------------------------------------------------------------------------
+// Hardware-specific lifecycle: real silicon retains session-table
+// state across tests, so an explicit "close fully frees the slot"
+// regression only makes sense on hw. The emu harness gets a fresh
+// factory reset per test and can't observe this.
+// ---------------------------------------------------------------------------
+
+/// Open a session, close it, then open again on the same fd. The
+/// second open must succeed — this guards against a stale slot or
+/// leaked FSM state that would otherwise wedge the second attempt.
+#[test]
+fn open_close_reopen_same_slot() {
+    let dev = open_hw_dev();
+    let first =
+        open_session(&dev, CU, SessionType::PlainText).expect("first hw handshake must succeed");
+    let first_id = first.session_id;
+    drop(first);
+    session_close(&dev, first_id).expect("first SessionClose must succeed");
+
+    let second =
+        open_session(&dev, CU, SessionType::PlainText).expect("reopen after close must succeed");
+    let second_id = second.session_id;
+    drop(second);
+    session_close(&dev, second_id).expect("second SessionClose must succeed");
+}
+
+/// `SessionClose` against a session id that does not match the
+/// active slot on this fd must be rejected. The Linux kernel driver
+/// enforces fd-scoping (`FileHandleNoExistingSession`) so we open a
+/// real session first, then close a mismatched id. Either the
+/// driver or the FW is a valid rejection surface.
+#[test]
+fn session_close_unknown_session_id_rejected() {
+    let dev = open_hw_dev();
+    let handshake = open_session(&dev, CU, SessionType::PlainText)
+        .expect("hw handshake to establish an Active slot must succeed");
+    let real_id = handshake.session_id;
+    drop(handshake);
+
+    let bogus_id = real_id ^ 0x8000;
+    let err =
+        session_close(&dev, bogus_id).expect_err("SessionClose against mismatched id must fail");
+    assert!(
+        matches!(
+            err,
+            azihsm_ddi_interface::DdiError::DdiError(_)
+                | azihsm_ddi_interface::DdiError::DdiStatus(_)
+        ),
+        "expected FW or driver rejection on close-unknown, got {err:?}",
+    );
+
+    // Close the real slot we opened for fixture setup.
+    session_close(&dev, real_id).expect("close of the real session must succeed");
+}
+
+// ---------------------------------------------------------------------------
+// Point-validation negatives. The FW `EccPublicKeyValidation` stage
+// checks that `pk_init` is a valid, non-identity point on the P-384
+// curve; the emu suite can't meaningfully hit the on-curve check
+// (SoftAES + mocks accept whatever), so these are genuine hw-only
+// coverage.
+//
+// We only assert a generic FW-side rejection rather than pinning
+// `EccPointValidationFailed` in case a future FW change collapses
+// validation errors into a broader category (e.g. `InvalidArg`).
+// ---------------------------------------------------------------------------
+
+/// `pk_init` all zeros is trivially off-curve (and encodes the point
+/// at infinity in some conventions) — FW must reject.
+#[test]
+fn pk_init_all_zero_rejected() {
+    let dev = open_hw_dev();
+    let req = TborSessionOpenInitReq {
+        psk_id: CU,
+        session_type: SessionType::PlainText.to_u8(),
+        suite_id: SESSION_SUITE_P384_HKDF_SHA384_AES_GCM_256,
+        pk_init: [0u8; PK_INIT_LEN],
+    };
+    let mut cookie = None;
+    let err = dev
+        .exec_op_tbor::<TborSessionOpenInitReq>(&req, None, &mut cookie)
+        .expect_err("all-zero pk_init must be rejected");
+    assert!(
+        matches!(err, azihsm_ddi_interface::DdiError::DdiError(_)),
+        "expected FW-side rejection for all-zero pk_init, got {err:?}",
+    );
+}
+
+/// `pk_init` with the SEC1 uncompressed prefix (`0x04`) but garbage
+/// coordinates that do not satisfy the P-384 curve equation. FW's
+/// on-curve validation must reject.
+#[test]
+fn pk_init_not_on_curve_rejected() {
+    let dev = open_hw_dev();
+    let mut pk_init = [0xFFu8; PK_INIT_LEN];
+    pk_init[0] = 0x04; // SEC1 uncompressed prefix
+    let req = TborSessionOpenInitReq {
+        psk_id: CU,
+        session_type: SessionType::PlainText.to_u8(),
+        suite_id: SESSION_SUITE_P384_HKDF_SHA384_AES_GCM_256,
+        pk_init,
+    };
+    let mut cookie = None;
+    let err = dev
+        .exec_op_tbor::<TborSessionOpenInitReq>(&req, None, &mut cookie)
+        .expect_err("off-curve pk_init must be rejected");
+    assert!(
+        matches!(err, azihsm_ddi_interface::DdiError::DdiError(_)),
+        "expected FW-side rejection for off-curve pk_init, got {err:?}",
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Session table exhaustion + recovery. Iteratively opens sessions on
+// fresh fds until the FW reports the table is full, then closes them
+// all and confirms one more open succeeds — the pending/active slot
+// cleanup path must fully reclaim capacity.
+//
+// We bound the loop at 16 to avoid running forever on future FW
+// builds with a much larger table. If the loop completes without a
+// rejection we still validate the cleanup path (close-all + reopen)
+// but skip the "at least one rejection observed" invariant with a
+// diagnostic message so the test remains meaningful across FW
+// capacity changes.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn open_session_fills_table_then_recovers() {
+    let dev = open_hw_dev();
+    let mut fds: Vec<<azihsm_ddi::AzihsmDdi as azihsm_ddi_interface::Ddi>::Dev> = Vec::new();
+    let mut ids: Vec<u16> = Vec::new();
+    let mut rejection_seen = false;
+
+    for _ in 0..16 {
+        let fd = open_additional_hw_dev_fd(&dev);
+        match open_session(&fd, CU, SessionType::PlainText) {
+            Ok(h) => {
+                ids.push(h.session_id);
+                fds.push(fd);
+                drop(h);
+            }
+            Err(e) => {
+                // FW rejected — treat as "table full". Verify it is
+                // an FW-side rejection (not a driver / decode fault)
+                // before ending the ramp-up.
+                assert!(
+                    matches!(e, azihsm_ddi_interface::DdiError::DdiError(_)),
+                    "table-full rejection must be FW-side, got {e:?}",
+                );
+                rejection_seen = true;
+                break;
+            }
+        }
+    }
+
+    // Close everything we opened before running the recovery check,
+    // so a recovery-side failure does not leak slots on the board.
+    for (fd, id) in fds.iter().zip(ids.iter()) {
+        let _ = session_close(fd, *id);
+    }
+
+    // Recovery: one fresh open must succeed after the batch close.
+    let recovered = open_session(&dev, CU, SessionType::PlainText)
+        .expect("session table must recover after close-all");
+    let recovered_id = recovered.session_id;
+    drop(recovered);
+    session_close(&dev, recovered_id).expect("SessionClose after recovery must succeed");
+
+    if !rejection_seen {
+        eprintln!(
+            "open_session_fills_table_then_recovers: FW accepted {} concurrent sessions              without emitting a table-full rejection; capacity limit not observed",
+            ids.len(),
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Two independent handshakes must derive distinct exported material,
+// which — for authenticated sessions — surfaces as distinct MAC
+// keys. This is the invariant that lets the host use per-session
+// MAC keys as replay-window nonces without cross-session collisions.
+// ---------------------------------------------------------------------------
+
+/// Two independent CO+Authenticated handshakes must derive distinct
+/// exported material — which surfaces as distinct per-direction MAC
+/// keys. Runs sequentially (open, snapshot, close, open again)
+/// because real hw refuses to hold two Authenticated sessions
+/// concurrently (`VaultSessionLimitReached`); the ephemeral-per-
+/// handshake invariant this test guards is unchanged by that.
+#[test]
+fn co_authenticated_derives_unique_keys_per_session() {
+    let dev = open_hw_dev();
+
+    // First handshake — snapshot keys then close.
+    let a = open_session(&dev, CO, SessionType::Authenticated)
+        .expect("first CO+Authenticated handshake must succeed");
+    let a_id = a.session_id;
+    let a_tx = a.derive_mac_tx_key().expect("derive a tx");
+    let a_rx = a.derive_mac_rx_key().expect("derive a rx");
+    let a_exported = a.exported.clone();
+    drop(a);
+    session_close(&dev, a_id).expect("close first session must succeed");
+
+    // Second handshake on the same fd — must derive fresh material
+    // because the VM ephemeral keypair is regenerated per Phase-1.
+    let b = open_session(&dev, CO, SessionType::Authenticated)
+        .expect("second CO+Authenticated handshake must succeed");
+    let b_id = b.session_id;
+    let b_tx = b.derive_mac_tx_key().expect("derive b tx");
+    let b_rx = b.derive_mac_rx_key().expect("derive b rx");
+    let b_exported = b.exported.clone();
+    drop(b);
+    // Close before asserting so a failing assertion never leaks.
+    session_close(&dev, b_id).expect("close second session must succeed");
+
+    assert_ne!(
+        a_exported, b_exported,
+        "two handshakes must derive distinct HPKE exported material",
+    );
+    assert_ne!(a_tx, b_tx, "per-session mac tx keys must differ");
+    assert_ne!(a_rx, b_rx, "per-session mac rx keys must differ");
+    // Sanity: within a single session, tx and rx are distinct.
+    assert_ne!(a_tx, a_rx);
+    assert_ne!(b_tx, b_rx);
+}

--- a/ddi/tbor/types/tests/hw/open_session.rs
+++ b/ddi/tbor/types/tests/hw/open_session.rs
@@ -1,0 +1,276 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Hardware end-to-end smoke tests for the TBOR
+//! `SessionOpenInit` / `SessionOpenFinish` two-phase handshake.
+//!
+//! Exercises the full host -> nix/win backend -> silicon fw
+//! `handle_tbor_op` pipeline against a live board. Each test either
+//!
+//! * runs a happy-path handshake and **explicitly** closes the
+//!   resulting Active session via `SessionClose` (real silicon can't
+//!   be factory-reset from a test binary — leaks would eventually
+//!   exhaust the session table), or
+//! * exercises a negative path that the firmware **already** cleans
+//!   up as part of its error-handling contract (parse-stage rejects
+//!   never allocate a slot; Phase-2 auth failures destroy the
+//!   Pending slot before returning).
+//!
+//! Cross-worker safety is provided by [`crate::hw::open_hw_dev`]'s
+//! process-global [`HW_TEST_LOCK`](crate::hw::HW_TEST_LOCK).
+//!
+//! Coverage mirrors the emu suite in `commands::open_session`:
+//! happy paths for both permitted (role, session_type) pairings,
+//! role/type mismatches, parse-stage negatives (psk_id,
+//! session_type byte, suite_id), Phase-2 MAC and seed-envelope
+//! tampering, and a concurrent-sessions distinctness check.
+//!
+//! Invoke with:
+//!
+//! ```text
+//! cargo test --no-default-features \
+//!     -p azihsm_ddi_tbor_types \
+//!     --test azihsm_ddi_tbor_tests hw::open_session
+//! ```
+
+use azihsm_ddi_interface::DdiDev;
+use azihsm_ddi_tbor_types::SessionType;
+use azihsm_ddi_tbor_types::TborSessionOpenFinishReq;
+use azihsm_ddi_tbor_types::TborSessionOpenInitReq;
+use azihsm_ddi_tbor_types::TborStatus;
+use azihsm_ddi_tbor_types::PK_INIT_LEN;
+use azihsm_ddi_tbor_types::SEED_ENVELOPE_LEN;
+use azihsm_ddi_tbor_types::SESSION_SUITE_P384_HKDF_SHA384_AES_GCM_256;
+
+use crate::hw::assertions::assert_fw_rejects;
+use crate::hw::open_additional_hw_dev_fd;
+use crate::hw::open_hw_dev;
+use crate::hw::session_helper::build_mac_fin;
+use crate::hw::session_helper::open_session;
+use crate::hw::session_helper::session_close;
+use crate::hw::session_helper::session_open_finish_with_mac;
+use crate::hw::session_helper::session_open_init;
+
+const CO: u8 = 0;
+const CU: u8 = 1;
+
+/// Ship `req` and expect an FW-side rejection with the given
+/// `TborStatus`. Small local wrapper so each negative-path test
+/// reads as a single call.
+#[track_caller]
+fn expect_init_rejects(req: &TborSessionOpenInitReq, expected: TborStatus) {
+    let dev = open_hw_dev();
+    let mut cookie = None;
+    let err = dev
+        .exec_op_tbor::<TborSessionOpenInitReq>(req, None, &mut cookie)
+        .expect_err("FW must reject the malformed SessionOpenInit request");
+    assert_fw_rejects(&err, expected);
+}
+
+// ---------------------------------------------------------------------------
+// Happy paths — full two-phase handshake against real silicon.
+// Each test explicitly closes the session; a bare `assert!` failure
+// still runs `SessionClose` because we call it inline before the
+// assertion (or in a helper that scopes cleanup around the check).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn co_authenticated_happy() {
+    let dev = open_hw_dev();
+    let handshake = open_session(&dev, CO, SessionType::Authenticated)
+        .expect("hw handshake CO+Authenticated must succeed");
+    let session_id = handshake.session_id;
+
+    // Snapshot the invariants we want to check, then close the
+    // session on the device before running assertions so a failure
+    // never leaks a slot on the physical board.
+    let psk_id = handshake.psk_id;
+    let is_auth = handshake.session_type.is_authenticated();
+    let bmk_len = handshake.bmk_session.len();
+    let tx = handshake.derive_mac_tx_key().expect("derive mac tx key");
+    let rx = handshake.derive_mac_rx_key().expect("derive mac rx key");
+    drop(handshake);
+    session_close(&dev, session_id).expect("SessionClose must succeed on hw");
+
+    assert_eq!(psk_id, CO, "handshake carrier must round-trip psk_id");
+    assert!(is_auth, "CO handshake must yield an Authenticated channel");
+    assert!(
+        bmk_len > 0,
+        "FW must return a non-empty bmk_session envelope",
+    );
+    assert_eq!(tx.len(), 48, "mac tx key length");
+    assert_eq!(rx.len(), 48, "mac rx key length");
+    assert_ne!(tx, rx, "mac tx and rx keys must differ per direction");
+}
+
+#[test]
+fn cu_plaintext_happy() {
+    let dev = open_hw_dev();
+    let handshake = open_session(&dev, CU, SessionType::PlainText)
+        .expect("hw handshake CU+PlainText must succeed");
+    let session_id = handshake.session_id;
+    let psk_id = handshake.psk_id;
+    let is_auth = handshake.session_type.is_authenticated();
+    let bmk_len = handshake.bmk_session.len();
+    drop(handshake);
+    session_close(&dev, session_id).expect("SessionClose must succeed on hw");
+
+    assert_eq!(psk_id, CU);
+    assert!(!is_auth, "CU handshake must yield a PlainText channel");
+    assert!(bmk_len > 0);
+}
+
+// ---------------------------------------------------------------------------
+// Role / session_type mismatches — parse-stage rejections in
+// `validate_for_role`. No pending slot is allocated, no cleanup
+// needed.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn co_plaintext_rejected() {
+    let dev = open_hw_dev();
+    let err = session_open_init(&dev, CO, SessionType::PlainText)
+        .expect_err("CO + PlainText must be rejected by validate_for_role");
+    assert_fw_rejects(&err, TborStatus::InvalidSessionType);
+}
+
+#[test]
+fn cu_authenticated_rejected() {
+    let dev = open_hw_dev();
+    let err = session_open_init(&dev, CU, SessionType::Authenticated)
+        .expect_err("CU + Authenticated must be rejected by validate_for_role");
+    assert_fw_rejects(&err, TborStatus::InvalidSessionType);
+}
+
+// ---------------------------------------------------------------------------
+// Parse-stage negatives — FW rejects before any HPKE work; no
+// pending slot allocated.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn invalid_psk_id_rejected() {
+    // Bypass the typed `PskId(0|1)` guard by shipping raw bytes.
+    // Spot-check a small set of out-of-range values covering: the
+    // smallest invalid value (`2`), a mid-range value (`0x7F`), and
+    // the all-ones byte (`0xFF`). All must surface `InvalidPskId`
+    // from the FW dispatcher before any HPKE work.
+    for bad in [2u8, 0x7F, 0xFF] {
+        let req = TborSessionOpenInitReq {
+            psk_id: bad,
+            session_type: SessionType::PlainText.to_u8(),
+            suite_id: SESSION_SUITE_P384_HKDF_SHA384_AES_GCM_256,
+            pk_init: [0x04u8; PK_INIT_LEN],
+        };
+        expect_init_rejects(&req, TborStatus::InvalidPskId);
+    }
+}
+
+#[test]
+fn invalid_session_type_byte_rejected() {
+    // Bypass the typed `SessionType` enum — ship an out-of-range byte
+    // directly so `SessionType::from_u8` in the FW rejects.
+    let req = TborSessionOpenInitReq {
+        psk_id: CU,
+        session_type: 42,
+        suite_id: SESSION_SUITE_P384_HKDF_SHA384_AES_GCM_256,
+        pk_init: [0x04u8; PK_INIT_LEN],
+    };
+    expect_init_rejects(&req, TborStatus::InvalidSessionType);
+}
+
+#[test]
+fn unsupported_suite_id_rejected() {
+    // Only 0x01 is supported; spot-check reserved (0x02), zero, and
+    // the all-ones byte.
+    for bad in [0x00u8, 0x02, 0xFF] {
+        let req = TborSessionOpenInitReq {
+            psk_id: CU,
+            session_type: SessionType::PlainText.to_u8(),
+            suite_id: bad,
+            pk_init: [0x04u8; PK_INIT_LEN],
+        };
+        expect_init_rejects(&req, TborStatus::UnsupportedSessionSuite);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Phase-2 auth failures — FW's contract is to destroy the pending
+// slot on either MAC mismatch or AEAD-open failure, so no explicit
+// cleanup is needed. Regression for the destroy-on-auth-failure
+// wiring.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn finish_mac_tampered() {
+    let dev = open_hw_dev();
+    let pending =
+        session_open_init(&dev, CU, SessionType::PlainText).expect("Phase 1 must succeed");
+    let mut mac_fin = build_mac_fin(&pending).expect("build phase-2 mac");
+    mac_fin[0] ^= 0x01;
+    let err = session_open_finish_with_mac(&dev, pending, mac_fin)
+        .expect_err("tampered mac_fin must be rejected by the FW");
+    assert_fw_rejects(&err, TborStatus::SessionAuthFailure);
+    // No SessionClose — FW destroyed the slot as part of the auth
+    // failure path (see `session_open_finish::on_start` +
+    // `TborSessionAuthFailure` arm).
+}
+
+#[test]
+fn finish_seed_envelope_tampered() {
+    let dev = open_hw_dev();
+    let pending =
+        session_open_init(&dev, CU, SessionType::PlainText).expect("Phase 1 must succeed");
+    let session_id = pending.session_id;
+    let mac_fin = build_mac_fin(&pending).expect("build phase-2 mac");
+    // Consume pending so it isn't reused; then hand-build a
+    // syntactically-valid-but-cryptographically-bogus envelope.
+    drop(pending);
+
+    let mut seed_envelope = [0u8; SEED_ENVELOPE_LEN];
+    seed_envelope[0..4].copy_from_slice(b"AEAD");
+    seed_envelope[4] = 0x03; // AeadAlg::AesGcm256
+                             // Bytes 5..8 remain zero (rsv=0, aad_len_be=0); IV/CT/TAG all
+                             // zero — the AES-GCM tag will fail to verify.
+
+    let req = TborSessionOpenFinishReq {
+        session_id,
+        mac_fin,
+        seed_envelope,
+    };
+    let mut cookie = None;
+    let err = dev
+        .exec_op_tbor::<TborSessionOpenFinishReq>(&req, None, &mut cookie)
+        .expect_err("tampered seed_envelope must be rejected by the FW");
+    assert_fw_rejects(&err, TborStatus::SessionAuthFailure);
+    // FW destroyed the slot on AEAD auth failure — no manual cleanup.
+}
+
+// ---------------------------------------------------------------------------
+// Concurrency
+// ---------------------------------------------------------------------------
+
+#[test]
+fn multiple_concurrent_sessions_have_distinct_ids() {
+    // The Linux kernel driver enforces `AZIHSM_MAX_SESSIONS_PER_FD = 1`
+    // (see drivers/linux/drvsrc/azihsm_hsm.h), so two concurrent
+    // sessions must be opened on two distinct file descriptors on
+    // the same physical device. `open_hw_dev()` takes the shared
+    // HW_TEST_LOCK; use `open_additional_hw_dev_fd()` for the
+    // second fd so we don''t deadlock re-acquiring a non-reentrant
+    // mutex.
+    let dev_a = open_hw_dev();
+    let dev_b = open_additional_hw_dev_fd(&dev_a);
+    let a = open_session(&dev_a, CU, SessionType::PlainText).expect("first session must open");
+    let b = open_session(&dev_b, CU, SessionType::PlainText).expect("second session must open");
+    let id_a = a.session_id;
+    let id_b = b.session_id;
+    drop(a);
+    drop(b);
+    // Close both regardless of the assertion outcome so nothing
+    // leaks on the physical board.
+    let close_a = session_close(&dev_a, id_a);
+    let close_b = session_close(&dev_b, id_b);
+    close_a.expect("close session A");
+    close_b.expect("close session B");
+    assert_ne!(id_a, id_b, "concurrent sessions must have distinct ids");
+}

--- a/ddi/tbor/types/tests/hw/part_info.rs
+++ b/ddi/tbor/types/tests/hw/part_info.rs
@@ -1,0 +1,51 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Hardware smoke test for the out-of-session TBOR `PartInfo`
+//! command.
+//!
+//! Exercises the full host -> nix/win backend -> silicon fw
+//! `handle_tbor_op` -> response path and asserts the invariant
+//! device/partition fields the firmware reports for the default
+//! provisioned partition. Safe to run against a live board because
+//! `PartInfo` is sessionless and does not mutate persistent state.
+
+use azihsm_ddi_interface::DdiDev;
+use azihsm_ddi_tbor_types::TborPartInfoReq;
+use azihsm_ddi_tbor_types::TborPartInfoResp;
+
+use crate::hw::open_hw_dev;
+
+/// `DdiDeviceKind::Physical` discriminant. Mirrors the emu-harness
+/// constant in `commands::part_info` so both paths pin the same
+/// contract.
+const DEVICE_KIND_PHYSICAL: u8 = 2;
+
+/// `PartState::Enabled` discriminant — the default provisioned state
+/// of a partition before any `PartInit`.
+const PART_STATE_ENABLED: u8 = 2;
+
+fn assert_default_part_info(resp: &TborPartInfoResp) {
+    assert_eq!(
+        resp.device_kind, DEVICE_KIND_PHYSICAL,
+        "uno firmware must report a physical device kind",
+    );
+    assert_eq!(
+        resp.part_state, PART_STATE_ENABLED,
+        "default provisioned partition must be Enabled",
+    );
+    assert!(
+        resp.pid_pub_key.iter().any(|&b| b != 0),
+        "identity public key must be materialized (non-zero)",
+    );
+}
+
+#[test]
+fn round_trip() {
+    let dev = open_hw_dev();
+    let mut cookie = None;
+    let resp = dev
+        .exec_op_tbor(&TborPartInfoReq::new(), &mut cookie)
+        .expect("TBOR PartInfo round-trip on hardware");
+    assert_default_part_info(&resp);
+}

--- a/ddi/tbor/types/tests/hw/part_info.rs
+++ b/ddi/tbor/types/tests/hw/part_info.rs
@@ -45,7 +45,7 @@ fn round_trip() {
     let dev = open_hw_dev();
     let mut cookie = None;
     let resp = dev
-        .exec_op_tbor(&TborPartInfoReq::new(), &mut cookie)
+        .exec_op_tbor(&TborPartInfoReq::new(), None, &mut cookie)
         .expect("TBOR PartInfo round-trip on hardware");
     assert_default_part_info(&resp);
 }

--- a/ddi/tbor/types/tests/hw/psk_change.rs
+++ b/ddi/tbor/types/tests/hw/psk_change.rs
@@ -1,0 +1,234 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Hardware end-to-end tests for the TBOR `PskChange` command.
+//!
+//! Mirrors the emu suite in `commands::psk_change`. Cross-test
+//! isolation comes from [`hw_test_reset`](crate::hw::harness::hw_test_reset)
+//! (NSSR before + after each `execute` body via `dev.erase()`), so
+//! every test starts with the partition at pristine defaults and
+//! leaves it that way even on panic.
+//!
+//! Invoke with:
+//!
+//! ```text
+//! cargo test --no-default-features \
+//!     -p azihsm_ddi_tbor_types \
+//!     --test azihsm_ddi_tbor_tests hw::psk_change
+//! ```
+
+use azihsm_crypto::aead_envelope;
+use azihsm_crypto::aead_envelope::AeadAlg;
+use azihsm_crypto::AesKey;
+use azihsm_crypto::Rng;
+use azihsm_ddi_interface::DdiDev;
+use azihsm_ddi_tbor_types::build_psk_change_aad;
+use azihsm_ddi_tbor_types::SessionType;
+use azihsm_ddi_tbor_types::TborPskChangeReq;
+use azihsm_ddi_tbor_types::TborStatus;
+use azihsm_ddi_tbor_types::DEFAULT_PSK_CO;
+use azihsm_ddi_tbor_types::DEFAULT_PSK_CU;
+use azihsm_ddi_tbor_types::PSK_LEN;
+
+use crate::hw::assertions::assert_fw_rejects;
+use crate::hw::harness::hw_test_reset;
+use crate::hw::session_helper::open_session;
+use crate::hw::session_helper::psk_change;
+use crate::hw::session_helper::session_close;
+use crate::hw::session_helper::session_open_finish;
+use crate::hw::session_helper::session_open_init_with_options;
+use crate::hw::session_helper::SessionOpenInitOptions;
+
+const CO: u8 = 0;
+const CU: u8 = 1;
+
+/// Non-default PSK used as the rotation target. Distinct per-role.
+const ROTATED_PSK_CO: [u8; PSK_LEN] = [
+    0xA1, 0xA2, 0xA3, 0xA4, 0xA5, 0xA6, 0xA7, 0xA8, 0xA9, 0xAA, 0xAB, 0xAC, 0xAD, 0xAE, 0xAF, 0xB0,
+    0xB1, 0xB2, 0xB3, 0xB4, 0xB5, 0xB6, 0xB7, 0xB8, 0xB9, 0xBA, 0xBB, 0xBC, 0xBD, 0xBE, 0xBF, 0xC0,
+];
+const ROTATED_PSK_CU: [u8; PSK_LEN] = [
+    0xC1, 0xC2, 0xC3, 0xC4, 0xC5, 0xC6, 0xC7, 0xC8, 0xC9, 0xCA, 0xCB, 0xCC, 0xCD, 0xCE, 0xCF, 0xD0,
+    0xD1, 0xD2, 0xD3, 0xD4, 0xD5, 0xD6, 0xD7, 0xD8, 0xD9, 0xDA, 0xDB, 0xDC, 0xDD, 0xDE, 0xDF, 0xE0,
+];
+
+/// Build an AEAD-GCM envelope under `param_key` with caller-supplied
+/// AAD + plaintext. Negatives use this to construct envelopes the FW
+/// must reject.
+fn build_envelope(param_key: &AesKey, aad: &[u8], plaintext: &[u8]) -> Vec<u8> {
+    let iv = Rng::rand_vec(12).expect("rng iv");
+    let total = aead_envelope::seal(AeadAlg::AesGcm256, param_key, &iv, aad, plaintext, None)
+        .expect("aead size");
+    let mut out = vec![0u8; total];
+    let n = aead_envelope::seal(
+        AeadAlg::AesGcm256,
+        param_key,
+        &iv,
+        aad,
+        plaintext,
+        Some(&mut out),
+    )
+    .expect("aead seal");
+    out.truncate(n);
+    out
+}
+
+// ---------------------------------------------------------------------------
+// Happy-path lifecycle: open under default -> rotate -> close ->
+// reopen under new PSK succeeds -> reopen under default fails.
+// ---------------------------------------------------------------------------
+
+fn run_lifecycle(role: u8, sty: SessionType, default_psk: &[u8; PSK_LEN], rotated: &[u8; PSK_LEN]) {
+    hw_test_reset(|dev| {
+        let session = open_session(dev, role, sty).expect("open under default PSK");
+        let session_id = session.session_id;
+        psk_change(dev, &session, rotated).expect("rotate to new PSK");
+        session_close(dev, session_id).expect("close rotating session");
+
+        let opts = SessionOpenInitOptions::new(role, sty).with_psk(rotated);
+        let pending = session_open_init_with_options(dev, opts).expect("reopen under rotated PSK");
+        let resumed = session_open_finish(dev, pending).expect("finish reopen under rotated PSK");
+        session_close(dev, resumed.session_id).expect("close resumed session");
+
+        let opts_default = SessionOpenInitOptions::new(role, sty).with_psk(default_psk);
+        let result = session_open_init_with_options(dev, opts_default)
+            .and_then(|p| session_open_finish(dev, p));
+        assert!(
+            result.is_err(),
+            "reopen with old default PSK must fail after rotation",
+        );
+    });
+}
+
+#[test]
+fn lifecycle_co() {
+    run_lifecycle(
+        CO,
+        SessionType::Authenticated,
+        &DEFAULT_PSK_CO,
+        &ROTATED_PSK_CO,
+    );
+}
+
+#[test]
+fn lifecycle_cu() {
+    run_lifecycle(CU, SessionType::PlainText, &DEFAULT_PSK_CU, &ROTATED_PSK_CU);
+}
+
+/// After a successful rotation, a second `PskChange` on the same
+/// session must fail with `InvalidPermissions` (one-shot budget).
+#[test]
+fn second_attempt_same_session_fails() {
+    hw_test_reset(|dev| {
+        let session = open_session(dev, CU, SessionType::PlainText).expect("open under default CU");
+        let session_id = session.session_id;
+
+        psk_change(dev, &session, &ROTATED_PSK_CU).expect("first rotate");
+        let err = psk_change(dev, &session, &DEFAULT_PSK_CU)
+            .expect_err("second PskChange on same session must fail");
+        assert_fw_rejects(&err, TborStatus::InvalidPermissions);
+
+        session_close(dev, session_id).expect("close");
+    });
+}
+
+// ---------------------------------------------------------------------------
+// Envelope-shape negatives (pre-commit rejects).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn envelope_ciphertext_bit_flip_rejected() {
+    hw_test_reset(|dev| {
+        let session = open_session(dev, CU, SessionType::PlainText).expect("open");
+        let session_id = session.session_id;
+
+        let aad = build_psk_change_aad(session_id);
+        let mut envelope = build_envelope(&session.param_key, &aad, &ROTATED_PSK_CU);
+        let target = envelope.len() / 2;
+        envelope[target] ^= 0x01;
+
+        let req = TborPskChangeReq {
+            session_id,
+            psk_envelope: envelope,
+        };
+        let mut cookie = None;
+        let err = dev
+            .exec_op_tbor::<TborPskChangeReq>(&req, None, &mut cookie)
+            .expect_err("bit-flipped ciphertext must be rejected");
+        assert_fw_rejects(&err, TborStatus::AeadEnvelopeAuthFailed);
+
+        session_close(dev, session_id).expect("close");
+    });
+}
+
+#[test]
+fn envelope_wrong_session_id_in_aad_rejected() {
+    hw_test_reset(|dev| {
+        let session = open_session(dev, CU, SessionType::PlainText).expect("open");
+        let session_id = session.session_id;
+
+        let bogus_aad = build_psk_change_aad(session_id ^ 0x1234);
+        let envelope = build_envelope(&session.param_key, &bogus_aad, &ROTATED_PSK_CU);
+        let req = TborPskChangeReq {
+            session_id,
+            psk_envelope: envelope,
+        };
+        let mut cookie = None;
+        let err = dev
+            .exec_op_tbor::<TborPskChangeReq>(&req, None, &mut cookie)
+            .expect_err("mismatched session_id in AAD must be rejected");
+        assert_fw_rejects(&err, TborStatus::AeadEnvelopeAuthFailed);
+
+        session_close(dev, session_id).expect("close");
+    });
+}
+
+#[test]
+fn envelope_wrong_plaintext_length_rejected() {
+    hw_test_reset(|dev| {
+        for len in [PSK_LEN - 1, PSK_LEN + 1] {
+            let session = open_session(dev, CU, SessionType::PlainText).expect("open");
+            let session_id = session.session_id;
+            let bogus_psk = vec![0xCDu8; len];
+            let aad = build_psk_change_aad(session_id);
+            let envelope = build_envelope(&session.param_key, &aad, &bogus_psk);
+            let req = TborPskChangeReq {
+                session_id,
+                psk_envelope: envelope,
+            };
+            let mut cookie = None;
+            let err = dev
+                .exec_op_tbor::<TborPskChangeReq>(&req, None, &mut cookie)
+                .expect_err("wrong plaintext length must be rejected");
+            // Hardware: wire decoder catches length mismatch (schema pins
+            // `psk_envelope` at 100 B via `#[tbor(buffer, len = 100)]`) and
+            // surfaces it as `DdiDecodeFailed` before the handler's defensive
+            // `TborInvalidFixedLength` branch is reached. Emu decoder returns
+            // the more specific `TborInvalidFixedLength`.
+            assert_fw_rejects(&err, TborStatus::DdiDecodeFailed);
+            session_close(dev, session_id).expect("close");
+        }
+    });
+}
+
+#[test]
+fn envelope_empty_rejected() {
+    hw_test_reset(|dev| {
+        let session = open_session(dev, CU, SessionType::PlainText).expect("open");
+        let session_id = session.session_id;
+
+        let req = TborPskChangeReq {
+            session_id,
+            psk_envelope: Vec::new(),
+        };
+        let mut cookie = None;
+        let err = dev
+            .exec_op_tbor::<TborPskChangeReq>(&req, None, &mut cookie)
+            .expect_err("empty envelope must be rejected");
+        // See `envelope_wrong_plaintext_length_rejected` for the hw-vs-emu
+        // decode-order rationale — empty envelope hits the same decoder path.
+        assert_fw_rejects(&err, TborStatus::DdiDecodeFailed);
+
+        session_close(dev, session_id).expect("close");
+    });
+}

--- a/ddi/tbor/types/tests/hw/session_helper.rs
+++ b/ddi/tbor/types/tests/hw/session_helper.rs
@@ -1,0 +1,50 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Session-establishment helpers for hardware smoke tests.
+//!
+//! Re-uses the same crypto/plumbing modules that back the emu harness'
+//! session helpers by pulling them in via `#[path]` — the files live
+//! under `../harness/session/` but the harness module tree itself is
+//! `#[cfg]`'d off in the hardware build (see
+//! `azihsm_ddi_tbor_tests.rs`), so we can't `use crate::harness::…`
+//! from here. Everything below is a thin surface over those shared
+//! files plus the one-shot [`open_session`] convenience wrapper.
+//!
+//! Only compiled in hardware mode (`hw::` is itself gated on the
+//! no-backend-feature build).
+
+#[path = "../harness/session/crypto.rs"]
+mod crypto;
+#[path = "../harness/session/finish.rs"]
+pub mod finish;
+#[path = "../harness/session/init.rs"]
+pub mod init;
+#[path = "../harness/session/session_close.rs"]
+pub mod session_close;
+
+use azihsm_ddi::AzihsmDdi;
+use azihsm_ddi_interface::Ddi;
+use azihsm_ddi_interface::DdiError;
+use azihsm_ddi_tbor_types::SessionType;
+pub use finish::build_mac_fin;
+pub use finish::session_open_finish;
+pub use finish::session_open_finish_with_mac;
+pub use finish::SessionHandshake;
+pub use init::session_open_init;
+pub use init::session_open_init_with_options;
+pub use init::PendingHandshake;
+pub use init::SessionOpenInitOptions;
+pub use session_close::session_close;
+
+/// One-shot happy-path handshake: `SessionOpenInit` +
+/// `SessionOpenFinish`. Mirrors `crate::harness::session::open_session`
+/// so hw tests and emu tests read the same at the call site.
+pub fn open_session(
+    dev: &<AzihsmDdi as Ddi>::Dev,
+    psk_id: u8,
+    session_type: SessionType,
+) -> Result<SessionHandshake, DdiError> {
+    let pending = session_open_init(dev, psk_id, session_type)?;
+    session_open_finish(dev, pending)
+}

--- a/ddi/tbor/types/tests/hw/session_helper.rs
+++ b/ddi/tbor/types/tests/hw/session_helper.rs
@@ -20,6 +20,10 @@ mod crypto;
 pub mod finish;
 #[path = "../harness/session/init.rs"]
 pub mod init;
+#[path = "../harness/session/part_init.rs"]
+pub mod part_init;
+#[path = "../harness/session/psk_change.rs"]
+pub mod psk_change;
 #[path = "../harness/session/session_close.rs"]
 pub mod session_close;
 
@@ -35,6 +39,11 @@ pub use init::session_open_init;
 pub use init::session_open_init_with_options;
 pub use init::PendingHandshake;
 pub use init::SessionOpenInitOptions;
+pub use part_init::build_part_init_mach_seed_aad;
+pub use part_init::encrypt_mach_seed_envelope;
+pub use part_init::part_init;
+pub use psk_change::encrypt_psk_envelope;
+pub use psk_change::psk_change;
 pub use session_close::session_close;
 
 /// One-shot happy-path handshake: `SessionOpenInit` +

--- a/ddi/win/Cargo.toml
+++ b/ddi/win/Cargo.toml
@@ -13,6 +13,7 @@ doctest = false
 azihsm_ddi_interface.workspace = true
 azihsm_ddi_mbor_codec.workspace = true
 azihsm_ddi_mbor_types.workspace = true
+azihsm_ddi_tbor_types.workspace = true
 bitfield-struct.workspace = true
 cfg-if.workspace = true
 libc.workspace = true

--- a/ddi/win/src/dev.rs
+++ b/ddi/win/src/dev.rs
@@ -26,6 +26,8 @@ use azihsm_ddi_mbor_types::DdiRespHdr;
 use azihsm_ddi_mbor_types::DdiStatus;
 use azihsm_ddi_mbor_types::MborError;
 use azihsm_ddi_mbor_types::SessionControlKind;
+use azihsm_ddi_tbor_types::TborOpReq;
+use azihsm_ddi_tbor_types::TborResp;
 use bitfield_struct::bitfield;
 use parking_lot::RwLock;
 use winapi::ctypes::c_void;
@@ -861,6 +863,168 @@ impl DdiDev for DdiWinDev {
         let resp = <T::OpResp>::mbor_decode(&mut decoder)
             .map_err(|_| DdiError::MborError(MborError::DecodeError))?;
         Ok(resp)
+    }
+
+    /// Execute a TBOR-encoded DDI command on the real Windows device.
+    ///
+    /// Mirrors [`Self::exec_op_mbor`] but:
+    ///
+    ///   * encodes the request via [`TborOpReq::encode_request`];
+    ///   * sets the SQE opcode field `opc` to [`OP_TBOR`] so the
+    ///     firmware routes the request through its TBOR dispatcher
+    ///     (`fw/core/lib/src/op.rs::OP_TBOR`);
+    ///   * decodes the response with [`TborResp::decode_response`],
+    ///     which already maps embedded fw-error status into
+    ///     [`DdiError::DdiError`] / [`DdiError::TborDecodeError`].
+    ///
+    /// The Windows kernel driver is wire-agnostic — it forwards the
+    /// `opc` and `cmdset` ioctl fields verbatim into the SQE — so
+    /// no driver change is required to route TBOR.
+    fn exec_op_tbor<T: TborOpReq>(
+        &self,
+        req: &T,
+        _cookie: &mut Option<DdiCookie>,
+    ) -> DdiResult<T::OpResp> {
+        /// SQE opcode that routes the command through the firmware's
+        /// TBOR dispatcher (see `fw/core/lib/src/op.rs::OP_TBOR`).
+        const OP_TBOR: u16 = 2;
+
+        const REQ_BUF_LEN: usize = 8192;
+        const RESP_BUF_LEN: usize = 8192;
+
+        // -- 1. Encode the TBOR request --------------------------------
+        let mut req_buf = [0u8; REQ_BUF_LEN];
+        let req_bytes = req.encode_request(&mut req_buf)?;
+        let req_len = req_bytes.len();
+
+        tracing::debug!(
+            opcode = T::OPCODE,
+            "TBOR Request Buffer (in hex): {:02x?}",
+            &req_buf[..req_len]
+        );
+
+        let mut resp_buf = Box::<[u8; RESP_BUF_LEN]>::new([0u8; RESP_BUF_LEN]);
+
+        // -- 2. Build the ioctl command --------------------------------
+        let mut ioctl_in_buffer = McrCpGenericIoctlIndata::default();
+        let ioctl_out_buffer = McrCpGenericIoctlOutData::default();
+
+        ioctl_in_buffer.ioctl_hdr.ioctl_data_size =
+            mem::size_of::<McrCpGenericIoctlIndata>() as u32;
+        ioctl_in_buffer.ioctl_hdr.app_cmd_id = 0xCD1DDEAD;
+        ioctl_in_buffer.ioctl_hdr.timeout = 100; // in ms
+        ioctl_in_buffer.ioctl_hdr.flags = 0;
+
+        ioctl_in_buffer.context = 0;
+        // OP_TBOR is THE flag the firmware uses to route the request
+        // through the TBOR dispatcher instead of `handle_mbor_op`.
+        ioctl_in_buffer.opc = OP_TBOR;
+        ioctl_in_buffer.cmdset = MCR_CP_CMD_SESSION_GENERIC;
+
+        ioctl_in_buffer.user_buffers.src_length = req_len as u32;
+        ioctl_in_buffer.user_buffers.src_buf = req_buf.as_ptr();
+        ioctl_in_buffer.user_buffers.dst_length = resp_buf.len() as u32;
+        ioctl_in_buffer.user_buffers.dst_buf = resp_buf.as_mut_ptr();
+
+        // Session control flags come from the TBOR request type;
+        // each request declares its own kind so the transport layer
+        // doesn't need a central opcode->ctrl table.
+        let session_ctrl = req.session_ctrl();
+        ioctl_in_buffer
+            .session_control
+            .set_kind(u8::from(session_ctrl));
+        if let Some(sid) = req.get_session_id() {
+            ioctl_in_buffer.session_id = sid;
+            ioctl_in_buffer
+                .session_control
+                .set_session_id_is_valid(true);
+        }
+
+        // -- 3. Issue the ioctl (overlapped, same as MBOR) ----------------
+        let ioctl_code: DWORD = CTL_CODE(
+            0x3F,
+            0x201,
+            METHOD_BUFFERED,
+            FILE_READ_ACCESS | FILE_WRITE_ACCESS,
+        );
+
+        // SAFETY: WINAPI call requires unsafe call. The pointers to the buffers are valid and have been checked via
+        // debugging as well as code reviews.
+        let mut overlapped: OVERLAPPED = unsafe { mem::zeroed() };
+        let mut bytes_returned: DWORD = 0;
+        let in_ptr = ptr::addr_of!(ioctl_in_buffer);
+        let out_ptr = ptr::addr_of!(ioctl_out_buffer);
+        let overlapped_ptr: *mut OVERLAPPED = &mut overlapped;
+
+        let event = IoEvent::new()?;
+        overlapped.hEvent = event.handle();
+
+        // SAFETY: WINAPI call requires unsafe call. The pointers to the buffers are valid and have been checked via
+        // debugging as well as code reviews.
+        let _ioctl_ret = unsafe {
+            DeviceIoControl(
+                self.file.read().as_raw_handle() as HANDLE,
+                ioctl_code,
+                in_ptr as *mut c_void,
+                mem::size_of::<McrCpGenericIoctlIndata>() as DWORD,
+                out_ptr as *mut c_void,
+                mem::size_of::<McrCpGenericIoctlOutData>() as DWORD,
+                ptr::null_mut(),
+                overlapped_ptr,
+            )
+        };
+
+        let last_error = std::io::Error::last_os_error();
+        if last_error.raw_os_error() != Some(ERROR_IO_PENDING as i32) {
+            tracing::warn!(
+                ?last_error,
+                "DeviceIoControl returned error after exec_op_tbor"
+            );
+            Err(DdiError::IoError(last_error))?;
+        }
+
+        // SAFETY: WINAPI call requires unsafe call. The pointers to the buffers are valid and have been checked via
+        // debugging as well as code reviews.
+        let result = unsafe {
+            GetOverlappedResult(
+                self.file.read().as_raw_handle() as HANDLE,
+                overlapped_ptr,
+                &mut bytes_returned,
+                1,
+            )
+        };
+
+        if result == 0 {
+            // WinApi failure path: driver does not copy any data,
+            // so the extended ioctl status is unreliable here.
+            let last_error = std::io::Error::last_os_error();
+            tracing::warn!(
+                ?last_error,
+                "GetOverlappedResult returned error after exec_op_tbor"
+            );
+            Err(DdiError::IoError(last_error))?;
+        }
+
+        self.map_ioctl_status(ioctl_out_buffer.ioctl_status)?;
+
+        if ioctl_out_buffer.ioctl_status != 0 {
+            Err(DdiError::WinError(ioctl_out_buffer.ioctl_status))?;
+        }
+
+        if ioctl_out_buffer.status != 0 {
+            Err(DdiError::DdiError(ioctl_out_buffer.status))?;
+        }
+
+        // -- 4. Decode the typed TBOR response --------------------
+        let resp_len = ioctl_out_buffer.byte_count as usize;
+        let resp_bytes = &resp_buf[..resp_len];
+        tracing::debug!(
+            opcode = T::OPCODE,
+            "TBOR Response Buffer (in hex): {:02x?}",
+            resp_bytes
+        );
+
+        Ok(<T::OpResp>::decode_response(resp_bytes)?)
     }
 
     /// Execute AES GCM operation (encryption/decryption) with slice-based buffers

--- a/ddi/win/src/dev.rs
+++ b/ddi/win/src/dev.rs
@@ -883,12 +883,19 @@ impl DdiDev for DdiWinDev {
     fn exec_op_tbor<T: TborOpReq>(
         &self,
         req: &T,
-        _oob_items: Option<&[&[u8]]>,
+        oob_items: Option<&[&[u8]]>,
         _cookie: &mut Option<DdiCookie>,
     ) -> DdiResult<T::OpResp> {
         /// SQE opcode that routes the command through the firmware's
         /// TBOR dispatcher (see `fw/core/lib/src/op.rs::OP_TBOR`).
         const OP_TBOR: u16 = 2;
+
+        // The Windows backend does not (yet) forward out-of-band
+        // items as SGL Data Block descriptors. Reject non-empty
+        // `oob_items` loudly rather than silently dropping payloads.
+        if oob_items.is_some_and(|items| !items.is_empty()) {
+            return Err(DdiError::InvalidParameter);
+        }
 
         const REQ_BUF_LEN: usize = 8192;
         const RESP_BUF_LEN: usize = 8192;
@@ -898,11 +905,9 @@ impl DdiDev for DdiWinDev {
         let req_bytes = req.encode_request(&mut req_buf)?;
         let req_len = req_bytes.len();
 
-        tracing::debug!(
-            opcode = T::OPCODE,
-            "TBOR Request Buffer (in hex): {:02x?}",
-            &req_buf[..req_len]
-        );
+        // Do not log raw request bytes: TBOR requests can carry
+        // sensitive material (e.g. encrypted PSK change envelopes).
+        tracing::debug!(opcode = T::OPCODE, req_len, "TBOR request encoded");
 
         let mut resp_buf = Box::<[u8; RESP_BUF_LEN]>::new([0u8; RESP_BUF_LEN]);
 
@@ -1017,13 +1022,17 @@ impl DdiDev for DdiWinDev {
         }
 
         // -- 4. Decode the typed TBOR response --------------------
+        // `byte_count` is driver-controlled; clamp it against the
+        // allocated response buffer to avoid a host-side panic on a
+        // bogus value.
         let resp_len = ioctl_out_buffer.byte_count as usize;
+        if resp_len > RESP_BUF_LEN {
+            return Err(DdiError::InvalidParameter);
+        }
         let resp_bytes = &resp_buf[..resp_len];
-        tracing::debug!(
-            opcode = T::OPCODE,
-            "TBOR Response Buffer (in hex): {:02x?}",
-            resp_bytes
-        );
+        // Do not log raw response bytes: responses can carry
+        // sensitive data depending on opcode.
+        tracing::debug!(opcode = T::OPCODE, resp_len, "TBOR response received");
 
         Ok(<T::OpResp>::decode_response(resp_bytes)?)
     }

--- a/ddi/win/src/dev.rs
+++ b/ddi/win/src/dev.rs
@@ -883,6 +883,7 @@ impl DdiDev for DdiWinDev {
     fn exec_op_tbor<T: TborOpReq>(
         &self,
         req: &T,
+        _oob_items: Option<&[&[u8]]>,
         _cookie: &mut Option<DdiCookie>,
     ) -> DdiResult<T::OpResp> {
         /// SQE opcode that routes the command through the firmware's


### PR DESCRIPTION
This PR enables the tbor DDI tests on the actual hardware instead of `emu` or `mock`