### PR TITLE
fw(crypto/tbor): x509-chain LE fix, hpke CBC opt-in, tbor-derive mutable+include

### DIFF
--- a/fw/core/crypto/hpke/Cargo.toml
+++ b/fw/core/crypto/hpke/Cargo.toml
@@ -12,8 +12,12 @@ doctest = false
 test = false
 
 [features]
+# AES-256-CBC + HMAC AEAD suites (RFC-9180-style CBC variants). Off by
+# default: firmware only ever negotiates the AES-GCM suites, so the CBC
+# code (seal_cbc/open_cbc) is compiled out to save flash. Enable this
+# feature to build the CBC suites back in.
 cbc = ["dep:azihsm_fw_core_crypto_aes_cbc_pad"]
-default = ["cbc"]
+default = []
 
 [dependencies]
 azihsm_fw_core_crypto_aes_cbc_pad = { optional = true, path = "../aes-cbc-pad" }

--- a/fw/core/crypto/hpke/src/aead.rs
+++ b/fw/core/crypto/hpke/src/aead.rs
@@ -26,9 +26,11 @@
 //! before unpadding so a tag mismatch never reveals padding-oracle
 //! information.
 
+use azihsm_fw_hsm_pal_traits::DmaBuf;
 use azihsm_fw_hsm_pal_traits::HsmAlloc;
 use azihsm_fw_hsm_pal_traits::HsmCrypto;
 use azihsm_fw_hsm_pal_traits::HsmError;
+#[cfg(feature = "cbc")]
 use azihsm_fw_hsm_pal_traits::HsmHashAlgo;
 use azihsm_fw_hsm_pal_traits::HsmIo;
 use azihsm_fw_hsm_pal_traits::HsmResult;
@@ -91,11 +93,11 @@ pub async fn seal<'a, P>(
     pal: &P,
     io: &impl HsmIo,
     suite: HpkeSuite,
-    key: &[u8],
-    base_nonce: &[u8],
+    key: &DmaBuf,
+    base_nonce: &DmaBuf,
     aad: &[u8],
-    pt: &[u8],
-    ct: &mut [u8],
+    pt: &DmaBuf,
+    ct: &mut DmaBuf,
     alloc: &'a impl HsmScopedAlloc,
 ) -> HsmResult<usize>
 where
@@ -109,7 +111,7 @@ where
         #[cfg(not(feature = "cbc"))]
         {
             let _ = (pal, io, suite, key, aad, pt, ct, alloc);
-            Err(HsmError::UnsupportedAlgorithm)
+            Err(HsmError::InvalidAlgorithm)
         }
     } else {
         seal_gcm(pal, io, key, base_nonce, aad, pt, ct, alloc).await
@@ -167,7 +169,7 @@ where
         #[cfg(not(feature = "cbc"))]
         {
             let _ = (pal, io, suite, key, aad, ct, pt, alloc);
-            Err(HsmError::UnsupportedAlgorithm)
+            Err(HsmError::InvalidAlgorithm)
         }
     } else {
         open_gcm(pal, io, key, base_nonce, aad, ct, pt, alloc).await
@@ -189,36 +191,33 @@ where
 async fn seal_gcm<'a, P>(
     pal: &P,
     io: &impl HsmIo,
-    key: &[u8],
-    nonce: &[u8],
+    key: &DmaBuf,
+    nonce: &DmaBuf,
     aad: &[u8],
-    pt: &[u8],
-    ct: &mut [u8],
+    pt: &DmaBuf,
+    ct: &mut DmaBuf,
     alloc: &'a impl HsmScopedAlloc,
 ) -> HsmResult<usize>
 where
     P: HsmCrypto + 'a,
 {
-    let key_dma = dma_copy_in(alloc, key)?;
-    let nonce_dma = dma_copy_in(alloc, nonce)?;
-
     if aad.is_empty() {
-        // No AAD — simple path, no buffer formatting needed.
+        // No AAD — GCM writes the ciphertext and tag straight into the
+        // caller's `ct` (split into text / tag regions); no scratch
+        // buffers, no copies.
         let ct_len = pt.len() + GCM_TAG_LEN;
         if ct.len() < ct_len {
             return Err(HsmError::InvalidArg);
         }
-        let pt_dma = dma_copy_in(alloc, pt)?;
-        let ct_scratch = alloc.dma_alloc(pt.len())?;
-        let tag_dma = alloc.dma_alloc(GCM_TAG_LEN)?;
-        pal.gcm_encrypt(io, key_dma, nonce_dma, 0, pt_dma, ct_scratch, tag_dma)
+        let (ct_text, rest) = ct.split_at_mut(pt.len());
+        let (ct_tag, _) = rest.split_at_mut(GCM_TAG_LEN);
+        pal.gcm_encrypt(io, key, nonce, 0, pt, ct_text, ct_tag)
             .await?;
-        ct[..pt.len()].copy_from_slice(ct_scratch);
-        ct[pt.len()..ct_len].copy_from_slice(tag_dma);
         Ok(ct_len)
     } else {
-        // Non-empty AAD — format [padded_aad | pt] into a DMA scratch
-        // buffer, encrypt in-place, then copy only text + tag to `ct`.
+        // Non-empty AAD — the padded-AAD layout still needs a work buffer
+        // for the in-place ciphertext, but the tag is written straight
+        // into `ct`.
         let buf_len = azihsm_fw_core_crypto_gcm_buf::gcm_buf_len(aad.len(), pt.len());
         let padded = azihsm_fw_core_crypto_gcm_buf::padded_aad_len(aad.len());
         let text_len = buf_len - padded;
@@ -227,15 +226,16 @@ where
             return Err(HsmError::InvalidArg);
         }
         let work = alloc.dma_alloc(buf_len)?;
-        let tag_dma = alloc.dma_alloc(GCM_TAG_LEN)?;
         // Format [padded_aad | pt] directly into DMA work buffer.
         // SAFETY: work derefs to &mut [u8] via DmaBuf::DerefMut.
         let aad_len = azihsm_fw_core_crypto_gcm_buf::format_gcm_buf(aad, pt, &mut work[..buf_len]);
-        pal.gcm_encrypt_in_place(io, key_dma, nonce_dma, aad_len, work, tag_dma)
+        let (ct_text, rest) = ct.split_at_mut(text_len);
+        let (ct_tag, _) = rest.split_at_mut(GCM_TAG_LEN);
+        pal.gcm_encrypt_in_place(io, key, nonce, aad_len, work, ct_tag)
             .await?;
-        // Copy only the encrypted text (after padded AAD) + tag to output.
-        ct[..text_len].copy_from_slice(&work[padded..buf_len]);
-        ct[text_len..out_len].copy_from_slice(tag_dma);
+        // Copy only the encrypted text (after padded AAD) to the output;
+        // the tag was written into `ct` directly.
+        ct_text.copy_from_slice(&work[padded..buf_len]);
         Ok(out_len)
     }
 }

