### PR TITLE
feat(engine): HSM lifecycle, logging, and provider-aligned OBK/MOBK

### DIFF
--- a/.github/workflows/engine-matrix.yml
+++ b/.github/workflows/engine-matrix.yml
@@ -114,10 +114,15 @@ jobs:
         run: curl -LsSf https://get.nexte.st/0.9.132/linux | tar zxf - -C "${CARGO_HOME:-$HOME/.cargo}/bin"
 
       # openssl-engine's unit tests (error queue, ex_data, set_destroy) depend
-      # only on the 1.1 FFI, so they run here. The azihsm_engine mock lifecycle
-      # tests pull the OpenSSL-3.x SDK and need separate handling (roadmap #19).
+      # only on the 1.1 FFI, so they run here.
       - name: Test openssl-engine
         run: cargo nextest run -p openssl-engine --features engine
+
+      # azihsm_engine's mock lifecycle tests drive the HSM open path against the
+      # mock DDI. umask 0077 so the resiliency storage dir is created 0700 (the
+      # open path rejects a group/other-accessible dir).
+      - name: Test azihsm_engine (mock lifecycle)
+        run: umask 0077 && cargo nextest run -p azihsm_engine --features engine,mock
 
       - name: Test azihsm_crypto
         run: cargo nextest run -p azihsm_crypto

--- a/.github/workflows/engine-matrix.yml
+++ b/.github/workflows/engine-matrix.yml
@@ -119,10 +119,9 @@ jobs:
         run: cargo nextest run -p openssl-engine --features engine
 
       # azihsm_engine's mock lifecycle tests drive the HSM open path against the
-      # mock DDI. umask 0077 so the resiliency storage dir is created 0700 (the
-      # open path rejects a group/other-accessible dir).
+      # mock DDI.
       - name: Test azihsm_engine (mock lifecycle)
-        run: umask 0077 && cargo nextest run -p azihsm_engine --features engine,mock
+        run: cargo nextest run -p azihsm_engine --features engine,mock
 
       - name: Test azihsm_crypto
         run: cargo nextest run -p azihsm_crypto

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -109,6 +109,7 @@ azihsm_res_test_dev = { path = "ddi/res_test_dev" }
 azihsm_resiliency_test_helpers = { path = "crates/resiliency_test_helpers" }
 azihsm_session_ex_crypto = { path = "crates/session_ex_crypto" }
 azihsm_tpm = { path = "crates/tpm" }
+engine-resiliency = { path = "plugins/ossl_engine/engine-resiliency" }
 openssl-engine = { path = "plugins/ossl_engine/openssl-engine" }
 openssl-sys-engine = { path = "plugins/ossl_engine/openssl-sys-engine" }
 resiliency_macro = { path = "crates/resiliency_macro" }
@@ -216,6 +217,7 @@ thiserror = "1.0"
 tokio = "1.0.0"
 toml_edit = "0.25.11"
 tracing = "0.1"
+tracing-appender = "0.2"
 tracing-subscriber = "0.3.16"
 tracing-tree = "0.4.1"
 trybuild = "1.0.114"

