### PR TITLE
refactor(tbor): index+length descriptor model for cert/report chains

### DIFF
--- a/ddi/tbor/types/src/evidence.rs
+++ b/ddi/tbor/types/src/evidence.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-//! Host-side evidence descriptors for TBOR side-band buffers.
+//! Host-side evidence descriptors for TBOR out-of-band chains.
 //!
 //! Several Security-Domain TBOR commands carry their bulk attestation
 //! evidence — DER certificate chains and COSE_Sign1 attestation reports —

--- a/ddi/tbor/types/src/evidence.rs
+++ b/ddi/tbor/types/src/evidence.rs
@@ -5,8 +5,8 @@
 //!
 //! Several Security-Domain TBOR commands carry their bulk attestation
 //! evidence — DER certificate chains and COSE_Sign1 attestation reports —
-//! **out of band** in a side-band data buffer, and reference each item
-//! from the TBOR message with a small `(offset, length)` descriptor.
+//! **out of band** as SGL Data Blocks, and reference each item from the
+//! TBOR message with a small `(index, length)` descriptor.
 //!
 //! The firmware schema groups these four descriptor TOC entries
 //! (`mfgr_cert_chain` / `owner_cert_chain` / `part_owner_cert_chain` /
@@ -24,23 +24,23 @@ use zerocopy::Unaligned;
 
 use crate::tbor_int::U16;
 
-/// Size of a single [`ReportDescriptor`] on the wire (`offset(2) ‖
+/// Size of a single [`ReportDescriptor`] on the wire (`index(1) ‖
 /// length(2)`, little-endian).
-pub const REPORT_DESCRIPTOR_LEN: usize = 4;
+pub const REPORT_DESCRIPTOR_LEN: usize = 3;
 
 /// Maximum number of certificate descriptors a single chain list may
 /// carry on the wire.  A wire-size bound (DMA), not a structural
 /// limit; mirrors `azihsm_fw_ddi_tbor_types::evidence::EVIDENCE_CHAIN_MAX_CERTS`.
 pub const EVIDENCE_CHAIN_MAX_CERTS: usize = 8;
 
-/// One attestation-report descriptor: the byte `offset` and `length` of a
-/// COSE_Sign1 report within the side-band data buffer.
+/// One attestation-report descriptor: the OOB SGL-descriptor `index` and
+/// byte `length` of a COSE_Sign1 report carried out of band.
 ///
 /// Host-side mirror of
 /// `azihsm_fw_ddi_tbor_types::evidence::ReportDescriptor`.  `#[repr(C)]`
-/// POD (size [`REPORT_DESCRIPTOR_LEN`] = 4 B, alignment 1); the
-/// [`U16`](crate::tbor_int::U16) fields are little-endian on the wire and
-/// keep the type `Unaligned`.
+/// POD (size [`REPORT_DESCRIPTOR_LEN`] = 3 B, alignment 1); `index` is a
+/// `u8` and `length` a little-endian [`U16`](crate::tbor_int::U16) on the
+/// wire, keeping the type `Unaligned`.
 #[derive(
     Debug,
     Default,