--- a/fw/core/crypto/hpke/src/kdf.rs
+++ b/fw/core/crypto/hpke/src/kdf.rs
@@ -23,8 +23,6 @@ use azihsm_fw_hsm_pal_traits::HsmKdf;
 use azihsm_fw_hsm_pal_traits::HsmResult;
 use azihsm_fw_hsm_pal_traits::HsmScopedAlloc;
 
-use crate::helpers::dma_copy_in;
-
 // =============================================================================
 // Constants
 // =============================================================================
@@ -77,14 +75,15 @@ fn concat_alloc<'a>(parts: &[&[u8]], alloc: &'a impl HsmScopedAlloc) -> HsmResul
 /// * `algo` — hash algorithm used by HKDF (selects `Nh`).
 /// * `suite_id` — HPKE suite identifier (`"HPKE" || I2OSP(kem_id,
 ///   2) || …`, opaque to this function).
-/// * `salt` — HKDF salt (may be empty).
+/// * `salt` — HKDF salt as a DMA buffer, or `None` for the RFC 5869
+///   default (all-zero) salt.
 /// * `label` — context-specific label (e.g. `b"eae_prk"`).
 /// * `ikm` — input keying material.
-/// * `prk_out` — destination buffer for the pseudo-random key;
+/// * `prk_out` — destination DMA buffer for the pseudo-random key;
 ///   must be at least `algo.digest_len()` bytes.  Only the leading
-///   `digest_len` bytes are written.
-/// * `alloc` — scoped allocator used for the labelled input buffer
-///   and output scratch.
+///   `digest_len` bytes are written.  The PAL writes into it directly —
+///   no intermediate scratch or copy.
+/// * `alloc` — scoped allocator used for the labelled input buffer.
 ///
 /// # Returns
 ///
@@ -98,22 +97,17 @@ pub async fn labeled_extract<'a, P>(
     io: &impl HsmIo,
     algo: HsmHashAlgo,
     suite_id: &[u8],
-    salt: &[u8],
+    salt: Option<&DmaBuf>,
     label: &[u8],
     ikm: &[u8],
-    prk_out: &mut [u8],
+    prk_out: &mut DmaBuf,
     alloc: &'a impl HsmScopedAlloc,
 ) -> HsmResult<()>
 where
     P: HsmKdf + HsmAlloc + 'a,
 {
     let labeled_ikm = concat_alloc(&[HPKE_V1, suite_id, label, ikm], alloc)?;
-    let salt_dma = dma_copy_in(alloc, salt)?;
-    let prk_scratch = alloc.dma_alloc(prk_out.len())?;
-    pal.hkdf_extract(io, algo, Some(salt_dma), labeled_ikm, prk_scratch)
-        .await?;
-    prk_out.copy_from_slice(prk_scratch);
-    Ok(())
+    pal.hkdf_extract(io, algo, salt, labeled_ikm, prk_out).await
 }
 
 /// HPKE `LabeledExpand` (RFC 9180 §4):
