### PR TITLE
fix(crypto): support raw no-padding RSA verify on Windows CNG

### DIFF
--- a/crates/crypto/src/rsa/rsa_sign_cng.rs
+++ b/crates/crypto/src/rsa/rsa_sign_cng.rs
@@ -204,6 +204,41 @@ impl VerifyOp for CngRsaSignAlgo {
     ) -> Result<bool, CryptoError> {
         let (pad, flags) = self.padding_info();
         let pad_ptr = pad_ptr(&pad);
+
+        // Windows CNG's `BCryptVerifySignature` only supports `BCRYPT_PAD_PKCS1`
+        // and `BCRYPT_PAD_PSS` — it rejects `BCRYPT_PAD_NONE`. For raw (no
+        // padding) verification, perform the public-key primitive `s^e mod n`
+        // directly via `BCryptEncrypt` (mirroring how `sign` special-cases
+        // `Padding::None` with `BCryptDecrypt`) and compare the recovered value
+        // against `data`.
+        if let Padding::None = self.padding {
+            let mut recovered = vec![0u8; signature.len()];
+            let mut len = 0u32;
+            // SAFETY: Calling Windows CNG BCryptEncrypt to perform the raw RSA
+            // public-key operation.
+            // - key.handle() is a valid BCRYPT_KEY_HANDLE from a CNG public key
+            //   object that outlives the call
+            // - signature is the "plaintext" input, valid for reads for the call
+            // - pad_ptr is None for BCRYPT_PAD_NONE; None IV (RSA has no IV)
+            // - recovered is a valid mutable slice sized to the modulus length;
+            //   BCrypt will not write beyond its bounds and errors if too small
+            // - len is a valid mutable u32 receiving the output size
+            // - flags is BCRYPT_PAD_NONE per padding_info()
+            let status = unsafe {
+                BCryptEncrypt(
+                    key.handle(),
+                    Some(signature),
+                    pad_ptr,
+                    None,
+                    Some(recovered.as_mut_slice()),
+                    &mut len,
+                    flags,
+                )
+            };
+            status.ok().map_err(|_| CryptoError::RsaVerifyError)?;
+            return Ok(recovered[..len as usize] == *data);
+        }
+
         // SAFETY: Calling Windows CNG BCryptVerifySignature API.
         // - key.handle() is a valid BCRYPT_KEY_HANDLE obtained from a CNG public key object
         //   that remains valid for the lifetime of the key reference

--- a/crates/crypto/src/rsa/rsa_sign_cng.rs
+++ b/crates/crypto/src/rsa/rsa_sign_cng.rs
@@ -212,7 +212,12 @@ impl VerifyOp for CngRsaSignAlgo {
         // `Padding::None` with `BCryptDecrypt`) and compare the recovered value
         // against `data`.
         if let Padding::None = self.padding {
-            let mut recovered = vec![0u8; signature.len()];
+            let modulus_size = key.size();
+            if data.len() != modulus_size || signature.len() != modulus_size {
+                return Ok(false);
+            }
+
+            let mut recovered = vec![0u8; modulus_size];
             let mut len = 0u32;
             // SAFETY: Calling Windows CNG BCryptEncrypt to perform the raw RSA
             // public-key operation.
@@ -235,8 +240,10 @@ impl VerifyOp for CngRsaSignAlgo {
                     flags,
                 )
             };
-            status.ok().map_err(|_| CryptoError::RsaVerifyError)?;
-            return Ok(recovered[..len as usize] == *data);
+            if status.is_err() || len as usize != modulus_size {
+                return Ok(false);
+            }
+            return Ok(constant_time_eq(&recovered, data));
         }
 
         // SAFETY: Calling Windows CNG BCryptVerifySignature API.
@@ -312,6 +319,17 @@ impl VerifyRecoverOp for CngRsaSignAlgo {
         status.ok().map_err(|_| CryptoError::RsaVerifyError)?;
         Ok(len as usize)
     }
+}
+
+fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
+    if a.len() != b.len() {
+        return false;
+    }
+    let mut diff = 0u8;
+    for (x, y) in a.iter().zip(b.iter()) {
+        diff |= x ^ y;
+    }
+    diff == 0
 }
 
 impl CngRsaSignAlgo {

--- a/crates/crypto/src/rsa/tests/mod.rs
+++ b/crates/crypto/src/rsa/tests/mod.rs
@@ -12,6 +12,7 @@ mod rsa_pad_oaep_tests;
 mod rsa_pad_pkcs1_enc_tests;
 mod rsa_pad_pkcs1_sign_tests;
 mod rsa_pad_pss_tests;
+mod rsa_sign_nopadding;
 mod rsa_sign_verify_pkcs1;
 mod rsa_sign_verify_pss;
 

--- a/crates/crypto/src/rsa/tests/rsa_sign_nopadding.rs
+++ b/crates/crypto/src/rsa/tests/rsa_sign_nopadding.rs
@@ -40,5 +40,31 @@ fn rsa_no_padding_sign_verify_roundtrip() {
             !verified,
             "raw no-padding verify must reject a modified message"
         );
+
+        let mut algo = RsaSignAlgo::with_no_padding();
+        let verified = Verifier::verify(
+            &mut algo,
+            &public_key,
+            &message[..modulus_size - 1],
+            &signature,
+        )
+        .expect("Verification must not error");
+        assert!(
+            !verified,
+            "raw no-padding verify must reject a short message"
+        );
+
+        let mut algo = RsaSignAlgo::with_no_padding();
+        let verified = Verifier::verify(
+            &mut algo,
+            &public_key,
+            &message,
+            &signature[..modulus_size - 1],
+        )
+        .expect("Verification must not error");
+        assert!(
+            !verified,
+            "raw no-padding verify must reject a short signature"
+        );
     }
 }

