### PR TITLE
TBOR API part final

### DIFF
--- a/api/lib/src/ddi/partition_ex.rs
+++ b/api/lib/src/ddi/partition_ex.rs
@@ -4,12 +4,17 @@
 //! Partition provisioning over the TBOR transport at the DDI layer.
 //!
 //! This module hosts the host-side dispatch for the in-session
-//! Crypto-Officer `PartInit` command, mirroring the firmware handler:
+//! Crypto-Officer partition-provisioning commands, mirroring the
+//! firmware handlers:
 //!
 //! * **`PartInit`** (opcode `0x07`) — derive the partition PTA keypair,
 //!   persist the caller-asserted unified `PartPolicy` plus the POTA /
 //!   SATA / optional SAPOTA thumbprints, and return the PTA CSR +
 //!   COSE_Sign1 attestation report.
+//! * **`PartFinal`** (opcode `0x08`) — re-supply the unified
+//!   `PartPolicy` (for `POTAPubKey` recovery) and the PTA cert-chain
+//!   descriptors, optionally restore a prior `local_mk` backup, and
+//!   return the current `local_mk` backup envelope.
 //!
 //! It runs **inside an already-open CO session** established by
 //! [`super::session_ex::open_session_ex`]: the request carries the
@@ -37,6 +42,18 @@ impl From<TborPartInitResp> for HsmPartInitExResult {
         Self {
             pta_csr: resp.pta_csr,
             pta_report: resp.pta_report,
+        }
+    }
+}
+
+/// Converts the DDI/wire `PartFinal` response into the API-layer
+/// [`HsmPartFinalExResult`] with owned bytes, so the wire response type
+/// stays confined to the DDI layer and never reaches `HsmSession`
+/// callers.
+impl From<TborPartFinalResp> for HsmPartFinalExResult {
+    fn from(resp: TborPartFinalResp) -> Self {
+        Self {
+            local_mk_backup: resp.local_mk_backup,
         }
     }
 }
@@ -178,6 +195,104 @@ pub(crate) fn part_init_ex(
         .map_err(HsmError::from)
 }
 
