### PR TITLE
feat(fw): implement DDI RsaModExp handler

### DIFF
--- a/ddi/mbor/types/tests/azihsm_ddi_tests.rs
+++ b/ddi/mbor/types/tests/azihsm_ddi_tests.rs
@@ -76,6 +76,7 @@ mod integration {
     pub mod rsa_4k_decrypt_with_crt;
     pub mod rsa_4k_sign;
     pub mod rsa_mod_exp;
+    pub mod rsa_mod_exp_smoke;
     pub mod rsa_unwrap_generated_key;
     pub mod rsa_unwrap_smoke;
     pub mod sealed_bk3_smoke;

--- a/ddi/mbor/types/tests/integration/common.rs
+++ b/ddi/mbor/types/tests/integration/common.rs
@@ -738,7 +738,7 @@ pub fn store_rsa_keys_crt(
         Some(sess_id),
         Some(DdiApiRev { major: 1, minor: 0 }),
         rsa_priv_key,
-        DdiKeyClass::Rsa,
+        DdiKeyClass::RsaCrt,
         key_usage,
         key_tag,
     );

--- a/ddi/mbor/types/tests/integration/rsa_mod_exp_smoke.rs
+++ b/ddi/mbor/types/tests/integration/rsa_mod_exp_smoke.rs
@@ -1,0 +1,399 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! RsaModExp smoke tests.
+//!
+//! Validates the `RsaModExp` firmware handler end-to-end against freshly
+//! imported RSA-2K / 3K / 4K private keys:
+//!
+//! - **Decrypt round-trip:** import an `EncryptDecrypt` key, raw-encrypt a
+//!   known message locally with the matching public key, run
+//!   `RsaModExp { Decrypt }` on the device, and confirm the original
+//!   message is recovered.
+//! - **Sign round-trip:** import a `SignVerify` key, run
+//!   `RsaModExp { Sign }` to produce `s = m^d mod n`, then verify locally
+//!   that `s^e mod n == m`.
+//! - **Wrong permission:** a `Decrypt` operation against a
+//!   `SignVerify`-only key is rejected with `InvalidPermissions`.
+//!
+//! The round-trips feed a non-palindrome integer through the device so
+//! they also exercise the wire little-endian operand handling.
+
+#![cfg(test)]
+
+use azihsm_crypto::*;
+use azihsm_ddi::*;
+use azihsm_ddi_mbor_codec::MborByteArray;
+use azihsm_ddi_mbor_types::*;
+use test_with_tracing::test;
+
+use super::common::*;
+
+/// Derive the public key matching a known RSA private DER.
+fn pub_from_priv(priv_der: &[u8]) -> RsaPublicKey {
+    RsaPrivateKey::from_bytes(priv_der)
+        .expect("parse known RSA private DER")
+        .public_key()
+        .expect("derive public key")
+}
+
+/// Import a known RSA private key with the given usage as either a CRT or
+/// non-CRT vault key, returning the imported private-key id.
+fn store_rsa(
+    dev: &mut <DdiTest as Ddi>::Dev,
+    session_id: u16,
+    key_usage: DdiKeyUsage,
+    crt: bool,
+    rsa_key_size_in_k: u8,
+) -> u16 {
+    if crt {
+        store_rsa_keys_crt(dev, session_id, key_usage, rsa_key_size_in_k, None).1
+    } else {
+        store_rsa_keys_no_crt(dev, session_id, key_usage, rsa_key_size_in_k, None).1
+    }
+}
+
+/// Import an `EncryptDecrypt` key, raw-encrypt a known message with the
+/// matching public key, decrypt it on the device via
+/// `RsaModExp { Decrypt }`, and confirm the message round-trips.
+fn decrypt_roundtrip(
+    dev: &mut <DdiTest as Ddi>::Dev,
+    session_id: u16,
+    crt: bool,
+    rsa_key_size_in_k: u8,
+    modulus_len: usize,
+    priv_der: &[u8],
+) {
+    let key_id = store_rsa(
+        dev,
+        session_id,
+        DdiKeyUsage::EncryptDecrypt,
+        crt,
+        rsa_key_size_in_k,
+    );
+
+    // Non-palindrome message that stays below the modulus (leading byte
+    // 0x01, so `m < n`).  Both `m` and the resulting ciphertext `c = m^e
+    // mod n` (fed to the device as `y`) are non-palindrome, so the
+    // round-trip exercises the wire little-endian operand handling.
+    let mut msg = vec![0x02u8; modulus_len];
+    msg[0] = 0x01;
+    let ciphertext = Encrypter::encrypt_vec(
+        &mut RsaEncryptAlgo::with_no_padding(),
+        &pub_from_priv(priv_der),
+        &msg,
+    )
+    .expect("raw RSA encrypt");
+
+    let resp = helper_rsa_mod_exp(
+        dev,
+        Some(session_id),
+        Some(DdiApiRev { major: 1, minor: 0 }),
+        key_id,
+        MborByteArray::from_slice(&ciphertext).expect("ciphertext fits"),
+        DdiRsaOpType::Decrypt,
+    )
+    .expect("RsaModExp Decrypt should succeed");
+
+    assert_eq!(resp.hdr.op, DdiOp::RsaModExp);
+    assert_eq!(resp.hdr.status, DdiStatus::Success);
+    assert_eq!(
+        &resp.data.x.data()[..resp.data.x.len()],
+        msg.as_slice(),
+        "RsaModExp Decrypt must recover the original message"
+    );
+}
+
+/// Import a `SignVerify` key, produce `s = m^d mod n` via
+/// `RsaModExp { Sign }`, and verify locally that `s^e mod n == m`.
+fn sign_roundtrip(
+    dev: &mut <DdiTest as Ddi>::Dev,
+    session_id: u16,
+    crt: bool,
+    rsa_key_size_in_k: u8,
+    modulus_len: usize,
+    priv_der: &[u8],
+) {
+    let key_id = store_rsa(
+        dev,
+        session_id,
+        DdiKeyUsage::SignVerify,
+        crt,
+        rsa_key_size_in_k,
+    );
+
+    // Non-palindrome message that stays below the modulus (leading byte
+    // 0x01, so `m < n`).
+    let mut msg = vec![0x02u8; modulus_len];
+    msg[0] = 0x01;
+
+    let resp = helper_rsa_mod_exp(
+        dev,
+        Some(session_id),
+        Some(DdiApiRev { major: 1, minor: 0 }),
+        key_id,
+        MborByteArray::from_slice(&msg).expect("message fits"),
+        DdiRsaOpType::Sign,
+    )
+    .expect("RsaModExp Sign should succeed");
+    assert_eq!(resp.hdr.status, DdiStatus::Success);
+    let signature = &resp.data.x.data()[..resp.data.x.len()];
+
+    // Verify the raw signature locally with the matching public key:
+    // `s^e mod n == m`.
+    let verified = Verifier::verify(
+        &mut RsaSignAlgo::with_no_padding(),
+        &pub_from_priv(priv_der),
+        &msg,
+        signature,
+    )
+    .expect("raw RSA verify");
+    assert!(
+        verified,
+        "RsaModExp Sign must produce a signature that verifies over the message"
+    );
+}
+
+#[test]
+fn test_rsa_mod_exp_decrypt_roundtrip_2k_smoke() {
+    ddi_dev_test(
+        common_setup,
+        common_cleanup,
+        |dev, _ddi, _path, session_id| {
+            decrypt_roundtrip(
+                dev,
+                session_id,
+                false,
+                2,
+                256,
+                TEST_RSA_2K_PRIVATE_KEY.as_slice(),
+            );
+        },
+    );
+}
+
+#[test]
+fn test_rsa_mod_exp_decrypt_roundtrip_3k_smoke() {
+    ddi_dev_test(
+        common_setup,
+        common_cleanup,
+        |dev, _ddi, _path, session_id| {
+            decrypt_roundtrip(
+                dev,
+                session_id,
+                false,
+                3,
+                384,
+                TEST_RSA_3K_PRIVATE_KEY.as_slice(),
+            );
+        },
+    );
+}
+
+#[test]
+fn test_rsa_mod_exp_decrypt_roundtrip_4k_smoke() {
+    ddi_dev_test(
+        common_setup,
+        common_cleanup,
+        |dev, _ddi, _path, session_id| {
+            decrypt_roundtrip(
+                dev,
+                session_id,
+                false,
+                4,
+                512,
+                TEST_RSA_4K_PRIVATE_KEY.as_slice(),
+            );
+        },
+    );
+}
+
+#[test]
+fn test_rsa_mod_exp_decrypt_roundtrip_2k_crt_smoke() {
+    ddi_dev_test(
+        common_setup,
+        common_cleanup,
+        |dev, _ddi, _path, session_id| {
+            decrypt_roundtrip(
+                dev,
+                session_id,
+                true,
+                2,
+                256,
+                TEST_RSA_2K_PRIVATE_KEY.as_slice(),
+            );
+        },
+    );
+}
+
+#[test]
+fn test_rsa_mod_exp_decrypt_roundtrip_3k_crt_smoke() {
+    ddi_dev_test(
+        common_setup,
+        common_cleanup,
+        |dev, _ddi, _path, session_id| {
+            decrypt_roundtrip(
+                dev,
+                session_id,
+                true,
+                3,
+                384,
+                TEST_RSA_3K_PRIVATE_KEY.as_slice(),
+            );
+        },
+    );
+}
+
+#[test]
+fn test_rsa_mod_exp_decrypt_roundtrip_4k_crt_smoke() {
+    ddi_dev_test(
+        common_setup,
+        common_cleanup,
+        |dev, _ddi, _path, session_id| {
+            decrypt_roundtrip(
+                dev,
+                session_id,
+                true,
+                4,
+                512,
+                TEST_RSA_4K_PRIVATE_KEY.as_slice(),
+            );
+        },
+    );
+}
+
+#[test]
+fn test_rsa_mod_exp_sign_roundtrip_2k_smoke() {
+    ddi_dev_test(
+        common_setup,
+        common_cleanup,
+        |dev, _ddi, _path, session_id| {
+            sign_roundtrip(
+                dev,
+                session_id,
+                false,
+                2,
+                256,
+                TEST_RSA_2K_PRIVATE_KEY.as_slice(),
+            );
+        },
+    );
+}
+
+#[test]
+fn test_rsa_mod_exp_sign_roundtrip_3k_smoke() {
+    ddi_dev_test(
+        common_setup,
+        common_cleanup,
+        |dev, _ddi, _path, session_id| {
+            sign_roundtrip(
+                dev,
+                session_id,
+                false,
+                3,
+                384,
+                TEST_RSA_3K_PRIVATE_KEY.as_slice(),
+            );
+        },
+    );
+}
+
+#[test]
+fn test_rsa_mod_exp_sign_roundtrip_4k_smoke() {
+    ddi_dev_test(
+        common_setup,
+        common_cleanup,
+        |dev, _ddi, _path, session_id| {
+            sign_roundtrip(
+                dev,
+                session_id,
+                false,
+                4,
+                512,
+                TEST_RSA_4K_PRIVATE_KEY.as_slice(),
+            );
+        },
+    );
+}
+
+#[test]
+fn test_rsa_mod_exp_sign_roundtrip_2k_crt_smoke() {
+    ddi_dev_test(
+        common_setup,
+        common_cleanup,
+        |dev, _ddi, _path, session_id| {
+            sign_roundtrip(
+                dev,
+                session_id,
+                true,
+                2,
+                256,
+                TEST_RSA_2K_PRIVATE_KEY.as_slice(),
+            );
+        },
+    );
+}
+
+#[test]
+fn test_rsa_mod_exp_sign_roundtrip_3k_crt_smoke() {
+    ddi_dev_test(
+        common_setup,
+        common_cleanup,
+        |dev, _ddi, _path, session_id| {
+            sign_roundtrip(
+                dev,
+                session_id,
+                true,
+                3,
+                384,
+                TEST_RSA_3K_PRIVATE_KEY.as_slice(),
+            );
+        },
+    );
+}
+
+#[test]
+fn test_rsa_mod_exp_sign_roundtrip_4k_crt_smoke() {
+    ddi_dev_test(
+        common_setup,
+        common_cleanup,
+        |dev, _ddi, _path, session_id| {
+            sign_roundtrip(
+                dev,
+                session_id,
+                true,
+                4,
+                512,
+                TEST_RSA_4K_PRIVATE_KEY.as_slice(),
+            );
+        },
+    );
+}
+
+#[test]
+fn test_rsa_mod_exp_wrong_permission_smoke() {
+    ddi_dev_test(
+        common_setup,
+        common_cleanup,
+        |dev, _ddi, _path, session_id| {
+            // A SignVerify-only key cannot perform a Decrypt primitive.
+            let (_pub, key_id, _) =
+                store_rsa_keys_no_crt(dev, session_id, DdiKeyUsage::SignVerify, 2, None);
+
+            let err = helper_rsa_mod_exp(
+                dev,
+                Some(session_id),
+                Some(DdiApiRev { major: 1, minor: 0 }),
+                key_id,
+                MborByteArray::new([0x01u8; 512], 256).expect("input fits"),
+                DdiRsaOpType::Decrypt,
+            )
+            .expect_err("Decrypt with a SignVerify-only key must be rejected");
+
+            assert!(
+                matches!(err, DdiError::DdiStatus(DdiStatus::InvalidPermissions)),
+                "expected InvalidPermissions, got {err:?}"
+            );
+        },
+    );
+}

--- a/fw/core/lib/src/ddi/mbor/from_pal.rs
+++ b/fw/core/lib/src/ddi/mbor/from_pal.rs
@@ -23,6 +23,7 @@ use azihsm_fw_hsm_pal_traits::HsmEccCurve;
 use azihsm_fw_hsm_pal_traits::HsmError;
 use azihsm_fw_hsm_pal_traits::HsmHashAlgo;
 use azihsm_fw_hsm_pal_traits::HsmResult;
+use azihsm_fw_hsm_pal_traits::HsmRsaKey;
 use azihsm_fw_hsm_pal_traits::HsmVaultKeyKind;
 
 // ── HsmVaultKeyKind → … ───────────────────────────────────────────
@@ -60,6 +61,21 @@ pub(crate) fn ecc_curve(kind: HsmVaultKeyKind) -> HsmResult<HsmEccCurve> {
 pub(crate) fn assert_aes(kind: HsmVaultKeyKind) -> HsmResult<()> {
     match kind {
         HsmVaultKeyKind::Aes128 | HsmVaultKeyKind::Aes192 | HsmVaultKeyKind::Aes256 => Ok(()),
+        _ => Err(HsmError::InvalidKeyType),
+    }
+}
+
+/// Map an RSA private vault kind (plain or CRT) to its [`HsmRsaKey`]
+/// modulus-size selector.  Any non-RSA-private kind returns
+/// [`HsmError::InvalidKeyType`].
+pub(crate) fn rsa_key(kind: HsmVaultKeyKind) -> HsmResult<HsmRsaKey> {
+    match kind {
+        HsmVaultKeyKind::Rsa2kPrivate => Ok(HsmRsaKey::Rsa2048Priv),
+        HsmVaultKeyKind::Rsa3kPrivate => Ok(HsmRsaKey::Rsa3072Priv),
+        HsmVaultKeyKind::Rsa4kPrivate => Ok(HsmRsaKey::Rsa4096Priv),
+        HsmVaultKeyKind::Rsa2kPrivateCrt => Ok(HsmRsaKey::Rsa2048CrtPriv),
+        HsmVaultKeyKind::Rsa3kPrivateCrt => Ok(HsmRsaKey::Rsa3072CrtPriv),
+        HsmVaultKeyKind::Rsa4kPrivateCrt => Ok(HsmRsaKey::Rsa4096CrtPriv),
         _ => Err(HsmError::InvalidKeyType),
     }
 }

--- a/fw/core/lib/src/ddi/mbor/mod.rs
+++ b/fw/core/lib/src/ddi/mbor/mod.rs
@@ -26,6 +26,7 @@ pub(crate) mod kbkdf_derive;
 pub(crate) mod kdf;
 pub(crate) mod key_attrs;
 pub(crate) mod open_session;
+pub(crate) mod rsa_mod_exp;
 pub(crate) mod rsa_unwrap;
 pub(crate) mod set_sealed_bk3;
 pub(crate) mod sha_digest;
@@ -56,6 +57,7 @@ pub(crate) use hmac::*;
 pub(crate) use init_bk3::*;
 pub(crate) use kbkdf_derive::*;
 pub(crate) use open_session::*;
+pub(crate) use rsa_mod_exp::*;
 pub(crate) use rsa_unwrap::*;
 pub(crate) use set_sealed_bk3::*;
 pub(crate) use sha_digest::*;
@@ -145,6 +147,7 @@ pub(crate) async fn dispatch<'p, P: HsmPal>(
         DdiOp::HkdfDerive => hkdf_derive(pal, io, decoder, hdr).await,
         DdiOp::KbkdfCounterHmacDerive => kbkdf_counter_hmac_derive(pal, io, decoder, hdr).await,
         DdiOp::Hmac => hmac(pal, io, decoder, hdr).await,
+        DdiOp::RsaModExp => rsa_mod_exp(pal, io, decoder, hdr).await,
         _ => Err(HsmError::UnsupportedCmd),
     }
 }

