### PR TITLE
feat(key-masking): add peek_metadata for pre-unmask AAD inspection

### DIFF
--- a/fw/core/crypto/aead-envelope/src/envelope.rs
+++ b/fw/core/crypto/aead-envelope/src/envelope.rs
@@ -38,6 +38,29 @@ pub struct AeadEnvelope<'a> {
     pub tag: &'a DmaBuf,
 }
 
+/// Borrowed view over the *cleartext* regions of an envelope that can
+/// be read **without the AEAD key** — i.e. without verifying the
+/// authentication tag.
+///
+/// Returned by [`peek`](crate::peek). Unlike [`AeadEnvelope`] — which
+/// [`open`](crate::open) produces only after verifying the tag and
+/// decrypting the payload — an `AeadPeek` involves no crypto and no
+/// I/O: the payload is still ciphertext and the tag is unverified. The
+/// exposed `iv` / `aad` bytes are therefore cleartext but
+/// **UNAUTHENTICATED** — a tampered blob would still fail
+/// [`open`](crate::open), so callers MUST NOT trust these bytes until a
+/// subsequent `open` verifies the tag.
+#[derive(Debug)]
+pub struct AeadPeek<'a> {
+    /// AEAD algorithm read from the envelope header.
+    pub alg: AeadAlg,
+    /// The GCM nonce (`alg.iv_len()` bytes).
+    pub iv: &'a DmaBuf,
+    /// Additional authenticated data (may be empty). Cleartext but
+    /// unauthenticated until [`open`](crate::open) verifies the tag.
+    pub aad: &'a DmaBuf,
+}
+
 /// Compute the byte offsets of the IV, AAD, payload, and tag
 /// regions given the parsed header and total envelope length.
 ///

--- a/fw/core/crypto/aead-envelope/src/lib.rs
+++ b/fw/core/crypto/aead-envelope/src/lib.rs
@@ -86,10 +86,12 @@ mod gcm;
 mod ops;
 
 pub use ops::open;
+pub use ops::peek;
 pub use ops::seal;
 pub use ops::AeadAlg;
 pub use ops::AeadEnvelope;
 pub use ops::AeadError;
+pub use ops::AeadPeek;
 pub use ops::FORMAT_TAG;
 pub use ops::HEADER_LEN;
 pub use ops::MAX_AAD_LEN;

--- a/fw/core/crypto/aead-envelope/src/ops.rs
+++ b/fw/core/crypto/aead-envelope/src/ops.rs
@@ -35,7 +35,9 @@ use azihsm_fw_hsm_pal_traits::HsmIo;
 use azihsm_fw_hsm_pal_traits::HsmResult;
 
 pub use crate::alg::AeadAlg;
+use crate::envelope::region_offsets;
 pub use crate::envelope::AeadEnvelope;
+pub use crate::envelope::AeadPeek;
 use crate::error::Error;
 pub use crate::error::Error as AeadError;
 use crate::format::is_valid_aad_len;
@@ -149,4 +151,50 @@ pub async fn open<'a>(
         AeadAlg::AesGcm256 => open_gcm(crypto, io, key, buf, header).await?,
     };
     Ok(env)
+}
+
+/// Parse and validate an envelope's header and framing **without the
+/// AEAD key**, borrowing its cleartext regions.
+///
+/// `peek` performs exactly the same envelope-framing validation as
+/// [`open`] — magic, reserved byte, `alg`, `aad_len` granularity, and
+/// the minimum envelope length (`HEADER + iv + aad + tag`, with
+/// `iv_len` / `tag_len` derived from the parsed `alg`) — but does
+/// **not** verify the authentication tag or decrypt the payload. It
+/// touches no crypto and no I/O, and takes no `key`.
+///
+/// It exists for callers that must read a cleartext binding carried in
+/// the `aad` region (e.g. a routing / identity tag) *before* they hold
+/// the key. Because the tag is not verified, the returned [`AeadPeek`]
+/// regions are cleartext but **UNAUTHENTICATED**: a tampered blob would
+/// still fail [`open`]. Callers MUST NOT trust the peeked bytes until a
+/// subsequent `open` verifies the tag.
+///
+/// # Parameters
+///
+/// * `buf` — the complete envelope. `buf.len()` is treated as the
+///   exact envelope length; a buffer shorter than
+///   `HEADER + iv + aad + tag` is rejected.
+///
+/// # Returns
+///
+/// * `Ok(peek)` — header and framing are well-formed; `iv` / `aad`
+///   borrow the corresponding regions of `buf`.
+/// * `Err(_)` — the same header / framing failures as [`open`]:
+///   [`AeadError::InvalidFormat`] (bad magic or reserved byte),
+///   [`AeadError::UnsupportedAlg`], [`AeadError::InvalidAadLength`], or
+///   [`AeadError::BufferTooSmall`] (buffer shorter than the framing
+///   implies).
+pub fn peek(buf: &DmaBuf) -> HsmResult<AeadPeek<'_>> {
+    let header = read_header(buf)?;
+    // Validates the minimum envelope length (HEADER + iv + aad + tag)
+    // and yields the region boundaries; iv_len / tag_len are derived
+    // from the `alg` parsed above. The payload / tag offsets are
+    // unused here — a peek never touches ciphertext or the tag.
+    let (iv_off, aad_off, payload_off, _tag_off) = region_offsets(header, buf.len())?;
+    Ok(AeadPeek {
+        alg: header.alg,
+        iv: &buf[iv_off..aad_off],
+        aad: &buf[aad_off..payload_off],
+    })
 }