+/// Issue `PartFinal` (opcode `0x08`) on the active CO session.
+///
+/// Re-supplies the unified `part_policy` (for `POTAPubKey` recovery)
+/// and the PTA cert-chain descriptors, optionally restoring a prior
+/// `local_mk` backup. Returns the current `local_mk` backup envelope.
+///
+/// # Arguments
+///
+/// * `partition` - The HSM partition handle.
+/// * `session_id` - The active CO session id this request binds to.
+/// * `part_policy` - Caller-asserted unified [`PartPolicy`] image
+///   ([`PART_POLICY_LEN`] bytes), re-supplied from `PartInit`.
+/// * `pta_cert_chain` - PTA certificate chain as a list of
+///   [`HsmCert`]s (`1..=`[`MAX_CERTS`] entries). Each cert's DER
+///   bytes ship as their own out-of-band SGL Data Block; the wrapper
+///   derives the matching `(index, length)` descriptor list.
+/// * `prev_local_mk_backup` - Optional prior `local_mk` backup envelope
+///   to restore; `None` on first finalization.
+///
+/// # Errors
+///
+/// Returns [`HsmError::InvalidArgument`] when `part_policy` has the
+/// wrong length or fails to decode, when `pta_cert_chain` is empty,
+/// exceeds [`MAX_CERTS`], contains an empty cert, or contains a cert
+/// whose length does not fit in the 16-bit descriptor field, or when a
+/// present `prev_local_mk_backup` is not exactly [`LOCAL_MK_BACKUP_LEN`]
+/// bytes; returns [`HsmError::InternalError`] if the device returns a
+/// malformed (wrong-length) `local_mk_backup`; and surfaces DDI/device
+/// failures from the round-trip.
+pub(crate) fn part_final_ex(
+    partition: &HsmPartition,
+    session_id: u16,
+    part_policy: &[u8],
+    pta_cert_chain: &[HsmCert<'_>],
+    prev_local_mk_backup: Option<&[u8]>,
+) -> HsmResult<HsmPartFinalExResult> {
+    if part_policy.len() != PART_POLICY_LEN {
+        return Err(HsmError::InvalidArgument);
+    }
+    if pta_cert_chain.is_empty() || pta_cert_chain.len() > MAX_CERTS {
+        return Err(HsmError::InvalidArgument);
+    }
+    // The firmware treats a non-empty `prev_local_mk_backup` as a
+    // fixed-size envelope of exactly `LOCAL_MK_BACKUP_LEN` bytes, so
+    // reject any other present length up front (deterministic guard).
+    if prev_local_mk_backup.is_some_and(|b| b.len() != LOCAL_MK_BACKUP_LEN) {
+        return Err(HsmError::InvalidArgument);
+    }
+
+    // Each DER cert ships as its own out-of-band SGL Data Block; the
+    // firmware locates each one by the descriptor's `index` (its position
+    // in the OOB item list) and reads `length` bytes from it.
+    let mut oob: Vec<&[u8]> = Vec::with_capacity(pta_cert_chain.len());
+    let mut cert_descriptors = Vec::with_capacity(pta_cert_chain.len());
+    for (i, desc) in pta_cert_chain.iter().enumerate() {
+        let cert = desc.cert;
+        let length = cert.len();
+        // An empty cert is not valid DER and would yield a zero-length
+        // descriptor; reject it up front alongside the other
+        // deterministic host-side guards.
+        if length == 0 || length > u16::MAX as usize {
+            return Err(HsmError::InvalidArgument);
+        }
+        // `i` is bounded by the `MAX_CERTS` check above, so it fits `u8`.
+        cert_descriptors.push(CertDescriptor {
+            index: i as u8,
+            length: tbor_int::U16::new(length as u16),
+        });
+        oob.push(cert);
+    }
+
+    let mut req = TborPartFinalReq {
+        session_id,
+        cert_descriptors,
+        ..Default::default()
+    };
+    req.part_policy = <PartPolicy as zerocopy::TryFromBytes>::try_read_from_bytes(part_policy)
+        .map_err(|_| HsmError::InvalidArgument)?;
+    if let Some(b) = prev_local_mk_backup {
+        req.prev_local_mk_backup = b.to_vec();
+    }
+
+    let inner = partition.inner().read();
+    let dev = inner.dev();
+    let mut cookie = None;
+    let resp = dev
+        .exec_op_tbor(&req, Some(&oob), &mut cookie)
+        .map_err(HsmError::from)?;
+
+    // The firmware always returns a fixed-size `local_mk_backup`
+    // envelope; reject a malformed (wrong-length) device response rather
+    // than surfacing it to callers.
+    if resp.local_mk_backup.len() != LOCAL_MK_BACKUP_LEN {
+        return Err(HsmError::InternalError);
+    }
+    Ok(HsmPartFinalExResult::from(resp))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -193,100 +308,5 @@ mod tests {
         assert_eq!(&aad[label_len..label_len + 2], &[0x34, 0x12]);
         assert!(aad[label_len + 2..].iter().all(|&b| b == 0));
         assert_eq!(aad.len(), PART_INIT_MACH_SEED_AAD_LEN);
-    }
-}
-
-#[cfg(all(test, feature = "emu"))]
-mod emu_tests {
-    use parking_lot::Mutex;
-
-    use super::*;
-    use crate::partition::HsmPartitionManager;
-
-    /// PSK id selecting the Crypto Officer role (`PartInit` is CO-only).
-    const CO: u8 = 0;
-
-    /// Serialises tests against the process-global FW emulator singleton.
-    /// `cargo-nextest` runs each test in its own process, but this keeps a
-    /// plain `cargo test` (single process, multi-threaded) correct too.
-    static EMU_LOCK: Mutex<()> = Mutex::new(());
-
-    /// Open the emu partition at its maximum revision, factory-reset it,
-    /// and bring up a Crypto-Officer V2 session ready for `part_init_ex`.
-    fn fresh_co_session() -> HsmSession {
-        let info = HsmPartitionManager::partition_info_list()
-            .into_iter()
-            .next()
-            .expect("emu backend should advertise a partition");
-        let rev = info
-            .api_rev_range
-            .expect("emu partition should report an api-rev range")
-            .max();
-        let part =
-            HsmPartitionManager::open_partition(&info.path, rev).expect("open emu partition");
-        part.reset().expect("factory-reset emu partition");
-        part.open_session_ex(rev, CO, HsmSessionExType::Authenticated)
-            .expect("open CO session")
-    }
-
-    /// Well-formed fixed-size inputs for the non-`part_policy` fields.
-    fn valid_inputs() -> (Vec<u8>, Vec<u8>, Vec<u8>) {
-        (
-            vec![0u8; MACH_SEED_LEN],
-            vec![0u8; POTA_THUMBPRINT_LEN],
-            vec![0u8; SATA_THUMBPRINT_LEN],
-        )
-    }
-
-    /// A wrong-length `part_policy` is rejected up front, before any
-    /// device round-trip.
-    #[test]
-    fn part_init_rejects_bad_part_policy_len() {
-        let _guard = EMU_LOCK.lock();
-        let session = fresh_co_session();
-        let (mach_seed, pota, sata) = valid_inputs();
-        let bad_policy = vec![0u8; PART_POLICY_LEN - 1];
-
-        let res = session.part_init_ex(&mach_seed, &bad_policy, &pota, &sata, None);
-        assert!(matches!(res, Err(HsmError::InvalidArgument)));
-    }
-
-    /// A wrong-length `pota_thumbprint` is rejected.
-    #[test]
-    fn part_init_rejects_bad_pota_thumbprint_len() {
-        let _guard = EMU_LOCK.lock();
-        let session = fresh_co_session();
-        let (mach_seed, _pota, sata) = valid_inputs();
-        let policy = vec![0u8; PART_POLICY_LEN];
-        let bad_pota = vec![0u8; POTA_THUMBPRINT_LEN + 1];
-
-        let res = session.part_init_ex(&mach_seed, &policy, &bad_pota, &sata, None);
-        assert!(matches!(res, Err(HsmError::InvalidArgument)));
-    }
-
-    /// A wrong-length `sata_thumbprint` is rejected.
-    #[test]
-    fn part_init_rejects_bad_sata_thumbprint_len() {
-        let _guard = EMU_LOCK.lock();
-        let session = fresh_co_session();
-        let (mach_seed, pota, _sata) = valid_inputs();
-        let policy = vec![0u8; PART_POLICY_LEN];
-        let bad_sata = vec![0u8; SATA_THUMBPRINT_LEN + 1];
-
-        let res = session.part_init_ex(&mach_seed, &policy, &pota, &bad_sata, None);
-        assert!(matches!(res, Err(HsmError::InvalidArgument)));
-    }
-
-    /// A present-but-wrong-length `sapota_thumbprint` is rejected.
-    #[test]
-    fn part_init_rejects_bad_sapota_thumbprint_len() {
-        let _guard = EMU_LOCK.lock();
-        let session = fresh_co_session();
-        let (mach_seed, pota, sata) = valid_inputs();
-        let policy = vec![0u8; PART_POLICY_LEN];
-        let bad_sapota = vec![0u8; SAPOTA_THUMBPRINT_LEN + 1];
-
-        let res = session.part_init_ex(&mach_seed, &policy, &pota, &sata, Some(&bad_sapota));
-        assert!(matches!(res, Err(HsmError::InvalidArgument)));
     }
 }

--- a/api/lib/src/session.rs
+++ b/api/lib/src/session.rs
@@ -164,6 +164,31 @@ impl HsmSession {
             SessionKind::Ver1 { .. } => Err(HsmError::InvalidSession),
         }
     }
