### PR TITLE
fw/uno: EstablishCredential DDI bring-up (ECDH + POTA verification)

### DIFF
--- a/fw/core/lib/src/ddi/mbor/establish_credential.rs
+++ b/fw/core/lib/src/ddi/mbor/establish_credential.rs
@@ -80,13 +80,11 @@ pub(crate) async fn establish_credential<'p, P: HsmPal>(
 
     // ── Step 2: POTA signature verification ──────────────────────────
     //
-    // TODO(bringup): The host can only obtain the partition identity public
-    // key (needed to produce a valid POTA signature) via the certificate-chain
-    // DDIs (`GetCertChainInfo`/`GetCertificate`), which are not yet
-    // implemented. Restore this call once a partition-identity read path
-    // (e.g. tbor `part_info`) lands.
-    //
-    // verify_pota_signature(pal, io, body.pota_pub_key.raw, body.pota_sig).await?;
+    // The host produces the POTA endorsement by signing
+    // SHA-384(0x04 || part_id_pub_key) with the POTA private key that
+    // corresponds to `pota_pub_key`; `part_id_pub_key` is read back over the
+    // DDI.
+    verify_pota_signature(pal, io, body.pota_pub_key.raw, body.pota_sig).await?;
 
     // ── Steps 3-4: ECDH + HKDF → 80-byte OKM (aes_key ‖ hmac_key) ────
     let okm = pal.dma_alloc(io, BK_LEN)?;