--- a/fw/core/lib/src/ddi/mbor/rsa_mod_exp.rs
+++ b/fw/core/lib/src/ddi/mbor/rsa_mod_exp.rs
@@ -1,0 +1,80 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! DDI RsaModExp command handler.
+//!
+//! Within an open session, perform the RSA private-key primitive
+//! `x = y^d mod n` using a vault-resident RSA private key (CRT or
+//! non-CRT) and return the result.  This is the raw modular
+//! exponentiation underlying RSA decrypt / sign — the host applies
+//! and removes any padding.
+//!
+//! The key must be an RSA private key whose attributes permit the
+//! requested operation: `Decrypt` requires `CKA_DECRYPT`, `Sign`
+//! requires `CKA_SIGN`.  A non-RSA key is rejected with
+//! `InvalidKeyType`, an unknown `key_id` with `KeyNotFound`, and a
+//! key lacking the required usage with `InvalidPermissions`.  The
+//! input `y` must be exactly the key's modulus length.
+
+use azihsm_fw_ddi_mbor_types::rsa_mod_exp::DdiRsaModExpReq;
+use azihsm_fw_ddi_mbor_types::rsa_mod_exp::DdiRsaModExpResp;
+use azihsm_fw_ddi_mbor_types::DdiRsaOpType;
+
+use super::*;
+
+/// Handle `DdiRsaModExpCmd`.
+///
+/// No `partition_lock` is needed: this handler only reads vault state
+/// (the RSA private key) and computes `y^d mod n` — it performs no
+/// partition mutation.
+pub(crate) async fn rsa_mod_exp<'p, P: HsmPal>(
+    pal: &'p P,
+    io: &impl HsmIo,
+    decoder: &mut DdiDecoder<'_>,
+    hdr: &DdiReqHdr,
+) -> HsmResult<&'p DmaBuf> {
+    let body: DdiRsaModExpReq = decoder.decode_data()?;
+    let sess_id = hdr.sess_id.ok_or(HsmError::SessionExpected)?;
+    let key_id = HsmKeyId::from(body.key_id);
+
+    // The key must be an RSA private key (plain or CRT); the size
+    // selector also drives the modulus length below.  Non-RSA kinds
+    // map to `InvalidKeyType`; an unknown id to `KeyNotFound`.
+    let key_size = super::from_pal::rsa_key(pal.vault_key_kind(io, key_id)?)?;
+
+    // The permitted operation depends on the key's usage attributes:
+    // a decrypt primitive needs `CKA_DECRYPT`, a sign primitive needs
+    // `CKA_SIGN`.
+    let attrs = pal.vault_key_attrs(io, key_id)?;
+    let permitted = match body.op_type {
+        DdiRsaOpType::Decrypt => attrs.decrypt(),
+        DdiRsaOpType::Sign => attrs.sign(),
+        _ => return Err(HsmError::InvalidArg),
+    };
+    if !permitted {
+        return Err(HsmError::InvalidPermissions);
+    }
+
+    // The input integer must be exactly the modulus length.
+    let modulus_len = key_size.modulus_len();
+    if body.y.len() != modulus_len {
+        return Err(HsmError::InvalidArg);
+    }
+
+    // Compute `x = y^d mod n` directly into the response's `x` slot —
+    // reserve the slot in the response buffer and hand it to the PAL, so
+    // there is no separate scratch buffer or copy.
+    let (resp, layout) = pal.dma_alloc_var_with(io, |buf| {
+        let mut encoder = super::encode_resp_hdr(
+            &super::success_hdr_sess(hdr, DdiOp::RsaModExp, sess_id),
+            buf,
+        )?;
+        let layout = DdiRsaModExpResp::reserve(&mut encoder, modulus_len)?;
+        Ok((encoder.position(), layout))
+    })?;
+    let frame = DdiRsaModExpResp::from_layout(resp, &layout);
+    let key = pal.vault_key(io, key_id)?;
+    pal.mod_exp_priv(io, key_size, key, body.y, frame.x).await?;
+
+    Ok(resp)
+}