+
+    /// Issues TBOR `PartFinal` (opcode `0x08`) on this CO session.
+    ///
+    /// Re-supplies the unified `part_policy` (for `POTAPubKey` recovery)
+    /// and the PTA certificate chain (as a list of [`HsmCert`]s),
+    /// optionally restoring a prior `local_mk` backup. Only valid on a V2
+    /// session; a V1 session returns [`HsmError::InvalidSession`].
+    pub fn part_final_ex(
+        &self,
+        part_policy: &[u8],
+        pta_cert_chain: &[HsmCert<'_>],
+        prev_local_mk_backup: Option<&[u8]>,
+    ) -> HsmResult<HsmPartFinalExResult> {
+        let inner = self.inner.read();
+        match &inner.kind {
+            SessionKind::Ver2 { .. } => ddi::part_final_ex(
+                &inner.partition,
+                inner.id,
+                part_policy,
+                pta_cert_chain,
+                prev_local_mk_backup,
+            ),
+            SessionKind::Ver1 { .. } => Err(HsmError::InvalidSession),
+        }
+    }
 }
 
 /// Transport-specific session state.

--- a/api/lib/src/shared_types.rs
+++ b/api/lib/src/shared_types.rs
@@ -9,6 +9,36 @@
 use open_enum::open_enum;
 use zerocopy::*;
 
