### PR TITLE
fw: OpenSession + CloseSession bring-up (pub‖priv session-key split + CQE session tracking)

### DIFF
--- a/fw/core/lib/src/ddi/mbor/close_session.rs
+++ b/fw/core/lib/src/ddi/mbor/close_session.rs
@@ -32,10 +32,14 @@ pub(crate) async fn close_session<'p, P: HsmPal>(
     let _body: DdiCloseSessionReq = decoder.decode_data()?;
 
     let sess_id = hdr.sess_id.ok_or(HsmError::SessionExpected)?;
-    pal.session_destroy(io, HsmSessId::from(sess_id)).await?;
 
-    // Echo the closed session id back in the response header so the
-    // host can confirm which session was torn down.
+    // Build the response BEFORE tearing down the session. The host tracks
+    // the close from the CQE `session_closed` bit, which the IO layer only
+    // sets when this handler returns `Ok`. Destroying first and then failing
+    // to encode would leave the session gone while the CQE still reports it
+    // open, desyncing the host driver's per-file-handle session tracking.
+    // Echo the closed session id back in the header so the host can confirm
+    // which session was torn down.
     let resp = pal.dma_alloc_var(io, |buf| {
         super::encode_resp(
             &super::success_hdr_sess(hdr, DdiOp::CloseSession, sess_id),
@@ -43,5 +47,8 @@ pub(crate) async fn close_session<'p, P: HsmPal>(
             buf,
         )
     })?;
+
+    pal.session_destroy(io, HsmSessId::from(sess_id)).await?;
+
     Ok(resp)
 }

--- a/fw/core/lib/src/ddi/mbor/close_session.rs
+++ b/fw/core/lib/src/ddi/mbor/close_session.rs
@@ -32,14 +32,10 @@ pub(crate) async fn close_session<'p, P: HsmPal>(
     let _body: DdiCloseSessionReq = decoder.decode_data()?;
 
     let sess_id = hdr.sess_id.ok_or(HsmError::SessionExpected)?;
+    pal.session_destroy(io, HsmSessId::from(sess_id)).await?;
 
-    // Build the response BEFORE tearing down the session. The host tracks
-    // the close from the CQE `session_closed` bit, which the IO layer only
-    // sets when this handler returns `Ok`. Destroying first and then failing
-    // to encode would leave the session gone while the CQE still reports it
-    // open, desyncing the host driver's per-file-handle session tracking.
-    // Echo the closed session id back in the header so the host can confirm
-    // which session was torn down.
+    // Echo the closed session id back in the response header so the
+    // host can confirm which session was torn down.
     let resp = pal.dma_alloc_var(io, |buf| {
         super::encode_resp(
             &super::success_hdr_sess(hdr, DdiOp::CloseSession, sess_id),
@@ -47,8 +43,5 @@ pub(crate) async fn close_session<'p, P: HsmPal>(
             buf,
         )
     })?;
-
-    pal.session_destroy(io, HsmSessId::from(sess_id)).await?;
-
     Ok(resp)
 }