--- a/fw/pal/traits/src/crypto/rsa.rs
+++ b/fw/pal/traits/src/crypto/rsa.rs
@@ -211,9 +211,12 @@ pub trait HsmRsa {
     /// - `key` — RSA private key in PAL-defined serialization
     ///   matching `key_size.is_crt()`.
     /// - `y` — input integer; must be exactly
-    ///   `key_size.modulus_len()` bytes.
+    ///   `key_size.modulus_len()` bytes, in wire **little-endian** byte
+    ///   order.  The PAL flips to its primitive's native order (e.g. the
+    ///   std/OpenSSL PAL reverses to big-endian).
     /// - `x` — output integer; must be exactly
-    ///   `key_size.modulus_len()` bytes.
+    ///   `key_size.modulus_len()` bytes, written in wire **little-endian**
+    ///   byte order.
     ///
     /// # Returns
     ///
@@ -239,9 +242,12 @@ pub trait HsmRsa {
     /// - `key_size` — modulus size selector.
     /// - `key` — RSA public key.
     /// - `x` — input integer; must be exactly
-    ///   `key_size.modulus_len()` bytes.
+    ///   `key_size.modulus_len()` bytes, in wire **little-endian** byte
+    ///   order.  The PAL flips to its primitive's native order (e.g. the
+    ///   std/OpenSSL PAL reverses to big-endian).
     /// - `y` — output integer; must be exactly
-    ///   `key_size.modulus_len()` bytes.
+    ///   `key_size.modulus_len()` bytes, written in wire **little-endian**
+    ///   byte order.
     ///
     /// # Returns
     ///

--- a/fw/plat/std/pal/src/drivers/rsa.rs
+++ b/fw/plat/std/pal/src/drivers/rsa.rs
@@ -181,7 +181,9 @@ impl StdRsa {
         x: &mut [u8],
     ) -> HsmResult<()> {
         let key = priv_key.clone();
-        let y_owned = y.to_vec();
+        // Wire operands are little-endian; OpenSSL is big-endian.
+        let mut y_be = y.to_vec();
+        y_be.reverse();
         let out_len = x.len();
 
         let result = self
@@ -189,13 +191,14 @@ impl StdRsa {
             .submit_with_result(async move {
                 let mut algo = RsaEncryptAlgo::with_no_padding();
                 let mut buf = vec![0u8; out_len];
-                algo.decrypt(&key, &y_owned, Some(&mut buf))
+                algo.decrypt(&key, &y_be, Some(&mut buf))
                     .map_err(|_| HsmError::RsaDecryptFailed)?;
                 Ok::<_, HsmError>(buf)
             })
             .await?;
 
-        x.copy_from_slice(&result);
+        // `result` is big-endian; emit the little-endian wire form.
+        super::reverse_copy(x, &result);
         Ok(())
     }
 
@@ -223,7 +226,9 @@ impl StdRsa {
         y: &mut [u8],
     ) -> HsmResult<()> {
         let key = pub_key.clone();
-        let x_owned = x_input.to_vec();
+        // Wire operands are little-endian; OpenSSL is big-endian.
+        let mut x_be = x_input.to_vec();
+        x_be.reverse();
         let out_len = y.len();
 
         let result = self
@@ -231,13 +236,14 @@ impl StdRsa {
             .submit_with_result(async move {
                 let mut algo = RsaEncryptAlgo::with_no_padding();
                 let mut buf = vec![0u8; out_len];
-                algo.encrypt(&key, &x_owned, Some(&mut buf))
+                algo.encrypt(&key, &x_be, Some(&mut buf))
                     .map_err(|_| HsmError::RsaEncryptFailed)?;
                 Ok::<_, HsmError>(buf)
             })
             .await?;
 
-        y.copy_from_slice(&result);
+        // `result` is big-endian; emit the little-endian wire form.
+        super::reverse_copy(y, &result);
         Ok(())
     }
 
@@ -406,6 +412,95 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(recovered, plaintext);
+    }
+
+    // ── Wire byte-order contract (little-endian operands) ────────
+    //
+    // The round-trip / identity tests above reverse symmetrically, so
+    // they pass even if the LE<->BE flips are wrong (or absent). These
+    // tests pin the *absolute* wire byte order by comparing the driver
+    // against a direct OpenSSL no-padding operation: on the wire the
+    // operands are little-endian, while OpenSSL is big-endian. A
+    // non-palindrome input (`m_be != reverse(m_be)`) makes the two byte
+    // orders distinguishable.
+
+    /// Build a non-palindrome big-endian test integer `< n` (leading
+    /// byte `0x01`), so reversing it yields a genuinely different value.
+    fn nonpalindrome_be(key_size_bytes: usize) -> Vec<u8> {
+        let mut m = vec![0u8; key_size_bytes];
+        m[0] = 0x01;
+        m[1] = 0x23;
+        m[key_size_bytes - 1] = 0x02;
+        m
+    }
+
+    /// `mod_exp_pub` must consume a little-endian `x` and emit a
+    /// little-endian `y`, i.e. `y == reverse(m_be^e mod n)`, verified
+    /// against a direct big-endian OpenSSL no-padding public op.
+    #[tokio::test]
+    async fn mod_exp_pub_wire_le_matches_openssl() {
+        let driver = make_driver();
+        let key_size_bytes = 256;
+        let (_priv_key, pub_key) = driver.gen_keypair(2048).await.unwrap();
+
+        let m_be = nonpalindrome_be(key_size_bytes);
+
+        // Independent reference: raw RSA public op in big-endian.
+        let mut ref_be = vec![0u8; key_size_bytes];
+        {
+            let mut algo = RsaEncryptAlgo::with_no_padding();
+            let written = algo.encrypt(&pub_key, &m_be, Some(&mut ref_be)).unwrap();
+            assert_eq!(written, key_size_bytes);
+        }
+        let mut expected_le = ref_be.clone();
+        expected_le.reverse();
+
+        // Driver consumes little-endian `x` and emits little-endian `y`.
+        let mut m_le = m_be.clone();
+        m_le.reverse();
+        let mut y_le = vec![0u8; key_size_bytes];
+        driver
+            .mod_exp_pub(&pub_key, &m_le, &mut y_le)
+            .await
+            .unwrap();
+
+        assert_eq!(y_le, expected_le);
+        // Guard: the output must be little-endian, not the big-endian
+        // OpenSSL form (would be equal only if the output flip were missing).
+        assert_ne!(y_le, ref_be);
+    }
+
+    /// `mod_exp_priv` must consume a little-endian `y` and emit a
+    /// little-endian `x`, i.e. `x == reverse(m_be^d mod n)`, verified
+    /// against a direct big-endian OpenSSL no-padding private op.
+    #[tokio::test]
+    async fn mod_exp_priv_wire_le_matches_openssl() {
+        let driver = make_driver();
+        let key_size_bytes = 256;
+        let (priv_key, _pub_key) = driver.gen_keypair(2048).await.unwrap();
+
+        let m_be = nonpalindrome_be(key_size_bytes);
+
+        // Independent reference: raw RSA private op in big-endian.
+        let mut ref_be = vec![0u8; key_size_bytes];
+        {
+            let mut algo = RsaEncryptAlgo::with_no_padding();
+            algo.decrypt(&priv_key, &m_be, Some(&mut ref_be)).unwrap();
+        }
+        let mut expected_le = ref_be.clone();
+        expected_le.reverse();
+
+        // Driver consumes little-endian `y` and emits little-endian `x`.
+        let mut m_le = m_be.clone();
+        m_le.reverse();
+        let mut x_le = vec![0u8; key_size_bytes];
+        driver
+            .mod_exp_priv(&priv_key, &m_le, &mut x_le)
+            .await
+            .unwrap();
+
+        assert_eq!(x_le, expected_le);
+        assert_ne!(x_le, ref_be);
     }
 
     // ── OAEP decrypt (wire-LE ciphertext → recovered plaintext) ──


### PR DESCRIPTION
Implement the RsaModExp DDI command handler: within an open session, perform the RSA private-key primitive `x = y^d mod n` using a vault-resident RSA private key (CRT or non-CRT) and return the result.  This is the raw modular exponentiation underlying RSA decrypt / sign — the host applies and removes any padding.

- Handler (fw/core/lib/src/ddi/mbor/rsa_mod_exp.rs): validate the key is an RSA private key (non-RSA -> InvalidKeyType, unknown id -> KeyNotFound), gate on the op's usage attribute (Decrypt needs CKA_DECRYPT, Sign needs CKA_SIGN -> InvalidPermissions), require the input `y` to be exactly the modulus length, then compute `y^d mod n` directly into the response's `x` slot (reserve + from_layout — no scratch buffer or copy).
- Add the HsmVaultKeyKind -> HsmRsaKey mapping (from_pal::rsa_key) and register the handler in the MBOR dispatch.
- std PAL: the DDI mod-exp operands `y`/`x` are little-endian on the wire (the host pre/post-encode reverses BE<->LE), but the std driver's mod_exp_priv / mod_exp_pub passed them straight to OpenSSL (big-endian) with no reversal, so a decrypt/sign round-trip produced garbage.  Reverse LE<->BE around the OpenSSL op in both, and document the wire-LE operand contract on the HsmRsa trait methods.

Tests:
- New rsa_mod_exp_smoke suite: decrypt and sign round-trips for RSA-2K/3K/4K in both non-CRT and CRT vault forms (non-palindrome operands, so the round-trips also exercise the wire little-endian handling), plus a wrong-permission rejection.  Sign verifies via the raw RSA verify API.
- Fix the store_rsa_keys_crt test helper, which was a copy-paste of the non-CRT helper (it passed DdiKeyClass::Rsa) and never actually stored a CRT key.  The existing rsa_*_sign / rsa_*_decrypt_with_crt / attest_key tests that use it now genuinely exercise CRT keys.

Validation: rsa_mod_exp (full + smoke) passes under emu and mock; the std PAL rsa driver unit tests, emu smoke, and Uno build stay green; clippy/fmt/copyright clean.  The store_rsa_keys_crt fix adds no new failures — the pre-existing emu attest / message-size-limit failures are unchanged.