+/// A single DER-encoded certificate in a certificate chain.
+///
+/// Borrowed view over one cert's DER bytes, used by the
+/// partition-provisioning API (e.g. [`HsmSession::part_final_ex`]) to accept
+/// a PTA chain as `&[HsmCert]`. It is a Rust borrow, **not** an
+/// ABI-stable `#[repr(C)]` type; a future native `part_final` FFI would
+/// build it from a C array of `{ data, len }` buffers (borrowing, not
+/// copying). The wire-level `(index, length)` OOB descriptors stay
+/// internal to the SDK.
+///
+/// [`HsmSession::part_final_ex`]: crate::HsmSession::part_final_ex
+#[derive(Debug, Clone, Copy)]
+pub struct HsmCert<'a> {
+    /// DER-encoded bytes of the certificate.
+    pub cert: &'a [u8],
+}
+
+/// Result of a security-domain partition-finalization (`part_final_ex`)
+/// command: the artifacts the device returns after finalizing a
+/// partition's security domain.
+///
+/// API-layer type with owned bytes. The DDI/wire response type
+/// (`TborPartFinalResp`) is converted into it inside the DDI layer, so the
+/// wire type never surfaces to public callers.
+#[derive(Debug, Clone, Default)]
+pub struct HsmPartFinalExResult {
+    /// Current `local_mk` backup envelope the firmware produced.
+    pub local_mk_backup: Vec<u8>,
+}
+
 /// Cryptographic key class.
 ///
 /// Defines the fundamental category of a cryptographic key.

--- a/api/tests/Cargo.toml
+++ b/api/tests/Cargo.toml
@@ -22,9 +22,11 @@ xshell.workspace = true
 azihsm_api.workspace = true
 azihsm_api_tests_macro.workspace = true
 azihsm_crypto = { features = ["testvectors"], workspace = true }
+azihsm_ddi_tbor_types.workspace = true
 azihsm_resiliency_test_helpers.workspace = true
 hex.workspace = true
 libtest-mimic.workspace = true
+parking_lot.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
 tracing-tree.workspace = true

--- a/api/tests/src/emu_helpers.rs
+++ b/api/tests/src/emu_helpers.rs
@@ -1,0 +1,50 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Shared helpers for the TBOR security-domain (`emu`-backed)
+//! integration tests.
+//!
+//! These exercise the public `azihsm_api` surface end to end against the
+//! FW emulator. `open_session_ex` / `part_*` run against the partition's
+//! *default* PSK and identity key, so they need only a freshly reset
+//! partition — no MBOR credential establishment (`init`).
+
+use azihsm_api::*;
+use parking_lot::Mutex;
+
+/// PSK id selecting the Crypto Officer role.
+pub(crate) const CO: u8 = 0;
+/// PSK id selecting the Crypto User role.
+pub(crate) const CU: u8 = 1;
+
+/// Serialises tests against the process-global FW emulator singleton.
+/// `cargo-nextest` runs each test in its own process, but this keeps a
+/// plain `cargo test` (single process, multi-threaded) correct too.
+pub(crate) static EMU_LOCK: Mutex<()> = Mutex::new(());
+
+/// Open the emu-backed partition at its maximum supported revision and
+/// factory-reset it, so each test starts from byte-identical state (no
+/// inherited session slots or PSK rotations). Returns the partition and
+/// the negotiated api revision.
+pub(crate) fn fresh_emu_partition() -> (HsmPartition, HsmApiRev) {
+    let info = HsmPartitionManager::partition_info_list()
+        .into_iter()
+        .next()
+        .expect("emu backend should advertise a partition");
+    let rev = info
+        .api_rev_range
+        .expect("emu partition should report an api-rev range")
+        .max();
+    let part = HsmPartitionManager::open_partition(&info.path, rev).expect("open emu partition");
+    part.reset().expect("factory-reset emu partition");
+    (part, rev)
+}
+
+/// Open a fresh partition and bring up a Crypto-Officer V2 session,
+/// ready for the in-session provisioning commands (`part_init_ex` /
+/// `part_final_ex`).
+pub(crate) fn fresh_co_session() -> HsmSession {
+    let (part, rev) = fresh_emu_partition();
+    part.open_session_ex(rev, CO, HsmSessionExType::Authenticated)
+        .expect("open CO session")
+}