@@ -136,15 +130,15 @@ where
 /// * `io` — caller's I/O context (per-IO scope).
 /// * `algo` — hash algorithm used by HKDF.
 /// * `suite_id` — HPKE suite identifier.
-/// * `prk` — pseudo-random key from a prior
+/// * `prk` — pseudo-random key DMA buffer from a prior
 ///   [`labeled_extract`] call.
 /// * `label` — context-specific label (e.g. `b"shared_secret"`).
 /// * `info` — application-specific context bytes (may be empty).
-/// * `out` — destination buffer; `L = out.len()` is encoded as a
+/// * `out` — destination DMA buffer; `L = out.len()` is encoded as a
 ///   2-byte big-endian prefix in `labeled_info`.  RFC 9180 caps
-///   `L` at `255 * Nh`.
-/// * `alloc` — scoped allocator used for the labelled input buffer
-///   and output scratch.
+///   `L` at `255 * Nh`.  The PAL writes into it directly — no
+///   intermediate scratch or copy.
+/// * `alloc` — scoped allocator used for the labelled input buffer.
 ///
 /// # Returns
 ///
@@ -160,21 +154,17 @@ pub async fn labeled_expand<'a, P>(
     io: &impl HsmIo,
     algo: HsmHashAlgo,
     suite_id: &[u8],
-    prk: &[u8],
+    prk: &DmaBuf,
     label: &[u8],
     info: &[u8],
-    out: &mut [u8],
+    out: &mut DmaBuf,
     alloc: &'a impl HsmScopedAlloc,
 ) -> HsmResult<()>
 where
     P: HsmKdf + HsmAlloc + 'a,
 {
     let l_bytes = (out.len() as u16).to_be_bytes();
-    let prk_dma = dma_copy_in(alloc, prk)?;
     let labeled_info = concat_alloc(&[&l_bytes, HPKE_V1, suite_id, label, info], alloc)?;
-    let out_scratch = alloc.dma_alloc(out.len())?;
-    pal.hkdf_expand(io, algo, prk_dma, Some(labeled_info), out_scratch)
-        .await?;
-    out.copy_from_slice(out_scratch);
-    Ok(())
+    pal.hkdf_expand(io, algo, prk, Some(labeled_info), out)
+        .await
 }

--- a/fw/core/crypto/hpke/src/kem.rs
+++ b/fw/core/crypto/hpke/src/kem.rs
@@ -194,7 +194,7 @@ pub async fn encap<'a, P>(
     suite: HpkeSuite,
     pk_r: &[u8],
     enc: &mut [u8],
-    shared_secret: &mut [u8],
+    shared_secret: &mut DmaBuf,
     alloc: &'a impl HsmScopedAlloc,
 ) -> HsmResult<()>
 where
@@ -216,8 +216,9 @@ where
     if pub_size != npk_pal {
         return Err(HsmError::InvalidArg);
     }
-    let sk_e = alloc_bytes(priv_size, alloc)?;
-    let pk_e_le = alloc_bytes(pub_size, alloc)?;
+    // Ephemeral `sk_e ‖ pk_e_le` share one allocation.
+    let ek = alloc_bytes(priv_size + pub_size, alloc)?;
+    let (sk_e, pk_e_le) = ek.split_at_mut(priv_size);
     let (sk_len, pk_len) = pal
         .ecc_gen_keypair(
             io,
@@ -279,7 +280,7 @@ pub async fn decap<'a, P>(
     enc: &[u8],
     sk_r: &[u8],
     pk_r: &[u8],
-    shared_secret: &mut [u8],
+    shared_secret: &mut DmaBuf,
     alloc: &'a impl HsmScopedAlloc,
 ) -> HsmResult<()>
 where
@@ -338,10 +339,10 @@ pub async fn auth_encap<'a, P>(
     io: &impl HsmIo,
     suite: HpkeSuite,
     pk_r: &[u8],
-    sk_s: &[u8],
+    sk_s: &DmaBuf,
     pk_s: &[u8],
     enc: &mut [u8],
-    shared_secret: &mut [u8],
+    shared_secret: &mut DmaBuf,
     alloc: &'a impl HsmScopedAlloc,
 ) -> HsmResult<()>
 where
@@ -362,8 +363,9 @@ where
     if pub_size != npk_pal {
         return Err(HsmError::InvalidArg);
     }