--- a/fw/core/crypto/key-masking/src/aead/decode.rs
+++ b/fw/core/crypto/key-masking/src/aead/decode.rs
@@ -7,8 +7,7 @@
 //! [`UnmaskedView`] covering the recovered plaintext.
 
 use azihsm_fw_core_crypto_aead_envelope::open as aead_open;
-use azihsm_fw_core_crypto_aead_envelope::AeadAlg;
-use azihsm_fw_core_crypto_aead_envelope::HEADER_LEN;
+use azihsm_fw_core_crypto_aead_envelope::peek as aead_peek;
 use azihsm_fw_hsm_pal_traits::DmaBuf;
 use azihsm_fw_hsm_pal_traits::HsmCrypto;
 use azihsm_fw_hsm_pal_traits::HsmError;
@@ -132,25 +131,43 @@ pub async fn unmask<'a>(
 /// unmasking; its result MUST NOT be trusted until a subsequent `unmask`
 /// verifies the tag.
 ///
+/// The blob's envelope header and framing are validated exactly as
+/// [`unmask`] validates them — magic, reserved byte, `alg`, `aad_len`
+/// granularity, IV length (derived from the parsed `alg`), and the
+/// minimum envelope length (`header ‖ iv ‖ aad ‖ tag`) — by delegating
+/// to the envelope crate's key-free peek. Only the AEAD tag
+/// verification and payload decryption are skipped, so this is the
+/// key-free analogue of [`unmask`], sharing its `META_LEN` and v1
+/// metadata checks.
+///
 /// # Errors
 ///
-/// * [`HsmError::MaskedKeyDecodeFailed`] — the blob is too short to hold
-///   the envelope header + metadata, or the metadata fails v1 validation.
+/// * [`HsmError::MaskedKeyDecodeFailed`] — the AAD region is not
+///   `META_LEN` bytes, or the metadata fails v1 validation.
+/// * Any [`HsmError`] surfaced by the envelope header / framing parse
+///   (malformed header, unsupported `alg`, or a blob too short to hold a
+///   complete `header ‖ iv ‖ aad ‖ tag` envelope).
 pub fn peek_metadata(blob: &DmaBuf) -> HsmResult<&MaskedKeyMetadata> {
-    // Envelope layout: header ‖ iv ‖ aad(META_LEN) ‖ ct ‖ tag. The
-    // metadata is the fixed-size AAD region; its offset is fixed by the
-    // AES-GCM envelope layout (all masked keys use AES-256-GCM).
-    const AAD_OFF: usize = HEADER_LEN + AeadAlg::AesGcm256.iv_len();
-    let end = AAD_OFF
-        .checked_add(META_LEN)
-        .ok_or(HsmError::MaskedKeyDecodeFailed)?;
-    if blob.len() < end {
+    // Parse + validate the envelope header and framing WITHOUT the
+    // masking key (no tag verification, no decryption). This checks the
+    // magic, reserved byte, `alg`, `aad_len` granularity, derives the IV
+    // length from the parsed `alg`, and requires the full envelope length
+    // (header ‖ iv ‖ aad ‖ tag) — so a non-envelope, wrong-alg, or
+    // truncated (e.g. tag-less) blob is rejected here rather than yielding
+    // "valid" metadata from a fixed offset.
+    let env = aead_peek(blob)?;
+
+    // Envelope-level schema check: only a META_LEN-byte AAD is a
+    // masked-key blob. Identical to the check in `unmask`.
+    if env.aad.len() != META_LEN {
         return Err(HsmError::MaskedKeyDecodeFailed);
     }
 
-    let aad: &[u8] = &blob[AAD_OFF..end];
+    // Parse the META_LEN-byte AAD region as MaskedKeyMetadata.
+    // `ref_from_bytes` never panics; the length check above guarantees a
+    // META_LEN-byte slice.
     let metadata =
-        MaskedKeyMetadata::ref_from_bytes(aad).map_err(|_| HsmError::MaskedKeyDecodeFailed)?;
+        MaskedKeyMetadata::ref_from_bytes(env.aad).map_err(|_| HsmError::MaskedKeyDecodeFailed)?;
     metadata.validate_v1()?;
     Ok(metadata)
 }

--- a/fw/core/crypto/key-masking/src/aead/decode.rs
+++ b/fw/core/crypto/key-masking/src/aead/decode.rs
@@ -7,6 +7,8 @@
 //! [`UnmaskedView`] covering the recovered plaintext.
 
 use azihsm_fw_core_crypto_aead_envelope::open as aead_open;
+use azihsm_fw_core_crypto_aead_envelope::AeadAlg;
+use azihsm_fw_core_crypto_aead_envelope::HEADER_LEN;
 use azihsm_fw_hsm_pal_traits::DmaBuf;
 use azihsm_fw_hsm_pal_traits::HsmCrypto;
 use azihsm_fw_hsm_pal_traits::HsmError;
@@ -118,4 +120,37 @@ pub async fn unmask<'a>(
         owner_seed_id: metadata.owner_seed_id.get(),
         target_key: env.payload,
     })