--- a/api/tests/src/lib.rs
+++ b/api/tests/src/lib.rs
@@ -12,5 +12,12 @@ mod resiliency_tests;
 mod session_tests;
 mod utils;
 
+#[cfg(feature = "emu")]
+mod emu_helpers;
+#[cfg(feature = "emu")]
+mod partition_ex_tests;
+#[cfg(feature = "emu")]
+mod session_ex_tests;
+
 use azihsm_api::*;
 use azihsm_api_tests_macro::*;

--- a/api/tests/src/partition_ex_tests.rs
+++ b/api/tests/src/partition_ex_tests.rs
@@ -188,9 +188,9 @@ fn part_init_valid_inputs_pass_host_guards() {
 }
 
 /// Valid-length `PartFinal` inputs pass every host-side guard, so the
-/// request is built — the cert chain is concatenated into the OOB
-/// side-band buffer and its `(offset, length)` descriptors derived — and
-/// shipped to the device. The call is therefore never rejected with
+/// request is built — each cert ships as its own out-of-band SGL Data
+/// Block and its `(index, length)` descriptor is derived — and shipped
+/// to the device. The call is therefore never rejected with
 /// [`HsmError::InvalidArgument`]; it may still fail on-device. This
 /// exercises the request-construction / TBOR-OOB wiring path.
 #[test]