-    let sk_e = alloc_bytes(priv_size, alloc)?;
-    let pk_e_le = alloc_bytes(pub_size, alloc)?;
+    // Ephemeral `sk_e ‖ pk_e_le` share one allocation.
+    let ek = alloc_bytes(priv_size + pub_size, alloc)?;
+    let (sk_e, pk_e_le) = ek.split_at_mut(priv_size);
     let (sk_len, pk_len) = pal
         .ecc_gen_keypair(
             io,
@@ -382,12 +384,10 @@ where
     let pk_r_le = alloc_bytes(npk_pal, alloc)?;
     sec1_be_to_pal_le(pk_r, &mut pk_r_le[..], coord_len)?;
 
-    let sk_s_dma = dma_copy_in(alloc, sk_s)?;
-
     let dh = alloc_bytes(ndh * 2, alloc)?;
     pal.ecdh_derive(io, curve, &sk_e[..sk_len], pk_r_le, &mut dh[..ndh])
         .await?;
-    pal.ecdh_derive(io, curve, sk_s_dma, pk_r_le, &mut dh[ndh..])
+    pal.ecdh_derive(io, curve, sk_s, pk_r_le, &mut dh[ndh..])
         .await?;
 
     pal_le_to_sec1_be(&pk_e_le[..pk_len], &mut enc[..npk_wire], coord_len)?;
@@ -430,7 +430,7 @@ pub async fn auth_decap<'a, P>(
     sk_r: &[u8],
     pk_r: &[u8],
     pk_s: &[u8],
-    shared_secret: &mut [u8],
+    shared_secret: &mut DmaBuf,
     alloc: &'a impl HsmScopedAlloc,
 ) -> HsmResult<()>
 where
@@ -497,7 +497,7 @@ async fn extract_and_expand<'a, P>(
     suite: HpkeSuite,
     dh: &[u8],
     kem_context: &[u8],
-    shared_secret: &mut [u8],
+    shared_secret: &mut DmaBuf,
     alloc: &'a impl HsmScopedAlloc,
 ) -> HsmResult<()>
 where
@@ -513,7 +513,7 @@ where
         io,
         algo,
         &kem_suite_id,
-        &[],
+        None,
         b"eae_prk",
         dh,
         eae_prk,

--- a/fw/core/crypto/hpke/src/ops.rs
+++ b/fw/core/crypto/hpke/src/ops.rs
@@ -67,8 +67,9 @@ pub struct PskParams<'a> {
 /// directly.
 #[derive(Debug, Clone, Copy)]
 pub struct AuthParams<'a> {
-    /// Sender private key.
-    pub sk_s: &'a [u8],
+    /// Sender private key (DMA buffer — consumed directly by the ECDH
+    /// engine, no internal copy).
+    pub sk_s: &'a DmaBuf,
     /// Sender public key.
     pub pk_s: &'a [u8],
 }
@@ -528,9 +529,9 @@ pub async fn seal<'a, P>(
     pal: &P,
     io: &impl HsmIo,
     cfg: &HpkeSealConfig<'_>,
-    pt: &[u8],
+    pt: &DmaBuf,
     enc_out: Option<&mut [u8]>,
-    ct_out: Option<&mut [u8]>,
+    ct_out: Option<&mut DmaBuf>,
     alloc: &'a impl HsmScopedAlloc,
 ) -> HsmResult<SealSizes>
 where
@@ -566,9 +567,9 @@ async fn do_seal<'a, P>(
     pal: &P,
     io: &impl HsmIo,
     cfg: &HpkeSealConfig<'_>,
-    pt: &[u8],
+    pt: &DmaBuf,
     enc_out: &mut [u8],
-    ct_out: &mut [u8],
+    ct_out: &mut DmaBuf,
     alloc: &'a impl HsmScopedAlloc,
 ) -> HsmResult<()>
 where
@@ -586,8 +587,11 @@ where
         _ => return Err(HsmError::InvalidArg),
     }
 
-    let key = alloc_bytes(suite.nk(), alloc)?;
-    let nonce = alloc_bytes(suite.nn(), alloc)?;
+    // AEAD `key ‖ base_nonce` share one allocation; the two LabeledExpand
+    // outputs write into the split halves.
+    let nk = suite.nk();
+    let kn = alloc_bytes(nk + suite.nn(), alloc)?;
+    let (key, nonce) = kn.split_at_mut(nk);
     let (psk, psk_id) = psk_bytes(&cfg.psk);
     schedule::key_schedule(
         pal,
@@ -807,7 +811,7 @@ async fn derive_exported<'a, P>(
     io: &impl HsmIo,
     suite: HpkeSuite,
     mode: Mode,
-    shared_secret: &[u8],
+    shared_secret: &DmaBuf,
     info: &[u8],
     psk: &Option<PskParams<'_>>,
     exporter_context: &[u8],
@@ -833,6 +837,10 @@ where
     )
     .await?;
 
