### PR TITLE
[fix] add workflow_dispatch trigger to any workflow that runs in PR

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -7,6 +7,7 @@ on:
     branches: [ main, dev, fw-main ]
   merge_group:
     branches: [ main, dev, fw-main ]
+  workflow_dispatch:
   schedule:
     - cron: '0 8 * * *'  # Daily at midnight PST (8 AM UTC)
 env:

--- a/.github/workflows/fw_uno.yml
+++ b/.github/workflows/fw_uno.yml
@@ -10,6 +10,7 @@ on:
     branches: [ main, dev, fw-main ]
   merge_group:
     branches: [ main, dev, fw-main ]
+  workflow_dispatch:
   schedule:
     - cron: '0 8 * * *'  # Daily at midnight PST (8 AM UTC)
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -7,6 +7,7 @@ on:
     branches: [ main, dev, fw-main ]
   merge_group:
     branches: [ main, dev, fw-main ]
+  workflow_dispatch:
   schedule:
     - cron: '0 8 * * *'  # Daily at midnight PST (8 AM UTC)
 env:


### PR DESCRIPTION
This change adds the workflow_dispatch event trigger to any workflow with the pull_request trigger, so all workflows that run as part of our PR CI can also be run manually to debug failures.