--- a/api/tests/src/partition_ex_tests.rs
+++ b/api/tests/src/partition_ex_tests.rs
@@ -1,0 +1,206 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Integration tests for the TBOR partition-provisioning session API
+//! (`HsmSession::part_init_ex` and `HsmSession::part_final_ex`).
+//!
+//! These exercise the input-validation guards through the *public*
+//! `azihsm_api` surface against the FW emulator. The negative-path guard
+//! tests return before the device round-trip, so they are deterministic
+//! and need no FW-accepted policy / cert chain; the
+//! `*_valid_inputs_pass_host_guards` tests deliberately clear the guards
+//! and reach the device to exercise the request-construction path.
+
+use azihsm_api::*;
+use azihsm_ddi_tbor_types::LOCAL_MK_BACKUP_LEN;
+use azihsm_ddi_tbor_types::MACH_SEED_LEN;
+use azihsm_ddi_tbor_types::MAX_CERTS;
+use azihsm_ddi_tbor_types::PART_POLICY_LEN;
+use azihsm_ddi_tbor_types::POTA_THUMBPRINT_LEN;
+use azihsm_ddi_tbor_types::SAPOTA_THUMBPRINT_LEN;
+use azihsm_ddi_tbor_types::SATA_THUMBPRINT_LEN;
+
+use crate::emu_helpers::*;
+
+/// Well-formed fixed-size inputs for the non-`part_policy` `PartInit`
+/// fields.
+fn valid_part_init_inputs() -> (Vec<u8>, Vec<u8>, Vec<u8>) {
+    (
+        vec![0u8; MACH_SEED_LEN],
+        vec![0u8; POTA_THUMBPRINT_LEN],
+        vec![0u8; SATA_THUMBPRINT_LEN],
+    )
+}
+
+/// A one-entry PTA cert placeholder (4 opaque bytes). The host-side
+/// guards never parse DER, so its contents are irrelevant.
+fn one_cert() -> Vec<u8> {
+    vec![0u8; 4]
+}
+
+// ── PartInit ────────────────────────────────────────────────────────────────
+
+/// A wrong-length `part_policy` is rejected up front, before any device
+/// round-trip.
+#[test]
+fn part_init_rejects_bad_part_policy_len() {
+    let _guard = EMU_LOCK.lock();
+    let session = fresh_co_session();
+    let (mach_seed, pota, sata) = valid_part_init_inputs();
+    let bad_policy = vec![0u8; PART_POLICY_LEN - 1];
+
+    let res = session.part_init_ex(&mach_seed, &bad_policy, &pota, &sata, None);
+    assert!(matches!(res, Err(HsmError::InvalidArgument)));
+}
+
+/// A wrong-length `pota_thumbprint` is rejected.
+#[test]
+fn part_init_rejects_bad_pota_thumbprint_len() {
+    let _guard = EMU_LOCK.lock();
+    let session = fresh_co_session();
+    let (mach_seed, _pota, sata) = valid_part_init_inputs();
+    let policy = vec![0u8; PART_POLICY_LEN];
+    let bad_pota = vec![0u8; POTA_THUMBPRINT_LEN + 1];
+
+    let res = session.part_init_ex(&mach_seed, &policy, &bad_pota, &sata, None);
+    assert!(matches!(res, Err(HsmError::InvalidArgument)));
+}
+
+/// A wrong-length `sata_thumbprint` is rejected.
+#[test]
+fn part_init_rejects_bad_sata_thumbprint_len() {
+    let _guard = EMU_LOCK.lock();
+    let session = fresh_co_session();
+    let (mach_seed, pota, _sata) = valid_part_init_inputs();
+    let policy = vec![0u8; PART_POLICY_LEN];
+    let bad_sata = vec![0u8; SATA_THUMBPRINT_LEN + 1];
+
+    let res = session.part_init_ex(&mach_seed, &policy, &pota, &bad_sata, None);
+    assert!(matches!(res, Err(HsmError::InvalidArgument)));
+}
+
+/// A present-but-wrong-length `sapota_thumbprint` is rejected.
+#[test]
+fn part_init_rejects_bad_sapota_thumbprint_len() {
+    let _guard = EMU_LOCK.lock();
+    let session = fresh_co_session();
+    let (mach_seed, pota, sata) = valid_part_init_inputs();
+    let policy = vec![0u8; PART_POLICY_LEN];
+    let bad_sapota = vec![0u8; SAPOTA_THUMBPRINT_LEN + 1];
+
+    let res = session.part_init_ex(&mach_seed, &policy, &pota, &sata, Some(&bad_sapota));
+    assert!(matches!(res, Err(HsmError::InvalidArgument)));
+}
+
+/// `PartFinal` rejects a wrong-length `part_policy` before any device
+/// round-trip.
+#[test]
+fn part_final_rejects_bad_part_policy_len() {
+    let _guard = EMU_LOCK.lock();
+    let session = fresh_co_session();
+    let bad_policy = vec![0u8; PART_POLICY_LEN - 1];
+
+    let cert = one_cert();
+    let chain = [HsmCert { cert: &cert }];
+    let res = session.part_final_ex(&bad_policy, &chain, None);
+    assert!(matches!(res, Err(HsmError::InvalidArgument)));
+}
+
+/// `PartFinal` rejects an empty cert chain.
+#[test]
+fn part_final_rejects_empty_cert_descriptors() {
+    let _guard = EMU_LOCK.lock();
+    let session = fresh_co_session();
+    let policy = vec![0u8; PART_POLICY_LEN];
+
+    let res = session.part_final_ex(&policy, &[], None);
+    assert!(matches!(res, Err(HsmError::InvalidArgument)));
+}
+
+/// `PartFinal` rejects a cert chain containing an empty (zero-length)
+/// certificate, which is not valid DER and would yield a zero-length
+/// out-of-band descriptor.
+#[test]
+fn part_final_rejects_empty_cert() {
+    let _guard = EMU_LOCK.lock();
+    let session = fresh_co_session();
+    let policy = vec![0u8; PART_POLICY_LEN];
+    let empty_cert: Vec<u8> = Vec::new();
+    let chain = [HsmCert {
+        cert: empty_cert.as_slice(),
+    }];
+
+    let res = session.part_final_ex(&policy, &chain, None);
+    assert!(matches!(res, Err(HsmError::InvalidArgument)));
+}
+
+/// `PartFinal` rejects more than [`MAX_CERTS`] certificates.
+#[test]
+fn part_final_rejects_too_many_cert_descriptors() {
+    let _guard = EMU_LOCK.lock();
+    let session = fresh_co_session();
+    let policy = vec![0u8; PART_POLICY_LEN];
+    let cert = one_cert();
+    let too_many = vec![
+        HsmCert {
+            cert: cert.as_slice()
+        };
+        MAX_CERTS + 1
+    ];
+
+    let res = session.part_final_ex(&policy, &too_many, None);
+    assert!(matches!(res, Err(HsmError::InvalidArgument)));
+}
+
+/// `PartFinal` rejects a `prev_local_mk_backup` whose length is not
+/// exactly [`LOCAL_MK_BACKUP_LEN`] (near-miss under-length), exercising
+/// the fixed-size guard rather than a coarse max-length check.
+#[test]
+fn part_final_rejects_wrong_len_prev_local_mk_backup() {
+    let _guard = EMU_LOCK.lock();
+    let session = fresh_co_session();
+    let policy = vec![0u8; PART_POLICY_LEN];
+    let wrong_len = vec![0u8; LOCAL_MK_BACKUP_LEN - 1];
+
+    let cert = one_cert();
+    let chain = [HsmCert { cert: &cert }];
+    let res = session.part_final_ex(&policy, &chain, Some(&wrong_len));
+    assert!(matches!(res, Err(HsmError::InvalidArgument)));
+}
+
+// ── Host-guard pass-through (request-construction / round-trip) ──────────────
+
+/// Valid-length `PartInit` inputs pass every host-side guard, so the
+/// request is sealed, constructed, and shipped to the device. The call
+/// is therefore never rejected with [`HsmError::InvalidArgument`] (the
+/// host-guard error); it may still fail on-device with a different
+/// error. This exercises the request-construction / TBOR wiring path
+/// that the negative guard tests skip.
+#[test]
+fn part_init_valid_inputs_pass_host_guards() {
+    let _guard = EMU_LOCK.lock();
+    let session = fresh_co_session();
+    let (mach_seed, pota, sata) = valid_part_init_inputs();
+    let policy = vec![0u8; PART_POLICY_LEN];
+
+    let res = session.part_init_ex(&mach_seed, &policy, &pota, &sata, None);
+    assert!(!matches!(res, Err(HsmError::InvalidArgument)));
+}
+
+/// Valid-length `PartFinal` inputs pass every host-side guard, so the
+/// request is built — the cert chain is concatenated into the OOB
+/// side-band buffer and its `(offset, length)` descriptors derived — and
+/// shipped to the device. The call is therefore never rejected with
+/// [`HsmError::InvalidArgument`]; it may still fail on-device. This
+/// exercises the request-construction / TBOR-OOB wiring path.
+#[test]
+fn part_final_valid_inputs_pass_host_guards() {
+    let _guard = EMU_LOCK.lock();
+    let session = fresh_co_session();
+    let policy = vec![0u8; PART_POLICY_LEN];
+    let cert = one_cert();
+    let chain = [HsmCert { cert: &cert }];
+
+    let res = session.part_final_ex(&policy, &chain, None);
+    assert!(!matches!(res, Err(HsmError::InvalidArgument)));
+}