+    // The caller's `out` is a plain `&mut [u8]` (not DMA-eligible), so the
+    // final LabeledExpand writes into a DMA scratch that is copied out —
+    // one boundary copy for the exported secret.
+    let out_scratch = alloc_bytes(out.len(), alloc)?;
     kdf::labeled_expand(
         pal,
         io,
@@ -841,8 +849,10 @@ where
         exp_secret,
         b"sec",
         exporter_context,
-        out,
+        out_scratch,
         alloc,
     )
-    .await
+    .await?;
+    out.copy_from_slice(out_scratch);
+    Ok(())
 }

--- a/fw/core/crypto/hpke/src/schedule.rs
+++ b/fw/core/crypto/hpke/src/schedule.rs
@@ -38,10 +38,10 @@ struct ScheduleState<'a> {
     /// Cached HPKE suite identifier.
     suite_id: [u8; 10],
     /// `secret = LabeledExtract(shared_secret, "secret", psk)` (`Nh` bytes).
-    secret: &'a [u8],
+    secret: &'a DmaBuf,
     /// `key_schedule_context = mode || psk_id_hash || info_hash`
     /// (`1 + 2*Nh` bytes).
-    ksc: &'a [u8],
+    ksc: &'a DmaBuf,
 }
 
 fn alloc_bytes(len: usize, alloc: &impl HsmScopedAlloc) -> HsmResult<&mut DmaBuf> {
@@ -78,7 +78,7 @@ async fn derive_secret_and_ksc<'a, P>(
     io: &impl HsmIo,
     suite: HpkeSuite,
     mode: u8,
-    shared_secret: &[u8],
+    shared_secret: &DmaBuf,
     info: &[u8],
     psk: &[u8],
     psk_id: &[u8],
@@ -91,38 +91,41 @@ where
     let nh = suite.nh();
     let suite_id = suite.hpke_suite_id();
 
-    let psk_id_hash = alloc_bytes(nh, alloc)?;
-    kdf::labeled_extract(
-        pal,
-        io,
-        algo,
-        &suite_id,
-        &[],
-        b"psk_id_hash",
-        psk_id,
-        psk_id_hash,
-        alloc,
-    )
-    .await?;
-
-    let info_hash = alloc_bytes(nh, alloc)?;
-    kdf::labeled_extract(
-        pal,
-        io,
-        algo,
-        &suite_id,
-        &[],
-        b"info_hash",
-        info,
-        info_hash,
-        alloc,
-    )
-    .await?;
-
+    // `key_schedule_context = mode ‖ psk_id_hash ‖ info_hash`.  Allocate
+    // it up front and write the two hashes straight into their slots —
+    // no separate hash buffers, no copy into the KSC.
     let ksc = alloc_bytes(1 + 2 * nh, alloc)?;
     ksc[0] = mode;
-    ksc[1..1 + nh].copy_from_slice(psk_id_hash);
-    ksc[1 + nh..].copy_from_slice(info_hash);
+    {
+        let slot = &mut ksc[1..1 + nh];
+        kdf::labeled_extract(
+            pal,
+            io,
+            algo,
+            &suite_id,
+            None,
+            b"psk_id_hash",
+            psk_id,
+            slot,
+            alloc,
+        )
+        .await?;
+    }
+    {
+        let slot = &mut ksc[1 + nh..1 + 2 * nh];
+        kdf::labeled_extract(
+            pal,
+            io,
+            algo,
+            &suite_id,
+            None,
+            b"info_hash",
+            info,
+            slot,
+            alloc,
+        )
+        .await?;
+    }
 
     let secret = alloc_bytes(nh, alloc)?;
     kdf::labeled_extract(
@@ -130,7 +133,7 @@ where
         io,
         algo,
         &suite_id,
-        shared_secret,
+        Some(shared_secret),
         b"secret",
         psk,
         secret,
@@ -187,12 +190,12 @@ pub async fn key_schedule<'a, P>(
     io: &impl HsmIo,
     suite: HpkeSuite,
     mode: u8,
-    shared_secret: &[u8],
+    shared_secret: &DmaBuf,
     info: &[u8],
     psk: &[u8],
     psk_id: &[u8],
-    key: &mut [u8],
-    base_nonce: &mut [u8],
+    key: &mut DmaBuf,
+    base_nonce: &mut DmaBuf,
     alloc: &'a impl HsmScopedAlloc,
 ) -> HsmResult<()>
 where
@@ -263,11 +266,11 @@ pub async fn key_schedule_export<'a, P>(
     io: &impl HsmIo,
     suite: HpkeSuite,
     mode: u8,
-    shared_secret: &[u8],
+    shared_secret: &DmaBuf,
     info: &[u8],
     psk: &[u8],
     psk_id: &[u8],
-    exporter_secret: &mut [u8],
+    exporter_secret: &mut DmaBuf,
     alloc: &'a impl HsmScopedAlloc,
 ) -> HsmResult<()>
 where