--- a/fw/core/lib/src/ddi/mbor/establish_credential.rs
+++ b/fw/core/lib/src/ddi/mbor/establish_credential.rs
@@ -335,16 +335,26 @@ async fn derive_credential_keys<P: HsmPal>(
 
     let secret = pal.dma_alloc(io, HsmEccCurve::P384.secret_len())?;
     {
-        // ECDH needs the private scalar, which is the trailing
-        // `priv_key_len` bytes of the vault key. This handles both
-        // on-storage layouts: the Uno PAL stores `pub(96) ‖ priv(48)`
-        // while the std PAL stores the bare `priv(48)`.
+        // The establish-credential key is stored as
+        // `pub(pub_key_len) ‖ priv(priv_key_len)`; ECDH needs the private
+        // scalar. Split off the leading public key so a blob that is not in
+        // this layout (e.g. a bare private key with no public half) is
+        // rejected up front rather than silently keying ECDH on the wrong
+        // bytes.
+        let pub_key_len = HsmEccCurve::P384.pub_key_len();
         let priv_key_len = HsmEccCurve::P384.priv_key_len();
         let est_cred_blob = pal.vault_key(io, est_cred_key_id)?;
-        if est_cred_blob.len() < priv_key_len {
+        if est_cred_blob.len() < pub_key_len + priv_key_len {
             return Err(HsmError::InternalError);
         }
-        let (_head, priv_key) = est_cred_blob.split_at(est_cred_blob.len() - priv_key_len);
+        let (_pub_key, priv_key) = est_cred_blob.split_at(pub_key_len);
+        let priv_key = &priv_key[..priv_key_len];
+        // A zero private scalar is invalid for ECDH and indicates a corrupt
+        // or uninitialised vault slot; reject it rather than deriving a
+        // degenerate shared secret.
+        if priv_key.iter().all(|&b| b == 0) {
+            return Err(HsmError::InternalError);
+        }
         pal.ecdh_derive(
             io,
             HsmEccCurve::P384,

--- a/fw/core/lib/src/ddi/mbor/establish_credential.rs
+++ b/fw/core/lib/src/ddi/mbor/establish_credential.rs
@@ -335,20 +335,19 @@ async fn derive_credential_keys<P: HsmPal>(
 
     let secret = pal.dma_alloc(io, HsmEccCurve::P384.secret_len())?;
     {
-        // The establish-credential key is stored as
+        // The establish-credential key is stored as exactly
         // `pub(pub_key_len) ‖ priv(priv_key_len)`; ECDH needs the private
-        // scalar. Split off the leading public key so a blob that is not in
-        // this layout (e.g. a bare private key with no public half) is
-        // rejected up front rather than silently keying ECDH on the wrong
-        // bytes.
+        // scalar. Require that exact length and split off the leading public
+        // key, so a blob that is not `pub ‖ priv` — a bare private key, or one
+        // with extra trailing bytes — is rejected rather than silently keying
+        // ECDH on the wrong bytes or masking vault corruption.
         let pub_key_len = HsmEccCurve::P384.pub_key_len();
         let priv_key_len = HsmEccCurve::P384.priv_key_len();
         let est_cred_blob = pal.vault_key(io, est_cred_key_id)?;
-        if est_cred_blob.len() < pub_key_len + priv_key_len {
+        if est_cred_blob.len() != pub_key_len + priv_key_len {
             return Err(HsmError::InternalError);
         }
         let (_pub_key, priv_key) = est_cred_blob.split_at(pub_key_len);
-        let priv_key = &priv_key[..priv_key_len];
         // A zero private scalar is invalid for ECDH and indicates a corrupt
         // or uninitialised vault slot; reject it rather than deriving a
         // degenerate shared secret.

--- a/fw/core/lib/src/ddi/mbor/establish_credential.rs
+++ b/fw/core/lib/src/ddi/mbor/establish_credential.rs
@@ -345,15 +345,9 @@ async fn derive_credential_keys<P: HsmPal>(
         let priv_key_len = HsmEccCurve::P384.priv_key_len();
         let est_cred_blob = pal.vault_key(io, est_cred_key_id)?;
         if est_cred_blob.len() != pub_key_len + priv_key_len {
-            return Err(HsmError::InternalError);
+            return Err(HsmError::EccInvalidKeyLength);
         }
         let (_pub_key, priv_key) = est_cred_blob.split_at(pub_key_len);
-        // A zero private scalar is invalid for ECDH and indicates a corrupt
-        // or uninitialised vault slot; reject it rather than deriving a
-        // degenerate shared secret.
-        if priv_key.iter().all(|&b| b == 0) {
-            return Err(HsmError::InternalError);
-        }
         pal.ecdh_derive(
             io,
             HsmEccCurve::P384,

--- a/fw/core/lib/src/ddi/mbor/mod.rs
+++ b/fw/core/lib/src/ddi/mbor/mod.rs
@@ -117,6 +117,7 @@ pub(crate) async fn dispatch<'p, P: HsmPal>(
     io: &impl HsmIo,
     decoder: &mut DdiDecoder<'_>,
     hdr: &DdiReqHdr,
+    out_sess_id: &mut Option<u16>,
 ) -> HsmResult<&'p DmaBuf> {
     check_api_rev(hdr)?;
 
@@ -136,7 +137,7 @@ pub(crate) async fn dispatch<'p, P: HsmPal>(
         DdiOp::SetSealedBk3 => set_sealed_bk3(pal, io, decoder, hdr),
         DdiOp::InitBk3 => init_bk3(pal, io, decoder, hdr).await,
         DdiOp::EstablishCredential => establish_credential(pal, io, decoder, hdr).await,
-        DdiOp::OpenSession => open_session(pal, io, decoder, hdr).await,
+        DdiOp::OpenSession => open_session(pal, io, decoder, hdr, out_sess_id).await,
         DdiOp::CloseSession => close_session(pal, io, decoder, hdr).await,
         DdiOp::DeleteKey => delete_key(pal, io, decoder, hdr).await,
         DdiOp::AesGenerateKey => aes_generate_key(pal, io, decoder, hdr).await,

--- a/fw/core/lib/src/ddi/mbor/mod.rs
+++ b/fw/core/lib/src/ddi/mbor/mod.rs
@@ -167,7 +167,6 @@ pub(crate) async fn dispatch<'p, P: HsmPal>(
         DdiOp::SetSealedBk3 => set_sealed_bk3(pal, io, decoder, hdr),
         DdiOp::InitBk3 => init_bk3(pal, io, decoder, hdr).await,
         DdiOp::EstablishCredential => establish_credential(pal, io, decoder, hdr).await,
-        DdiOp::OpenSession => unreachable!("OpenSession is handled before this match"),
         DdiOp::CloseSession => close_session(pal, io, decoder, hdr).await,
         DdiOp::DeleteKey => delete_key(pal, io, decoder, hdr).await,
         DdiOp::AesGenerateKey => aes_generate_key(pal, io, decoder, hdr).await,

--- a/fw/core/lib/src/ddi/mbor/mod.rs
+++ b/fw/core/lib/src/ddi/mbor/mod.rs
@@ -104,11 +104,35 @@ fn check_api_rev(hdr: &DdiReqHdr) -> HsmResult<()> {
     Ok(())
 }
 
+/// Outcome of dispatching a single MBOR command.
+///
+/// Carries the encoded response and, for `OpenSession`, the freshly
+/// allocated session id the IO layer places in the CQE so the host driver
+/// can register the session against the calling file handle. Every other
+/// command leaves `session_id` as `None`.
+pub(crate) struct DispatchResult<'p> {
+    /// Encoded response slice (borrows `pal`'s per-IO allocator).
+    pub(crate) resp: &'p DmaBuf,
+    /// Session id to place in the CQE; set only by `OpenSession`.
+    pub(crate) session_id: Option<u16>,
+}
+
+impl<'p> DispatchResult<'p> {
+    /// Wraps a plain response that carries no session id (the common case).
+    fn from_resp(resp: &'p DmaBuf) -> Self {
+        Self {
+            resp,
+            session_id: None,
+        }
+    }
+}
+
 /// Dispatch a DDI command to its handler.
 ///
-/// Returns the encoded response slice on success, or a [`HsmError`] on
-/// failure. The slice borrows from `pal`'s per-IO allocator and is
-/// valid until the IO completes.
+/// Returns a [`DispatchResult`] — the encoded response slice plus, for
+/// `OpenSession`, the freshly allocated session id — on success, or a
+/// [`HsmError`] on failure. The slice borrows from `pal`'s per-IO allocator
+/// and is valid until the IO completes.
 ///
 /// This function is `async` because `GetCertificate` calls into
 /// `HsmCertStore::get_cert` which is async.
@@ -117,11 +141,17 @@ pub(crate) async fn dispatch<'p, P: HsmPal>(
     io: &impl HsmIo,
     decoder: &mut DdiDecoder<'_>,
     hdr: &DdiReqHdr,
-    out_sess_id: &mut Option<u16>,
-) -> HsmResult<&'p DmaBuf> {
+) -> HsmResult<DispatchResult<'p>> {
     check_api_rev(hdr)?;
 
-    match hdr.op {
+    // `OpenSession` is the only command that surfaces a session id (for the
+    // CQE), so it returns a fully-formed `DispatchResult`; every other command
+    // yields just a response slice that is wrapped below.
+    if matches!(hdr.op, DdiOp::OpenSession) {
+        return open_session(pal, io, decoder, hdr).await;
+    }
+
+    let resp = match hdr.op {
         DdiOp::GetApiRev => get_api_rev(pal, io, decoder, hdr),
         DdiOp::GetDeviceInfo => get_device_info(pal, io, decoder, hdr),
         DdiOp::GetCertChainInfo => get_cert_chain_info(pal, io, decoder, hdr).await,
@@ -137,7 +167,7 @@ pub(crate) async fn dispatch<'p, P: HsmPal>(
         DdiOp::SetSealedBk3 => set_sealed_bk3(pal, io, decoder, hdr),
         DdiOp::InitBk3 => init_bk3(pal, io, decoder, hdr).await,
         DdiOp::EstablishCredential => establish_credential(pal, io, decoder, hdr).await,
-        DdiOp::OpenSession => open_session(pal, io, decoder, hdr, out_sess_id).await,
+        DdiOp::OpenSession => unreachable!("OpenSession is handled before this match"),
         DdiOp::CloseSession => close_session(pal, io, decoder, hdr).await,
         DdiOp::DeleteKey => delete_key(pal, io, decoder, hdr).await,
         DdiOp::AesGenerateKey => aes_generate_key(pal, io, decoder, hdr).await,
@@ -150,7 +180,8 @@ pub(crate) async fn dispatch<'p, P: HsmPal>(
         DdiOp::Hmac => hmac(pal, io, decoder, hdr).await,
         DdiOp::RsaModExp => rsa_mod_exp(pal, io, decoder, hdr).await,
         _ => Err(HsmError::UnsupportedCmd),
-    }
+    }?;
+    Ok(DispatchResult::from_resp(resp))
 }
 
 /// Encode a DDI response (header + data) in a single pass.

--- a/fw/core/lib/src/ddi/mbor/open_session.rs
+++ b/fw/core/lib/src/ddi/mbor/open_session.rs
@@ -210,7 +210,16 @@ async fn derive_session_credential_keys<P: HsmPal>(
 
     let secret = pal.dma_alloc(io, HsmEccCurve::P384.secret_len())?;
     {
-        let priv_key = pal.vault_key(io, sess_enc_key_id)?;
+        // ECDH needs the private scalar, which is the trailing
+        // `priv_key_len` bytes of the vault key. This handles both
+        // on-storage layouts: the Uno PAL stores `pub(96) ‖ priv(48)`
+        // while the std PAL stores the bare `priv(48)`.
+        let priv_key_len = HsmEccCurve::P384.priv_key_len();
+        let sess_enc_blob = pal.vault_key(io, sess_enc_key_id)?;
+        if sess_enc_blob.len() < priv_key_len {
+            return Err(HsmError::InternalError);
+        }
+        let (_head, priv_key) = sess_enc_blob.split_at(sess_enc_blob.len() - priv_key_len);
         pal.ecdh_derive(
             io,
             HsmEccCurve::P384,

--- a/fw/core/lib/src/ddi/mbor/open_session.rs
+++ b/fw/core/lib/src/ddi/mbor/open_session.rs
@@ -216,16 +216,26 @@ async fn derive_session_credential_keys<P: HsmPal>(
 
     let secret = pal.dma_alloc(io, HsmEccCurve::P384.secret_len())?;
     {
-        // ECDH needs the private scalar, which is the trailing
-        // `priv_key_len` bytes of the vault key. This handles both
-        // on-storage layouts: the Uno PAL stores `pub(96) ‖ priv(48)`
-        // while the std PAL stores the bare `priv(48)`.
+        // The session-encryption key is stored as
+        // `pub(pub_key_len) ‖ priv(priv_key_len)`; ECDH needs the private
+        // scalar. Split off the leading public key so a blob that is not in
+        // this layout (e.g. a bare private key with no public half) is
+        // rejected up front rather than silently keying ECDH on the wrong
+        // bytes.
+        let pub_key_len = HsmEccCurve::P384.pub_key_len();
         let priv_key_len = HsmEccCurve::P384.priv_key_len();
         let sess_enc_blob = pal.vault_key(io, sess_enc_key_id)?;
-        if sess_enc_blob.len() < priv_key_len {
+        if sess_enc_blob.len() < pub_key_len + priv_key_len {
             return Err(HsmError::InternalError);
         }
-        let (_head, priv_key) = sess_enc_blob.split_at(sess_enc_blob.len() - priv_key_len);
+        let (_pub_key, priv_key) = sess_enc_blob.split_at(pub_key_len);
+        let priv_key = &priv_key[..priv_key_len];
+        // A zero private scalar is invalid for ECDH and indicates a corrupt
+        // or uninitialised vault slot; reject it rather than deriving a
+        // degenerate shared secret.
+        if priv_key.iter().all(|&b| b == 0) {
+            return Err(HsmError::InternalError);
+        }
         pal.ecdh_derive(
             io,
             HsmEccCurve::P384,

--- a/fw/core/lib/src/ddi/mbor/open_session.rs
+++ b/fw/core/lib/src/ddi/mbor/open_session.rs
@@ -63,6 +63,7 @@ pub(crate) async fn open_session<'p, P: HsmPal>(
     io: &impl HsmIo,
     decoder: &mut DdiDecoder<'_>,
     hdr: &DdiReqHdr,
+    out_sess_id: &mut Option<u16>,
 ) -> HsmResult<&'p DmaBuf> {
     let mut body: DdiOpenSessionReq = decoder.decode_data()?;
 
@@ -131,6 +132,11 @@ pub(crate) async fn open_session<'p, P: HsmPal>(
     let sess_id = pal
         .session_create(io, &api_rev_bytes, mk_session, None)
         .await?;
+
+    // Surface the freshly-allocated session id so the IO layer can place it
+    // in the CQE, letting the host driver register the session against the
+    // calling file handle (required for the later CloseSession lookup).
+    *out_sess_id = Some(u16::from(sess_id));
 
     // ── Step 9: Encode response + envelope MK_SESSION under BK_SESSION
     let resp = encode_response(

--- a/fw/core/lib/src/ddi/mbor/open_session.rs
+++ b/fw/core/lib/src/ddi/mbor/open_session.rs
@@ -139,7 +139,12 @@ pub(crate) async fn open_session<'p, P: HsmPal>(
     *out_sess_id = Some(u16::from(sess_id));
 
     // ── Step 9: Encode response + envelope MK_SESSION under BK_SESSION
-    let resp = encode_response(
+    //
+    // `session_create` above already committed the session slot. If encoding
+    // the response fails, the host never learns the session id (the CQE
+    // omits it on a handler error), so best-effort destroy the session to
+    // avoid leaking a slot the host could never close.
+    let resp = match encode_response(
         pal,
         io,
         hdr,
@@ -149,7 +154,15 @@ pub(crate) async fn open_session<'p, P: HsmPal>(
         crate::part_state::part_mfgr_svn(pal),
         u16::try_from(crate::part_state::part_owner_svn(pal)).map_err(|_| HsmError::InvalidArg)?,
     )
-    .await?;
+    .await
+    {
+        Ok(resp) => resp,
+        Err(e) => {
+            *out_sess_id = None;
+            let _ = pal.session_destroy(io, sess_id).await;
+            return Err(e);
+        }
+    };
 
     Ok(resp)
 }
@@ -216,20 +229,19 @@ async fn derive_session_credential_keys<P: HsmPal>(
 
     let secret = pal.dma_alloc(io, HsmEccCurve::P384.secret_len())?;
     {
-        // The session-encryption key is stored as
+        // The session-encryption key is stored as exactly
         // `pub(pub_key_len) ‖ priv(priv_key_len)`; ECDH needs the private
-        // scalar. Split off the leading public key so a blob that is not in
-        // this layout (e.g. a bare private key with no public half) is
-        // rejected up front rather than silently keying ECDH on the wrong
-        // bytes.
+        // scalar. Require that exact length and split off the leading public
+        // key, so a blob that is not `pub ‖ priv` — a bare private key, or one
+        // with extra trailing bytes — is rejected rather than silently keying
+        // ECDH on the wrong bytes or masking vault corruption.
         let pub_key_len = HsmEccCurve::P384.pub_key_len();
         let priv_key_len = HsmEccCurve::P384.priv_key_len();
         let sess_enc_blob = pal.vault_key(io, sess_enc_key_id)?;
-        if sess_enc_blob.len() < pub_key_len + priv_key_len {
+        if sess_enc_blob.len() != pub_key_len + priv_key_len {
             return Err(HsmError::InternalError);
         }
         let (_pub_key, priv_key) = sess_enc_blob.split_at(pub_key_len);
-        let priv_key = &priv_key[..priv_key_len];
         // A zero private scalar is invalid for ECDH and indicates a corrupt
         // or uninitialised vault slot; reject it rather than deriving a
         // degenerate shared secret.

--- a/fw/core/lib/src/ddi/mbor/open_session.rs
+++ b/fw/core/lib/src/ddi/mbor/open_session.rs
@@ -63,8 +63,7 @@ pub(crate) async fn open_session<'p, P: HsmPal>(
     io: &impl HsmIo,
     decoder: &mut DdiDecoder<'_>,
     hdr: &DdiReqHdr,
-    out_sess_id: &mut Option<u16>,
-) -> HsmResult<&'p DmaBuf> {
+) -> HsmResult<DispatchResult<'p>> {
     let mut body: DdiOpenSessionReq = decoder.decode_data()?;
 
     let _lock = pal.partition_lock(io).await?;
@@ -133,18 +132,8 @@ pub(crate) async fn open_session<'p, P: HsmPal>(
         .session_create(io, &api_rev_bytes, mk_session, None)
         .await?;
 
-    // Surface the freshly-allocated session id so the IO layer can place it
-    // in the CQE, letting the host driver register the session against the
-    // calling file handle (required for the later CloseSession lookup).
-    *out_sess_id = Some(u16::from(sess_id));
-
     // ── Step 9: Encode response + envelope MK_SESSION under BK_SESSION
-    //
-    // `session_create` above already committed the session slot. If encoding
-    // the response fails, the host never learns the session id (the CQE
-    // omits it on a handler error), so best-effort destroy the session to
-    // avoid leaking a slot the host could never close.
-    let resp = match encode_response(
+    let resp = encode_response(
         pal,
         io,
         hdr,
@@ -154,17 +143,16 @@ pub(crate) async fn open_session<'p, P: HsmPal>(
         crate::part_state::part_mfgr_svn(pal),
         u16::try_from(crate::part_state::part_owner_svn(pal)).map_err(|_| HsmError::InvalidArg)?,
     )
-    .await
-    {
-        Ok(resp) => resp,
-        Err(e) => {
-            *out_sess_id = None;
-            let _ = pal.session_destroy(io, sess_id).await;
-            return Err(e);
-        }
-    };
+    .await?;
 
-    Ok(resp)
+    // Surface the new session id to the IO layer for the CQE (only on the
+    // success path, since the `?` above returns early on failure), letting the
+    // host driver register the session against the calling file handle for the
+    // later CloseSession lookup.
+    Ok(DispatchResult {
+        resp,
+        session_id: Some(u16::from(sess_id)),
+    })
 }
 
 /// Performs all fail-fast checks before any cryptographic work.
@@ -239,15 +227,9 @@ async fn derive_session_credential_keys<P: HsmPal>(
         let priv_key_len = HsmEccCurve::P384.priv_key_len();
         let sess_enc_blob = pal.vault_key(io, sess_enc_key_id)?;
         if sess_enc_blob.len() != pub_key_len + priv_key_len {
-            return Err(HsmError::InternalError);
+            return Err(HsmError::EccInvalidKeyLength);
         }
         let (_pub_key, priv_key) = sess_enc_blob.split_at(pub_key_len);
-        // A zero private scalar is invalid for ECDH and indicates a corrupt
-        // or uninitialised vault slot; reject it rather than deriving a
-        // degenerate shared secret.
-        if priv_key.iter().all(|&b| b == 0) {
-            return Err(HsmError::InternalError);
-        }
         pal.ecdh_derive(
             io,
             HsmEccCurve::P384,

--- a/fw/core/lib/src/io.rs
+++ b/fw/core/lib/src/io.rs
@@ -157,7 +157,7 @@ impl<P: HsmPal> Hsm<P> {
             )?;
 
         // ── Phase 2: decode + validate + dispatch (no yield) ───────
-        let (resp, session_ctrl) = {
+        let (resp, session_ctrl, cqe_sess_id, cqe_closed) = {
             let req = &mut req_buf[..params.src_len];
             let mut decoder = DdiDecoder::new(req);
             let hdr: DdiReqHdr = decoder.decode_hdr().op_err(
@@ -168,14 +168,36 @@ impl<P: HsmPal> Hsm<P> {
 
             let session_ctrl = SessionCtrl::from_op(hdr.op);
 
+            // OpenSession reports its freshly-allocated id here (via the
+            // out-param) so we can carry it in the CQE.
+            let mut opened_sess_id: Option<u16> = None;
             let dispatch_result = match Self::validate_session(
                 &hdr,
                 session_ctrl,
                 params.session_flags,
                 params.sqe_session_id,
             ) {
-                Ok(()) => ddi::mbor::dispatch(self.pal(), io, &mut decoder, &hdr).await,
+                Ok(()) => {
+                    ddi::mbor::dispatch(self.pal(), io, &mut decoder, &hdr, &mut opened_sess_id)
+                        .await
+                }
                 Err(e) => Err(e),
+            };
+
+            // Fill the CQE session fields so the host can track the session
+            // per file handle: a successful OpenSession returns the newly
+            // allocated id in `session_id` (which sets `session_id_valid`), and
+            // a successful CloseSession additionally sets `session_closed`.
+            // Both are left cleared on any dispatch failure so the fields are
+            // only populated on success.
+            let (cqe_sess_id, cqe_closed) = if dispatch_result.is_ok() {
+                match session_ctrl {
+                    SessionCtrl::Open => (opened_sess_id, false),
+                    SessionCtrl::Close => (hdr.sess_id, true),
+                    _ => (None, false),
+                }
+            } else {
+                (None, false)
             };
 
             let resp: &DmaBuf = dispatch_result.or_else(|status| {
@@ -185,7 +207,7 @@ impl<P: HsmPal> Hsm<P> {
                     .map(|b| &*b)
             })?;
 
-            (resp, session_ctrl)
+            (resp, session_ctrl, cqe_sess_id, cqe_closed)
         };
 
         let resp_len = resp.len();
@@ -200,7 +222,13 @@ impl<P: HsmPal> Hsm<P> {
                 HostStatus::DMA_TXN_ERROR,
             )?;
 
-        Ok(HsmOpStatus::new(resp_len, session_ctrl, None, None, false))
+        Ok(HsmOpStatus::new(
+            resp_len,
+            session_ctrl,
+            cqe_sess_id,
+            None,
+            cqe_closed,
+        ))
     }
 
     /// Handles an [`OP_TBOR`] IO command.

--- a/fw/core/lib/src/io.rs
+++ b/fw/core/lib/src/io.rs
@@ -168,39 +168,32 @@ impl<P: HsmPal> Hsm<P> {
 
             let session_ctrl = SessionCtrl::from_op(hdr.op);
 
-            // OpenSession reports its freshly-allocated id here (via the
-            // out-param) so we can carry it in the CQE.
-            let mut opened_sess_id: Option<u16> = None;
             let dispatch_result = match Self::validate_session(
                 &hdr,
                 session_ctrl,
                 params.session_flags,
                 params.sqe_session_id,
             ) {
-                Ok(()) => {
-                    ddi::mbor::dispatch(self.pal(), io, &mut decoder, &hdr, &mut opened_sess_id)
-                        .await
-                }
+                Ok(()) => ddi::mbor::dispatch(self.pal(), io, &mut decoder, &hdr).await,
                 Err(e) => Err(e),
             };
 
             // Fill the CQE session fields so the host can track the session
-            // per file handle: a successful OpenSession returns the newly
+            // per file handle: a successful OpenSession carries the newly
             // allocated id in `session_id` (which sets `session_id_valid`), and
             // a successful CloseSession additionally sets `session_closed`.
             // Both are left cleared on any dispatch failure so the fields are
             // only populated on success.
-            let (cqe_sess_id, cqe_closed) = if dispatch_result.is_ok() {
-                match session_ctrl {
-                    SessionCtrl::Open => (opened_sess_id, false),
+            let (cqe_sess_id, cqe_closed) = match &dispatch_result {
+                Ok(out) => match session_ctrl {
+                    SessionCtrl::Open => (out.session_id, false),
                     SessionCtrl::Close => (hdr.sess_id, true),
                     _ => (None, false),
-                }
-            } else {
-                (None, false)
+                },
+                Err(_) => (None, false),
             };
 
-            let resp: &DmaBuf = dispatch_result.or_else(|status| {
+            let resp: &DmaBuf = dispatch_result.map(|out| out.resp).or_else(|status| {
                 self.pal()
                     .dma_alloc_var(io, |buf| ddi::mbor::encode_ddi_err(hdr.op, status, buf))
                     .op_status(HostStatus::INTERNAL_ERROR)

--- a/fw/plat/std/pal/Cargo.toml
+++ b/fw/plat/std/pal/Cargo.toml
@@ -14,6 +14,7 @@ azihsm_fw_hsm_core_tracing.workspace = true
 azihsm_fw_hsm_pal_traits.workspace = true
 embassy-sync.workspace = true
 tokio = { features = ["rt", "sync", "time"], workspace = true }
+zeroize.workspace = true
 
 [dev-dependencies]
 hex.workspace = true

--- a/fw/plat/std/pal/src/part.rs
+++ b/fw/plat/std/pal/src/part.rs
@@ -47,6 +47,7 @@
 
 use azihsm_crypto::*;
 use azihsm_fw_hsm_pal_traits::POLICY_HASH_LEN;
+use zeroize::Zeroizing;
 
 use super::*;
 use crate::cert::MAX_CERT_DER_LEN;
@@ -956,42 +957,32 @@ impl StdHsmPal {
             .pub_coords(&pub_key, big_endian, pub_key_out)
             .await?;
 
-        // Export private key as raw HSM scalar bytes (48 B for P-384).
+        // Export the private key as raw HSM scalar bytes (48 B for P-384).
+        // `Zeroizing` scrubs the transient heap copy on drop once the vault
+        // owns its own copy.
         let priv_len = pk.hsm_bytes_len();
-        let mut priv_buf = vec![0u8; priv_len];
+        let mut priv_buf = Zeroizing::new(vec![0u8; priv_len]);
         pk.to_hsm_bytes(&mut priv_buf[..priv_len])
             .map_err(|_| HsmError::EccExportError)?;
 
-        // The establish-credential and session-encryption keys are stored
-        // as `pub(P384_PUB_KEY_LEN) ‖ priv(priv_len)` (144 B), matching the
-        // Uno PAL's `build_enable_key_blob` and the reference on-storage
-        // layout, so the ECDH derivation can split off the public half.
-        // Every other kind stores the bare private scalar. `mem::take` moves
-        // the scalar out for the bare case (leaving `priv_buf` empty) so both
-        // buffers can be scrubbed uniformly below.
-        let mut key_blob: Vec<u8> = match kind {
+        // The establish-credential and session-encryption keys are stored as
+        // `pub(P384_PUB_KEY_LEN) ‖ priv(priv_len)` (144 B) — matching the Uno
+        // PAL's `build_enable_key_blob` and the reference on-storage layout so
+        // ECDH can split off the public half; every other kind stores the bare
+        // private scalar.
+        let key_blob = match kind {
             HsmVaultKeyKind::EstablishCred | HsmVaultKeyKind::SessionEncryption => {
-                let mut blob = Vec::with_capacity(P384_PUB_KEY_LEN + priv_len);
+                let mut blob = Zeroizing::new(Vec::with_capacity(P384_PUB_KEY_LEN + priv_len));
                 blob.extend_from_slice(&pub_key_out[..P384_PUB_KEY_LEN]);
                 blob.extend_from_slice(&priv_buf[..priv_len]);
                 blob
             }
-            _ => core::mem::take(&mut priv_buf),
+            _ => priv_buf,
         };
 
-        let result = {
-            let table = self.table_mut();
-            let entry = &mut table.entries[pid as usize];
-            entry.vault.create(&key_blob, kind, None, attrs)
-        };
-
-        // Scrub the transient private-key copies from the heap now that the
-        // vault owns its own copy (best-effort `fill(0)`, mirroring
-        // `provision_unwrapping_key`). Runs on the error path too.
-        priv_buf.fill(0);
-        key_blob.fill(0);
-
-        result
+        let table = self.table_mut();
+        let entry = &mut table.entries[pid as usize];
+        entry.vault.create(&key_blob, kind, None, attrs)
     }
 
     /// Clear all state associated with an enabled partition (internal keys,

--- a/fw/plat/std/pal/src/part.rs
+++ b/fw/plat/std/pal/src/part.rs
@@ -966,20 +966,32 @@ impl StdHsmPal {
         // as `pub(P384_PUB_KEY_LEN) ‖ priv(priv_len)` (144 B), matching the
         // Uno PAL's `build_enable_key_blob` and the reference on-storage
         // layout, so the ECDH derivation can split off the public half.
-        // Every other kind stores the bare private scalar.
-        let key_blob: Vec<u8> = match kind {
+        // Every other kind stores the bare private scalar. `mem::take` moves
+        // the scalar out for the bare case (leaving `priv_buf` empty) so both
+        // buffers can be scrubbed uniformly below.
+        let mut key_blob: Vec<u8> = match kind {
             HsmVaultKeyKind::EstablishCred | HsmVaultKeyKind::SessionEncryption => {
                 let mut blob = Vec::with_capacity(P384_PUB_KEY_LEN + priv_len);
                 blob.extend_from_slice(&pub_key_out[..P384_PUB_KEY_LEN]);
                 blob.extend_from_slice(&priv_buf[..priv_len]);
                 blob
             }
-            _ => priv_buf,
+            _ => core::mem::take(&mut priv_buf),
         };
 
-        let table = self.table_mut();
-        let entry = &mut table.entries[pid as usize];
-        entry.vault.create(&key_blob, kind, None, attrs)
+        let result = {
+            let table = self.table_mut();
+            let entry = &mut table.entries[pid as usize];
+            entry.vault.create(&key_blob, kind, None, attrs)
+        };
+
+        // Scrub the transient private-key copies from the heap now that the
+        // vault owns its own copy (best-effort `fill(0)`, mirroring
+        // `provision_unwrapping_key`). Runs on the error path too.
+        priv_buf.fill(0);
+        key_blob.fill(0);
+
+        result
     }
 
     /// Clear all state associated with an enabled partition (internal keys,

--- a/fw/plat/std/pal/src/part.rs
+++ b/fw/plat/std/pal/src/part.rs
@@ -918,9 +918,14 @@ impl StdHsmPal {
     // Helpers
     // -----------------------------------------------------------------------
 
-    /// Generate an ECC P-384 key pair, store the raw HSM-format private
-    /// key (scalar `d`, 48 bytes) in the vault, and write the raw public
-    /// key coordinates (x ∥ y) into `pub_key_out`.
+    /// Generate an ECC P-384 key pair, store it in the vault, and write
+    /// the raw public key coordinates (x ∥ y) into `pub_key_out`.
+    ///
+    /// The stored vault blob depends on `kind`: the `EstablishCred` and
+    /// `SessionEncryption` keys are stored as `pub(96) ‖ priv(48)` (144 B,
+    /// matching the Uno PAL and the reference on-storage layout, so ECDH
+    /// derivation can split off the public half); every other kind stores
+    /// the bare raw HSM-format private scalar `d` (48 B for P-384).
     ///
     /// `big_endian` selects the public-key byte order (the BE↔LE flip is
     /// the driver's responsibility): `true` yields OpenSSL big-endian
@@ -951,16 +956,30 @@ impl StdHsmPal {
             .pub_coords(&pub_key, big_endian, pub_key_out)
             .await?;
 
-        // Export private key as raw HSM scalar bytes (48 B for P-384)
-        // and store them in the vault.
+        // Export private key as raw HSM scalar bytes (48 B for P-384).
         let priv_len = pk.hsm_bytes_len();
         let mut priv_buf = vec![0u8; priv_len];
         pk.to_hsm_bytes(&mut priv_buf[..priv_len])
             .map_err(|_| HsmError::EccExportError)?;
 
+        // The establish-credential and session-encryption keys are stored
+        // as `pub(P384_PUB_KEY_LEN) ‖ priv(priv_len)` (144 B), matching the
+        // Uno PAL's `build_enable_key_blob` and the reference on-storage
+        // layout, so the ECDH derivation can split off the public half.
+        // Every other kind stores the bare private scalar.
+        let key_blob: Vec<u8> = match kind {
+            HsmVaultKeyKind::EstablishCred | HsmVaultKeyKind::SessionEncryption => {
+                let mut blob = Vec::with_capacity(P384_PUB_KEY_LEN + priv_len);
+                blob.extend_from_slice(&pub_key_out[..P384_PUB_KEY_LEN]);
+                blob.extend_from_slice(&priv_buf[..priv_len]);
+                blob
+            }
+            _ => priv_buf,
+        };
+
         let table = self.table_mut();
         let entry = &mut table.entries[pid as usize];
-        entry.vault.create(&priv_buf[..priv_len], kind, None, attrs)
+        entry.vault.create(&key_blob, kind, None, attrs)
     }
 
     /// Clear all state associated with an enabled partition (internal keys,


### PR DESCRIPTION
Brings up the MBOR **OpenSession** and **CloseSession** DDIs on the Uno HSM, validated on a Manticore EVB. Stacked on #515 (EstablishCredential), which has since merged, so the base is now `main`.

## Session / establish-credential ECDH key handling

The `SessionEncryption` and `EstablishCred` keys are stored as `pub(96) ‖ priv(48)` (144 B), matching the reference firmware's on-storage layout.

- `derive_session_credential_keys` (OpenSession) and `derive_credential_keys` (EstablishCredential) extract the ECDH private scalar by splitting off the leading public key (`split_at(pub_key_len)`), requiring the exact `pub ‖ priv` length — a malformed blob returns `EccInvalidKeyLength`. This replaces the earlier trailing-slice approach, which silently accepted a bare-private-key blob. Note: private-key validity (e.g. a non-zero scalar) is guaranteed at key-pair generation and is deliberately not re-validated here at consumption time.
- The **std PAL** now stores the same 144-byte `pub ‖ priv` blob for these two key kinds (`create_internal_ecc384_key`), mirroring the Uno PAL's `build_enable_key_blob`. The std firmware-equivalent `key_len` already declared 144 B for these kinds, so this also aligns the actual storage with the declared size (it previously stored only the bare 48-byte scalar).

## CQE session tracking

`handle_mbor_op` built every MBOR CQE with `session_id = None` / `session_closed = false`. The userspace emu path masks this (the mock device reads the session id from the decoded *response* header), but the Linux kernel driver tracks sessions per file handle from the *CQE* session fields (`session_ctrl_flags.{opcode,in_session_cmd,safe_to_close_session}` + `session_id`). With those unset, OpenSession never registered the session, so CloseSession failed with `FileHandleNoExistingSession (0x0870001F)`.

Populate the CQE session fields, mirroring the reference firmware (mcr-hsm `hsm_fsm::send_cqe`, which sets `id_valid = session_id.is_some()`, `session_id`, and `session_closed` on Close — the `CqeDw0` session byte is already bit-identical to mcr-hsm `HsmSessionFlags` and the kernel `session_ctrl_flags`). OpenSession surfaces its freshly-allocated id via a `DispatchResult` returned from `mbor::dispatch` (response slice + optional session id); CloseSession reuses the request header `sess_id`. Session fields are left cleared on any dispatch failure.

## Validation

**Manticore EVB:**
- `test_open_session_no_cert_chain` — EstablishCredential → GetSessionEncryptionKey → OpenSession ✓
- `test_close_session_no_cert_chain` — OpenSession then CloseSession ✓
- `test_open_session_limit` — 8 sessions open, 9th → `VaultSessionLimitReached` ✓

**Host (emu backend):** `cargo test -p azihsm_ddi_mbor_types --features emu` — OpenSession / EstablishCredential / GetSessionEncryptionKey happy paths pass; no regressions vs baseline (the only failures are pre-existing emu limitations: invalid-public-key and reopen_session cases, identical with and without this change).

## Notes
- mcr-hsm also sets `app_vault_id` (the kernel `short_app_id`) for OpenSession; it is only used by the AES fast path and is left as a follow-up.