--- a/api/tests/src/session_ex_tests.rs
+++ b/api/tests/src/session_ex_tests.rs
@@ -1,0 +1,64 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Integration tests for the TBOR security-domain session API
+//! (`HsmPartition::open_session_ex`).
+//!
+//! These go through the *public* `azihsm_api` surface — the two-phase
+//! HPKE handshake plus the resulting `HsmSession` (V2) handle — against
+//! the FW emulator, exactly as an external caller (and the native FFI)
+//! would.
+
+use azihsm_api::*;
+
+use crate::emu_helpers::*;
+
+/// Happy path: CO pairs with an Authenticated session and returns a
+/// live `HsmSession` over the public API.
+#[test]
+fn open_session_ex_co_authenticated() {
+    let _guard = EMU_LOCK.lock();
+    let (part, rev) = fresh_emu_partition();
+
+    let session = part
+        .open_session_ex(rev, CO, HsmSessionExType::Authenticated)
+        .expect("CO/Authenticated open_session_ex should succeed against emu");
+
+    // The V2 session must carry the negotiated api revision through.
+    let sess_rev = session.api_rev();
+    assert_eq!(
+        (sess_rev.major, sess_rev.minor),
+        (rev.major, rev.minor),
+        "session must echo the negotiated api revision"
+    );
+}
+
+/// Happy path: CU pairs with a PlainText session.
+#[test]
+fn open_session_ex_cu_plaintext() {
+    let _guard = EMU_LOCK.lock();
+    let (part, rev) = fresh_emu_partition();
+
+    let session = part
+        .open_session_ex(rev, CU, HsmSessionExType::PlainText)
+        .expect("CU/PlainText open_session_ex should succeed against emu");
+
+    let sess_rev = session.api_rev();
+    assert_eq!(
+        (sess_rev.major, sess_rev.minor),
+        (rev.major, rev.minor),
+        "session must echo the negotiated api revision"
+    );
+}
+
+/// Negative path: an unknown `psk_id` (neither CO nor CU) is rejected by
+/// the FW during Phase 1.
+#[test]
+fn open_session_ex_rejects_unknown_psk_id() {
+    let _guard = EMU_LOCK.lock();
+    let (part, rev) = fresh_emu_partition();
+
+    let result = part.open_session_ex(rev, 2, HsmSessionExType::Authenticated);
+
+    assert!(result.is_err(), "unknown psk_id must not yield a session");
+}