--- a/crates/crypto/src/rsa/tests/rsa_sign_nopadding.rs
+++ b/crates/crypto/src/rsa/tests/rsa_sign_nopadding.rs
@@ -1,0 +1,44 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+use super::*;
+
+/// Round-trips the raw (no padding) RSA sign/verify primitive: sign computes
+/// `s = m^d mod n` and verify checks `s^e mod n == m`.
+///
+/// This exercises the `Padding::None` verify path on both backends — OpenSSL's
+/// `EVP_PKEY_verify` and Windows CNG, whose `BCryptVerifySignature` rejects
+/// `BCRYPT_PAD_NONE` and so must fall back to a raw public-key operation.
+#[test]
+fn rsa_no_padding_sign_verify_roundtrip() {
+    for modulus_size in [256, 384, 512] {
+        let private_key =
+            RsaPrivateKey::generate(modulus_size).expect("Failed to generate RSA private key");
+        let public_key = private_key
+            .public_key()
+            .expect("Failed to get RSA public key");
+
+        // A raw message strictly below the modulus (leading byte 0x01).
+        let mut message = vec![0x02u8; modulus_size];
+        message[0] = 0x01;
+
+        let mut algo = RsaSignAlgo::with_no_padding();
+        let signature =
+            Signer::sign_vec(&mut algo, &private_key, &message).expect("Signing failed");
+
+        let mut algo = RsaSignAlgo::with_no_padding();
+        let verified = Verifier::verify(&mut algo, &public_key, &message, &signature)
+            .expect("Verification failed");
+        assert!(verified, "raw no-padding signature must verify");
+
+        // A modified message must not verify.
+        let mut tampered = message.clone();
+        tampered[modulus_size - 1] ^= 0x01;
+        let mut algo = RsaSignAlgo::with_no_padding();
+        let verified = Verifier::verify(&mut algo, &public_key, &tampered, &signature)
+            .expect("Verification must not error");
+        assert!(
+            !verified,
+            "raw no-padding verify must reject a modified message"
+        );
+    }
+}


### PR DESCRIPTION
BCryptVerifySignature rejects BCRYPT_PAD_NONE, so raw (no padding) RSA verify always failed on Windows/CNG while passing on Linux/OpenSSL. For Padding::None, perform the public-key primitive s^e mod n via BCryptEncrypt and compare against the message, mirroring how sign special-cases Padding::None with BCryptDecrypt.

Add rsa_sign_nopadding test covering the raw sign/verify round-trip and tamper rejection.