--- a/fw/core/crypto/x509-chain/src/validate.rs
+++ b/fw/core/crypto/x509-chain/src/validate.rs
@@ -316,28 +316,40 @@ impl ChainValidator {
         let curve = verify_key.curve;
         let coord_len = curve.priv_key_len();
         let hw_len = curve.wire_coord_len();
-        let sig_len = curve.sig_len();
 
         // Allocate DMA buffer for digest output.
         let digest_dma = alloc.dma_alloc(digest_len)?;
 
-        // Hash the TBSCertificate (already in DMA memory).
+        // Hash the TBSCertificate (already in DMA memory).  The digest is
+        // the natural big-endian SHA value the signer signed over.
         pal.hash(io, hash_algo, curr.tbs_raw, digest_dma, true)
             .await?;
 
-        // Decode DER ECDSA signature directly into a DMA buffer (raw format).
-        let sig_dma = alloc.dma_alloc(sig_len)?;
-        ecdsa::decode_ecdsa_sig(curr.signature, curve, sig_dma)?;
-
-        // Copy public key into hardware wire format.
-        // X.509 uses coord_len per coordinate (66 for P-521),
-        // hardware expects hw_len (68 for P-521) with leading zeros.
+        // `HsmEcc::ecc_verify` wants the public key and signature in the
+        // little-endian wire form: each component's magnitude in the first
+        // `coord_len` bytes of its `hw_len` slot (any padding — P-521 — at
+        // the slot tail).  X.509 carries both big-endian, so place each
+        // component in its slot and reverse it in place.
         let pk_dma = alloc.dma_alloc(curve.wire_pub_key_len())?;
         pk_dma.fill(0);
-        let pad = hw_len - coord_len;
-        pk_dma[pad..pad + coord_len].copy_from_slice(&verify_key.point[..coord_len]);
-        pk_dma[hw_len + pad..hw_len + pad + coord_len]
+        pk_dma[..coord_len].copy_from_slice(&verify_key.point[..coord_len]);
+        pk_dma[hw_len..hw_len + coord_len]
             .copy_from_slice(&verify_key.point[coord_len..coord_len * 2]);
+        pk_dma[..coord_len].reverse();
+        pk_dma[hw_len..hw_len + coord_len].reverse();
+
+        // Decode the DER ECDSA signature (big-endian `r ‖ s`, contiguous)
+        // directly into the wire buffer, shift `s` to its slot when the
+        // slot is padded (P-521), then reverse each component in place.
+        let sig_dma = alloc.dma_alloc(curve.wire_sig_len())?;
+        sig_dma.fill(0);
+        ecdsa::decode_ecdsa_sig(curr.signature, curve, sig_dma)?;
+        if hw_len != coord_len {
+            sig_dma.copy_within(coord_len..coord_len * 2, hw_len);
+            sig_dma[coord_len..hw_len].fill(0);
+        }
+        sig_dma[..coord_len].reverse();
+        sig_dma[hw_len..hw_len + coord_len].reverse();
 
         let result_dma = alloc.dma_alloc(4)?;
 

--- a/fw/core/ddi/tbor/api/tests/derive_tests.rs
+++ b/fw/core/ddi/tbor/api/tests/derive_tests.rs
@@ -1367,8 +1367,8 @@ fn decode_mut_with_uint32_uint64_siblings() {
         .finish();
 
     let frame_len = frame.len();
-    // SAFETY: test-only branding of a heap-resident buffer; see
-    // module-level brand() helper.
+    // SAFETY: test-only re-branding of a stack-allocated wire buffer
+    // that outlives `wire_mut` and is not aliased for the borrow.
     let wire_mut: &mut DmaBuf = unsafe { DmaBuf::from_raw_mut(&mut buf[..frame_len]) };
     let view = MixedMutableReq::decode_mut(wire_mut).unwrap();
     assert_eq!(view.epoch, 0xCAFEBABE);
@@ -1476,4 +1476,89 @@ fn single_typed_pod_ref_top_level_round_trip() {
     let view = SinglePodReq::decode(brand(frame.as_bytes())).unwrap();
     assert_eq!(view.pair(), &p);
     assert_eq!(&**view.tail(), b"z");
+}
+
+// ── ViewMut with an include-group sibling ─────────────────────────────
+//
+// Regression guard for codegen_view_mut: `#[tbor(mutable)]` must coexist
+// with a `#[tbor(include)]` group. A group sub-view borrows the whole
+// buffer (its members' offsets are message-relative), which cannot
+// coexist with a `&mut` sub-region of the same buffer — so the group is
+// **omitted** from `ViewMut`. The mutable field must still be split out
+// correctly, with the group's data bytes discarded in the inter-field
+// gap, and the trailing field must read at its group-adjusted offset.
+// The group itself is read through the shared `View` (`decode`).
+#[tbor(opcode = 0x7D)]
+pub struct GroupMutableReq<'a> {
+    #[tbor(max_len = 32, mutable)]
+    secret: &'a [u8],
+    #[tbor(include)]
+    ev: EvidenceLikeGroup<'a>,
+    #[tbor(max_len = 32)]
+    tail: &'a [u8],
+}
+
+#[test]
+fn decode_mut_with_include_group_sibling() {
+    let pairs = [
+        GrpPair {
+            a: zerocopy::little_endian::U16::new(0x0102),
+            b: zerocopy::little_endian::U16::new(0x0304),
+        },
+        GrpPair {
+            a: zerocopy::little_endian::U16::new(0x0506),
+            b: zerocopy::little_endian::U16::new(0x0708),
+        },
+    ];
+    let one = GrpPair {
+        a: zerocopy::little_endian::U16::new(0xAABB),
+        b: zerocopy::little_endian::U16::new(0xCCDD),
+    };
+
+    let mut buf = [0u8; 512];
+    let frame = GroupMutableReq::encode(&mut buf)
+        .unwrap()
+        .secret(b"initial-secret!!")
+        .unwrap()
+        .ev(|g| {
+            g.session(azihsm_fw_ddi_tbor_api::SessionId(7))?
+                .items(&pairs)?
+                .one(&one)?
+                .blob(b"BLOB")
+        })
+        .unwrap()
+        .tail(b"TAIL")
+        .unwrap()
+        .finish();
+    let frame_len = frame.len();
+
+    // Shared view: the include group is read through `decode`.
+    {
+        let view = GroupMutableReq::decode(brand(&buf[..frame_len])).unwrap();
+        let ev = view.ev();
+        assert_eq!(ev.session(), azihsm_fw_ddi_tbor_api::SessionId(7));
+        assert_eq!(ev.items(), &pairs[..]);
+        assert_eq!(&**ev.blob(), b"BLOB");
+        assert_eq!(&**view.tail(), b"TAIL");
+    }
+
+    // Mutable view: the group is omitted; `secret` (&mut) and `tail` (&)
+    // are still split out correctly across the group's data gap.
+    {
+        // SAFETY: test-only re-branding of a stack-allocated wire buffer
+        // that outlives `wire_mut` and is not aliased for the borrow.
+        let wire_mut: &mut DmaBuf = unsafe { DmaBuf::from_raw_mut(&mut buf[..frame_len]) };
+        let view = GroupMutableReq::decode_mut(wire_mut).unwrap();
+        assert_eq!(&**view.secret, b"initial-secret!!");
+        assert_eq!(&**view.tail, b"TAIL");
+        // Mutate the secret in place.
+        view.secret[0] = b'X';
+    }
+
+    // Re-decode: the in-place mutation stuck and the group + tail bytes
+    // are intact (the split did not corrupt neighbouring regions).
+    let view = GroupMutableReq::decode(brand(&buf[..frame_len])).unwrap();
+    assert_eq!(&**view.tail(), b"TAIL");
+    assert_eq!(view.ev().items(), &pairs[..]);
+    assert_eq!(&**view.ev().blob(), b"BLOB");
 }

--- a/fw/core/ddi/tbor/derive/src/codegen_view_mut.rs
+++ b/fw/core/ddi/tbor/derive/src/codegen_view_mut.rs
@@ -15,6 +15,13 @@
 //!   from a split-off mutable region; all field borrows are disjoint).
 //! * Scalar fields (`u8`/`u16`/`u32`/`u64`/`SessionId`/`KeyId`): owned
 //!   by value, copied out of the TOC during construction.
+//! * `#[tbor(include)]` field groups are **omitted** from `ViewMut`.
+//!   A group sub-view borrows the whole buffer (its members' offsets
+//!   are message-relative), which cannot coexist with a `&mut`
+//!   sub-region of the same buffer. The group's data-section bytes are
+//!   simply skipped by the split chain (they fall in an inter-field
+//!   gap); read the group through the shared `View` (`decode`) instead
+//!   — the two decodes are used sequentially by the handler.
 //!
 //! ## Layout invariants
 //!
@@ -48,11 +55,15 @@ pub fn gen_view_mut(schema: &Schema) -> TokenStream {
     let view_mut_name = format_ident!("{}ViewMut", schema.name);
     let name = &schema.name;
 
-    let struct_fields = schema.fields.iter().map(|field| {
-        let fname = &field.name;
-        let ty = field_type_tokens(field);
-        quote! { pub #fname: #ty, }
-    });
+    let struct_fields = schema
+        .fields
+        .iter()
+        .filter(|field| field.include_group.is_none())
+        .map(|field| {
+            let fname = &field.name;
+            let ty = field_type_tokens(field);
+            quote! { pub #fname: #ty, }
+        });
 
     quote! {
         /// Destructured zero-copy view over an encoded message. All
@@ -93,12 +104,17 @@ pub fn gen_decode_mut_body(schema: &Schema) -> Option<TokenStream> {
     // Today only Buffer/SealedKey can be `mutable`; other
     // data-section types (Uint32/Uint64) are admitted as shared
     // fields if present, since they still occupy data-section space.
-    let data_fields: Vec<(usize, &SchemaField)> = schema
+    let data_fields: Vec<(TokenStream, &SchemaField)> = schema
         .fields
         .iter()
         .enumerate()
         .filter(|(_, f)| f.wire_type.uses_data_section())
-        .map(|(i, f)| (layout.field_toc_indices[i], f))
+        .map(|(i, f)| {
+            (
+                crate::codegen_enc::effective_toc_idx(i, &layout, &schema.fields),
+                f,
+            )
+        })
         .collect();
 
     // Scalar (inline-encoded) field captures: read directly via a
@@ -107,8 +123,9 @@ pub fn gen_decode_mut_body(schema: &Schema) -> Option<TokenStream> {
         .fields
         .iter()
         .enumerate()
+        .filter(|(_, field)| field.include_group.is_none())
         .filter_map(|(i, field)| {
-            let toc_idx = layout.field_toc_indices[i];
+            let toc_idx = crate::codegen_enc::effective_toc_idx(i, &layout, &schema.fields);
             let var = format_ident!("__scalar_{}", field.name);
             let body = match field.wire_type {
                 WireType::Uint8 => Some(quote! {
@@ -210,6 +227,7 @@ pub fn gen_decode_mut_body(schema: &Schema) -> Option<TokenStream> {
     let struct_init: Vec<TokenStream> = schema
         .fields
         .iter()
+        .filter(|field| field.include_group.is_none())
         .map(|field| {
             let fname = &field.name;
             let value = match field.wire_type {


### PR DESCRIPTION
Three independent, self-contained changes extracted from the in-flight
SD remote-backup work. None depends on that feature (or on any other
in-flight stack): every file here is base-identical to `main`, and the
branch is cut directly from `main`. Presented as one PR with three
focused commits for easy per-concern review.

## 1. `fix(x509-chain)`: little-endian pubkey/signature to `ecc_verify`
`ChainValidator::verify_signature` placed the EC public key and ECDSA
signature into their hardware slots **big-endian**, but `HsmEcc::ecc_verify`
expects the **little-endian** wire form. The big-endian point failed the
PAL's on-curve check and surfaced as `InvalidArg` *before* the signature
was evaluated, so every chain link failed to verify. Now each component
is placed in its wire slot and reversed in place (P-521 `s` shifted into
its padded slot first); the signature buffer uses `curve.wire_sig_len()`.

## 2. `refactor(hpke)`: make CBC opt-in + thread `DmaBuf`
- Crate `default` feature set → `[]`, so the AES-CBC AEAD path (and its
  `HsmHashAlgo` import) compile out unless `cbc` is explicitly enabled —
  a meaningful `.text` saving on the GCM-only firmware build.
- Fix two bit-rotted `#[cfg(not(feature = "cbc"))]` fallbacks that
  returned the non-existent `HsmError::UnsupportedAlgorithm`; use the real
  `InvalidAlgorithm`.
- Thread `&DmaBuf`/`&mut DmaBuf` (instead of `&[u8]`) through the **seal**
  and **send_export** paths and the KEM / KDF / key-schedule internals, so
  senders hand DMA-resident buffers straight to the crypto verbs. The AEAD
  **open/decrypt** path is intentionally left slice-based — it has no
  firmware caller yet; a symmetric conversion is future work.

Public entry points keep their names; existing GCM callers (session
establishment) already pass `DmaBuf` and are unaffected — verified by
building `fw/core/lib` on this branch.

## 3. `feat(tbor-derive)`: `#[tbor(mutable)]` + `#[tbor(include)]` coexistence
A `#[tbor(mutable)]` field (in-place `decode_mut`/`ViewMut`) could not
coexist with an `#[tbor(include)]` group: the group's placeholder `Uint8`
TOC entries made the mutable-view codegen mistype the group as a scalar
and read post-group fields from the wrong (static) TOC slot, yielding
`TborNonMonotonicTocOffsets`. Include groups are now omitted from
`ViewMut` (still readable via the shared `decode` view) and data/scalar
TOC reads use the dynamic `effective_toc_idx` (static index + preceding
groups' `TOC_COUNT`). Adds a round-trip regression test.

## Validation
- `fw/core/crypto/hpke`, `fw/core/crypto/x509-chain`, and `fw/core/lib`
  build clean (default features) on `main`.
- `azihsm_fw_ddi_tbor_api` derive tests: 56 passed (incl. the new case).
- `clippy` clean on all three crates.