### PR DESCRIPTION
This pull request adds support for the TBOR `PartFinal` (partition finalization) command in the DDI and public API, including robust input validation and comprehensive integration tests. It introduces a new `HsmSession::part_final_ex` method, defines supporting types, and moves and expands emulator-based tests to cover both `part_init_ex` and `part_final_ex`. The changes improve modularity, test coverage, and maintainability.

**New API and DDI support for PartFinal:**

* Added `HsmSession::part_final_ex` as a public API method, which issues the TBOR `PartFinal` command, with input validation and support for certificate chains and optional key backup restoration (`api/lib/src/session.rs`, `api/lib/src/ddi/partition_ex.rs`, `api/lib/src/shared_types.rs`). [[1]](diffhunk://#diff-e581060cd3ba888831dfe31d9189175deeee6536648d05ba1f61f75be4ae0170R167-R191) [[2]](diffhunk://#diff-0c1f64dc7dbb6db39d5a0d78eee2546d2580570b1c1b19b14fdb0023b9299273R198-R295) [[3]](diffhunk://#diff-85a29a7bdf800dd335c8a2fa339d4244b61fd802b282ceb10834b86454698f95R12-R41)
* Introduced new types `HsmCert` (for DER-encoded certificates) and `HsmPartFinalExResult` (for the result of partition finalization) to the API surface (`api/lib/src/shared_types.rs`).
* Implemented DDI-layer request construction, input validation, and response conversion for `PartFinal`, including certificate chain handling and error guards (`api/lib/src/ddi/partition_ex.rs`). [[1]](diffhunk://#diff-0c1f64dc7dbb6db39d5a0d78eee2546d2580570b1c1b19b14fdb0023b9299273R198-R295) [[2]](diffhunk://#diff-0c1f64dc7dbb6db39d5a0d78eee2546d2580570b1c1b19b14fdb0023b9299273R49-R60)

**Documentation and modularity improvements:**

* Updated module-level documentation to cover both `PartInit` and `PartFinal` commands, reflecting the expanded API (`api/lib/src/ddi/partition_ex.rs`).
* Refactored emulator test helpers into a shared module (`api/tests/src/emu_helpers.rs`) for reuse across integration tests.

**Expanded and improved test coverage:**

* Moved and extended the emulator-based tests for input validation and request construction for both `part_init_ex` and `part_final_ex` into new, focused test modules (`api/tests/src/partition_ex_tests.rs`, `api/tests/src/emu_helpers.rs`, `api/tests/src/lib.rs`). [[1]](diffhunk://#diff-d612edacf3491f5e096dfaae37b51c22a0f706a9a1b4a6853dba382a79b87f69R1-R206) [[2]](diffhunk://#diff-a60fa4934a0b478fb61c4bfe38e7e2e53c5af75071312e089e1bd9ad63859b96R1-R50) [[3]](diffhunk://#diff-318e36ad0ce43193cc0d6214a4467cf7b5a7b11a14e6a323a3a4660fb9809b9aR15-R21)
* Updated test dependencies to include required crates (`api/tests/Cargo.toml`).
* Removed legacy emulator tests from the DDI module, consolidating test logic in the new test modules (`api/lib/src/ddi/partition_ex.rs`).