--- a/plugins/ossl_engine/engine-resiliency/src/config.rs
+++ b/plugins/ossl_engine/engine-resiliency/src/config.rs
@@ -64,8 +64,8 @@ pub enum ConfigError {
     #[error("env var {0} is required but unset")]
     Missing(&'static str),
 
-    #[error("resiliency storage directory {0:?} could not be created or is insecure")]
-    StorageDir(PathBuf),
+    #[error("resiliency storage directory {0:?} {1}")]
+    StorageDir(PathBuf, &'static str),
 
     #[error("env var {0} has unsafe path {1:?} (must be non-empty and contain no \"..\")")]
     UnsafePath(&'static str, PathBuf),
@@ -259,23 +259,40 @@ fn current_uid() -> u32 {
 /// provider's storage-directory setup so misconfiguration fails up front
 /// rather than as a generic IO error on the first write.
 fn setup_storage_dir(dir: &Path) -> Result<(), ConfigError> {
-    let err = || ConfigError::StorageDir(dir.to_path_buf());
+    use std::io::ErrorKind;
+
+    let err = |reason: &'static str| ConfigError::StorageDir(dir.to_path_buf(), reason);
     match fs::DirBuilder::new().mode(0o700).create(dir) {
         Ok(()) => Ok(()),
-        Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
+        Err(e) if e.kind() == ErrorKind::AlreadyExists => {
             // symlink_metadata (lstat) so a symlink at `dir` is rejected here
             // rather than silently followed.
-            let meta = fs::symlink_metadata(dir).map_err(|_| err())?;
+            let meta = fs::symlink_metadata(dir)
+                .map_err(|_| err("exists but its metadata could not be read"))?;
             // Require exactly owner-rwx, no group/other (i.e. mode 0700, what
             // we create above): rejecting too-loose perms protects the key
             // material, and rejecting too-tight owner perms surfaces the
             // misconfig here rather than as a generic IO error on first write.
-            if !meta.is_dir() || meta.uid() != current_uid() || meta.mode() & 0o777 != 0o700 {
-                return Err(err());
+            if !meta.is_dir() {
+                return Err(err("exists but is not a directory"));
+            }
+            if meta.uid() != current_uid() {
+                return Err(err("exists but is not owned by the current user"));
+            }
+            if meta.mode() & 0o777 != 0o700 {
+                return Err(err("has insecure permissions (must be mode 0700, owner-only)"));
             }
             Ok(())
         }
-        Err(_) => Err(err()),
+        // DirBuilder is non-recursive, so NotFound means the parent is missing.
+        Err(e) if e.kind() == ErrorKind::NotFound => Err(err(
+            "does not exist and its parent directory is missing; create it first \
+             (e.g. `sudo install -d -m 700 -o \"$USER\" <dir>`)",
+        )),
+        Err(e) if e.kind() == ErrorKind::PermissionDenied => Err(err(
+            "does not exist and cannot be created: permission denied for the current user",
+        )),
+        Err(_) => Err(err("could not be created")),
     }
 }
 
@@ -356,7 +373,7 @@ mod tests {
         let s = caller_caller_settings(dir);
         assert!(matches!(
             s.into_resiliency_config(),
-            Err(ConfigError::StorageDir(_))
+            Err(ConfigError::StorageDir(_, _))
         ));
     }
 
@@ -371,8 +388,23 @@ mod tests {
         let s = caller_caller_settings(dir);
         assert!(matches!(
             s.into_resiliency_config(),
-            Err(ConfigError::StorageDir(_))
+            Err(ConfigError::StorageDir(_, _))
         ));
+    }
+
+    #[test]
+    fn reports_missing_storage_dir_with_clear_message() {
+        // Parent "nope" does not exist, so the non-recursive create fails with
+        // NotFound and must surface a "does not exist" message, not a generic one.
+        let scratch = Scratch::new("cfg-missing");
+        let s = caller_caller_settings(scratch.0.join("nope").join("store"));
+        assert!(
+            matches!(
+                s.into_resiliency_config(),
+                Err(ConfigError::StorageDir(_, reason)) if reason.contains("does not exist")
+            ),
+            "expected a missing-directory message"
+        );
     }
 
     #[test]

--- a/plugins/ossl_engine/engine-resiliency/src/config.rs
+++ b/plugins/ossl_engine/engine-resiliency/src/config.rs
@@ -55,6 +55,13 @@ const DEFAULT_STORAGE_DIR: &str = "/var/lib/azihsm/resiliency";
 const DEFAULT_OBK_PATH: &str = "./obk.bin";
 const DEFAULT_MOBK_PATH: &str = "./mobk.bin";
 
+/// Required mode for the resiliency storage directory: owner rwx only.
+const STORAGE_DIR_MODE: u32 = 0o700;
+/// Permission bits masked out of a directory's mode for the comparison.
+/// The special bits (setuid/setgid/sticky) are intentionally excluded — unlike
+/// the engine's log-file check — since they can be legitimate on a directory.
+const PERMISSION_BITS_MASK: u32 = 0o777;
+
 /// Error from reading the engine's resiliency environment variables.
 #[derive(Debug, thiserror::Error)]
 pub enum ConfigError {
@@ -267,7 +274,7 @@ fn setup_storage_dir(dir: &Path) -> Result<(), ConfigError> {
     use std::io::ErrorKind;
 
     let err = |reason: &'static str| ConfigError::StorageDir(dir.to_path_buf(), reason);
-    match fs::DirBuilder::new().mode(0o700).create(dir) {
+    match fs::DirBuilder::new().mode(STORAGE_DIR_MODE).create(dir) {
         Ok(()) => Ok(()),
         Err(e) if e.kind() == ErrorKind::AlreadyExists => {
             // symlink_metadata (lstat) so a symlink at `dir` is rejected here
@@ -284,7 +291,7 @@ fn setup_storage_dir(dir: &Path) -> Result<(), ConfigError> {
             if meta.uid() != current_uid() {
                 return Err(err("exists but is not owned by the current user"));
             }
-            if meta.mode() & 0o777 != 0o700 {
+            if meta.mode() & PERMISSION_BITS_MASK != STORAGE_DIR_MODE {
                 return Err(err(
                     "has insecure permissions (must be mode 0700, owner-only)",
                 ));

--- a/plugins/ossl_engine/engine-resiliency/src/config.rs
+++ b/plugins/ossl_engine/engine-resiliency/src/config.rs
@@ -280,7 +280,9 @@ fn setup_storage_dir(dir: &Path) -> Result<(), ConfigError> {
                 return Err(err("exists but is not owned by the current user"));
             }
             if meta.mode() & 0o777 != 0o700 {
-                return Err(err("has insecure permissions (must be mode 0700, owner-only)"));
+                return Err(err(
+                    "has insecure permissions (must be mode 0700, owner-only)",
+                ));
             }
             Ok(())
         }

--- a/plugins/ossl_engine/engine-resiliency/src/config.rs
+++ b/plugins/ossl_engine/engine-resiliency/src/config.rs
@@ -127,12 +127,17 @@ impl ResiliencySettings {
             validate_path(ENV_MOBK_PATH, &mobk_path)?;
         }
         if matches!(pota_source, HsmPotaEndorsementSource::Caller) {
-            if let Some(p) = &pota_priv_path {
-                validate_path(ENV_POTA_PRIV, p)?;
-            }
-            if let Some(p) = &pota_pub_path {
-                validate_path(ENV_POTA_PUB, p)?;
-            }
+            // Caller POTA needs both key paths; require them here so a
+            // misconfiguration fails at parse time with a consistent
+            // ConfigError rather than later in the open path.
+            let priv_p = pota_priv_path
+                .as_ref()
+                .ok_or(ConfigError::Missing(ENV_POTA_PRIV))?;
+            validate_path(ENV_POTA_PRIV, priv_p)?;
+            let pub_p = pota_pub_path
+                .as_ref()
+                .ok_or(ConfigError::Missing(ENV_POTA_PUB))?;
+            validate_path(ENV_POTA_PUB, pub_p)?;
         }
 
         Ok(Self {

--- a/plugins/ossl_engine/engine-resiliency/src/config.rs
+++ b/plugins/ossl_engine/engine-resiliency/src/config.rs
@@ -23,7 +23,7 @@
 //! | `AZIHSM_OBK_PATH`                | `./obk.bin`                      | plaintext OBK, first init; used when `OBK_SOURCE=caller` |
 //! | `AZIHSM_MOBK_PATH`               | `./mobk.bin`                     | cached MOBK, written after init / read to re-init a warm device |
 //! | `AZIHSM_POTA_SOURCE`             | `caller`                         | `caller` or `tpm` |
-//! | `AZIHSM_POTA_PRIVATE_KEY_PATH`   | none                             | required when `POTA_SOURCE=caller` and resiliency enabled |
+//! | `AZIHSM_POTA_PRIVATE_KEY_PATH`   | none                             | required when `POTA_SOURCE=caller` (validated at parse time, regardless of `RESILIENCY_ENABLED`) |
 //! | `AZIHSM_POTA_PUBLIC_KEY_PATH`    | none                             | same |
 
 use std::fs;

--- a/plugins/ossl_engine/engine-resiliency/src/config.rs
+++ b/plugins/ossl_engine/engine-resiliency/src/config.rs
@@ -99,44 +99,39 @@ impl ResiliencySettings {
         let storage_dir = env_nonempty(ENV_STORAGE_DIR)
             .map(PathBuf::from)
             .unwrap_or_else(|| PathBuf::from(DEFAULT_STORAGE_DIR));
-        // Sources parse (and can error on a bad value) only when enabled; a
-        // disabled engine must not fail over a var it will never use.
-        let obk_source = if enabled {
-            parse_obk_source(&std::env::var(ENV_OBK_SOURCE).unwrap_or_default())?
-        } else {
-            HsmOwnerBackupKeySource::Caller
-        };
+        // Sources are honored whether or not resiliency is enabled: the engine
+        // opens the partition (OBK/POTA init) using these fields regardless of
+        // `enabled`, so parsing them only when enabled would silently ignore
+        // e.g. AZIHSM_OBK_SOURCE=tpm with resiliency off.
+        let obk_source = parse_obk_source(&std::env::var(ENV_OBK_SOURCE).unwrap_or_default())?;
         let obk_path = env_nonempty(ENV_OBK_PATH)
             .map(PathBuf::from)
             .unwrap_or_else(|| PathBuf::from(DEFAULT_OBK_PATH));
         let mobk_path = env_nonempty(ENV_MOBK_PATH)
             .map(PathBuf::from)
             .unwrap_or_else(|| PathBuf::from(DEFAULT_MOBK_PATH));
-        let pota_source = if enabled {
-            parse_pota_source(&std::env::var(ENV_POTA_SOURCE).unwrap_or_default())?
-        } else {
-            HsmPotaEndorsementSource::Caller
-        };
+        let pota_source = parse_pota_source(&std::env::var(ENV_POTA_SOURCE).unwrap_or_default())?;
         let pota_priv_path = env_nonempty(ENV_POTA_PRIV).map(PathBuf::from);
         let pota_pub_path = env_nonempty(ENV_POTA_PUB).map(PathBuf::from);
 
         // Reject unsafe paths up front (mirrors the provider's path_is_safe),
-        // but only those that will actually be used: a disabled engine, or a
-        // `tpm` source whose file paths are ignored, must not fail to start
-        // over a path it will never read.
+        // but only those that will actually be used. The OBK/POTA paths are
+        // read/written by the open path regardless of `enabled`, so validate
+        // them by source; a `tpm` source ignores its files. storage_dir is only
+        // used by the resiliency store, so validate it only when enabled.
         if enabled {
             validate_path(ENV_STORAGE_DIR, &storage_dir)?;
-            if matches!(obk_source, HsmOwnerBackupKeySource::Caller) {
-                validate_path(ENV_OBK_PATH, &obk_path)?;
-                validate_path(ENV_MOBK_PATH, &mobk_path)?;
+        }
+        if matches!(obk_source, HsmOwnerBackupKeySource::Caller) {
+            validate_path(ENV_OBK_PATH, &obk_path)?;
+            validate_path(ENV_MOBK_PATH, &mobk_path)?;
+        }
+        if matches!(pota_source, HsmPotaEndorsementSource::Caller) {
+            if let Some(p) = &pota_priv_path {
+                validate_path(ENV_POTA_PRIV, p)?;
             }
-            if matches!(pota_source, HsmPotaEndorsementSource::Caller) {
-                if let Some(p) = &pota_priv_path {
-                    validate_path(ENV_POTA_PRIV, p)?;
-                }
-                if let Some(p) = &pota_pub_path {
-                    validate_path(ENV_POTA_PUB, p)?;
-                }
+            if let Some(p) = &pota_pub_path {
+                validate_path(ENV_POTA_PUB, p)?;
             }
         }
 

--- a/plugins/ossl_engine/engine-resiliency/src/lib.rs
+++ b/plugins/ossl_engine/engine-resiliency/src/lib.rs
@@ -50,6 +50,10 @@ const MAX_STORAGE_FILE_SIZE: u64 = 64 * 1024;
 /// storage key so storage operations can't clobber the lock.
 pub(crate) const LOCK_FILE_NAME: &str = ".lock";
 
+/// Mode for files the resiliency layer creates (state + lock): owner
+/// read/write only, since they can hold or guard key material.
+const SECRET_FILE_MODE: u32 = 0o600;
+
 /// Reject empty, over-long, or path-traversal keys, keys with a separator or
 /// interior NUL, and the reserved lock-file name, so `dir.join(key)` can never
 /// escape the storage directory or clobber the lock file, and an invalid key
@@ -128,7 +132,7 @@ impl FileStorage {
             .create(true)
             .truncate(true)
             .custom_flags(libc::O_NOFOLLOW | libc::O_CLOEXEC)
-            .mode(0o600)
+            .mode(SECRET_FILE_MODE)
             .open(tmp_path)?;
         file.write_all(data)?;
         file.sync_all()?;
@@ -238,7 +242,7 @@ impl ResiliencyLock for FileLock {
             .create(true)
             .truncate(false)
             .custom_flags(libc::O_NOFOLLOW | libc::O_CLOEXEC)
-            .mode(0o600)
+            .mode(SECRET_FILE_MODE)
             .open(&self.path)
             .map_err(|_| HsmError::InternalError)?;
         // Reject a FIFO/device/etc. at the lock path (O_NOFOLLOW only blocks

--- a/plugins/ossl_engine/engine/Cargo.toml
+++ b/plugins/ossl_engine/engine/Cargo.toml
@@ -13,9 +13,28 @@ crate-type = ["cdylib", "lib"]
 [features]
 default = []
 engine = ["openssl-engine/engine"]
+mock = ["azihsm_api/mock"]
 
 [dependencies]
+azihsm_api.workspace = true
+engine-resiliency.workspace = true
 openssl-engine.workspace = true
+parking_lot.workspace = true
+tracing.workspace = true
+tracing-appender.workspace = true
+tracing-subscriber = { features = ["env-filter"], workspace = true }
+zeroize.workspace = true
+
+# libc backs the O_NOFOLLOW hardening on the Linux-only file opens.
+[target.'cfg(unix)'.dependencies]
+libc.workspace = true
+
+# Only the Linux-only `context` tests use these; gating keeps the workspace
+# `--all-targets` build on Windows from pulling OpenSSL (openssl-sys won't build
+# there). Mirrors engine-resiliency.
+[target.'cfg(target_os = "linux")'.dev-dependencies]
+openssl.workspace = true
+serial_test.workspace = true
 
 [lints]
 workspace = true

--- a/plugins/ossl_engine/engine/src/context.rs
+++ b/plugins/ossl_engine/engine/src/context.rs
@@ -232,21 +232,24 @@ fn persist_secret_file(path: &Path, bytes: &[u8]) -> std::io::Result<()> {
     tmp_name.push(format!(".tmp.{}.{seq}", std::process::id()));
     let tmp = path.with_file_name(tmp_name);
 
-    // On any failure remove the temp so a partial copy of key material is not
-    // left behind.
-    let write = || -> std::io::Result<()> {
-        let mut f = std::fs::OpenOptions::new()
-            .create(true)
-            .write(true)
-            .truncate(true)
-            .mode(0o600)
-            .custom_flags(libc::O_NOFOLLOW | libc::O_CLOEXEC)
-            .open(&tmp)?;
+    // Exclusive-create (O_EXCL via create_new): if a file already exists at
+    // this temp name — a crash leftover or a planted file in a shared dir —
+    // fail instead of truncating it, so secret material is never written into
+    // a file we did not just create with 0600.
+    let mut f = std::fs::OpenOptions::new()
+        .create_new(true)
+        .write(true)
+        .mode(0o600)
+        .custom_flags(libc::O_NOFOLLOW | libc::O_CLOEXEC)
+        .open(&tmp)?;
+
+    // We own `tmp` now, so on any later failure remove it (and only it) so a
+    // partial copy of key material is not left behind.
+    if let Err(e) = (|| -> std::io::Result<()> {
         f.write_all(bytes)?;
         f.sync_all()?;
         std::fs::rename(&tmp, path)
-    };
-    if let Err(e) = write() {
+    })() {
         let _ = std::fs::remove_file(&tmp);
         return Err(e);
     }

--- a/plugins/ossl_engine/engine/src/context.rs
+++ b/plugins/ossl_engine/engine/src/context.rs
@@ -560,8 +560,8 @@ mod tests {
 ///
 /// ```text
 /// export AZIHSM_CREDENTIALS_ID=<32 hex>  AZIHSM_CREDENTIALS_PIN=<32 hex>
-/// export AZIHSM_RESILIENCY_ENABLED=1        # required, else OBK/POTA source is ignored
-/// export AZIHSM_OBK_SOURCE=tpm  AZIHSM_POTA_SOURCE=tpm
+/// export AZIHSM_RESILIENCY_ENABLED=1        # turns on resiliency persistence (storage dir + MOBK/POTA callbacks)
+/// export AZIHSM_OBK_SOURCE=tpm  AZIHSM_POTA_SOURCE=tpm  # source selection applies regardless of the flag above
 /// # Storage dir must already exist, be mode 0700, and be owned by you. The
 /// # default is /var/lib/azihsm/resiliency; create it once (override with
 /// # AZIHSM_RESILIENCY_STORAGE_DIR to use e.g. a path under $HOME):

--- a/plugins/ossl_engine/engine/src/context.rs
+++ b/plugins/ossl_engine/engine/src/context.rs
@@ -5,7 +5,7 @@
 //!
 //! [`EngineData`] is the per-engine state stored in the `ENGINE`'s ex_data
 //! and retrieved via `ENGINE_get_ex_data`. It owns one lazily-populated
-//! [`HsmContext`] (partition + session).
+//! [`HsmEngineContext`] (partition + session).
 
 use std::path::Path;
 
@@ -31,6 +31,8 @@ use parking_lot::Mutex;
 use zeroize::Zeroize;
 use zeroize::Zeroizing;
 
+use crate::SECRET_FILE_MODE;
+
 /// Test-only credentials. Match the values used throughout the API test
 /// suite (`api/tests/src/utils/partition.rs`), so the mock DDI accepts
 /// the engine out of the box. Compiled in **only** for `mock` builds: a
@@ -46,7 +48,7 @@ const ENV_CREDENTIALS_PIN: &str = "AZIHSM_CREDENTIALS_PIN";
 
 /// Per-engine state stored in `ENGINE` ex_data.
 pub struct EngineData {
-    hsm: Mutex<Option<HsmContext>>,
+    hsm: Mutex<Option<HsmEngineContext>>,
 }
 
 impl Default for EngineData {
@@ -62,7 +64,7 @@ impl EngineData {
         }
     }
 
-    /// True once an `HsmContext` has been installed via `open_hsm_*`.
+    /// True once an `HsmEngineContext` has been installed via `open_hsm_*`.
     pub fn is_hsm_open(&self) -> bool {
         self.hsm.lock().is_some()
     }
@@ -70,7 +72,7 @@ impl EngineData {
     /// Open the HSM using `settings` (already parsed) and `creds`.
     /// Idempotent: subsequent calls return `Ok(())` without re-opening.
     ///
-    /// The lock is held across `HsmContext::open` so concurrent first-use
+    /// The lock is held across `HsmEngineContext::open` so concurrent first-use
     /// callers serialize on the open instead of racing two sessions open
     /// and discarding one.
     pub fn open_hsm_with(
@@ -82,7 +84,7 @@ impl EngineData {
         if guard.is_some() {
             return Ok(());
         }
-        *guard = Some(HsmContext::open(settings, creds)?);
+        *guard = Some(HsmEngineContext::open(settings, creds)?);
         Ok(())
     }
 
@@ -101,14 +103,14 @@ impl EngineData {
 /// Both fields are RAII holders: dropping them closes the session and
 /// releases the partition. They are held (not currently read) to keep the
 /// session open for the lifetime of the `EngineData`.
-struct HsmContext {
+struct HsmEngineContext {
     #[allow(dead_code)]
     partition: HsmPartition,
     #[allow(dead_code)]
     session: HsmSession,
 }
 
-impl HsmContext {
+impl HsmEngineContext {
     fn open(settings: ResiliencySettings, creds: HsmCredentials) -> EngineResult<Self> {
         let info = HsmPartitionManager::partition_info_list()
             .into_iter()
@@ -152,35 +154,7 @@ impl HsmContext {
         match first {
             Ok(()) => {}
             Err(HsmError::Bk3AlreadyInitialized) if caller_obk => {
-                let mobk = Zeroizing::new(
-                    FileMobkCallback::new(settings.mobk_path.clone())
-                        .get_mobk()
-                        .map_err(|e| {
-                            EngineError::wrap(
-                                format!(
-                                    "device reports BK3 already initialized but cached MOBK \
-                                     '{}' is unusable — restore it or reset/power-cycle the \
-                                     device",
-                                    settings.mobk_path.display()
-                                ),
-                                e,
-                            )
-                        })?,
-                );
-                let obk_config = HsmOwnerBackupKeyConfig::new(
-                    HsmOwnerBackupKeySource::Caller,
-                    HsmOwnerBackupKey::from_masked_key(mobk.as_slice()),
-                );
-                partition
-                    .init(
-                        creds,
-                        None,
-                        None,
-                        obk_config,
-                        pota,
-                        build_resiliency_config(&settings)?,
-                    )
-                    .map_err(|e| EngineError::wrap("partition init (MOBK retry)", e))?;
+                reinit_with_cached_mobk(&partition, creds, &settings, pota)?;
             }
             Err(e) => return Err(EngineError::wrap("partition init", e)),
         }
@@ -212,6 +186,46 @@ impl HsmContext {
     }
 }
 
+/// Warm-device re-init: the plaintext OBK was rejected with
+/// `Bk3AlreadyInitialized`, so re-init from the MOBK a previous cold init
+/// persisted at `settings.mobk_path`. Caller-OBK source only.
+fn reinit_with_cached_mobk(
+    partition: &HsmPartition,
+    creds: HsmCredentials,
+    settings: &ResiliencySettings,
+    pota: HsmPotaEndorsement,
+) -> EngineResult<()> {
+    let mobk = Zeroizing::new(
+        FileMobkCallback::new(settings.mobk_path.clone())
+            .get_mobk()
+            .map_err(|e| {
+                EngineError::wrap(
+                    format!(
+                        "device reports BK3 already initialized but cached MOBK \
+                         '{}' is unusable — restore it or reset/power-cycle the \
+                         device",
+                        settings.mobk_path.display()
+                    ),
+                    e,
+                )
+            })?,
+    );
+    let obk_config = HsmOwnerBackupKeyConfig::new(
+        HsmOwnerBackupKeySource::Caller,
+        HsmOwnerBackupKey::from_masked_key(mobk.as_slice()),
+    );
+    partition
+        .init(
+            creds,
+            None,
+            None,
+            obk_config,
+            pota,
+            build_resiliency_config(settings)?,
+        )
+        .map_err(|e| EngineError::wrap("partition init (MOBK retry)", e))
+}
+
 /// Persist key material to `path` durably: write a `0600` temp file, flush it,
 /// then atomically rename into place, so a torn write can't leave a corrupt
 /// MOBK that would break a later warm re-init.
@@ -239,7 +253,7 @@ fn persist_secret_file(path: &Path, bytes: &[u8]) -> std::io::Result<()> {
     let mut f = std::fs::OpenOptions::new()
         .create_new(true)
         .write(true)
-        .mode(0o600)
+        .mode(SECRET_FILE_MODE)
         .custom_flags(libc::O_NOFOLLOW | libc::O_CLOEXEC)
         .open(&tmp)?;
 
@@ -312,7 +326,7 @@ fn build_pota_endorsement(
 
 /// Build the OBK config for the *first* `partition.init` attempt: Caller
 /// source supplies the plaintext OBK (which runs `init_bk3`); Tpm supplies an
-/// empty key. The warm-device MOBK retry is handled in [`HsmContext::open`].
+/// empty key. The warm-device MOBK retry is handled in [`HsmEngineContext::open`].
 fn build_obk_config(settings: &ResiliencySettings) -> EngineResult<HsmOwnerBackupKeyConfig> {
     match settings.obk_source {
         HsmOwnerBackupKeySource::Caller => {

--- a/plugins/ossl_engine/engine/src/context.rs
+++ b/plugins/ossl_engine/engine/src/context.rs
@@ -531,3 +531,36 @@ mod tests {
         assert_eq!(got, def);
     }
 }
+
+/// Hardware smoke test. Drives the full device open (`open_hsm_from_env`:
+/// partition open → init → session) using the ambient `AZIHSM_*` environment,
+/// so a real HSM host can validate a configuration end to end — e.g. the TPM
+/// OBK/POTA sources, which the mock cannot exercise.
+///
+/// Compiled only in non-mock builds and `#[ignore]`d, so it never runs in the
+/// normal (mock) CI cell — invoke it explicitly on a provisioned host:
+///
+/// ```text
+/// export AZIHSM_CREDENTIALS_ID=<32 hex>  AZIHSM_CREDENTIALS_PIN=<32 hex>
+/// export AZIHSM_RESILIENCY_ENABLED=1        # required, else OBK/POTA source is ignored
+/// export AZIHSM_OBK_SOURCE=tpm  AZIHSM_POTA_SOURCE=tpm
+/// export AZIHSM_RESILIENCY_STORAGE_DIR=/run/azihsm/resiliency   # mode 0700
+/// umask 0077
+/// cargo test -p azihsm_engine --features engine open_from_env_smoke -- --ignored --nocapture
+/// ```
+#[cfg(all(test, not(feature = "mock")))]
+mod hw_tests {
+    use super::*;
+
+    #[test]
+    #[ignore = "requires a provisioned HSM host; configure AZIHSM_* env first"]
+    fn open_from_env_smoke() -> EngineResult<()> {
+        let data = EngineData::new();
+        data.open_hsm_from_env()?;
+        assert!(
+            data.is_hsm_open(),
+            "HSM should be open after open_hsm_from_env"
+        );
+        Ok(())
+    }
+}

--- a/plugins/ossl_engine/engine/src/context.rs
+++ b/plugins/ossl_engine/engine/src/context.rs
@@ -3,8 +3,8 @@
 
 //! Engine context parked in `ENGINE` ex_data.
 //!
-//! [`EngineData`] is the per-engine state OpenSSL will hand back to every
-//! algorithm callback via `ENGINE_get_ex_data`. It owns one lazily-populated
+//! [`EngineData`] is the per-engine state stored in the `ENGINE`'s ex_data
+//! and retrieved via `ENGINE_get_ex_data`. It owns one lazily-populated
 //! [`HsmContext`] (partition + session).
 
 use std::path::Path;
@@ -98,9 +98,9 @@ impl EngineData {
 
 /// Live HSM partition + session.
 ///
-/// Both fields are RAII holders: they are never read, but dropping them
-/// closes the session and releases the partition. Later algorithm
-/// callbacks will read `session` to issue crypto operations.
+/// Both fields are RAII holders: dropping them closes the session and
+/// releases the partition. They are held (not currently read) to keep the
+/// session open for the lifetime of the `EngineData`.
 struct HsmContext {
     #[allow(dead_code)]
     partition: HsmPartition,
@@ -516,8 +516,8 @@ mod tests {
         );
     }
 
-    // SEC-4: an unset credential with no default must be a hard error, not a
-    // silent fallback. (In production builds cred_field is called with None.)
+    // An unset credential with no default must be a hard error, not a silent
+    // fallback. (In production builds cred_field is called with None.)
     #[test]
     fn cred_field_missing_without_default_errors() {
         let r = cred_field("AZIHSM_CRED_FIELD_DEFINITELY_UNSET_XYZ", None);

--- a/plugins/ossl_engine/engine/src/context.rs
+++ b/plugins/ossl_engine/engine/src/context.rs
@@ -1,0 +1,533 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Engine context parked in `ENGINE` ex_data.
+//!
+//! [`EngineData`] is the per-engine state OpenSSL will hand back to every
+//! algorithm callback via `ENGINE_get_ex_data`. It owns one lazily-populated
+//! [`HsmContext`] (partition + session).
+
+use std::path::Path;
+
+use azihsm_api::HsmCredentials;
+use azihsm_api::HsmError;
+use azihsm_api::HsmOwnerBackupKey;
+use azihsm_api::HsmOwnerBackupKeyConfig;
+use azihsm_api::HsmOwnerBackupKeySource;
+use azihsm_api::HsmPartition;
+use azihsm_api::HsmPartitionManager;
+use azihsm_api::HsmPotaEndorsement;
+use azihsm_api::HsmPotaEndorsementData;
+use azihsm_api::HsmPotaEndorsementSource;
+use azihsm_api::HsmSession;
+use azihsm_api::MobkProviderCallback;
+use azihsm_api::PotaEndorsementCallback;
+use engine_resiliency::FileMobkCallback;
+use engine_resiliency::FilePotaCallback;
+use engine_resiliency::ResiliencySettings;
+use openssl_engine::error::EngineError;
+use openssl_engine::error::EngineResult;
+use parking_lot::Mutex;
+use zeroize::Zeroize;
+use zeroize::Zeroizing;
+
+/// Test-only credentials. Match the values used throughout the API test
+/// suite (`api/tests/src/utils/partition.rs`), so the mock DDI accepts
+/// the engine out of the box. Compiled in **only** for `mock` builds: a
+/// production build has no default, so an unset `AZIHSM_CREDENTIALS_*` is a
+/// hard error rather than a silent authentication with a well-known PIN.
+#[cfg(feature = "mock")]
+const DEFAULT_CRED_ID: [u8; 16] = [1u8; 16];
+#[cfg(feature = "mock")]
+const DEFAULT_CRED_PIN: [u8; 16] = [2u8; 16];
+
+const ENV_CREDENTIALS_ID: &str = "AZIHSM_CREDENTIALS_ID";
+const ENV_CREDENTIALS_PIN: &str = "AZIHSM_CREDENTIALS_PIN";
+
+/// Per-engine state stored in `ENGINE` ex_data.
+pub struct EngineData {
+    hsm: Mutex<Option<HsmContext>>,
+}
+
+impl Default for EngineData {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl EngineData {
+    pub fn new() -> Self {
+        Self {
+            hsm: Mutex::new(None),
+        }
+    }
+
+    /// True once an `HsmContext` has been installed via `open_hsm_*`.
+    pub fn is_hsm_open(&self) -> bool {
+        self.hsm.lock().is_some()
+    }
+
+    /// Open the HSM using `settings` (already parsed) and `creds`.
+    /// Idempotent: subsequent calls return `Ok(())` without re-opening.
+    ///
+    /// The lock is held across `HsmContext::open` so concurrent first-use
+    /// callers serialize on the open instead of racing two sessions open
+    /// and discarding one.
+    pub fn open_hsm_with(
+        &self,
+        settings: ResiliencySettings,
+        creds: HsmCredentials,
+    ) -> EngineResult<()> {
+        let mut guard = self.hsm.lock();
+        if guard.is_some() {
+            return Ok(());
+        }
+        *guard = Some(HsmContext::open(settings, creds)?);
+        Ok(())
+    }
+
+    /// Open the HSM by reading settings + credentials from the process
+    /// environment.
+    pub fn open_hsm_from_env(&self) -> EngineResult<()> {
+        let settings = ResiliencySettings::from_env()
+            .map_err(|e| EngineError::wrap("resiliency settings", e))?;
+        let creds = credentials_from_env()?;
+        self.open_hsm_with(settings, creds)
+    }
+}
+
+/// Live HSM partition + session.
+///
+/// Both fields are RAII holders: they are never read, but dropping them
+/// closes the session and releases the partition. Later algorithm
+/// callbacks will read `session` to issue crypto operations.
+struct HsmContext {
+    #[allow(dead_code)]
+    partition: HsmPartition,
+    #[allow(dead_code)]
+    session: HsmSession,
+}
+
+impl HsmContext {
+    fn open(settings: ResiliencySettings, creds: HsmCredentials) -> EngineResult<Self> {
+        let info = HsmPartitionManager::partition_info_list()
+            .into_iter()
+            .next()
+            .ok_or_else(|| EngineError::Other("no HSM partitions found".into()))?;
+
+        let api_rev_range = info
+            .api_rev_range
+            .ok_or_else(|| EngineError::Other(format!("partition {} has no API rev", info.path)))?;
+        let api_rev = api_rev_range.max();
+
+        let partition = HsmPartitionManager::open_partition(&info.path, api_rev)
+            .map_err(|e| EngineError::wrap(format!("open_partition({})", info.path), e))?;
+
+        // With resiliency off the SDK wants a clean partition. reset() is a
+        // no-op on a freshly opened one and does NOT clear BK3 (one-shot per
+        // power cycle) — the warm-device case is handled by the OBK→MOBK
+        // fallback below.
+        if !settings.enabled {
+            partition
+                .reset()
+                .map_err(|e| EngineError::wrap("partition reset", e))?;
+        }
+
+        // Mirror the provider (azihsm_ossl_hsm.c): always attempt init with
+        // the plaintext OBK first. On a cold device `init_bk3` runs and
+        // derives a fresh MOBK; on a warm device the SDK returns
+        // Bk3AlreadyInitialized and we retry with the MOBK a previous init
+        // persisted.
+        let caller_obk = matches!(settings.obk_source, HsmOwnerBackupKeySource::Caller);
+        let pota = build_pota_endorsement(&partition, &settings)?;
+        let first = partition.init(
+            creds,
+            None,
+            None,
+            build_obk_config(&settings)?,
+            pota.clone(),
+            build_resiliency_config(&settings)?,
+        );
+
+        match first {
+            Ok(()) => {}
+            Err(HsmError::Bk3AlreadyInitialized) if caller_obk => {
+                let mobk = Zeroizing::new(
+                    FileMobkCallback::new(settings.mobk_path.clone())
+                        .get_mobk()
+                        .map_err(|e| {
+                            EngineError::wrap(
+                                format!(
+                                    "device reports BK3 already initialized but cached MOBK \
+                                     '{}' is unusable — restore it or reset/power-cycle the \
+                                     device",
+                                    settings.mobk_path.display()
+                                ),
+                                e,
+                            )
+                        })?,
+                );
+                let obk_config = HsmOwnerBackupKeyConfig::new(
+                    HsmOwnerBackupKeySource::Caller,
+                    HsmOwnerBackupKey::from_masked_key(mobk.as_slice()),
+                );
+                partition
+                    .init(
+                        creds,
+                        None,
+                        None,
+                        obk_config,
+                        pota,
+                        build_resiliency_config(&settings)?,
+                    )
+                    .map_err(|e| EngineError::wrap("partition init (MOBK retry)", e))?;
+            }
+            Err(e) => return Err(EngineError::wrap("partition init", e)),
+        }
+
+        // Persist the device's MOBK so a later warm re-init can recover
+        // (mirrors the provider). `mobk_vec()` is populated only when this
+        // init actually derived the MOBK — the cold-device `init_bk3` path.
+        // On a warm re-init the SDK reports credentials already established
+        // and returns no MOBK; the file persisted by the original cold init
+        // is still valid, so there is nothing new to write. Caller source
+        // only; TPM re-derives the MOBK each init.
+        if caller_obk {
+            let mobk = Zeroizing::new(partition.mobk_vec());
+            if !mobk.is_empty() {
+                persist_secret_file(&settings.mobk_path, mobk.as_slice()).map_err(|e| {
+                    EngineError::wrap(
+                        format!("persist MOBK to '{}'", settings.mobk_path.display()),
+                        e,
+                    )
+                })?;
+            }
+        }
+
+        let session = partition
+            .open_session(api_rev, &creds, None)
+            .map_err(|e| EngineError::wrap("open_session", e))?;
+
+        Ok(Self { partition, session })
+    }
+}
+
+/// Persist key material to `path` durably: write a `0600` temp file, flush it,
+/// then atomically rename into place, so a torn write can't leave a corrupt
+/// MOBK that would break a later warm re-init.
+fn persist_secret_file(path: &Path, bytes: &[u8]) -> std::io::Result<()> {
+    use std::io::Write;
+    use std::os::unix::fs::OpenOptionsExt;
+    use std::sync::atomic::AtomicU64;
+    use std::sync::atomic::Ordering;
+
+    // PID plus a per-call counter, so two engines in one process writing the
+    // same target path can't collide on the temp name.
+    static SEQ: AtomicU64 = AtomicU64::new(0);
+    let seq = SEQ.fetch_add(1, Ordering::Relaxed);
+    let mut tmp_name = path
+        .file_name()
+        .ok_or_else(|| std::io::Error::new(std::io::ErrorKind::InvalidInput, "no file name"))?
+        .to_os_string();
+    tmp_name.push(format!(".tmp.{}.{seq}", std::process::id()));
+    let tmp = path.with_file_name(tmp_name);
+
+    // On any failure remove the temp so a partial copy of key material is not
+    // left behind.
+    let write = || -> std::io::Result<()> {
+        let mut f = std::fs::OpenOptions::new()
+            .create(true)
+            .write(true)
+            .truncate(true)
+            .mode(0o600)
+            .custom_flags(libc::O_NOFOLLOW | libc::O_CLOEXEC)
+            .open(&tmp)?;
+        f.write_all(bytes)?;
+        f.sync_all()?;
+        std::fs::rename(&tmp, path)
+    };
+    if let Err(e) = write() {
+        let _ = std::fs::remove_file(&tmp);
+        return Err(e);
+    }
+
+    // fsync the directory so the rename itself survives a crash.
+    if let Some(dir) = path.parent().filter(|d| !d.as_os_str().is_empty()) {
+        if let Ok(d) = std::fs::File::open(dir) {
+            let _ = d.sync_all();
+        }
+    }
+    Ok(())
+}
+
+/// Assemble the resiliency config for one `partition.init` attempt.
+///
+/// `HsmResiliencyConfig` is consumed by `init` and holds non-`Clone` callback
+/// boxes, so each attempt rebuilds it from a `settings` clone.
+fn build_resiliency_config(
+    settings: &ResiliencySettings,
+) -> EngineResult<Option<azihsm_api::HsmResiliencyConfig>> {
+    settings
+        .clone()
+        .into_resiliency_config()
+        .map_err(|e| EngineError::wrap("resiliency config", e))
+}
+
+/// Build the initial POTA endorsement OpenSSL hands to `partition.init`.
+/// When source is `Caller` we use [`FilePotaCallback`] to sign the
+/// partition's PID public key; when source is `Tpm` we pass `None`.
+fn build_pota_endorsement(
+    partition: &HsmPartition,
+    settings: &ResiliencySettings,
+) -> EngineResult<HsmPotaEndorsement> {
+    match settings.pota_source {
+        HsmPotaEndorsementSource::Caller => {
+            let priv_path = settings.pota_priv_path.clone().ok_or_else(|| {
+                EngineError::Other(
+                    "AZIHSM_POTA_PRIVATE_KEY_PATH is required for caller POTA".into(),
+                )
+            })?;
+            let pub_path = settings.pota_pub_path.clone().ok_or_else(|| {
+                EngineError::Other("AZIHSM_POTA_PUBLIC_KEY_PATH is required for caller POTA".into())
+            })?;
+            let pid_pub = partition
+                .pub_key()
+                .map_err(|e| EngineError::wrap("partition pub_key", e))?;
+            let cb = FilePotaCallback::new(priv_path, pub_path);
+            let data = cb
+                .endorse(&[], &pid_pub, &[])
+                .map_err(|e| EngineError::wrap("POTA endorse", e))?;
+            let endorsement = HsmPotaEndorsementData::new(data.signature(), data.pub_key());
+            Ok(HsmPotaEndorsement::new(
+                HsmPotaEndorsementSource::Caller,
+                Some(endorsement),
+            ))
+        }
+        _ => Ok(HsmPotaEndorsement::new(settings.pota_source, None)),
+    }
+}
+
+/// Build the OBK config for the *first* `partition.init` attempt: Caller
+/// source supplies the plaintext OBK (which runs `init_bk3`); Tpm supplies an
+/// empty key. The warm-device MOBK retry is handled in [`HsmContext::open`].
+fn build_obk_config(settings: &ResiliencySettings) -> EngineResult<HsmOwnerBackupKeyConfig> {
+    match settings.obk_source {
+        HsmOwnerBackupKeySource::Caller => {
+            // Plaintext OBK (BK3); our copy is scrubbed on drop.
+            let cb = FileMobkCallback::new(settings.obk_path.clone());
+            let obk = Zeroizing::new(
+                cb.get_mobk()
+                    .map_err(|e| EngineError::wrap("OBK load", e))?,
+            );
+            Ok(HsmOwnerBackupKeyConfig::new(
+                HsmOwnerBackupKeySource::Caller,
+                HsmOwnerBackupKey::from_obk(obk.as_slice()),
+            ))
+        }
+        _ => Ok(HsmOwnerBackupKeyConfig::new(
+            settings.obk_source,
+            HsmOwnerBackupKey::default(),
+        )),
+    }
+}
+
+fn credentials_from_env() -> EngineResult<HsmCredentials> {
+    // Defaults exist only in mock builds; a production build requires the
+    // env vars (see DEFAULT_CRED_* above).
+    #[cfg(feature = "mock")]
+    let (def_id, def_pin) = (Some(DEFAULT_CRED_ID), Some(DEFAULT_CRED_PIN));
+    #[cfg(not(feature = "mock"))]
+    let (def_id, def_pin): (Option<[u8; 16]>, Option<[u8; 16]>) = (None, None);
+
+    let mut id = cred_field(ENV_CREDENTIALS_ID, def_id)?;
+    let mut pin = cred_field(ENV_CREDENTIALS_PIN, def_pin)?;
+    let creds = HsmCredentials::new(&id, &pin);
+    // Scrub our decoded copies; HsmCredentials holds its own.
+    id.zeroize();
+    pin.zeroize();
+    Ok(creds)
+}
+
+/// Read a 16-byte credential from `var` (32 hex chars). Falls back to
+/// `default` when the var is unset; in non-mock builds `default` is `None`,
+/// so a missing credential is a hard error rather than a silent well-known PIN.
+fn cred_field(var: &'static str, default: Option<[u8; 16]>) -> EngineResult<[u8; 16]> {
+    match std::env::var(var) {
+        Ok(s) => {
+            // The source hex string holds the secret; scrub it on drop.
+            let s = Zeroizing::new(s);
+            hex_decode_16(&s, var)
+        }
+        // Only a truly-unset var falls back to the default; a present but
+        // non-UTF-8 value is an error, not "unset".
+        Err(std::env::VarError::NotPresent) => {
+            default.ok_or_else(|| EngineError::Other(format!("{var} must be set (32 hex chars)")))
+        }
+        Err(std::env::VarError::NotUnicode(_)) => {
+            Err(EngineError::Other(format!("{var} is not valid UTF-8")))
+        }
+    }
+}
+
+fn hex_decode_16(s: &str, var: &'static str) -> EngineResult<[u8; 16]> {
+    if s.len() != 32 {
+        return Err(EngineError::Other(format!(
+            "{var} must be 32 hex chars (16 bytes), got {}",
+            s.len()
+        )));
+    }
+    let mut out = [0u8; 16];
+    for (dst, pair) in out.iter_mut().zip(s.as_bytes().chunks_exact(2)) {
+        let pair_str = std::str::from_utf8(pair)
+            .map_err(|_| EngineError::Other(format!("{var} has non-ASCII byte")))?;
+        *dst = u8::from_str_radix(pair_str, 16)
+            .map_err(|_| EngineError::Other(format!("{var} has non-hex byte")))?;
+    }
+    Ok(out)
+}
+
+#[cfg(all(test, feature = "mock"))]
+mod tests {
+    #![allow(clippy::unwrap_used)]
+
+    use std::fs;
+    use std::path::PathBuf;
+    use std::sync::atomic::AtomicU64;
+    use std::sync::atomic::Ordering;
+
+    use openssl::ec::EcGroup;
+    use openssl::ec::EcKey;
+    use openssl::nid::Nid;
+    use openssl::pkey::PKey;
+    use serial_test::serial;
+
+    use super::*;
+
+    /// Shared per-process MOBK path. The mock device's BK3 is global to the
+    /// process: the first test establishes it (plaintext OBK) and the engine
+    /// persists the MOBK here; later tests re-init from that MOBK (re-running
+    /// init_bk3 fails). Shared across tests so the second open sees the first
+    /// open's persisted MOBK.
+    fn shared_mobk_path() -> PathBuf {
+        std::env::temp_dir().join(format!("engine-test-mobk-{}.bin", std::process::id()))
+    }
+
+    struct Scratch(PathBuf);
+    impl Scratch {
+        fn new(tag: &str) -> Self {
+            static N: AtomicU64 = AtomicU64::new(0);
+            let n = N.fetch_add(1, Ordering::SeqCst);
+            let pid = std::process::id();
+            let dir = std::env::temp_dir().join(format!("engine-ctx-{tag}-{pid}-{n}"));
+            fs::create_dir_all(&dir).unwrap();
+            Self(dir)
+        }
+    }
+    impl Drop for Scratch {
+        fn drop(&mut self) {
+            let _ = fs::remove_dir_all(&self.0);
+        }
+    }
+
+    /// Materialize a fresh P-384 key pair on disk + a 48-byte OBK, return
+    /// settings pointing at them with resiliency enabled.
+    fn caller_settings(scratch: &Scratch) -> ResiliencySettings {
+        let group = EcGroup::from_curve_name(Nid::SECP384R1).unwrap();
+        let ec = EcKey::generate(&group).unwrap();
+        let pkey = PKey::from_ec_key(ec).unwrap();
+        // PKCS#8: FilePotaCallback signs via azihsm_crypto, which accepts only
+        // that private-key format.
+        let priv_der = pkey.private_key_to_pkcs8().unwrap();
+        let pub_der = pkey.public_key_to_der().unwrap();
+
+        let priv_path = scratch.0.join("pota_priv.der");
+        let pub_path = scratch.0.join("pota_pub.der");
+        let obk_path = scratch.0.join("obk.bin");
+        fs::write(&priv_path, &priv_der).unwrap();
+        fs::write(&pub_path, &pub_der).unwrap();
+        fs::write(&obk_path, vec![0u8; 48]).unwrap();
+
+        ResiliencySettings {
+            enabled: true,
+            storage_dir: scratch.0.join("res"),
+            obk_source: HsmOwnerBackupKeySource::Caller,
+            obk_path,
+            mobk_path: shared_mobk_path(),
+            pota_source: HsmPotaEndorsementSource::Caller,
+            pota_priv_path: Some(priv_path),
+            pota_pub_path: Some(pub_path),
+        }
+    }
+
+    // `#[serial]`: these share the process-global mock device (BK3 state),
+    // so they must not run concurrently.
+    #[test]
+    #[serial]
+    fn open_hsm_with_resiliency_succeeds() {
+        let scratch = Scratch::new("open");
+        fs::create_dir_all(scratch.0.join("res")).unwrap();
+
+        let settings = caller_settings(&scratch);
+        let creds = HsmCredentials::new(&DEFAULT_CRED_ID, &DEFAULT_CRED_PIN);
+
+        let data = EngineData::new();
+        assert!(!data.is_hsm_open());
+        data.open_hsm_with(settings, creds).unwrap();
+        assert!(data.is_hsm_open());
+    }
+
+    #[test]
+    #[serial]
+    fn open_hsm_is_idempotent() {
+        let scratch = Scratch::new("idem");
+        fs::create_dir_all(scratch.0.join("res")).unwrap();
+
+        let data = EngineData::new();
+        let creds = HsmCredentials::new(&DEFAULT_CRED_ID, &DEFAULT_CRED_PIN);
+
+        data.open_hsm_with(
+            caller_settings(&scratch),
+            HsmCredentials::new(&DEFAULT_CRED_ID, &DEFAULT_CRED_PIN),
+        )
+        .unwrap();
+        // Second call must not panic, must not re-open, must succeed.
+        data.open_hsm_with(caller_settings(&scratch), creds)
+            .unwrap();
+        assert!(data.is_hsm_open());
+    }
+
+    #[test]
+    fn hex_decode_rejects_wrong_length() {
+        assert!(hex_decode_16("abcd", "X").is_err());
+    }
+
+    #[test]
+    fn hex_decode_rejects_non_hex() {
+        let s = "g".repeat(32);
+        assert!(hex_decode_16(&s, "X").is_err());
+    }
+
+    #[test]
+    fn hex_decode_round_trip() {
+        let s = "000102030405060708090a0b0c0d0e0f";
+        assert_eq!(
+            hex_decode_16(s, "X").unwrap(),
+            [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]
+        );
+    }
+
+    // SEC-4: an unset credential with no default must be a hard error, not a
+    // silent fallback. (In production builds cred_field is called with None.)
+    #[test]
+    fn cred_field_missing_without_default_errors() {
+        let r = cred_field("AZIHSM_CRED_FIELD_DEFINITELY_UNSET_XYZ", None);
+        assert!(matches!(r, Err(EngineError::Other(_))));
+    }
+
+    #[test]
+    fn cred_field_missing_with_default_uses_default() {
+        let def = [7u8; 16];
+        let got = cred_field("AZIHSM_CRED_FIELD_DEFINITELY_UNSET_XYZ", Some(def)).unwrap();
+        assert_eq!(got, def);
+    }
+}

--- a/plugins/ossl_engine/engine/src/context.rs
+++ b/plugins/ossl_engine/engine/src/context.rs
@@ -544,7 +544,10 @@ mod tests {
 /// export AZIHSM_CREDENTIALS_ID=<32 hex>  AZIHSM_CREDENTIALS_PIN=<32 hex>
 /// export AZIHSM_RESILIENCY_ENABLED=1        # required, else OBK/POTA source is ignored
 /// export AZIHSM_OBK_SOURCE=tpm  AZIHSM_POTA_SOURCE=tpm
-/// export AZIHSM_RESILIENCY_STORAGE_DIR=/run/azihsm/resiliency   # mode 0700
+/// # Storage dir must already exist, be mode 0700, and be owned by you. The
+/// # default is /var/lib/azihsm/resiliency; create it once (override with
+/// # AZIHSM_RESILIENCY_STORAGE_DIR to use e.g. a path under $HOME):
+/// sudo install -d -m 700 -o "$USER" /var/lib/azihsm/resiliency
 /// umask 0077
 /// cargo test -p azihsm_engine --features engine open_from_env_smoke -- --ignored --nocapture
 /// ```

--- a/plugins/ossl_engine/engine/src/context.rs
+++ b/plugins/ossl_engine/engine/src/context.rs
@@ -468,8 +468,9 @@ mod tests {
     #[serial]
     fn open_hsm_with_resiliency_succeeds() {
         let scratch = Scratch::new("open");
-        fs::create_dir_all(scratch.0.join("res")).unwrap();
-
+        // The storage dir is created by the open path (setup_storage_dir) with
+        // mode 0700; pre-creating it here would inherit the umask and could be
+        // rejected, so leave it to the open path to stay umask-independent.
         let settings = caller_settings(&scratch);
         let creds = HsmCredentials::new(&DEFAULT_CRED_ID, &DEFAULT_CRED_PIN);
 
@@ -483,8 +484,8 @@ mod tests {
     #[serial]
     fn open_hsm_is_idempotent() {
         let scratch = Scratch::new("idem");
-        fs::create_dir_all(scratch.0.join("res")).unwrap();
-
+        // See open_hsm_with_resiliency_succeeds: let the open path create the
+        // storage dir at 0700 rather than depending on the umask here.
         let data = EngineData::new();
         let creds = HsmCredentials::new(&DEFAULT_CRED_ID, &DEFAULT_CRED_PIN);
 

--- a/plugins/ossl_engine/engine/src/lib.rs
+++ b/plugins/ossl_engine/engine/src/lib.rs
@@ -10,6 +10,12 @@
 
 //! Azure Integrated HSM -- OpenSSL 1.1.x Engine. Linux only.
 
+/// File mode for secret material the engine writes (the cached MOBK and the
+/// log file): owner read/write only, no group/other. Mirrors the provider's
+/// 0600 hardening.
+#[cfg(all(target_os = "linux", feature = "engine"))]
+pub(crate) const SECRET_FILE_MODE: u32 = 0o600;
+
 // `context` is `pub` so the engine's HSM-open API (EngineData and its
 // open_hsm_* methods) is public crate API rather than dead code. The cdylib
 // entry point (`bind_helper`) constructs an EngineData and parks it in the

--- a/plugins/ossl_engine/engine/src/lib.rs
+++ b/plugins/ossl_engine/engine/src/lib.rs
@@ -10,23 +10,74 @@
 
 //! Azure Integrated HSM -- OpenSSL 1.1.x Engine. Linux only.
 
+// `context` is `pub` so the engine's HSM-open API (EngineData and its
+// open_hsm_* methods) counts as reachable crate API rather than dead code.
+// The cdylib glue only calls EngineData::new today; the open path is wired
+// by later algorithm callbacks.
+#[cfg(all(target_os = "linux", feature = "engine"))]
+pub mod context;
+
+#[cfg(all(target_os = "linux", feature = "engine"))]
+mod logging;
+
 #[cfg(all(target_os = "linux", feature = "engine"))]
 mod engine_impl {
     use std::ffi::CStr;
     use std::ffi::c_int;
     use std::ffi::c_ulong;
     use std::ptr::NonNull;
+    use std::sync::OnceLock;
 
+    use openssl_engine::engine::DestroyHandler;
     use openssl_engine::engine::Engine;
     use openssl_engine::error::EngineError;
     use openssl_engine::error::EngineResult;
     use openssl_engine::error::RetCode;
     use openssl_engine::error::catch_panic;
     use openssl_engine::error::result_to_int;
+    use openssl_engine::exdata::EngineExData;
     use openssl_engine::ffi;
+    use parking_lot::Mutex;
+
+    use crate::context::EngineData;
+    use crate::logging;
 
     const ENGINE_ID: &CStr = c"azihsm";
     const ENGINE_NAME: &CStr = c"Azure Integrated HSM Engine";
+
+    /// Process-global cached ex_data slot for `EngineData`.
+    /// `CRYPTO_get_ex_new_index` does not dedupe, so we register at most once.
+    static ENGINE_DATA_SLOT: OnceLock<EngineExData<EngineData>> = OnceLock::new();
+
+    fn engine_data_slot() -> EngineResult<EngineExData<EngineData>> {
+        if let Some(slot) = ENGINE_DATA_SLOT.get() {
+            return Ok(*slot);
+        }
+        // Serialize registration so two concurrent binds can't each allocate an
+        // ex_data index (OpenSSL never dedupes them).
+        static INIT: Mutex<()> = Mutex::new(());
+        let _guard = INIT.lock();
+        if let Some(slot) = ENGINE_DATA_SLOT.get() {
+            return Ok(*slot);
+        }
+        let slot = EngineExData::<EngineData>::register()?;
+        let _ = ENGINE_DATA_SLOT.set(slot);
+        Ok(slot)
+    }
+
+    struct AzihsmDestroy;
+    impl DestroyHandler for AzihsmDestroy {
+        fn destroy(engine: &mut Engine) -> EngineResult<()> {
+            // The ex_data slot has no auto-free callback (see exdata.rs module
+            // docs); the destroy handler drops the Box. Use the already-cached
+            // slot: if it was never registered there is nothing to clear, and
+            // registering one here would just leak an index.
+            if let Some(slot) = ENGINE_DATA_SLOT.get() {
+                slot.take(engine)?;
+            }
+            Ok(())
+        }
+    }
 
     #[unsafe(no_mangle)]
     #[allow(unsafe_code)]
@@ -93,9 +144,23 @@ mod engine_impl {
             return Err(EngineError::IdMismatch);
         }
 
+        // Best-effort logging install. A misconfigured AZIHSM_ENGINE_LOG_FILE
+        // surfaces as an error here; everything else is silently ignored
+        // (already-installed subscriber is fine).
+        logging::install_from_env()?;
+
         engine.set_id(ENGINE_ID)?;
         engine.set_name(ENGINE_NAME)?;
+        engine.set_destroy::<AzihsmDestroy>()?;
 
+        // Park an empty EngineData. The HSM session opens on demand (later
+        // algorithm callbacks will call EngineData::open_hsm_from_env on
+        // first use); AzihsmDestroy::destroy takes() and drops the Box at
+        // ENGINE_free time.
+        let slot = engine_data_slot()?;
+        slot.set(engine, Box::new(EngineData::new()))?;
+
+        tracing::info!(target: "azihsm", "azihsm engine bound");
         Ok(())
     }
 }

--- a/plugins/ossl_engine/engine/src/lib.rs
+++ b/plugins/ossl_engine/engine/src/lib.rs
@@ -11,9 +11,9 @@
 //! Azure Integrated HSM -- OpenSSL 1.1.x Engine. Linux only.
 
 // `context` is `pub` so the engine's HSM-open API (EngineData and its
-// open_hsm_* methods) counts as reachable crate API rather than dead code.
-// The cdylib glue only calls EngineData::new today; the open path is wired
-// by later algorithm callbacks.
+// open_hsm_* methods) is public crate API rather than dead code. The cdylib
+// entry point (`bind_helper`) constructs an EngineData and parks it in the
+// ENGINE's ex_data.
 #[cfg(all(target_os = "linux", feature = "engine"))]
 pub mod context;
 
@@ -153,10 +153,9 @@ mod engine_impl {
         engine.set_name(ENGINE_NAME)?;
         engine.set_destroy::<AzihsmDestroy>()?;
 
-        // Park an empty EngineData. The HSM session opens on demand (later
-        // algorithm callbacks will call EngineData::open_hsm_from_env on
-        // first use); AzihsmDestroy::destroy takes() and drops the Box at
-        // ENGINE_free time.
+        // Park an empty EngineData. Its HSM session is opened on demand via
+        // EngineData::open_hsm_from_env; AzihsmDestroy::destroy takes() and
+        // drops the Box at ENGINE_free time.
         let slot = engine_data_slot()?;
         slot.set(engine, Box::new(EngineData::new()))?;
 

--- a/plugins/ossl_engine/engine/src/logging.rs
+++ b/plugins/ossl_engine/engine/src/logging.rs
@@ -39,6 +39,8 @@ use tracing_subscriber::Layer;
 use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::util::SubscriberInitExt;
 
+use crate::SECRET_FILE_MODE;
+
 const ENV_LOG_STDERR: &str = "AZIHSM_ENGINE_LOG_STDERR";
 const ENV_LOG_FILE: &str = "AZIHSM_ENGINE_LOG_FILE";
 
@@ -132,7 +134,7 @@ fn open_file_layer(
     let file = OpenOptions::new()
         .create(true)
         .append(true)
-        .mode(0o600)
+        .mode(SECRET_FILE_MODE)
         .custom_flags(libc::O_NOFOLLOW | libc::O_CLOEXEC)
         .open(path)
         .map_err(|e| EngineError::wrap(format!("AZIHSM_ENGINE_LOG_FILE {path:?}"), e))?;
@@ -150,7 +152,7 @@ fn open_file_layer(
             "AZIHSM_ENGINE_LOG_FILE {path:?} is not a regular file"
         )));
     }
-    if meta.mode() & 0o777 != 0o600 {
+    if meta.mode() & 0o777 != SECRET_FILE_MODE {
         return Err(EngineError::Other(format!(
             "AZIHSM_ENGINE_LOG_FILE {path:?} has insecure permissions \
              (must be owner-only, mode 0600)"

--- a/plugins/ossl_engine/engine/src/logging.rs
+++ b/plugins/ossl_engine/engine/src/logging.rs
@@ -136,11 +136,15 @@ fn open_file_layer(
     Box<dyn Layer<tracing_subscriber::Registry> + Send + Sync + 'static>,
     WorkerGuard,
 )> {
+    // O_NONBLOCK so opening a FIFO at `path` can't block waiting for a reader
+    // before the is_file() check below runs (it fails fast / is then rejected);
+    // a no-op for a regular file. Mirrors read_regular_hardened in
+    // engine-resiliency.
     let file = OpenOptions::new()
         .create(true)
         .append(true)
         .mode(SECRET_FILE_MODE)
-        .custom_flags(libc::O_NOFOLLOW | libc::O_CLOEXEC)
+        .custom_flags(libc::O_NOFOLLOW | libc::O_NONBLOCK | libc::O_CLOEXEC)
         .open(path)
         .map_err(|e| EngineError::wrap(format!("AZIHSM_ENGINE_LOG_FILE {path:?}"), e))?;
 
@@ -243,5 +247,18 @@ mod tests {
             r.is_err(),
             "a non-0600 (owner-exec) log file must be rejected"
         );
+    }
+
+    #[test]
+    fn install_rejects_non_regular_file() {
+        // A character device is not a regular file; the is_file() check must
+        // reject it. O_NONBLOCK also keeps a special file's open from hanging
+        // before that check runs. Uses /dev/null (opens without blocking),
+        // since creating a FIFO would need unsafe mkfifo.
+        let r = install(LogSettings {
+            stderr: false,
+            file: Some(PathBuf::from("/dev/null")),
+        });
+        assert!(r.is_err(), "a non-regular log file must be rejected");
     }
 }

--- a/plugins/ossl_engine/engine/src/logging.rs
+++ b/plugins/ossl_engine/engine/src/logging.rs
@@ -25,6 +25,7 @@
 
 use std::env;
 use std::fs::OpenOptions;
+use std::os::unix::fs::MetadataExt;
 use std::os::unix::fs::OpenOptionsExt;
 use std::path::Path;
 use std::path::PathBuf;
@@ -135,6 +136,26 @@ fn open_file_layer(
         .custom_flags(libc::O_NOFOLLOW | libc::O_CLOEXEC)
         .open(path)
         .map_err(|e| EngineError::wrap(format!("AZIHSM_ENGINE_LOG_FILE {path:?}"), e))?;
+
+    // O_NOFOLLOW already refuses a symlink at `path`. Also refuse a
+    // pre-existing non-regular file (fifo, device, …) or one accessible by
+    // group/other, so enabling logging can't append into an unexpected file
+    // type or leak events through a world-readable file.
+    let meta = file
+        .metadata()
+        .map_err(|e| EngineError::wrap(format!("stat AZIHSM_ENGINE_LOG_FILE {path:?}"), e))?;
+    if !meta.is_file() {
+        return Err(EngineError::Other(format!(
+            "AZIHSM_ENGINE_LOG_FILE {path:?} is not a regular file"
+        )));
+    }
+    if meta.mode() & 0o077 != 0 {
+        return Err(EngineError::Other(format!(
+            "AZIHSM_ENGINE_LOG_FILE {path:?} has insecure permissions \
+             (must be owner-only, mode 0600)"
+        )));
+    }
+
     let (writer, guard) = tracing_appender::non_blocking(file);
     let layer = tracing_subscriber::fmt::layer()
         .with_writer(writer)
@@ -170,5 +191,27 @@ mod tests {
             file: Some(PathBuf::from("/no/such/directory/engine.log")),
         };
         assert!(install(s).is_err());
+    }
+
+    #[test]
+    fn install_rejects_group_or_other_accessible_file() {
+        use std::os::unix::fs::PermissionsExt;
+
+        // A pre-existing log file readable by group/other must be rejected
+        // (checked before any subscriber is installed, so this stays hermetic).
+        let path = std::env::temp_dir().join(format!("engine-log-perm-{}.log", std::process::id()));
+        let _ = std::fs::remove_file(&path);
+        std::fs::write(&path, b"").unwrap();
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o644)).unwrap();
+
+        let r = install(LogSettings {
+            stderr: false,
+            file: Some(path.clone()),
+        });
+        let _ = std::fs::remove_file(&path);
+        assert!(
+            r.is_err(),
+            "group/other-accessible log file must be rejected"
+        );
     }
 }

--- a/plugins/ossl_engine/engine/src/logging.rs
+++ b/plugins/ossl_engine/engine/src/logging.rs
@@ -261,4 +261,37 @@ mod tests {
         });
         assert!(r.is_err(), "a non-regular log file must be rejected");
     }
+
+    #[test]
+    fn file_layer_actually_emits() {
+        use std::io::Read;
+
+        // Guards against the "compiles but silently drops the layers" failure
+        // mode: build the exact Vec<Box<dyn Layer>> stack install() composes,
+        // make it the *scoped* default (with_default, so we avoid the global
+        // one-shot try_init), emit an event, flush the appender, and assert the
+        // file actually received it.
+        let path = std::env::temp_dir().join(format!("engine-log-emit-{}.log", std::process::id()));
+        let _ = std::fs::remove_file(&path);
+
+        let (layer, guard) = open_file_layer(&path).unwrap();
+        let subscriber = tracing_subscriber::registry()
+            .with(vec![layer])
+            .with(EnvFilter::new("info"));
+        tracing::subscriber::with_default(subscriber, || {
+            tracing::info!(target: "azihsm", "canary-emit-check");
+        });
+        drop(guard); // flush the non-blocking appender's worker thread
+
+        let mut contents = String::new();
+        std::fs::File::open(&path)
+            .unwrap()
+            .read_to_string(&mut contents)
+            .unwrap();
+        let _ = std::fs::remove_file(&path);
+        assert!(
+            contents.contains("canary-emit-check"),
+            "the Vec-of-layers stack did not emit the event (silent drop?): {contents:?}"
+        );
+    }
 }

--- a/plugins/ossl_engine/engine/src/logging.rs
+++ b/plugins/ossl_engine/engine/src/logging.rs
@@ -1,0 +1,174 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Env-var-driven `tracing_subscriber` install.
+//!
+//! Two env vars gate logging:
+//!
+//! | Var                       | Effect                                              |
+//! |---------------------------|-----------------------------------------------------|
+//! | `AZIHSM_ENGINE_LOG_STDERR`| presence → emit formatted events to stderr          |
+//! | `AZIHSM_ENGINE_LOG_FILE`  | path → append formatted events to that file         |
+//!
+//! Level filtering comes from `RUST_LOG`; an unset or malformed value falls
+//! back to `info`.
+//!
+//! Both env vars unset → no subscriber is installed and engine code emits
+//! into the void (the current behavior).
+//!
+//! The subscriber is process-global: `set_global_default` is one-shot, so
+//! [`install_from_env`] uses `try_init` and yields to any subscriber the host
+//! (`openssl`, NGINX, …) already installed. The file sink's `WorkerGuard`
+//! (whose Drop stops the writer thread) therefore also lives in a process
+//! static, not per-engine `EngineData` — else the first `ENGINE_free` would
+//! stop logging for everyone.
+
+use std::env;
+use std::fs::OpenOptions;
+use std::os::unix::fs::OpenOptionsExt;
+use std::path::Path;
+use std::path::PathBuf;
+use std::sync::OnceLock;
+
+use openssl_engine::error::EngineError;
+use openssl_engine::error::EngineResult;
+use tracing_appender::non_blocking::WorkerGuard;
+use tracing_subscriber::EnvFilter;
+use tracing_subscriber::Layer;
+use tracing_subscriber::layer::SubscriberExt;
+use tracing_subscriber::util::SubscriberInitExt;
+
+const ENV_LOG_STDERR: &str = "AZIHSM_ENGINE_LOG_STDERR";
+const ENV_LOG_FILE: &str = "AZIHSM_ENGINE_LOG_FILE";
+
+/// Owns the non-blocking writer's worker thread for the lifetime of the process.
+static LOG_GUARD: OnceLock<WorkerGuard> = OnceLock::new();
+
+/// Parsed view of the logging env vars.
+#[derive(Default)]
+pub struct LogSettings {
+    pub stderr: bool,
+    pub file: Option<PathBuf>,
+}
+
+impl LogSettings {
+    pub fn from_env() -> Self {
+        Self {
+            stderr: env::var_os(ENV_LOG_STDERR).is_some(),
+            file: env::var_os(ENV_LOG_FILE).map(PathBuf::from),
+        }
+    }
+}
+
+/// Best-effort: install a global tracing subscriber based on env vars.
+///
+/// Returns Ok even when a subscriber is already installed (idempotent
+/// across re-loads); only file-system or argument errors surface.
+pub fn install_from_env() -> EngineResult<()> {
+    install(LogSettings::from_env())
+}
+
+fn install(settings: LogSettings) -> EngineResult<()> {
+    if !settings.stderr && settings.file.is_none() {
+        return Ok(());
+    }
+
+    // RUST_LOG controls verbosity; default to `info` when it is unset
+    // or malformed (an empty EnvFilter would suppress every event).
+    let filter = std::env::var("RUST_LOG")
+        .ok()
+        .filter(|s| !s.is_empty())
+        .and_then(|s| EnvFilter::try_new(s).ok())
+        .unwrap_or_else(|| EnvFilter::new("info"));
+
+    let mut layers: Vec<Box<dyn Layer<tracing_subscriber::Registry> + Send + Sync + 'static>> =
+        Vec::new();
+
+    if settings.stderr {
+        layers.push(
+            tracing_subscriber::fmt::layer()
+                .with_writer(std::io::stderr)
+                .with_target(true)
+                .boxed(),
+        );
+    }
+    let mut file_guard = None;
+    if let Some(path) = settings.file.as_deref() {
+        let (layer, guard) = open_file_layer(path)?;
+        layers.push(layer);
+        file_guard = Some(guard);
+    }
+
+    // EnvFilter goes last so it sits at the top of the layer stack and
+    // filters events before they propagate into the fmt layers.
+    let installed = tracing_subscriber::registry()
+        .with(layers)
+        .with(filter)
+        .try_init()
+        .is_ok();
+
+    // Park the appender's worker guard only when we actually installed the
+    // subscriber; if a host already had one, try_init fails and dropping the
+    // guard here stops the otherwise-orphaned worker thread.
+    if installed {
+        if let Some(guard) = file_guard {
+            let _ = LOG_GUARD.set(guard);
+        }
+    }
+    Ok(())
+}
+
+/// Open `path` (mode 0600 on creation) for append, wrap it in a non-blocking
+/// writer, and return the layer plus its `WorkerGuard`. The caller parks the
+/// guard only if the subscriber is actually installed, so a dropped layer stops
+/// its worker.
+fn open_file_layer(
+    path: &Path,
+) -> EngineResult<(
+    Box<dyn Layer<tracing_subscriber::Registry> + Send + Sync + 'static>,
+    WorkerGuard,
+)> {
+    let file = OpenOptions::new()
+        .create(true)
+        .append(true)
+        .mode(0o600)
+        .custom_flags(libc::O_NOFOLLOW | libc::O_CLOEXEC)
+        .open(path)
+        .map_err(|e| EngineError::wrap(format!("AZIHSM_ENGINE_LOG_FILE {path:?}"), e))?;
+    let (writer, guard) = tracing_appender::non_blocking(file);
+    let layer = tracing_subscriber::fmt::layer()
+        .with_writer(writer)
+        .with_target(true)
+        .boxed();
+    Ok((layer, guard))
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used)]
+
+    use super::*;
+
+    #[test]
+    fn settings_default_is_off() {
+        let s = LogSettings::default();
+        assert!(!s.stderr);
+        assert!(s.file.is_none());
+    }
+
+    #[test]
+    fn install_noop_when_both_disabled() {
+        // With no layers there's nothing to fail on; this must not panic
+        // even if a subscriber is already installed in the test process.
+        install(LogSettings::default()).unwrap();
+    }
+
+    #[test]
+    fn install_rejects_unwritable_file_path() {
+        let s = LogSettings {
+            stderr: false,
+            file: Some(PathBuf::from("/no/such/directory/engine.log")),
+        };
+        assert!(install(s).is_err());
+    }
+}

--- a/plugins/ossl_engine/engine/src/logging.rs
+++ b/plugins/ossl_engine/engine/src/logging.rs
@@ -44,6 +44,11 @@ use crate::SECRET_FILE_MODE;
 const ENV_LOG_STDERR: &str = "AZIHSM_ENGINE_LOG_STDERR";
 const ENV_LOG_FILE: &str = "AZIHSM_ENGINE_LOG_FILE";
 
+/// Mode bits compared against [`SECRET_FILE_MODE`]: the 9 permission bits plus
+/// the setuid/setgid/sticky bits (i.e. everything but the file-type bits), so
+/// the check is truly "exactly 0600" and rejects special-bit files too.
+const MODE_BITS_MASK: u32 = 0o7777;
+
 /// Owns the non-blocking writer's worker thread for the lifetime of the process.
 static LOG_GUARD: OnceLock<WorkerGuard> = OnceLock::new();
 
@@ -152,7 +157,7 @@ fn open_file_layer(
             "AZIHSM_ENGINE_LOG_FILE {path:?} is not a regular file"
         )));
     }
-    if meta.mode() & 0o777 != SECRET_FILE_MODE {
+    if meta.mode() & MODE_BITS_MASK != SECRET_FILE_MODE {
         return Err(EngineError::Other(format!(
             "AZIHSM_ENGINE_LOG_FILE {path:?} has insecure permissions \
              (must be owner-only, mode 0600)"

--- a/plugins/ossl_engine/engine/src/logging.rs
+++ b/plugins/ossl_engine/engine/src/logging.rs
@@ -138,9 +138,10 @@ fn open_file_layer(
         .map_err(|e| EngineError::wrap(format!("AZIHSM_ENGINE_LOG_FILE {path:?}"), e))?;
 
     // O_NOFOLLOW already refuses a symlink at `path`. Also refuse a
-    // pre-existing non-regular file (fifo, device, …) or one accessible by
-    // group/other, so enabling logging can't append into an unexpected file
-    // type or leak events through a world-readable file.
+    // pre-existing non-regular file (fifo, device, …) or one whose mode is not
+    // exactly 0600, so enabling logging can't append into an unexpected file
+    // type or leak events through a group/other-accessible file. Mirrors the
+    // exact-mode requirement setup_storage_dir enforces for the storage dir.
     let meta = file
         .metadata()
         .map_err(|e| EngineError::wrap(format!("stat AZIHSM_ENGINE_LOG_FILE {path:?}"), e))?;
@@ -149,7 +150,7 @@ fn open_file_layer(
             "AZIHSM_ENGINE_LOG_FILE {path:?} is not a regular file"
         )));
     }
-    if meta.mode() & 0o077 != 0 {
+    if meta.mode() & 0o777 != 0o600 {
         return Err(EngineError::Other(format!(
             "AZIHSM_ENGINE_LOG_FILE {path:?} has insecure permissions \
              (must be owner-only, mode 0600)"
@@ -212,6 +213,28 @@ mod tests {
         assert!(
             r.is_err(),
             "group/other-accessible log file must be rejected"
+        );
+    }
+
+    #[test]
+    fn install_rejects_owner_exec_file() {
+        use std::os::unix::fs::PermissionsExt;
+
+        // 0700 has no group/other access but is not exactly 0600; it must be
+        // rejected to match the documented owner-only-0600 requirement.
+        let path = std::env::temp_dir().join(format!("engine-log-exec-{}.log", std::process::id()));
+        let _ = std::fs::remove_file(&path);
+        std::fs::write(&path, b"").unwrap();
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o700)).unwrap();
+
+        let r = install(LogSettings {
+            stderr: false,
+            file: Some(path.clone()),
+        });
+        let _ = std::fs::remove_file(&path);
+        assert!(
+            r.is_err(),
+            "a non-0600 (owner-exec) log file must be rejected"
         );
     }
 }


### PR DESCRIPTION
Adds the HSM lifecycle + logging layer to the OpenSSL 1.1.x engine, on top of the resiliency toolkit and azihsm_crypto's 1.1.x support.

- engine/src/context.rs — EngineData (parked in ENGINE ex_data) owns a lazily-opened HsmContext (partition + session). HsmContext::open performs the full device bring-up, mirroring the 3.x provider:
  - list partitions → open the first at its max API revision;
  - partition.init with the plaintext OBK; on a warm device (Bk3AlreadyInitialized) retry with the caller-persisted MOBK, and persist the freshly-derived MOBK on cold init;
  - POTA endorsement signed via azihsm_crypto (caller source) or delegated to the platform TPM (tpm source);
  - open_session.
  - Credentials + resiliency settings come from the environment; key material is zeroized.
- engine/src/logging.rs — env-gated tracing_subscriber (stderr and/or file), installed at bind.
- engine/src/lib.rs — registers the ex_data slot and parks an empty EngineData at bind. The open is lazy — nothing opens a session yet; the trigger arrives with key-loading / algorithm callbacks in a follow-up.

No behavior change for current users: openssl engine -t still only binds; it does not touch a device.

For manual testing with TPM:

```
export AZIHSM_CREDENTIALS_ID=<32 hex chars>
export AZIHSM_CREDENTIALS_PIN=<32 hex chars>
export AZIHSM_RESILIENCY_ENABLED=1
export AZIHSM_RESILIENCY_STORAGE_DIR=/run/azihsm/resiliency   # must be mode 0700
export AZIHSM_POTA_SOURCE=tpm
export AZIHSM_OBK_SOURCE=tpm
```