@@ -56,8 +56,9 @@ pub const EVIDENCE_CHAIN_MAX_CERTS: usize = 8;
 )]
 #[repr(C)]
 pub struct ReportDescriptor {
-    /// Byte offset of the report in the side-band buffer.
-    pub offset: U16,
+    /// Index of the report's SGL Data Block descriptor in the OOB
+    /// descriptor page.
+    pub index: u8,
 
     /// Byte length of the report.
     pub length: U16,
@@ -68,7 +69,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn report_descriptor_layout_is_packed_4_bytes() {
+    fn report_descriptor_layout_is_packed_3_bytes() {
         const _: () = assert!(core::mem::size_of::<ReportDescriptor>() == REPORT_DESCRIPTOR_LEN);
         const _: () = assert!(core::mem::align_of::<ReportDescriptor>() == 1);
     }
@@ -76,10 +77,10 @@ mod tests {
     #[test]
     fn report_descriptor_round_trips_bytes() {
         let d = ReportDescriptor {
-            offset: U16::new(0x1234),
+            index: 0x12,
             length: U16::new(0x0567),
         };
-        // Little-endian on the wire (offset then length).
-        assert_eq!(IntoBytes::as_bytes(&d), &[0x34, 0x12, 0x67, 0x05]);
+        // Little-endian on the wire (index byte then length).
+        assert_eq!(IntoBytes::as_bytes(&d), &[0x12, 0x67, 0x05]);
     }
 }

--- a/ddi/tbor/types/src/part_final.rs
+++ b/ddi/tbor/types/src/part_final.rs
@@ -27,9 +27,9 @@ use crate::tbor_int::U16;
 /// TBOR opcode for `PartFinal`.
 pub const TBOR_OP_PART_FINAL: u8 = 0x08;
 
-/// Size of a single [`CertDescriptor`] on the wire (`offset(2) ‖
+/// Size of a single [`CertDescriptor`] on the wire (`index(1) ‖
 /// length(2)`, little-endian).
-pub const CERT_DESCRIPTOR_LEN: usize = 4;
+pub const CERT_DESCRIPTOR_LEN: usize = 3;
 
 /// Maximum number of certificates the PTA chain descriptor list may
 /// carry.
@@ -41,14 +41,14 @@ pub const CERT_DESCRIPTORS_MAX_LEN: usize = MAX_CERTS * CERT_DESCRIPTOR_LEN;
 /// Maximum on-the-wire length of a `local_mk` backup envelope.
 pub const LOCAL_MK_BACKUP_MAX_LEN: usize = 1024;
 
-/// One PTA-chain certificate descriptor: the byte `offset` and `length`
-/// of a DER certificate within the side-band data buffer.
+/// One PTA-chain certificate descriptor: the OOB SGL-descriptor `index`
+/// and byte `length` of a DER certificate carried out of band.
 ///
 /// Host-side mirror of
 /// `azihsm_fw_ddi_tbor_types::evidence::CertDescriptor`.  `#[repr(C)]`
-/// POD (size [`CERT_DESCRIPTOR_LEN`] = 4 B, alignment 1); the
-/// [`U16`](crate::tbor_int::U16) fields are little-endian on the wire and
-/// keep the type `Unaligned`.
+/// POD (size [`CERT_DESCRIPTOR_LEN`] = 3 B, alignment 1); `index` is a
+/// `u8` and `length` a little-endian [`U16`](crate::tbor_int::U16) on the
+/// wire, keeping the type `Unaligned`.
 #[derive(
     Debug,
     Default,
@@ -64,8 +64,9 @@ pub const LOCAL_MK_BACKUP_MAX_LEN: usize = 1024;
 )]
 #[repr(C)]
 pub struct CertDescriptor {
-    /// Byte offset of the DER certificate in the side-band buffer.
-    pub offset: U16,
+    /// Index of the DER certificate's SGL Data Block descriptor in the
+    /// OOB descriptor page.
+    pub index: u8,
 
     /// Byte length of the DER certificate.
     pub length: U16,
@@ -133,11 +134,11 @@ mod tests {
             part_policy: PartPolicy::zeroed(),
             cert_descriptors: alloc::vec![
                 CertDescriptor {
-                    offset: U16::new(0x1234),
+                    index: 0x12,
                     length: U16::new(0x0567),
                 },
                 CertDescriptor {
-                    offset: U16::new(16),
+                    index: 16,
                     length: U16::new(32),
                 },
             ],
@@ -149,7 +150,7 @@ mod tests {
 
         // The packed little-endian descriptor image must appear verbatim
         // somewhere in the encoded frame's data section.
-        let needle = [0x34, 0x12, 0x67, 0x05, 0x10, 0x00, 0x20, 0x00];
+        let needle = [0x12, 0x67, 0x05, 0x10, 0x20, 0x00];
         assert!(
             frame.windows(needle.len()).any(|w| w == needle),
             "encoded frame must carry the packed LE cert descriptors",
@@ -165,7 +166,7 @@ mod tests {
             session_id: 7,
             part_policy: PartPolicy::zeroed(),
             cert_descriptors: alloc::vec![CertDescriptor {
-                offset: U16::new(16),
+                index: 16,
                 length: U16::new(32),
             }],
             prev_local_mk_backup: Vec::new(),

--- a/ddi/tbor/types/src/part_final.rs
+++ b/ddi/tbor/types/src/part_final.rs
@@ -7,7 +7,7 @@
 //! `PartInit` by installing the POTA-endorsed PTA certificate chain and
 //! deriving the partition's local masking keys.  It re-supplies the
 //! unified `PartPolicy` (for `POTAPubKey` recovery), the PTA cert-chain
-//! descriptor list (pointing into the side-band data buffer), and an
+//! descriptor list (referencing out-of-band SGL Data Blocks), and an
 //! optional prior `local_mk` backup to restore; it returns the current
 //! `local_mk` backup.  See `azihsm_fw_ddi_tbor_types::part_final` for the
 //! full wire schema.
@@ -90,10 +90,11 @@ pub struct TborPartFinalReq {
     /// little-endian image.
     pub part_policy: PartPolicy,
 
-    /// PTA certificate chain descriptors `(offset, length)` pointing into
-    /// the side-band buffer.  Encoded as the packed little-endian byte
-    /// image of the elements; carries 1..=[`MAX_CERTS`] entries.
-    #[tbor(min_len = 1, max_len = 8)]
+    /// PTA certificate chain descriptors `(index, length)` referencing
+    /// the out-of-band SGL Data Blocks.  Encoded as the packed
+    /// little-endian byte image of the elements; carries 1..=[`MAX_CERTS`]
+    /// entries.
+    #[tbor(min_len = 3, max_len = 6)]
     pub cert_descriptors: Vec<CertDescriptor>,
 
     /// Optional previously-generated `local_mk` backup to restore.
@@ -134,11 +135,11 @@ mod tests {
             part_policy: PartPolicy::zeroed(),
             cert_descriptors: alloc::vec![
                 CertDescriptor {
-                    index: 0x12,
+                    index: 0,
                     length: U16::new(0x0567),
                 },
                 CertDescriptor {
-                    index: 16,
+                    index: 1,
                     length: U16::new(32),
                 },
             ],
@@ -150,7 +151,7 @@ mod tests {
 
         // The packed little-endian descriptor image must appear verbatim
         // somewhere in the encoded frame's data section.
-        let needle = [0x12, 0x67, 0x05, 0x10, 0x20, 0x00];
+        let needle = [0x00, 0x67, 0x05, 0x01, 0x20, 0x00];
         assert!(
             frame.windows(needle.len()).any(|w| w == needle),
             "encoded frame must carry the packed LE cert descriptors",
@@ -166,7 +167,7 @@ mod tests {
             session_id: 7,
             part_policy: PartPolicy::zeroed(),
             cert_descriptors: alloc::vec![CertDescriptor {
-                index: 16,
+                index: 0,
                 length: U16::new(32),
             }],
             prev_local_mk_backup: Vec::new(),

--- a/fw/core/ddi/tbor/types/src/evidence.rs
+++ b/fw/core/ddi/tbor/types/src/evidence.rs
@@ -1,18 +1,19 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-//! Evidence descriptors for TBOR side-band buffers.
+//! Evidence descriptors for TBOR out-of-band certificate/report chains.
 //!
 //! Several TBOR commands carry their bulk evidence — DER certificate
-//! chains and COSE_Sign1 attestation reports — **out of band** in a
-//! side-band data buffer, and reference each item from the TBOR message
-//! with a small `(offset, length)` descriptor.  This module defines the
-//! packed, `Unaligned` descriptor POD types shared by those schemas.
+//! chains and COSE_Sign1 attestation reports — **out of band** as SGL
+//! Data Blocks, and reference each item from the TBOR message with a
+//! small `(index, length)` descriptor.  This module defines the packed,
+//! `Unaligned` descriptor POD types shared by those schemas.
 //!
-//! Each descriptor is a `#[repr(C)]` POD whose two little-endian
-//! [`U16`](crate::tbor_int::U16) fields keep it alignment-1
-//! (`Unaligned`), so a `&[T]` typed slice is borrowed zero-copy from the
-//! data section at any offset with no alignment padding.
+//! Each descriptor is a `#[repr(C)]` POD whose `u8` `index` and
+//! little-endian [`U16`](crate::tbor_int::U16) `length` keep it
+//! alignment-1 (`Unaligned`), so a `&[T]` typed slice is borrowed
+//! zero-copy from the data section at any offset with no alignment
+//! padding.
 
 use azihsm_fw_ddi_tbor_api::tbor;
 use zerocopy::FromBytes;
@@ -97,7 +98,7 @@ pub const EVIDENCE_CHAIN_MAX_CERTS: usize = 8;
 pub const EVIDENCE_CHAIN_MAX_LEN: usize = EVIDENCE_CHAIN_MAX_CERTS * CERT_DESCRIPTOR_LEN;
 const _: () = assert!(EVIDENCE_CHAIN_MAX_LEN == 24);
 
-/// Side-band evidence as a reusable TBOR **field group**: the three
+/// Out-of-band evidence as a reusable TBOR **field group**: the three
 /// certificate-chain descriptor lists plus the attestation-report
 /// descriptor list.  `#[tbor(include)]` it into a command to splice these
 /// four TOC entries into the message.
@@ -107,19 +108,19 @@ const _: () = assert!(EVIDENCE_CHAIN_MAX_LEN == 24);
 /// `(index, length)` descriptors referencing them.  Each list is a
 /// variable-length typed slice (`&[CertDescriptor]` /
 /// `&[ReportDescriptor]`) — there is no fixed per-chain cap, only the
-/// wire-size `max_len` bound.
+/// wire-size [`EVIDENCE_CHAIN_MAX_LEN`] bound (24 B = 8 descriptors).
 #[tbor(fields)]
 pub struct Evidence<'a> {
     /// Manufacturer certificate-chain descriptors.
-    #[tbor(buffer, max_len = 8)]
+    #[tbor(buffer, max_len = 24)]
     pub mfgr_cert_chain: &'a [CertDescriptor],
 
     /// Owner certificate-chain descriptors.
-    #[tbor(buffer, max_len = 8)]
+    #[tbor(buffer, max_len = 24)]
     pub owner_cert_chain: &'a [CertDescriptor],
 
     /// Partition-owner certificate-chain descriptors.
-    #[tbor(buffer, max_len = 8)]
+    #[tbor(buffer, max_len = 24)]
     pub part_owner_cert_chain: &'a [CertDescriptor],
 
     /// Attestation-report (COSE_Sign1) descriptor.  A single zero-copy

--- a/fw/core/ddi/tbor/types/src/evidence.rs
+++ b/fw/core/ddi/tbor/types/src/evidence.rs
@@ -23,9 +23,9 @@ use zerocopy::Unaligned;
 
 use crate::tbor_int::U16;
 
-/// Size of a single [`CertDescriptor`] on the wire (`offset(2) ‖
+/// Size of a single [`CertDescriptor`] on the wire (`index(1) ‖
 /// length(2)`, little-endian).
-pub const CERT_DESCRIPTOR_LEN: usize = 4;
+pub const CERT_DESCRIPTOR_LEN: usize = 3;
 
 /// Maximum number of certificates a PTA chain descriptor list may carry.
 pub const MAX_CERTS: usize = 2;
@@ -34,29 +34,30 @@ pub const MAX_CERTS: usize = 2;
 /// (`MAX_CERTS × CERT_DESCRIPTOR_LEN`).
 pub const CERT_DESCRIPTORS_MAX_LEN: usize = MAX_CERTS * CERT_DESCRIPTOR_LEN;
 
-/// One PTA-chain certificate descriptor: the byte `offset` and `length`
-/// of a DER certificate within the side-band data buffer.
+/// One PTA-chain certificate descriptor: the OOB SGL-descriptor `index`
+/// and byte `length` of a DER certificate carried out of band.
 ///
-/// `#[repr(C)]` POD (size [`CERT_DESCRIPTOR_LEN`] = 4 B, alignment 1).
-/// The fields are little-endian [`U16`](crate::tbor_int::U16), so the
-/// type is `Unaligned` (alignment 1) and the zero-copy
-/// `&[CertDescriptor]` cast is sound at any data-section offset — no
-/// alignment padding is inserted for the descriptor slice.
+/// `#[repr(C)]` POD (size [`CERT_DESCRIPTOR_LEN`] = 3 B, alignment 1).
+/// `index` is a `u8` and `length` a little-endian
+/// [`U16`](crate::tbor_int::U16).  The type is therefore `Unaligned`, so
+/// the zero-copy `&[CertDescriptor]` cast is sound at any data-section
+/// offset (no alignment padding is inserted for the descriptor slice).
 #[derive(
     Debug, Clone, Copy, PartialEq, Eq, FromBytes, IntoBytes, Immutable, KnownLayout, Unaligned,
 )]
 #[repr(C)]
 pub struct CertDescriptor {
-    /// Byte offset of the DER certificate in the side-band buffer.
-    pub offset: U16,
+    /// Index of the DER certificate's SGL Data Block descriptor in the
+    /// OOB descriptor page.
+    pub index: u8,
 
     /// Byte length of the DER certificate.
     pub length: U16,
 }
 
-/// Size of a single [`ReportDescriptor`] on the wire (`offset(2) ‖
+/// Size of a single [`ReportDescriptor`] on the wire (`index(1) ‖
 /// length(2)`, little-endian).
-pub const REPORT_DESCRIPTOR_LEN: usize = 4;
+pub const REPORT_DESCRIPTOR_LEN: usize = 3;
 
 /// Maximum number of reports a descriptor list may carry.
 pub const MAX_REPORTS: usize = 2;
@@ -65,20 +66,22 @@ pub const MAX_REPORTS: usize = 2;
 /// (`MAX_REPORTS × REPORT_DESCRIPTOR_LEN`).
 pub const REPORT_DESCRIPTORS_MAX_LEN: usize = MAX_REPORTS * REPORT_DESCRIPTOR_LEN;
 
-/// One attestation-report descriptor: the byte `offset` and `length` of
-/// a COSE_Sign1 report within the side-band data buffer.
+/// One attestation-report descriptor: the OOB SGL-descriptor `index`
+/// and byte `length` of a COSE_Sign1 report carried out of band.
 ///
-/// `#[repr(C)]` POD (size [`REPORT_DESCRIPTOR_LEN`] = 4 B, alignment 1).
-/// Like [`CertDescriptor`], the fields are little-endian
-/// [`U16`](crate::tbor_int::U16) so the type is `Unaligned` and the
-/// zero-copy `&[ReportDescriptor]` cast is sound at any offset.
+/// `#[repr(C)]` POD (size [`REPORT_DESCRIPTOR_LEN`] = 3 B, alignment 1).
+/// Like [`CertDescriptor`], `index` is a `u8` and `length` a
+/// little-endian [`U16`](crate::tbor_int::U16), so the type is
+/// `Unaligned` and the zero-copy `&[ReportDescriptor]` cast is sound at
+/// any offset.
 #[derive(
     Debug, Clone, Copy, PartialEq, Eq, FromBytes, IntoBytes, Immutable, KnownLayout, Unaligned,
 )]
 #[repr(C)]
 pub struct ReportDescriptor {
-    /// Byte offset of the report in the side-band buffer.
-    pub offset: U16,
+    /// Index of the report's SGL Data Block descriptor in the OOB
+    /// descriptor page.
+    pub index: u8,
 
     /// Byte length of the report.
     pub length: U16,
@@ -92,7 +95,7 @@ pub const EVIDENCE_CHAIN_MAX_CERTS: usize = 8;
 /// Maximum on-the-wire length of one cert-chain descriptor list
 /// (`EVIDENCE_CHAIN_MAX_CERTS × CERT_DESCRIPTOR_LEN`).
 pub const EVIDENCE_CHAIN_MAX_LEN: usize = EVIDENCE_CHAIN_MAX_CERTS * CERT_DESCRIPTOR_LEN;
-const _: () = assert!(EVIDENCE_CHAIN_MAX_LEN == 32);
+const _: () = assert!(EVIDENCE_CHAIN_MAX_LEN == 24);
 
 /// Side-band evidence as a reusable TBOR **field group**: the three
 /// certificate-chain descriptor lists plus the attestation-report
@@ -100,8 +103,8 @@ const _: () = assert!(EVIDENCE_CHAIN_MAX_LEN == 32);
 /// four TOC entries into the message.
 ///
 /// The bulk bytes (the DER chains and the COSE_Sign1 report) travel **out
-/// of band** in a side-band data buffer; this group carries only the
-/// `(offset, length)` descriptors pointing into it.  Each list is a
+/// of band** as SGL Data Blocks; this group carries only the
+/// `(index, length)` descriptors referencing them.  Each list is a
 /// variable-length typed slice (`&[CertDescriptor]` /
 /// `&[ReportDescriptor]`) — there is no fixed per-chain cap, only the
 /// wire-size `max_len` bound.
@@ -120,9 +123,9 @@ pub struct Evidence<'a> {
     pub part_owner_cert_chain: &'a [CertDescriptor],
 
     /// Attestation-report (COSE_Sign1) descriptor.  A single zero-copy
-    /// [`ReportDescriptor`] reference; its 4-byte image is pinned on the
+    /// [`ReportDescriptor`] reference; its 3-byte image is pinned on the
     /// wire.
-    #[tbor(buffer, len = 4)]
+    #[tbor(buffer, len = 3)]
     pub evidence: &'a ReportDescriptor,
 }
 
@@ -131,7 +134,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn cert_descriptor_layout_is_packed_4_bytes() {
+    fn cert_descriptor_layout_is_packed_3_bytes() {
         const _: () = assert!(core::mem::size_of::<CertDescriptor>() == CERT_DESCRIPTOR_LEN);
         const _: () = assert!(core::mem::align_of::<CertDescriptor>() == 1);
         assert_eq!(CERT_DESCRIPTORS_MAX_LEN, MAX_CERTS * CERT_DESCRIPTOR_LEN);
@@ -140,15 +143,15 @@ mod tests {
     #[test]
     fn cert_descriptor_round_trips_bytes() {
         let d = CertDescriptor {
-            offset: U16::new(0x1234),
+            index: 0x12,
             length: U16::new(0x0567),
         };
-        // Little-endian on the wire (offset then length).
-        assert_eq!(IntoBytes::as_bytes(&d), &[0x34, 0x12, 0x67, 0x05]);
+        // Little-endian on the wire (index byte then length).
+        assert_eq!(IntoBytes::as_bytes(&d), &[0x12, 0x67, 0x05]);
     }
 
     #[test]
-    fn report_descriptor_layout_is_packed_4_bytes() {
+    fn report_descriptor_layout_is_packed_3_bytes() {
         const _: () = assert!(core::mem::size_of::<ReportDescriptor>() == REPORT_DESCRIPTOR_LEN);
         const _: () = assert!(core::mem::align_of::<ReportDescriptor>() == 1);
         assert_eq!(
@@ -160,10 +163,10 @@ mod tests {
     #[test]
     fn report_descriptor_round_trips_bytes() {
         let d = ReportDescriptor {
-            offset: U16::new(0x1234),
+            index: 0x12,
             length: U16::new(0x0567),
         };
-        // Little-endian on the wire (offset then length).
-        assert_eq!(IntoBytes::as_bytes(&d), &[0x34, 0x12, 0x67, 0x05]);
+        // Little-endian on the wire (index byte then length).
+        assert_eq!(IntoBytes::as_bytes(&d), &[0x12, 0x67, 0x05]);
     }
 }

--- a/fw/core/ddi/tbor/types/src/evidence.rs
+++ b/fw/core/ddi/tbor/types/src/evidence.rs
@@ -96,7 +96,11 @@ pub const EVIDENCE_CHAIN_MAX_CERTS: usize = 8;
 /// Maximum on-the-wire length of one cert-chain descriptor list
 /// (`EVIDENCE_CHAIN_MAX_CERTS × CERT_DESCRIPTOR_LEN`).
 pub const EVIDENCE_CHAIN_MAX_LEN: usize = EVIDENCE_CHAIN_MAX_CERTS * CERT_DESCRIPTOR_LEN;
+// Pin the `Evidence` group's `#[tbor(... = N)]` byte literals to their
+// descriptor-size constants (the derive requires integer literals):
+// `max_len = 24` on the cert-chain lists and `len = 3` on `evidence`.
 const _: () = assert!(EVIDENCE_CHAIN_MAX_LEN == 24);
+const _: () = assert!(REPORT_DESCRIPTOR_LEN == 3);
 
 /// Out-of-band evidence as a reusable TBOR **field group**: the three
 /// certificate-chain descriptor lists plus the attestation-report

--- a/fw/core/ddi/tbor/types/src/part_final.rs
+++ b/fw/core/ddi/tbor/types/src/part_final.rs
@@ -72,9 +72,9 @@ const _: () = assert!(LOCAL_MK_BACKUP_LEN == 164);
 /// `PartFinal` request schema.
 ///
 /// Finalizes the partition: re-supplies the unified [`PartPolicy`] (for
-/// `POTAPubKey` recovery), the PTA cert-chain descriptor list (pointing
-/// into the side-band buffer), and an optional prior `local_mk` backup
-/// to restore.
+/// `POTAPubKey` recovery), the PTA cert-chain descriptor list
+/// (referencing out-of-band SGL Data Blocks), and an optional prior
+/// `local_mk` backup to restore.
 ///
 /// [`PartPolicy`]: crate::policy::PartPolicy
 #[tbor(opcode = 0x08)]
@@ -105,7 +105,7 @@ pub struct TborPartFinalReq<'a> {
     /// so no alignment padding is inserted.  Byte length is a non-zero
     /// multiple of [`CERT_DESCRIPTOR_LEN`](crate::evidence::CERT_DESCRIPTOR_LEN), up to
     /// [`CERT_DESCRIPTORS_MAX_LEN`](crate::evidence::CERT_DESCRIPTORS_MAX_LEN).
-    #[tbor(buffer, min_len = 1, max_len = 8)]
+    #[tbor(buffer, min_len = 3, max_len = 6)]
     pub cert_descriptors: &'a [CertDescriptor],
 
     /// Optional previously-generated `local_mk` backup envelope to
@@ -152,11 +152,11 @@ mod tests {
         let policy = [0u8; PART_POLICY_LEN];
         let descs = [
             CertDescriptor {
-                index: 16,
+                index: 0,
                 length: U16::new(32),
             },
             CertDescriptor {
-                index: 48,
+                index: 1,
                 length: U16::new(64),
             },
         ];

--- a/fw/core/ddi/tbor/types/src/part_final.rs
+++ b/fw/core/ddi/tbor/types/src/part_final.rs
@@ -25,8 +25,8 @@
 //!   `(index, length)` referencing where each DER certificate of the PTA
 //!   chain is carried **out of band** as an SGL Data Block (the
 //!   certificate bytes are transferred out of band, not in the TBOR
-//!   message).  The number of certificates is
-//!   `cert_descriptors.len() / CERT_DESCRIPTOR_LEN`, capped at
+//!   message).  Decoded as a `&[CertDescriptor]`, so the certificate
+//!   count is `cert_descriptors.len()`, capped at
 //!   [`MAX_CERTS`](crate::evidence::MAX_CERTS).
 //! * `prev_local_mk_backup` — optional previously-generated `local_mk`
 //!   backup envelope to restore.  An **empty** field means absent — the
@@ -102,9 +102,16 @@ pub struct TborPartFinalReq<'a> {
     /// the PTA certificate chain carried out of band.  Decoded as a
     /// zero-copy typed slice; because [`CertDescriptor`] is `Unaligned`
     /// (alignment 1) the `&[CertDescriptor]` cast is sound at any offset,
-    /// so no alignment padding is inserted.  Byte length is a non-zero
-    /// multiple of [`CERT_DESCRIPTOR_LEN`](crate::evidence::CERT_DESCRIPTOR_LEN), up to
-    /// [`CERT_DESCRIPTORS_MAX_LEN`](crate::evidence::CERT_DESCRIPTORS_MAX_LEN).
+    /// so no alignment padding is inserted.
+    ///
+    /// `min_len`/`max_len` are a coarse wire-size guard bounding the byte
+    /// length to `[CERT_DESCRIPTOR_LEN, CERT_DESCRIPTORS_MAX_LEN]` =
+    /// `[3, 6]`; they cannot by themselves enforce a whole-descriptor
+    /// multiple.  A wire length that is not a multiple of
+    /// [`CERT_DESCRIPTOR_LEN`](crate::evidence::CERT_DESCRIPTOR_LEN) (e.g.
+    /// 4 or 5 B) fails the zero-copy cast and decodes as an **empty**
+    /// slice (`try_ref_from_bytes(..).unwrap_or(&[])`), so a decoder MUST
+    /// reject an empty `cert_descriptors` as a malformed request.
     #[tbor(buffer, min_len = 3, max_len = 6)]
     pub cert_descriptors: &'a [CertDescriptor],
 

--- a/fw/core/ddi/tbor/types/src/part_final.rs
+++ b/fw/core/ddi/tbor/types/src/part_final.rs
@@ -22,11 +22,12 @@
 //!   it.  Layout owned by [`crate::policy::PartPolicy`]; length pinned by
 //!   [`PART_POLICY_LEN`].
 //! * `cert_descriptors` — a packed list of [`CertDescriptor`] entries
-//!   `(offset, length)` describing where each DER certificate of the PTA
-//!   chain lives in the **side-band** data buffer (the certificate bytes
-//!   are transferred out of band, not in the TBOR message).  The number
-//!   of certificates is `cert_descriptors.len() / CERT_DESCRIPTOR_LEN`,
-//!   capped at [`MAX_CERTS`](crate::evidence::MAX_CERTS).
+//!   `(index, length)` referencing where each DER certificate of the PTA
+//!   chain is carried **out of band** as an SGL Data Block (the
+//!   certificate bytes are transferred out of band, not in the TBOR
+//!   message).  The number of certificates is
+//!   `cert_descriptors.len() / CERT_DESCRIPTOR_LEN`, capped at
+//!   [`MAX_CERTS`](crate::evidence::MAX_CERTS).
 //! * `prev_local_mk_backup` — optional previously-generated `local_mk`
 //!   backup envelope to restore.  An **empty** field means absent — the
 //!   handler then generates a fresh `local_mk` and returns its backup.
@@ -97,8 +98,8 @@ pub struct TborPartFinalReq<'a> {
     #[tbor(buffer, len = 484)]
     pub part_policy: &'a [u8],
 
-    /// Packed list of [`CertDescriptor`] entries `(offset, length)` for
-    /// the PTA certificate chain in the side-band buffer.  Decoded as a
+    /// Packed list of [`CertDescriptor`] entries `(index, length)` for
+    /// the PTA certificate chain carried out of band.  Decoded as a
     /// zero-copy typed slice; because [`CertDescriptor`] is `Unaligned`
     /// (alignment 1) the `&[CertDescriptor]` cast is sound at any offset,
     /// so no alignment padding is inserted.  Byte length is a non-zero
@@ -151,11 +152,11 @@ mod tests {
         let policy = [0u8; PART_POLICY_LEN];
         let descs = [
             CertDescriptor {
-                offset: U16::new(16),
+                index: 16,
                 length: U16::new(32),
             },
             CertDescriptor {
-                offset: U16::new(48),
+                index: 48,
                 length: U16::new(64),
             },
         ];
@@ -174,7 +175,7 @@ mod tests {
             .finish();
 
         // The encoder serialized `&[CertDescriptor]` to its raw bytes:
-        // two 4-byte descriptors, little-endian.
+        // two 3-byte descriptors, little-endian.
         let raw = frame.cert_descriptors();
         assert_eq!(raw.len(), descs.len() * CERT_DESCRIPTOR_LEN);
         assert_eq!(raw, IntoBytes::as_bytes(&descs[..]));

--- a/fw/core/ddi/tbor/types/src/part_final.rs
+++ b/fw/core/ddi/tbor/types/src/part_final.rs
@@ -69,6 +69,13 @@ pub const LOCAL_MK_BACKUP_LEN: usize = 8 + 12 + 96 + 32 + 16;
 // both the breakdown above and the field attributes.
 const _: () = assert!(LOCAL_MK_BACKUP_LEN == 164);
 
+// Pin the `cert_descriptors` `#[tbor(min_len/max_len)]` literals to their
+// descriptor-size constants (the derive requires integer literals): a
+// single descriptor (`min_len`) and `MAX_CERTS` descriptors (`max_len`).
+// If a descriptor size or `MAX_CERTS` changes, update the field attribute.
+const _: () = assert!(crate::evidence::CERT_DESCRIPTOR_LEN == 3);
+const _: () = assert!(crate::evidence::CERT_DESCRIPTORS_MAX_LEN == 6);
+
 /// `PartFinal` request schema.
 ///
 /// Finalizes the partition: re-supplies the unified [`PartPolicy`] (for
@@ -110,8 +117,10 @@ pub struct TborPartFinalReq<'a> {
     /// multiple.  A wire length that is not a multiple of
     /// [`CERT_DESCRIPTOR_LEN`](crate::evidence::CERT_DESCRIPTOR_LEN) (e.g.
     /// 4 or 5 B) fails the zero-copy cast and decodes as an **empty**
-    /// slice (`try_ref_from_bytes(..).unwrap_or(&[])`), so a decoder MUST
-    /// reject an empty `cert_descriptors` as a malformed request.
+    /// slice — the derive does **not** reject it
+    /// (`try_ref_from_bytes(..).unwrap_or(&[])`); the PartFinal handler is
+    /// therefore responsible for treating an empty `cert_descriptors` as a
+    /// malformed request.
     #[tbor(buffer, min_len = 3, max_len = 6)]
     pub cert_descriptors: &'a [CertDescriptor],
 

--- a/fw/core/ddi/tbor/types/src/sd_create_peer_backup.rs
+++ b/fw/core/ddi/tbor/types/src/sd_create_peer_backup.rs
@@ -113,7 +113,7 @@ mod tests {
             length: crate::tbor_int::U16::new(8),
         };
         let report = ReportDescriptor {
-            index: 8,
+            index: 1,
             length: crate::tbor_int::U16::new(16),
         };
         let chain = [cert];

--- a/fw/core/ddi/tbor/types/src/sd_create_peer_backup.rs
+++ b/fw/core/ddi/tbor/types/src/sd_create_peer_backup.rs
@@ -109,11 +109,11 @@ mod tests {
         let policy = [0u8; PART_POLICY_LEN];
         let pok_local = [0xABu8; MASKED_SD_LEN];
         let cert = CertDescriptor {
-            offset: crate::tbor_int::U16::new(0),
+            index: 0,
             length: crate::tbor_int::U16::new(8),
         };
         let report = ReportDescriptor {
-            offset: crate::tbor_int::U16::new(8),
+            index: 8,
             length: crate::tbor_int::U16::new(16),
         };
         let chain = [cert];

--- a/fw/core/ddi/tbor/types/src/sd_create_remote_backup.rs
+++ b/fw/core/ddi/tbor/types/src/sd_create_remote_backup.rs
@@ -108,11 +108,11 @@ mod tests {
     fn request_round_trips_policy() {
         let policy = [0u8; PART_POLICY_LEN];
         let cert = CertDescriptor {
-            offset: crate::tbor_int::U16::new(0),
+            index: 0,
             length: crate::tbor_int::U16::new(8),
         };
         let report = ReportDescriptor {
-            offset: crate::tbor_int::U16::new(8),
+            index: 8,
             length: crate::tbor_int::U16::new(16),
         };
         let chain = [cert];

--- a/fw/core/ddi/tbor/types/src/sd_create_remote_backup.rs
+++ b/fw/core/ddi/tbor/types/src/sd_create_remote_backup.rs
@@ -112,7 +112,7 @@ mod tests {
             length: crate::tbor_int::U16::new(8),
         };
         let report = ReportDescriptor {
-            index: 8,
+            index: 1,
             length: crate::tbor_int::U16::new(16),
         };
         let chain = [cert];

--- a/fw/core/ddi/tbor/types/src/sd_reseal_backup.rs
+++ b/fw/core/ddi/tbor/types/src/sd_reseal_backup.rs
@@ -122,7 +122,7 @@ mod tests {
             length: crate::tbor_int::U16::new(8),
         };
         let report = ReportDescriptor {
-            index: 8,
+            index: 1,
             length: crate::tbor_int::U16::new(16),
         };
         let chain = [cert];

--- a/fw/core/ddi/tbor/types/src/sd_reseal_backup.rs
+++ b/fw/core/ddi/tbor/types/src/sd_reseal_backup.rs
@@ -118,11 +118,11 @@ mod tests {
         let policy = [0u8; PART_POLICY_LEN];
         let masked = [0xABu8; MASKED_SD_LEN];
         let cert = CertDescriptor {
-            offset: crate::tbor_int::U16::new(0),
+            index: 0,
             length: crate::tbor_int::U16::new(8),
         };
         let report = ReportDescriptor {
-            offset: crate::tbor_int::U16::new(8),
+            index: 8,
             length: crate::tbor_int::U16::new(16),
         };
         let chain = [cert];

--- a/fw/core/ddi/tbor/types/src/sd_restore_peer_backup.rs
+++ b/fw/core/ddi/tbor/types/src/sd_restore_peer_backup.rs
@@ -133,7 +133,7 @@ mod tests {
             length: crate::tbor_int::U16::new(8),
         };
         let report = ReportDescriptor {
-            index: 8,
+            index: 1,
             length: crate::tbor_int::U16::new(16),
         };
         let chain = [cert];

--- a/fw/core/ddi/tbor/types/src/sd_restore_peer_backup.rs
+++ b/fw/core/ddi/tbor/types/src/sd_restore_peer_backup.rs
@@ -129,11 +129,11 @@ mod tests {
         let pok_peer = [0xABu8; MASKED_SD_LEN];
         let sd_mk = [0xCDu8; LOCAL_MK_BACKUP_LEN];
         let cert = CertDescriptor {
-            offset: crate::tbor_int::U16::new(0),
+            index: 0,
             length: crate::tbor_int::U16::new(8),
         };
         let report = ReportDescriptor {
-            offset: crate::tbor_int::U16::new(8),
+            index: 8,
             length: crate::tbor_int::U16::new(16),
         };
         let chain = [cert];

--- a/fw/core/ddi/tbor/types/src/sd_restore_remote_backup.rs
+++ b/fw/core/ddi/tbor/types/src/sd_restore_remote_backup.rs
@@ -135,7 +135,7 @@ mod tests {
             length: crate::tbor_int::U16::new(8),
         };
         let report = ReportDescriptor {
-            index: 8,
+            index: 1,
             length: crate::tbor_int::U16::new(16),
         };
         let chain = [cert];
@@ -174,7 +174,7 @@ mod tests {
             length: crate::tbor_int::U16::new(8),
         };
         let report = ReportDescriptor {
-            index: 8,
+            index: 1,
             length: crate::tbor_int::U16::new(16),
         };
         let chain = [cert];

--- a/fw/core/ddi/tbor/types/src/sd_restore_remote_backup.rs
+++ b/fw/core/ddi/tbor/types/src/sd_restore_remote_backup.rs
@@ -131,11 +131,11 @@ mod tests {
         let pok_remote = [0xABu8; MASKED_SD_LEN];
         let sd_mk = [0xCDu8; LOCAL_MK_BACKUP_LEN];
         let cert = CertDescriptor {
-            offset: crate::tbor_int::U16::new(0),
+            index: 0,
             length: crate::tbor_int::U16::new(8),
         };
         let report = ReportDescriptor {
-            offset: crate::tbor_int::U16::new(8),
+            index: 8,
             length: crate::tbor_int::U16::new(16),
         };
         let chain = [cert];
@@ -170,11 +170,11 @@ mod tests {
         let policy = [0u8; PART_POLICY_LEN];
         let pok_remote = [0xABu8; MASKED_SD_LEN];
         let cert = CertDescriptor {
-            offset: crate::tbor_int::U16::new(0),
+            index: 0,
             length: crate::tbor_int::U16::new(8),
         };
         let report = ReportDescriptor {
-            offset: crate::tbor_int::U16::new(8),
+            index: 8,
             length: crate::tbor_int::U16::new(16),
         };
         let chain = [cert];


### PR DESCRIPTION
## Summary

Changes `CertDescriptor` and `ReportDescriptor` from a **byte-offset** model
`{offset: U16, length: U16}` (4 B) to an **OOB SGL-descriptor index** model
`{index: u8, length: U16}` (3 B).

This aligns the PTA-chain / evidence-chain certificate descriptors with the
out-of-band SGL Data Block addressing introduced by the OOB transport
plumbing (#517): a descriptor now names *which* SGL Data Block descriptor in
the OOB page carries the DER bytes (`index`) plus the byte `length`, instead of
a byte offset into a monolithic side-band buffer.

## Changes

- fw + host `CertDescriptor`/`ReportDescriptor` definitions and docs updated to
  `{index: u8, length: U16}`.
- `CERT_DESCRIPTOR_LEN` / `REPORT_DESCRIPTOR_LEN`: `4 -> 3`;
  `EVIDENCE_CHAIN_MAX_LEN`: `32 -> 24`.
- All Security-Domain backup schema construction sites
  (`sd_create_peer` / `sd_create_remote` / `sd_reseal` / `sd_restore_peer` /
  `sd_restore_remote`) emit `index` instead of `offset`.
- Round-trip unit tests updated for the packed 3-byte little-endian layout.

## Validation

- `cargo test -p azihsm_ddi_tbor_types -p azihsm_fw_ddi_tbor_types --lib` — 16 + 32 pass.
- rustfmt clean.

## Notes

Wire-format-only schema change; inert until a consumer walks the descriptors.
Part of a stack splitting the PartFinal PTA cert-chain work into independently
reviewable pieces.