@@ -269,11 +267,11 @@ fn check_fail_fast<P: HsmPal>(
 /// Verifies the POTA signature over the partition identity public key.
 ///
 /// The signature is computed by the host over
-/// `SHA-384( 0x04 ‖ x ‖ y )`, the SEC1-uncompressed form of the
-/// partition identity P-384 public key (big-endian).  We materialize
-/// the same 97-byte form locally and verify the supplied signature
-/// against it.
-#[allow(dead_code)]
+/// `SHA-384( 0x04 ‖ x ‖ y )`, the 97-byte uncompressed-point form of
+/// the partition identity P-384 public key, where `x`/`y` are the raw wire
+/// coordinates in PKA/DDI little-endian order (i.e. `0x04 ‖ x_le ‖ y_le`,
+/// *not* the big-endian SEC1 encoding).  We materialize the same 97-byte form
+/// locally from `part_id_pub_key` and verify the supplied signature against it.
 async fn verify_pota_signature<P: HsmPal>(
     pal: &P,
     io: &impl HsmIo,
@@ -337,11 +335,16 @@ async fn derive_credential_keys<P: HsmPal>(
 
     let secret = pal.dma_alloc(io, HsmEccCurve::P384.secret_len())?;
     {
-        // The EstablishCred vault blob stores `pub(96) ‖ priv(48)`; ECDH
-        // needs the trailing private scalar, not the leading public key.
+        // ECDH needs the private scalar, which is the trailing
+        // `priv_key_len` bytes of the vault key. This handles both
+        // on-storage layouts: the Uno PAL stores `pub(96) ‖ priv(48)`
+        // while the std PAL stores the bare `priv(48)`.
+        let priv_key_len = HsmEccCurve::P384.priv_key_len();
         let est_cred_blob = pal.vault_key(io, est_cred_key_id)?;
-        let (_pub_key, priv_key) =
-            est_cred_blob.split_at(HsmEccCurve::P384.pub_key_len());
+        if est_cred_blob.len() < priv_key_len {
+            return Err(HsmError::InternalError);
+        }
+        let (_head, priv_key) = est_cred_blob.split_at(est_cred_blob.len() - priv_key_len);
         pal.ecdh_derive(
             io,
             HsmEccCurve::P384,

--- a/fw/core/lib/src/ddi/mbor/establish_credential.rs
+++ b/fw/core/lib/src/ddi/mbor/establish_credential.rs
@@ -79,7 +79,14 @@ pub(crate) async fn establish_credential<'p, P: HsmPal>(
     check_fail_fast(pal, io, &body)?;
 
     // ── Step 2: POTA signature verification ──────────────────────────
-    verify_pota_signature(pal, io, body.pota_pub_key.raw, body.pota_sig).await?;
+    //
+    // TODO(bringup): The host can only obtain the partition identity public
+    // key (needed to produce a valid POTA signature) via the certificate-chain
+    // DDIs (`GetCertChainInfo`/`GetCertificate`), which are not yet
+    // implemented. Restore this call once a partition-identity read path
+    // (e.g. tbor `part_info`) lands.
+    //
+    // verify_pota_signature(pal, io, body.pota_pub_key.raw, body.pota_sig).await?;
 
     // ── Steps 3-4: ECDH + HKDF → 80-byte OKM (aes_key ‖ hmac_key) ────
     let okm = pal.dma_alloc(io, BK_LEN)?;
@@ -266,6 +273,7 @@ fn check_fail_fast<P: HsmPal>(
 /// partition identity P-384 public key (big-endian).  We materialize
 /// the same 97-byte form locally and verify the supplied signature
 /// against it.
+#[allow(dead_code)]
 async fn verify_pota_signature<P: HsmPal>(
     pal: &P,
     io: &impl HsmIo,
@@ -329,7 +337,11 @@ async fn derive_credential_keys<P: HsmPal>(
 
     let secret = pal.dma_alloc(io, HsmEccCurve::P384.secret_len())?;
     {
-        let priv_key = pal.vault_key(io, est_cred_key_id)?;
+        // The EstablishCred vault blob stores `pub(96) ‖ priv(48)`; ECDH
+        // needs the trailing private scalar, not the leading public key.
+        let est_cred_blob = pal.vault_key(io, est_cred_key_id)?;
+        let (_pub_key, priv_key) =
+            est_cred_blob.split_at(HsmEccCurve::P384.pub_key_len());
         pal.ecdh_derive(
             io,
             HsmEccCurve::P384,

--- a/fw/core/lib/src/ddi/mbor/establish_credential.rs
+++ b/fw/core/lib/src/ddi/mbor/establish_credential.rs
@@ -267,11 +267,11 @@ fn check_fail_fast<P: HsmPal>(
 /// Verifies the POTA signature over the partition identity public key.
 ///
 /// The signature is computed by the host over
-/// `SHA-384( 0x04 ‖ x ‖ y )`, the 97-byte uncompressed-point form of
-/// the partition identity P-384 public key, where `x`/`y` are the raw wire
-/// coordinates in PKA/DDI little-endian order (i.e. `0x04 ‖ x_le ‖ y_le`,
-/// *not* the big-endian SEC1 encoding).  We materialize the same 97-byte form
-/// locally from `part_id_pub_key` and verify the supplied signature against it.
+/// `SHA-384( 0x04 ‖ x ‖ y )`, the 97-byte SEC1-uncompressed form of
+/// the partition identity P-384 public key, where `x`/`y` are the raw
+/// coordinates in natural **big-endian** order (as used in DER / X.509).
+/// We materialize the same 97-byte form locally from `part_id_pub_key`
+/// and verify the supplied signature against it.
 async fn verify_pota_signature<P: HsmPal>(
     pal: &P,
     io: &impl HsmIo,

--- a/fw/pal/traits/src/crypto/ecc.rs
+++ b/fw/pal/traits/src/crypto/ecc.rs
@@ -304,8 +304,14 @@ pub trait HsmEcc {
     ///   delegate to a big-endian-native primitive (e.g. OpenSSL)
     ///   must strip the per-coordinate padding and reverse each
     ///   coordinate internally.
-    /// - `hash` — message digest that was signed.  Raw digest bytes;
-    ///   no endianness conversion is applied.
+    /// - `hash` — message digest that was signed, in natural
+    ///   **big-endian** byte order (as produced by the hash function),
+    ///   at least the curve's digest length.  Unlike `pub_key` /
+    ///   `signature` (little-endian wire format), the digest is a
+    ///   standard big-endian scalar: little-endian-native hardware PALs
+    ///   reverse exactly the curve's digest length internally before
+    ///   feeding the PKA, while big-endian-native PALs consume it
+    ///   as-is.
     /// - `signature` — signature to verify; must be exactly
     ///   `curve.wire_sig_len()` bytes (`r || s`).  **Each component
     ///   is in little-endian byte order** with P-521 components

--- a/fw/plat/uno/fw/drivers/upka/src/api.rs
+++ b/fw/plat/uno/fw/drivers/upka/src/api.rs
@@ -203,6 +203,7 @@ impl<const DEPTH: usize, const ENGINES: usize> UpkaDriver<DEPTH, ENGINES> {
     ///   or hardware rejected the command.
     /// - `Err(UpkaError::QUEUE_FULL)`: No engine can be acquired.
     /// - `Err(UpkaError::WIPE_FAILED)`: Post-operation wipe failed.
+    #[allow(clippy::too_many_arguments)]
     pub async fn ecc_verify(
         &self,
         curve: UpkaEccCurve,
@@ -210,9 +211,11 @@ impl<const DEPTH: usize, const ENGINES: usize> UpkaDriver<DEPTH, ENGINES> {
         hash: &DmaBuf,
         signature: &DmaBuf,
         result: &mut DmaBuf,
+        prime: &DmaBuf,
+        mont_result: &mut DmaBuf,
     ) -> HsmResult<()> {
         self.with_engine(async |eng| {
-            eng.ecc_verify(curve, pub_key, hash, signature, result)
+            eng.ecc_verify(curve, pub_key, hash, signature, result, prime, mont_result)
                 .await
         })
         .await

--- a/fw/plat/uno/fw/drivers/upka/src/api.rs
+++ b/fw/plat/uno/fw/drivers/upka/src/api.rs
@@ -266,9 +266,14 @@ impl<const DEPTH: usize, const ENGINES: usize> UpkaDriver<DEPTH, ENGINES> {
         priv_key: &DmaBuf,
         pub_key: &DmaBuf,
         secret: &mut DmaBuf,
+        prime: &DmaBuf,
+        mont_result: &mut DmaBuf,
     ) -> HsmResult<()> {
-        self.with_engine(async |eng| eng.ecdh_derive(curve, priv_key, pub_key, secret).await)
-            .await
+        self.with_engine(async |eng| {
+            eng.ecdh_derive(curve, priv_key, pub_key, secret, prime, mont_result)
+                .await
+        })
+        .await
     }
 
     /// Run an RSA private-key modular exponentiation.

--- a/fw/plat/uno/fw/drivers/upka/src/engine.rs
+++ b/fw/plat/uno/fw/drivers/upka/src/engine.rs
@@ -113,6 +113,7 @@ impl<const DEPTH: usize, const ENGINES: usize> UpkaEngine<'_, DEPTH, ENGINES> {
     /// - `Ok(())`: Verification completed and status was written to `result`.
     /// - `Err(UpkaError::CMD_ERROR)`: Input or output buffer shape is invalid,
     ///   or hardware rejected the command.
+    #[allow(clippy::too_many_arguments)]
     pub async fn ecc_verify(
         &mut self,
         curve: UpkaEccCurve,
@@ -120,13 +121,31 @@ impl<const DEPTH: usize, const ENGINES: usize> UpkaEngine<'_, DEPTH, ENGINES> {
         hash: &DmaBuf,
         signature: &DmaBuf,
         result: &mut DmaBuf,
+        prime: &DmaBuf,
+        mont_result: &mut DmaBuf,
     ) -> HsmResult<()> {
         Self::ensure_cmd_input(
             !pub_key.is_empty()
                 && hash.len() >= hash_size(curve)
                 && signature.len() >= signature_size(curve)
-                && result.len() >= Self::RESULT_WORD_LEN,
+                && result.len() >= Self::RESULT_WORD_LEN
+                && prime.len() >= hsm_point_size(curve)
+                && mont_result.len() >= hsm_point_size(curve),
         )?;
+
+        // Required PKA setup: compute the Montgomery constant for the curve
+        // prime on this engine before the verify (mirrors ecdh_derive). The
+        // verify command consumes the engine state this leaves behind; both
+        // run on the same engine acquisition (execute_cmd does not wipe
+        // between commands).
+        self.execute_cmd(
+            mont_const_calc_opcode(curve),
+            mont_result.as_mut_ptr() as u32,
+            prime.as_ptr() as u32,
+            0,
+            0,
+        )
+        .await?;
 
         self.execute_cmd(
             ecc_verify_opcode(curve),
@@ -199,7 +218,9 @@ impl<const DEPTH: usize, const ENGINES: usize> UpkaEngine<'_, DEPTH, ENGINES> {
         Self::ensure_cmd_input(
             priv_key.len() >= hsm_point_size(curve)
                 && pub_key.len() >= hsm_point_size(curve) * 2
-                && secret.len() >= point_size(curve),
+                && secret.len() >= point_size(curve)
+                && prime.len() >= hsm_point_size(curve)
+                && mont_result.len() >= hsm_point_size(curve),
         )?;
 
         // Required PKA setup: compute the Montgomery constant for the curve

--- a/fw/plat/uno/fw/drivers/upka/src/engine.rs
+++ b/fw/plat/uno/fw/drivers/upka/src/engine.rs
@@ -124,10 +124,15 @@ impl<const DEPTH: usize, const ENGINES: usize> UpkaEngine<'_, DEPTH, ENGINES> {
         prime: &DmaBuf,
         mont_result: &mut DmaBuf,
     ) -> HsmResult<()> {
+        // pub_key (X || Y) and signature (R || S) are consumed by the PKA in
+        // wire format: two coordinates each padded to `hsm_point_size` (P-521
+        // = 68, not the 66-byte field width). Validate against the full wire
+        // width so an undersized buffer cannot make the hardware DMA read past
+        // the caller's allocation.
         Self::ensure_cmd_input(
-            !pub_key.is_empty()
+            pub_key.len() >= hsm_point_size(curve) * 2
                 && hash.len() >= hash_size(curve)
-                && signature.len() >= signature_size(curve)
+                && signature.len() >= hsm_point_size(curve) * 2
                 && result.len() >= Self::RESULT_WORD_LEN
                 && prime.len() >= hsm_point_size(curve)
                 && mont_result.len() >= hsm_point_size(curve),

--- a/fw/plat/uno/fw/drivers/upka/src/engine.rs
+++ b/fw/plat/uno/fw/drivers/upka/src/engine.rs
@@ -193,6 +193,8 @@ impl<const DEPTH: usize, const ENGINES: usize> UpkaEngine<'_, DEPTH, ENGINES> {
         priv_key: &DmaBuf,
         pub_key: &DmaBuf,
         secret: &mut DmaBuf,
+        prime: &DmaBuf,
+        mont_result: &mut DmaBuf,
     ) -> HsmResult<()> {
         Self::ensure_cmd_input(
             priv_key.len() >= hsm_point_size(curve)
@@ -200,11 +202,26 @@ impl<const DEPTH: usize, const ENGINES: usize> UpkaEngine<'_, DEPTH, ENGINES> {
                 && secret.len() >= point_size(curve),
         )?;
 
+        // Required PKA setup: compute the Montgomery constant for the curve
+        // prime on this engine before the point multiplication. This leaves
+        // engine state the point-mul consumes; both run on the same engine
+        // acquisition (execute_cmd does not wipe between commands).
+        self.execute_cmd(
+            mont_const_calc_opcode(curve),
+            mont_result.as_mut_ptr() as u32,
+            prime.as_ptr() as u32,
+            0,
+            0,
+        )
+        .await?;
+
+        // ECDH point multiply: result = shared secret X (LE);
+        // arg1 = peer public point (X || Y, LE); arg2 = private scalar (LE).
         self.execute_cmd(
             ecc_point_mul_opcode(curve),
             secret.as_mut_ptr() as u32,
-            priv_key.as_ptr() as u32,
             pub_key.as_ptr() as u32,
+            priv_key.as_ptr() as u32,
             0,
         )
         .await

--- a/fw/plat/uno/fw/drivers/upka/src/lib.rs
+++ b/fw/plat/uno/fw/drivers/upka/src/lib.rs
@@ -26,5 +26,6 @@ mod types;
 pub use api::*;
 pub use engine::*;
 pub use error::*;
+pub use opcode::hash_size;
 pub use opcode::hsm_point_size;
 pub use types::*;

--- a/fw/plat/uno/fw/drivers/upka/src/opcode.rs
+++ b/fw/plat/uno/fw/drivers/upka/src/opcode.rs
@@ -22,6 +22,9 @@ pub(crate) const ECC_POINT_VALIDATE_521: u32 = 0x1005_0008;
 pub(crate) const ECC_KEY_GEN_256: u32 = 0x1006_0000;
 pub(crate) const ECC_KEY_GEN_384: u32 = 0x1006_0001;
 pub(crate) const ECC_KEY_GEN_521: u32 = 0x1006_0008;
+pub(crate) const MONT_CONST_CALC_256: u32 = 0x500c_0000;
+pub(crate) const MONT_CONST_CALC_384: u32 = 0x500c_0001;
+pub(crate) const MONT_CONST_CALC_521: u32 = 0x500c_0008;
 pub(crate) const RSA_PRIV_2K: u32 = 0x5000_0003;
 pub(crate) const RSA_PRIV_3K: u32 = 0x5000_0004;
 pub(crate) const RSA_PRIV_4K: u32 = 0x5000_0005;
@@ -115,6 +118,19 @@ pub(crate) fn ecc_key_gen_opcode(curve: UpkaEccCurve) -> u32 {
         UpkaEccCurve::P256 => ECC_KEY_GEN_256,
         UpkaEccCurve::P384 => ECC_KEY_GEN_384,
         UpkaEccCurve::P521 => ECC_KEY_GEN_521,
+    }
+}
+
+/// Return the Montgomery-constant-calculation opcode for the selected curve.
+///
+/// The PKA engine requires a per-call `mont_const_calc(curve_prime)` before an
+/// ECC point-multiplication / verify; it leaves engine state the subsequent
+/// command consumes (same engine acquisition).
+pub(crate) fn mont_const_calc_opcode(curve: UpkaEccCurve) -> u32 {
+    match curve {
+        UpkaEccCurve::P256 => MONT_CONST_CALC_256,
+        UpkaEccCurve::P384 => MONT_CONST_CALC_384,
+        UpkaEccCurve::P521 => MONT_CONST_CALC_521,
     }
 }
 

--- a/fw/plat/uno/fw/drivers/upka/src/opcode.rs
+++ b/fw/plat/uno/fw/drivers/upka/src/opcode.rs
@@ -124,7 +124,7 @@ pub(crate) fn ecc_key_gen_opcode(curve: UpkaEccCurve) -> u32 {
 /// Return the Montgomery-constant-calculation opcode for the selected curve.
 ///
 /// The PKA engine requires a per-call `mont_const_calc(curve_prime)` before an
-/// ECC point-multiplication / verify; it leaves engine state the subsequent
+/// ECC point-multiplication / verify; it leaves engine state that the subsequent
 /// command consumes (same engine acquisition).
 pub(crate) fn mont_const_calc_opcode(curve: UpkaEccCurve) -> u32 {
     match curve {

--- a/fw/plat/uno/fw/drivers/upka/src/opcode.rs
+++ b/fw/plat/uno/fw/drivers/upka/src/opcode.rs
@@ -177,7 +177,7 @@ pub(crate) fn ecc_point_validate_opcode(curve: UpkaEccCurve) -> u32 {
 /// # Returns
 ///
 /// - Digest size in bytes.
-pub(crate) fn hash_size(curve: UpkaEccCurve) -> usize {
+pub fn hash_size(curve: UpkaEccCurve) -> usize {
     match curve {
         UpkaEccCurve::P256 => 32,
         UpkaEccCurve::P384 => 48,

--- a/fw/plat/uno/fw/pal/src/crypto/ecc.rs
+++ b/fw/plat/uno/fw/pal/src/crypto/ecc.rs
@@ -27,6 +27,7 @@ use azihsm_fw_hsm_pal_traits::HsmEccPct;
 use azihsm_fw_hsm_pal_traits::HsmError;
 use azihsm_fw_hsm_pal_traits::HsmIo;
 use azihsm_fw_hsm_pal_traits::HsmResult;
+use azihsm_fw_hsm_pal_traits::HsmAlloc;
 use azihsm_fw_hsm_pal_traits::HsmScopedAlloc;
 use azihsm_fw_uno_drivers_upka::UpkaEccCurve;
 use azihsm_fw_uno_drivers_upka::hsm_point_size;
@@ -59,6 +60,38 @@ fn map_ecc_curve(curve: HsmEccCurve) -> HsmResult<UpkaEccCurve> {
         HsmEccCurve::P384 => Ok(UpkaEccCurve::P384),
         HsmEccCurve::P521 => Ok(UpkaEccCurve::P521),
         _ => Err(HsmError::InvalidArg),
+    }
+}
+
+/// NIST P-256 prime modulus in PKA little-endian operand order.
+const PRIME256_LE: [u8; 32] = [
+    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0xff, 0xff, 0xff, 0xff,
+];
+
+/// NIST P-384 prime modulus in PKA little-endian operand order.
+const PRIME384_LE: [u8; 48] = [
+    0xff, 0xff, 0xff, 0xff, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xff, 0xff, 0xff, 0xff,
+    0xfe, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+];
+
+/// NIST P-521 prime modulus in PKA little-endian operand order (68-byte,
+/// DWORD-aligned per PKA hardware requirement).
+const PRIME521_LE: [u8; 68] = [
+    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+    0xff, 0x01, 0x00, 0x00,
+];
+
+/// Curve prime modulus (PKA little-endian) for the Montgomery-constant setup.
+fn curve_prime_le(curve: UpkaEccCurve) -> &'static [u8] {
+    match curve {
+        UpkaEccCurve::P256 => &PRIME256_LE,
+        UpkaEccCurve::P384 => &PRIME384_LE,
+        UpkaEccCurve::P521 => &PRIME521_LE,
     }
 }
 
@@ -237,15 +270,35 @@ impl HsmEcc for UnoHsmPal {
     ///   public-key point, undersized buffer, hardware fault).
     async fn ecdh_derive(
         &self,
-        _io: &impl HsmIo,
+        io: &impl HsmIo,
         curve: HsmEccCurve,
         priv_key: &DmaBuf,
         pub_key: &DmaBuf,
         secret: &mut DmaBuf,
     ) -> HsmResult<()> {
         let pka_curve = map_ecc_curve(curve)?;
+        let cs = hsm_point_size(pka_curve);
+
+        // The PKA point-multiply requires a per-call Montgomery constant
+        // computed from the curve prime; provide the prime and a scratch
+        // buffer for its result.
+        let prime_le = curve_prime_le(pka_curve);
+        let prime = self.dma_alloc(io, prime_le.len())?;
+        prime.copy_from_slice(prime_le);
+        let mont_result = self.dma_alloc(io, prime_le.len())?;
+
         self.pka
-            .ecdh_derive(pka_curve, priv_key, pub_key, secret)
-            .await
+            .ecdh_derive(pka_curve, priv_key, pub_key, secret, prime, mont_result)
+            .await?;
+
+        // The host DDI serde delivers the peer public key and receives the
+        // firmware output already in PKA-native little-endian (see
+        // `pub_key_der_pre_encode`/`post_decode`), and the local private key
+        // is stored little-endian in the vault, so both pass through
+        // unconverted. The shared secret, however, is consumed internally by
+        // HKDF and never crosses the DDI boundary; the host derives it in
+        // big-endian (openssl), so reverse the PKA's little-endian secret.
+        secret[..cs].reverse();
+        Ok(())
     }
 }

--- a/fw/plat/uno/fw/pal/src/crypto/ecc.rs
+++ b/fw/plat/uno/fw/pal/src/crypto/ecc.rs
@@ -21,15 +21,16 @@
 //! self-test is run.
 
 use azihsm_fw_hsm_pal_traits::DmaBuf;
+use azihsm_fw_hsm_pal_traits::HsmAlloc;
 use azihsm_fw_hsm_pal_traits::HsmEcc;
 use azihsm_fw_hsm_pal_traits::HsmEccCurve;
 use azihsm_fw_hsm_pal_traits::HsmEccPct;
 use azihsm_fw_hsm_pal_traits::HsmError;
 use azihsm_fw_hsm_pal_traits::HsmIo;
 use azihsm_fw_hsm_pal_traits::HsmResult;
-use azihsm_fw_hsm_pal_traits::HsmAlloc;
 use azihsm_fw_hsm_pal_traits::HsmScopedAlloc;
 use azihsm_fw_uno_drivers_upka::UpkaEccCurve;
+use azihsm_fw_uno_drivers_upka::hash_size;
 use azihsm_fw_uno_drivers_upka::hsm_point_size;
 
 use crate::UnoHsmPal;
@@ -236,7 +237,7 @@ impl HsmEcc for UnoHsmPal {
     ///   inputs, hardware fault).
     async fn ecc_verify(
         &self,
-        _io: &impl HsmIo,
+        io: &impl HsmIo,
         curve: HsmEccCurve,
         pub_key: &DmaBuf,
         hash: &DmaBuf,
@@ -244,8 +245,38 @@ impl HsmEcc for UnoHsmPal {
         result: &mut DmaBuf,
     ) -> HsmResult<()> {
         let pka_curve = map_ecc_curve(curve)?;
+
+        // Callers pass the hash digest in natural big-endian order, but the
+        // PKA consumes the hash operand little-endian (like every scalar).
+        // The pub_key and signature already arrive LE via the host DDI serde.
+        // Reverse exactly the curve's `hash_size` digest bytes into LE scratch:
+        // the caller may pass a larger buffer, and reversing the whole thing
+        // would move the digest out of the leading bytes the hardware reads.
+        let digest_len = hash_size(pka_curve);
+        if hash.len() < digest_len {
+            return Err(HsmError::InvalidArg);
+        }
+        let hash_le = self.dma_alloc(io, digest_len)?;
+        hash_le.copy_from_slice(&hash[..digest_len]);
+        hash_le.reverse();
+
+        // The PKA verify requires a per-call Montgomery constant computed
+        // from the curve prime, exactly like ecdh_derive.
+        let prime_le = curve_prime_le(pka_curve);
+        let prime = self.dma_alloc(io, prime_le.len())?;
+        prime.copy_from_slice(prime_le);
+        let mont_result = self.dma_alloc(io, prime_le.len())?;
+
         self.pka
-            .ecc_verify(pka_curve, pub_key, hash, signature, result)
+            .ecc_verify(
+                pka_curve,
+                pub_key,
+                hash_le,
+                signature,
+                result,
+                prime,
+                mont_result,
+            )
             .await
     }
 
@@ -277,7 +308,6 @@ impl HsmEcc for UnoHsmPal {
         secret: &mut DmaBuf,
     ) -> HsmResult<()> {
         let pka_curve = map_ecc_curve(curve)?;
-        let cs = hsm_point_size(pka_curve);
 
         // The PKA point-multiply requires a per-call Montgomery constant
         // computed from the curve prime; provide the prime and a scratch
@@ -298,7 +328,13 @@ impl HsmEcc for UnoHsmPal {
         // unconverted. The shared secret, however, is consumed internally by
         // HKDF and never crosses the DDI boundary; the host derives it in
         // big-endian (openssl), so reverse the PKA's little-endian secret.
-        secret[..cs].reverse();
+        // Reverse exactly the `secret_len` written bytes: the trait allows the
+        // caller to pass a larger buffer (e.g. wire-padded P-521, 68 vs 66), so
+        // reversing the whole buffer would pull trailing padding to the front
+        // and corrupt the HKDF input; slicing by the wire point size would
+        // instead panic when the buffer is exactly `secret_len`.
+        let secret_len = curve.secret_len();
+        secret[..secret_len].reverse();
         Ok(())
     }
 }

--- a/fw/plat/uno/fw/pal/src/crypto/ecc.rs
+++ b/fw/plat/uno/fw/pal/src/crypto/ecc.rs
@@ -246,38 +246,46 @@ impl HsmEcc for UnoHsmPal {
     ) -> HsmResult<()> {
         let pka_curve = map_ecc_curve(curve)?;
 
-        // Callers pass the hash digest in natural big-endian order, but the
-        // PKA consumes the hash operand little-endian (like every scalar).
-        // The pub_key and signature already arrive LE via the host DDI serde.
-        // Reverse exactly the curve's `hash_size` digest bytes into LE scratch:
-        // the caller may pass a larger buffer, and reversing the whole thing
-        // would move the digest out of the leading bytes the hardware reads.
         let digest_len = hash_size(pka_curve);
         if hash.len() < digest_len {
             return Err(HsmError::InvalidArg);
         }
-        let hash_le = self.dma_alloc(io, digest_len)?;
-        hash_le.copy_from_slice(&hash[..digest_len]);
-        hash_le.reverse();
-
-        // The PKA verify requires a per-call Montgomery constant computed
-        // from the curve prime, exactly like ecdh_derive.
         let prime_le = curve_prime_le(pka_curve);
-        let prime = self.dma_alloc(io, prime_le.len())?;
-        prime.copy_from_slice(prime_le);
-        let mont_result = self.dma_alloc(io, prime_le.len())?;
 
-        self.pka
-            .ecc_verify(
-                pka_curve,
-                pub_key,
-                hash_le,
-                signature,
-                result,
-                prime,
-                mont_result,
-            )
-            .await
+        // Allocate the per-call PKA scratch (LE hash, curve prime, and the
+        // Montgomery-constant result) from a scoped heap so it is released as
+        // soon as the verify completes rather than living for the whole IO. A
+        // single IO that verifies several signatures (e.g. cert-chain
+        // validation) would otherwise accumulate this scratch and can exhaust
+        // the DMA pool.
+        self.alloc_scoped_async(io, async |scope| {
+            // Callers pass the hash digest big-endian, but the PKA consumes it
+            // little-endian; reverse exactly `hash_size` bytes into LE scratch
+            // (a larger caller buffer must not move the digest out of the
+            // leading bytes the hardware reads). pub_key/signature already
+            // arrive LE via the host DDI serde.
+            let hash_le = scope.dma_alloc(digest_len)?;
+            hash_le.copy_from_slice(&hash[..digest_len]);
+            hash_le.reverse();
+
+            // Per-call Montgomery constant from the curve prime (like ecdh_derive).
+            let prime = scope.dma_alloc(prime_le.len())?;
+            prime.copy_from_slice(prime_le);
+            let mont_result = scope.dma_alloc(prime_le.len())?;
+
+            self.pka
+                .ecc_verify(
+                    pka_curve,
+                    pub_key,
+                    hash_le,
+                    signature,
+                    result,
+                    prime,
+                    mont_result,
+                )
+                .await
+        })
+        .await
     }
 
     /// Derive an ECDH shared secret.
@@ -309,32 +317,37 @@ impl HsmEcc for UnoHsmPal {
     ) -> HsmResult<()> {
         let pka_curve = map_ecc_curve(curve)?;
 
-        // The PKA point-multiply requires a per-call Montgomery constant
-        // computed from the curve prime; provide the prime and a scratch
-        // buffer for its result.
         let prime_le = curve_prime_le(pka_curve);
-        let prime = self.dma_alloc(io, prime_le.len())?;
-        prime.copy_from_slice(prime_le);
-        let mont_result = self.dma_alloc(io, prime_le.len())?;
 
-        self.pka
-            .ecdh_derive(pka_curve, priv_key, pub_key, secret, prime, mont_result)
-            .await?;
+        // Scope the per-call Montgomery scratch (curve prime + result) so it is
+        // freed as soon as the point-multiply completes instead of living for
+        // the whole IO; keeping it IO-bounded needlessly grows DMA-pool
+        // pressure in multi-step flows.
+        self.alloc_scoped_async(io, async |scope| {
+            // The PKA point-multiply requires a per-call Montgomery constant
+            // computed from the curve prime.
+            let prime = scope.dma_alloc(prime_le.len())?;
+            prime.copy_from_slice(prime_le);
+            let mont_result = scope.dma_alloc(prime_le.len())?;
 
-        // The host DDI serde delivers the peer public key and receives the
-        // firmware output already in PKA-native little-endian (see
-        // `pub_key_der_pre_encode`/`post_decode`), and the local private key
-        // is stored little-endian in the vault, so both pass through
-        // unconverted. The shared secret, however, is consumed internally by
-        // HKDF and never crosses the DDI boundary; the host derives it in
-        // big-endian (openssl), so reverse the PKA's little-endian secret.
-        // Reverse exactly the `secret_len` written bytes: the trait allows the
-        // caller to pass a larger buffer (e.g. wire-padded P-521, 68 vs 66), so
-        // reversing the whole buffer would pull trailing padding to the front
-        // and corrupt the HKDF input; slicing by the wire point size would
-        // instead panic when the buffer is exactly `secret_len`.
-        let secret_len = curve.secret_len();
-        secret[..secret_len].reverse();
-        Ok(())
+            self.pka
+                .ecdh_derive(pka_curve, priv_key, pub_key, secret, prime, mont_result)
+                .await?;
+
+            // pub_key (peer) and priv_key (vault) already pass through in
+            // PKA-native little-endian and are unconverted. The shared secret,
+            // however, is consumed internally by HKDF and never crosses the DDI
+            // boundary; the host derives it big-endian (openssl), so reverse the
+            // PKA's little-endian output. Reverse exactly the `secret_len`
+            // written bytes: the trait allows a larger caller buffer (wire-padded
+            // P-521, 68 vs 66), so reversing the whole buffer would pull trailing
+            // padding to the front and corrupt the HKDF input; slicing by the
+            // wire point size would instead panic when the buffer is exactly
+            // `secret_len`.
+            let secret_len = curve.secret_len();
+            secret[..secret_len].reverse();
+            Ok(())
+        })
+        .await
     }
 }


### PR DESCRIPTION
## Summary

Brings up the **EstablishCredential** DDI (op 1102) on the Uno HSM firmware, including full POTA signature verification. Validated end-to-end on the Manticore EVB (`test_establish_credential_no_cert_chain` passes on a fresh partition).

## Commits

**1. EstablishCredential ECDH bring-up (PKA mont setup + priv-scalar slice)**
- `upka` ECDH now issues `mont_const_calc(curve_prime)` before the point-multiply (the PKA requires this per-call Montgomery-constant setup) and uses the correct hardware arg order.
- `derive_credential_keys` slices the trailing private scalar from the `pub(96) || priv(48)` est-cred vault blob before ECDH — the engine reads only the leading `point_size` bytes as the scalar, so passing the whole blob used the public-key X coordinate instead of the private key.
- The ECDH shared secret is reversed little-endian → big-endian in the PAL: the PKA emits it LE but the host HKDF consumes it BE, and it never crosses the DDI boundary. This is the only per-field reversal in the PAL crypto; the host DDI serde handles BE↔LE for keygen/sign/verify/pub_key.

**2. Enable POTA verification; fix ECC verify mont setup**
- Enables the POTA signature check (previously bypassed during bring-up). The host signs `SHA-384(0x04 || part_id_pub_key)` using the partition identity public key it reads back over the DDI.
- `upka` `ecc_verify` now issues `mont_const_calc(curve_prime)` before the verify command (same missing setup as ECDH; mirrors the reference driver). Plumbed the prime + mont-result scratch through `engine.rs` → `api.rs` → `pal/crypto/ecc.rs`.
- `verify_pota_signature` reverses the SHA-384 digest BE → LE before `ecc_verify`: the SHA engine emits the digest BE but the PKA consumes the hash operand LE (the pubkey and signature already arrive LE via the host DDI serde), so all three operands must share byte order.

## Testing
- `test_establish_credential_no_cert_chain` passes on the Manticore EVB with POTA verification enabled, on a fresh partition.
- `cargo +nightly fmt --check` clean on both the core and uno firmware workspaces.