+}
+
+/// Peek the cleartext [`MaskedKeyMetadata`] of a masked-key blob **without
+/// the masking key** — i.e. without verifying the AEAD tag.
+///
+/// The metadata is the envelope's AAD region; it is cleartext but bound
+/// by the tag, so a tampered blob would still fail [`unmask`]. This peek
+/// exists purely for reading cleartext bindings (e.g. the `{svn,
+/// owner_seed_id}` platform identity or the key `scope`) *before*
+/// unmasking; its result MUST NOT be trusted until a subsequent `unmask`
+/// verifies the tag.
+///
+/// # Errors
+///
+/// * [`HsmError::MaskedKeyDecodeFailed`] — the blob is too short to hold
+///   the envelope header + metadata, or the metadata fails v1 validation.
+pub fn peek_metadata(blob: &DmaBuf) -> HsmResult<&MaskedKeyMetadata> {
+    // Envelope layout: header ‖ iv ‖ aad(META_LEN) ‖ ct ‖ tag. The
+    // metadata is the fixed-size AAD region; its offset is fixed by the
+    // AES-GCM envelope layout (all masked keys use AES-256-GCM).
+    const AAD_OFF: usize = HEADER_LEN + AeadAlg::AesGcm256.iv_len();
+    let end = AAD_OFF
+        .checked_add(META_LEN)
+        .ok_or(HsmError::MaskedKeyDecodeFailed)?;
+    if blob.len() < end {
+        return Err(HsmError::MaskedKeyDecodeFailed);
+    }
+
+    let aad: &[u8] = &blob[AAD_OFF..end];
+    let metadata =
+        MaskedKeyMetadata::ref_from_bytes(aad).map_err(|_| HsmError::MaskedKeyDecodeFailed)?;
+    metadata.validate_v1()?;
+    Ok(metadata)
 }

--- a/fw/core/crypto/key-masking/src/aead/mod.rs
+++ b/fw/core/crypto/key-masking/src/aead/mod.rs
@@ -17,6 +17,7 @@ mod encode;
 mod format;
 
 pub use azihsm_fw_core_crypto_aead_envelope::AeadAlg;
+pub use decode::peek_metadata;
 pub use decode::unmask;
 pub use decode::UnmaskedView;
 pub use encode::mask;


### PR DESCRIPTION
## Summary

Adds `peek_metadata`, which reads the cleartext `MaskedKeyMetadata` (the AEAD
envelope's AAD region) of a masked-key blob **without the masking key** — i.e.
without verifying the AEAD tag.

## Why

Some handlers need to read cleartext bindings — the `{svn, owner_seed_id}`
platform identity, or the key `scope` — *before* unmasking, e.g. to apply a
policy check or reject a stale-SVN backup early without first deriving the
masking key.

## Safety

The metadata is cleartext but **tag-bound**, so a tampered blob would still
fail `unmask`. The peeked value **MUST NOT be trusted** until a subsequent
`unmask` verifies the tag — this is documented on the function.

The offset is computed from the fixed AES-256-GCM envelope layout
(`HEADER_LEN + iv_len`); the read is bounds-checked (`checked_add` + length
guard) and the metadata is `validate_v1`-checked, returning
`MaskedKeyDecodeFailed` on a short or malformed blob. No panics across the
trust boundary.

## Validation

- `cargo build` / `cargo clippy --all-targets` on
  `azihsm_fw_core_crypto_key_masking` — clean.
- rustfmt clean.

## Notes

Purely additive; **inert until a consumer calls it**. Part of a stack
splitting the PartFinal PTA cert-chain work into reviewable pieces.