### PR TITLE
fw: fix ECC endianness in establish-credential path (PAL strictly LE-native)

### DIFF
--- a/fw/core/crypto/hpke/src/kem.rs
+++ b/fw/core/crypto/hpke/src/kem.rs
@@ -240,6 +240,9 @@ where
     let dh = alloc_bytes(ndh, alloc)?;
     pal.ecdh_derive(io, curve, &sk_e[..sk_len], pk_r_le, dh)
         .await?;
+    // `ecdh_derive` returns the shared secret PKA-native little-endian; HPKE
+    // (RFC 9180) feeds the SEC1 big-endian secret to the KDF, so reverse it.
+    dh[..ndh].reverse();
 
     // Serialise ephemeral public key into SEC1 BE wire form for `enc`
     // and the transcript-binding `kem_context`.
@@ -301,6 +304,8 @@ where
     let dh = alloc_bytes(ndh, alloc)?;
     let sk_r_dma = dma_copy_in(alloc, sk_r)?;
     pal.ecdh_derive(io, curve, sk_r_dma, pk_e_le, dh).await?;
+    // PKA-native LE -> SEC1 BE for the HPKE KDF input (RFC 9180).
+    dh[..ndh].reverse();
 
     let kem_context = alloc_bytes(npk_wire * 2, alloc)?;
     build_kem_context(kem_context, npk_wire, enc, pk_r, None);
@@ -389,6 +394,10 @@ where
         .await?;
     pal.ecdh_derive(io, curve, sk_s, pk_r_le, &mut dh[ndh..])
         .await?;
+    // Each ECDH secret is PKA-native LE; reverse each `Ndh` half to SEC1 BE
+    // for the HPKE `dh1 || dh2` KDF input (RFC 9180).
+    dh[..ndh].reverse();
+    dh[ndh..].reverse();
 
     pal_le_to_sec1_be(&pk_e_le[..pk_len], &mut enc[..npk_wire], coord_len)?;
 
@@ -455,6 +464,10 @@ where
         .await?;
     pal.ecdh_derive(io, curve, sk_r_dma, pk_s_le, &mut dh[ndh..])
         .await?;
+    // Each ECDH secret is PKA-native LE; reverse each `Ndh` half to SEC1 BE
+    // for the HPKE `dh1 || dh2` KDF input (RFC 9180).
+    dh[..ndh].reverse();
+    dh[ndh..].reverse();
 
     let kem_context = alloc_bytes(npk_wire * 3, alloc)?;
     build_kem_context(kem_context, npk_wire, enc, pk_r, Some(pk_s));

--- a/fw/core/crypto/key-report/src/decode.rs
+++ b/fw/core/crypto/key-report/src/decode.rs
@@ -222,12 +222,15 @@ where
     minicbor::encode(&sig_struct_val, crate::codec::as_mut_slice(sig_struct))
         .map_err(|_| HsmError::InternalError)?;
 
-    // SHA-384. Unlike the signing path (which feeds `ecc_sign` a
-    // little-endian digest), `ecc_verify` requires the digest in its
-    // natural big-endian byte order, so hash with `big_endian = true`.
+    // SHA-384. `ecc_verify` is PKA little-endian native, so hash
+    // big-endian and then fully byte-reverse the digest into PKA-LE,
+    // matching the other verify callers (establish_credential /
+    // x509-chain). SHA's `big_endian = false` is only a per-word swap,
+    // not the full-digest reversal the PKA needs.
     let digest = alloc.dma_alloc(SHA384_LEN)?;
     pal.hash(io, HsmHashAlgo::Sha384, sig_struct, digest, true)
         .await?;
+    digest[..SHA384_LEN].reverse();
 
     // The COSE signature stores `r || s` big-endian per half; convert
     // to the little-endian `ecc_verify` wire form.

--- a/fw/core/crypto/x509-chain/src/validate.rs
+++ b/fw/core/crypto/x509-chain/src/validate.rs
@@ -326,9 +326,12 @@ impl ChainValidator {
         let digest_dma = alloc.dma_alloc(digest_len)?;
 
         // Hash the TBSCertificate (already in DMA memory).  The digest is
-        // the natural big-endian SHA value the signer signed over.
+        // the natural big-endian SHA value the signer signed over; reverse it
+        // in place to the PKA-LE order the (now LE-native) `ecc_verify` expects,
+        // like the public key / signature components below.
         pal.hash(io, hash_algo, curr.tbs_raw, digest_dma, true)
             .await?;
+        digest_dma[..digest_len].reverse();
 
         // `HsmEcc::ecc_verify` wants the public key and signature in the
         // little-endian wire form: each component's magnitude in the first

--- a/fw/core/lib/src/ddi/mbor/establish_credential.rs
+++ b/fw/core/lib/src/ddi/mbor/establish_credential.rs
@@ -291,6 +291,12 @@ async fn verify_pota_signature<P: HsmPal>(
     let digest = pal.dma_alloc(io, HsmHashAlgo::Sha384.digest_len())?;
     pal.hash(io, HsmHashAlgo::Sha384, id_uncompressed, digest, true)
         .await?;
+    // The POTA signature was produced over the natural big-endian digest; the
+    // LE-native `ecc_verify` consumes the PKA-LE (fully byte-reversed) digest,
+    // so reverse it here in the handler. (SHA's `big_endian = false` does a
+    // per-word byte-swap, not the full-digest reversal the PKA needs.)
+    // Byte-order conversion lives in the handler now, not the PAL.
+    digest[..HsmHashAlgo::Sha384.digest_len()].reverse();
 
     let verify_result = pal.dma_alloc(io, 4)?;
 
@@ -357,6 +363,12 @@ async fn derive_credential_keys<P: HsmPal>(
         )
         .await?;
     }
+
+    // The ECDH secret is returned PKA-native little-endian; reverse it to the
+    // host's big-endian (openssl) order so the firmware HKDF matches the host,
+    // which runs the same HKDF over its openssl-BE secret. Byte-order
+    // conversion lives in the handler now, not the PAL.
+    secret[..HsmEccCurve::P384.secret_len()].reverse();
 
     // HKDF-Extract with the RFC 5869 §2.2 default (absent) salt.
     let prk = pal.dma_alloc(io, HsmHashAlgo::Sha384.digest_len())?;

--- a/fw/core/lib/src/ddi/mbor/open_session.rs
+++ b/fw/core/lib/src/ddi/mbor/open_session.rs
@@ -240,6 +240,12 @@ async fn derive_session_credential_keys<P: HsmPal>(
         .await?;
     }
 
+    // The ECDH secret is returned PKA-native little-endian; reverse it to the
+    // host's big-endian (openssl) order so the firmware HKDF matches the host,
+    // which runs the same HKDF over its openssl-BE secret. Byte-order
+    // conversion lives in the handler now, not the PAL.
+    secret[..HsmEccCurve::P384.secret_len()].reverse();
+
     // HKDF-Extract with the RFC 5869 §2.2 default (absent) salt.
     let prk = pal.dma_alloc(io, HsmHashAlgo::Sha384.digest_len())?;
     pal.hkdf_extract(io, HsmHashAlgo::Sha384, None, secret, prk)

--- a/fw/docs/traits/crypto.md
+++ b/fw/docs/traits/crypto.md
@@ -80,7 +80,11 @@ pub trait HsmEcc {
 }
 ```
 
-Key parameters are `&[u8]` byte slices: raw HSM-format scalar `d` for private keys (32/48/68 bytes, P-521 4-byte aligned), raw x∥y little-endian coordinates for public keys, raw r∥s for signatures.
+Key parameters are `&[u8]` byte slices, all in HSM-native **little-endian** (PKA operand order): raw HSM-format scalar `d` for private keys (32/48/68 bytes, P-521 4-byte aligned), raw x∥y coordinates for public keys, and raw r∥s for signatures (each component little-endian).
+
+Byte order also governs the digest and the ECDH secret:
+- `ecc_sign` / `ecc_verify` take the message `hash` in PKA **little-endian** — a *full byte reversal* of the natural big-endian digest. (This is **not** `HsmHash::hash(.., big_endian = false)`, which only byte-swaps within each 32-bit word.) Callers hash big-endian, then reverse the digest.
+- `ecdh_derive` writes `secret` as the shared x-coordinate in **little-endian**. Consumers that need big-endian — e.g. an openssl-matching HKDF, or HPKE/DHKEM per RFC 9180 — must reverse it to big-endian themselves.
 
 **PCT (Pairwise Consistency Test):** After key generation, a self-test is performed:
 - `SignVerify` — sign + verify a test message

--- a/fw/docs/traits/crypto.md
+++ b/fw/docs/traits/crypto.md
@@ -11,6 +11,16 @@
 pub trait HsmCrypto: HsmRng + HsmHash + HsmHmac + HsmAes + HsmEcc + HsmRsa + HsmKdf {}
 ```
 
+> **Note — signatures are simplified.** The trait signatures shown throughout
+> this document use plain `&[u8]` / `&mut [u8]` for readability. In the actual
+> firmware PAL traits (`fw/pal/traits/src/crypto/`) the byte-buffer parameters
+> are DMA-capable [`DmaBuf`] buffers (`&DmaBuf` / `&mut DmaBuf`), **not** plain
+> slices, and most methods also take an `io: &impl HsmIo` context. The `DmaBuf`
+> requirement is load-bearing: the Uno PKA/SHA/AES engines DMA directly from
+> these buffers, so non-DMA memory (e.g. DTCM stack/heap) is **not** acceptable
+> on the hardware path. Read the buffers below as "raw byte buffers,
+> conceptually" but `DmaBuf` in practice.
+
 ## Sub-traits
 
 ### HsmRng — Random Number Generation
@@ -80,7 +90,7 @@ pub trait HsmEcc {
 }
 ```
 
-Key parameters are `&[u8]` byte slices, all in HSM-native **little-endian** (PKA operand order): raw HSM-format scalar `d` for private keys (32/48/68 bytes, P-521 4-byte aligned), raw x∥y coordinates for public keys, and raw r∥s for signatures (each component little-endian).
+Key parameters are raw byte buffers (DMA-backed `DmaBuf` in the firmware PAL traits — see the note above), all in HSM-native **little-endian** (PKA operand order): raw HSM-format scalar `d` for private keys (32/48/68 bytes, P-521 4-byte aligned), raw x∥y coordinates for public keys, and raw r∥s for signatures (each component little-endian).
 
 Byte order also governs the digest and the ECDH secret:
 - `ecc_sign` / `ecc_verify` take the message `hash` in PKA **little-endian** — a *full byte reversal* of the natural big-endian digest. (This is **not** `HsmHash::hash(.., big_endian = false)`, which only byte-swaps within each 32-bit word.) Callers hash big-endian, then reverse the digest.

--- a/fw/pal/traits/src/crypto/ecc.rs
+++ b/fw/pal/traits/src/crypto/ecc.rs
@@ -304,14 +304,12 @@ pub trait HsmEcc {
     ///   delegate to a big-endian-native primitive (e.g. OpenSSL)
     ///   must strip the per-coordinate padding and reverse each
     ///   coordinate internally.
-    /// - `hash` — message digest that was signed, in natural
-    ///   **big-endian** byte order (as produced by the hash function),
-    ///   at least the curve's digest length.  Unlike `pub_key` /
-    ///   `signature` (little-endian wire format), the digest is a
-    ///   standard big-endian scalar: little-endian-native hardware PALs
-    ///   reverse exactly the curve's digest length internally before
-    ///   feeding the PKA, while big-endian-native PALs consume it
-    ///   as-is.
+    /// - `hash` — message digest that was signed, in **little-endian**
+    ///   byte order (as `HsmHash::hash(.., big_endian = false)` produces it),
+    ///   at least the curve's digest length.  The digest is PKA-native LE like
+    ///   `pub_key` / `signature`; byte-order conversion is the DDI handler's
+    ///   responsibility, so PKA-native PALs consume it as-is while
+    ///   big-endian-native PALs (e.g. OpenSSL) reverse it internally.
     /// - `signature` — signature to verify; must be exactly
     ///   `curve.wire_sig_len()` bytes (`r || s`).  **Each component
     ///   is in little-endian byte order** with P-521 components
@@ -398,8 +396,10 @@ pub trait HsmEcc {
     ///   OpenSSL) must strip the per-coordinate padding and reverse
     ///   each coordinate internally.
     /// - `secret` — output buffer; must be at least
-    ///   `curve.secret_len()` bytes.  On success, holds the
-    ///   x-coordinate of the shared point.
+    ///   `curve.secret_len()` bytes.  On success, holds the x-coordinate of
+    ///   the shared point in **little-endian** (PKA-native) byte order.
+    ///   Byte-order conversion for a specific consumer (e.g. LE->BE before an
+    ///   openssl-matching HKDF) is the DDI handler's responsibility.
     ///
     /// # Returns
     ///

--- a/fw/pal/traits/src/crypto/ecc.rs
+++ b/fw/pal/traits/src/crypto/ecc.rs
@@ -305,10 +305,13 @@ pub trait HsmEcc {
     ///   must strip the per-coordinate padding and reverse each
     ///   coordinate internally.
     /// - `hash` — message digest that was signed, in **little-endian**
-    ///   byte order (as `HsmHash::hash(.., big_endian = false)` produces it),
-    ///   at least the curve's digest length.  The digest is PKA-native LE like
-    ///   `pub_key` / `signature`; byte-order conversion is the DDI handler's
-    ///   responsibility, so PKA-native PALs consume it as-is while
+    ///   byte order: the natural big-endian digest with **all bytes fully
+    ///   reversed** (BE->LE), at least the curve's digest length.  This is a
+    ///   full-digest reversal, distinct from
+    ///   `HsmHash::hash(.., big_endian = false)`, which only byte-swaps within
+    ///   each 32-bit word.  The digest is PKA-native LE like `pub_key` /
+    ///   `signature`; the DDI handler performs the conversion (hash big-endian,
+    ///   then reverse), so PKA-native PALs consume it as-is while
     ///   big-endian-native PALs (e.g. OpenSSL) reverse it internally.
     /// - `signature` — signature to verify; must be exactly
     ///   `curve.wire_sig_len()` bytes (`r || s`).  **Each component

--- a/fw/plat/std/pal/src/drivers/ecc.rs
+++ b/fw/plat/std/pal/src/drivers/ecc.rs
@@ -265,15 +265,19 @@ impl StdEcc {
         reverse_copy(&mut sig_be[..coord_len], &r_wire[..coord_len]);
         reverse_copy(&mut sig_be[coord_len..sig_len], &s_wire[..coord_len]);
 
-        // Reverse the wire-LE digest into BE scratch for OpenSSL (symmetric
-        // with `ecc_sign_le`).
-        if hash.len() > 64 {
+        // The PAL trait allows a `hash` buffer larger than the curve digest;
+        // verify only the leading curve-digest bytes (matching the uno PAL,
+        // which feeds the PKA exactly `hash_size(curve)`). Reverse that prefix
+        // from wire-LE into BE scratch for OpenSSL (symmetric with
+        // `ecc_sign_le`).
+        let digest_len = ecc_digest_len(curve);
+        if hash.len() < digest_len {
             return Err(HsmError::InvalidArg);
         }
         let mut hash_be = [0u8; 64];
-        reverse_copy(&mut hash_be[..hash.len()], hash);
+        reverse_copy(&mut hash_be[..digest_len], &hash[..digest_len]);
 
-        self.ecc_verify(&key, &hash_be[..hash.len()], &sig_be[..sig_len])
+        self.ecc_verify(&key, &hash_be[..digest_len], &sig_be[..sig_len])
             .await
     }
 
@@ -371,6 +375,15 @@ fn priv_key_len(curve: EccCurve) -> usize {
         EccCurve::P256 => 32,
         EccCurve::P384 => 48,
         EccCurve::P521 => 66,
+    }
+}
+
+/// ECDSA digest length for the curve's standard hash (SHA-256/384/512).
+fn ecc_digest_len(curve: EccCurve) -> usize {
+    match curve {
+        EccCurve::P256 => 32,
+        EccCurve::P384 => 48,
+        EccCurve::P521 => 64,
     }
 }
 

--- a/fw/plat/std/pal/src/drivers/ecc.rs
+++ b/fw/plat/std/pal/src/drivers/ecc.rs
@@ -227,12 +227,9 @@ impl StdEcc {
     /// P-521 per-coordinate de-padding internally so the PAL doesn't
     /// have to.
     ///
-    /// `hash` is passed through to OpenSSL **unmodified** — the PAL
-    /// trait's verify contract says "Raw digest bytes; no endianness
-    /// conversion is applied", so callers pass the BE hash they got
-    /// from SHA directly.  (The asymmetry with [`Self::ecc_sign_le`]
-    /// matches the upstream trait contract; both internal
-    /// firmware callers of verify pass BE digests.)
+    /// `hash` is the wire-LE digest (the PAL trait is now LE-native); it is
+    /// reversed into OpenSSL big-endian form internally, symmetric with
+    /// [`Self::ecc_sign_le`].
     ///
     /// `pub_le.len()` must be `wire_pub_key_len(curve)`
     /// (64 / 96 / 136 for P-256 / P-384 / P-521).
@@ -268,7 +265,16 @@ impl StdEcc {
         reverse_copy(&mut sig_be[..coord_len], &r_wire[..coord_len]);
         reverse_copy(&mut sig_be[coord_len..sig_len], &s_wire[..coord_len]);
 
-        self.ecc_verify(&key, hash, &sig_be[..sig_len]).await
+        // Reverse the wire-LE digest into BE scratch for OpenSSL (symmetric
+        // with `ecc_sign_le`).
+        if hash.len() > 64 {
+            return Err(HsmError::InvalidArg);
+        }
+        let mut hash_be = [0u8; 64];
+        reverse_copy(&mut hash_be[..hash.len()], hash);
+
+        self.ecc_verify(&key, &hash_be[..hash.len()], &sig_be[..sig_len])
+            .await
     }
 
     /// ECDH key agreement — derives a shared secret into `secret`.
@@ -319,11 +325,10 @@ impl StdEcc {
     /// per-coordinate padding.
     ///
     /// `pub_le.len()` must be `wire_pub_key_len(curve)`
-    /// (64 / 96 / 136 for P-256 / P-384 / P-521).  The shared
-    /// secret is written into `secret_out` in OpenSSL's native
-    /// big-endian form — the trait contract leaves the secret
-    /// endianness unspecified and current callers consume it as
-    /// opaque HKDF input, so no flip is applied.
+    /// (64 / 96 / 136 for P-256 / P-384 / P-521).  The shared secret is
+    /// written into `secret_out` in wire **little-endian** form to match the
+    /// PKA-native (LE) trait contract; the DDI handler converts to the
+    /// consumer's byte order (e.g. LE->BE before an openssl-matching HKDF).
     pub async fn ecdh_derive_le(
         &self,
         priv_key: &EccPrivateKey,
@@ -346,7 +351,14 @@ impl StdEcc {
         let pubk = EccPublicKey::from_coordinates(curve, &x_be[..coord_len], &y_be[..coord_len])
             .map_err(|_| HsmError::InvalidArg)?;
 
-        self.ecdh_derive(priv_key, &pubk, secret_out).await
+        self.ecdh_derive(priv_key, &pubk, secret_out).await?;
+
+        // OpenSSL derives the secret big-endian; the trait is LE-native, so
+        // reverse the derived x-coordinate into wire-LE. Reverse exactly
+        // `coord_len` bytes so a larger (wire-padded) caller buffer keeps its
+        // trailing padding.
+        secret_out[..coord_len].reverse();
+        Ok(())
     }
 }
 

--- a/fw/plat/uno/fw/drivers/upka/src/api.rs
+++ b/fw/plat/uno/fw/drivers/upka/src/api.rs
@@ -194,7 +194,11 @@ impl<const DEPTH: usize, const ENGINES: usize> UpkaDriver<DEPTH, ENGINES> {
     /// - `pub_key`: DMA-capable public key buffer.
     /// - `hash`: DMA-capable digest buffer.
     /// - `signature`: DMA-capable signature buffer.
-    /// - `result`: DMA-capable output status word buffer.
+    /// - `result`: DMA-capable output buffer that receives the 4-byte
+    ///   hardware status word.
+    /// - `prime`: DMA-capable curve prime buffer (LE).
+    /// - `mont_result`: DMA-capable transient scratch for the Montgomery-
+    ///   constant setup write. Content is not surfaced to the caller.
     ///
     /// # Returns
     ///
@@ -255,6 +259,9 @@ impl<const DEPTH: usize, const ENGINES: usize> UpkaDriver<DEPTH, ENGINES> {
     /// - `priv_key`: DMA-capable private key buffer.
     /// - `pub_key`: DMA-capable peer public key buffer.
     /// - `secret`: DMA-capable output buffer for the derived secret.
+    /// - `prime`: DMA-capable curve prime buffer (LE).
+    /// - `mont_result`: DMA-capable transient scratch for the Montgomery-
+    ///   constant setup write. Content is not surfaced to the caller.
     ///
     /// # Returns
     ///

--- a/fw/plat/uno/fw/drivers/upka/src/engine.rs
+++ b/fw/plat/uno/fw/drivers/upka/src/engine.rs
@@ -97,8 +97,13 @@ impl<const DEPTH: usize, const ENGINES: usize> UpkaEngine<'_, DEPTH, ENGINES> {
 
     /// Verify an ECDSA signature.
     ///
-    /// `result` is a caller-allocated DMA-capable buffer (at least 4 bytes)
-    /// that receives the hardware status word.
+    /// The verify command internally computes and consumes a Montgomery
+    /// constant for `curve` as a required PKA setup step (performed on the
+    /// same engine acquisition, before the verification), writing the
+    /// transient constant into `mont_result` (see below). All hardware writes
+    /// go through DMA into the caller-provided buffers, so those buffers must
+    /// live in DMA-reachable memory (GSRAM, e.g. from the PAL scoped
+    /// allocator's `dma_alloc`).
     ///
     /// # Parameters
     ///
@@ -106,7 +111,14 @@ impl<const DEPTH: usize, const ENGINES: usize> UpkaEngine<'_, DEPTH, ENGINES> {
     /// - `pub_key`: DMA-capable public key buffer.
     /// - `hash`: DMA-capable digest buffer.
     /// - `signature`: DMA-capable signature buffer.
-    /// - `result`: DMA-capable output status word buffer.
+    /// - `result`: DMA-capable output buffer that receives the 4-byte
+    ///   hardware status word.
+    /// - `prime`: DMA-capable curve prime buffer (LE).
+    /// - `mont_result`: DMA-capable transient scratch for the Montgomery-
+    ///   constant setup write. Its contents are consumed by the engine as
+    ///   part of the verify command's internal state; the DMA output is not
+    ///   surfaced to the caller and the buffer can be released as soon as
+    ///   the verify future resolves.
     ///
     /// # Returns
     ///
@@ -140,8 +152,9 @@ impl<const DEPTH: usize, const ENGINES: usize> UpkaEngine<'_, DEPTH, ENGINES> {
 
         // Required PKA setup: compute the Montgomery constant for the curve
         // prime on this engine before the verify (mirrors ecdh_derive). The
-        // verify command consumes the engine state this leaves behind; both
-        // run on the same engine acquisition (execute_cmd does not wipe
+        // verify command consumes the engine state this leaves behind; the
+        // `mont_result` DMA output itself is transient scratch. Both commands
+        // run on the same engine acquisition (`execute_cmd` does not wipe
         // between commands).
         self.execute_cmd(
             mont_const_calc_opcode(curve),
@@ -199,12 +212,26 @@ impl<const DEPTH: usize, const ENGINES: usize> UpkaEngine<'_, DEPTH, ENGINES> {
 
     /// Derive an ECDH shared secret.
     ///
+    /// The point-multiplication internally computes and consumes a Montgomery
+    /// constant for `curve` as a required PKA setup step (performed on the
+    /// same engine acquisition, before the point-multiply), writing the
+    /// transient constant into `mont_result` (see below). All hardware writes
+    /// go through DMA into the caller-provided buffers, so those buffers must
+    /// live in DMA-reachable memory (GSRAM, e.g. from the PAL scoped
+    /// allocator's `dma_alloc`).
+    ///
     /// # Parameters
     ///
     /// - `curve`: ECC curve selector.
     /// - `priv_key`: DMA-capable private key buffer.
     /// - `pub_key`: DMA-capable peer public key buffer.
     /// - `secret`: DMA-capable output buffer for the derived secret.
+    /// - `prime`: DMA-capable curve prime buffer (LE).
+    /// - `mont_result`: DMA-capable transient scratch for the Montgomery-
+    ///   constant setup write. Its contents are consumed by the engine as
+    ///   part of the point-multiply's internal state; the DMA output is not
+    ///   surfaced to the caller and the buffer can be released as soon as
+    ///   the derive future resolves.
     ///
     /// # Returns
     ///

--- a/fw/plat/uno/fw/pal/src/crypto/ecc.rs
+++ b/fw/plat/uno/fw/pal/src/crypto/ecc.rs
@@ -29,9 +29,9 @@ use azihsm_fw_hsm_pal_traits::HsmError;
 use azihsm_fw_hsm_pal_traits::HsmIo;
 use azihsm_fw_hsm_pal_traits::HsmResult;
 use azihsm_fw_hsm_pal_traits::HsmScopedAlloc;
-use azihsm_fw_uno_drivers_upka::UpkaEccCurve;
 use azihsm_fw_uno_drivers_upka::hash_size;
 use azihsm_fw_uno_drivers_upka::hsm_point_size;
+use azihsm_fw_uno_drivers_upka::UpkaEccCurve;
 
 use crate::UnoHsmPal;
 
@@ -259,14 +259,10 @@ impl HsmEcc for UnoHsmPal {
         // validation) would otherwise accumulate this scratch and can exhaust
         // the DMA pool.
         self.alloc_scoped_async(io, async |scope| {
-            // Callers pass the hash digest big-endian, but the PKA consumes it
-            // little-endian; reverse exactly `hash_size` bytes into LE scratch
-            // (a larger caller buffer must not move the digest out of the
-            // leading bytes the hardware reads). pub_key/signature already
-            // arrive LE via the host DDI serde.
-            let hash_le = scope.dma_alloc(digest_len)?;
-            hash_le.copy_from_slice(&hash[..digest_len]);
-            hash_le.reverse();
+            // The digest arrives PKA-native little-endian (the DDI handler asks
+            // `hash(.., big_endian = false)` for it); pub_key and signature
+            // likewise arrive LE via the host DDI serde. No byte-order
+            // conversion is done below the PAL.
 
             // Per-call Montgomery constant from the curve prime (like ecdh_derive).
             let prime = scope.dma_alloc(prime_le.len())?;
@@ -277,7 +273,7 @@ impl HsmEcc for UnoHsmPal {
                 .ecc_verify(
                     pka_curve,
                     pub_key,
-                    hash_le,
+                    &hash[..digest_len],
                     signature,
                     result,
                     prime,
@@ -334,18 +330,10 @@ impl HsmEcc for UnoHsmPal {
                 .ecdh_derive(pka_curve, priv_key, pub_key, secret, prime, mont_result)
                 .await?;
 
-            // pub_key (peer) and priv_key (vault) already pass through in
-            // PKA-native little-endian and are unconverted. The shared secret,
-            // however, is consumed internally by HKDF and never crosses the DDI
-            // boundary; the host derives it big-endian (openssl), so reverse the
-            // PKA's little-endian output. Reverse exactly the `secret_len`
-            // written bytes: the trait allows a larger caller buffer (wire-padded
-            // P-521, 68 vs 66), so reversing the whole buffer would pull trailing
-            // padding to the front and corrupt the HKDF input; slicing by the
-            // wire point size would instead panic when the buffer is exactly
-            // `secret_len`.
-            let secret_len = curve.secret_len();
-            secret[..secret_len].reverse();
+            // The shared secret is returned PKA-native little-endian, like
+            // pub_key and priv_key. Any byte-order conversion (e.g. LE->BE for
+            // an internal HKDF consumer that must match the host's openssl-BE
+            // secret) is the DDI handler's responsibility, not the PAL's.
             Ok(())
         })
         .await

--- a/fw/plat/uno/fw/pal/src/crypto/ecc.rs
+++ b/fw/plat/uno/fw/pal/src/crypto/ecc.rs
@@ -259,10 +259,12 @@ impl HsmEcc for UnoHsmPal {
         // validation) would otherwise accumulate this scratch and can
         // exhaust the DMA pool.
         self.alloc_scoped_async(io, async |scope| {
-            // The digest arrives PKA-native little-endian (the DDI handler asks
-            // `hash(.., big_endian = false)` for it); pub_key and signature
-            // likewise arrive LE via the host DDI serde. No byte-order
-            // conversion is done below the PAL.
+            // The digest arrives PKA-native little-endian: the DDI handler
+            // hashes big-endian and then fully byte-reverses it (a full BE->LE
+            // reversal, not `hash(.., big_endian = false)`, which only swaps
+            // within each 32-bit word). pub_key and signature likewise arrive
+            // LE via the host DDI serde. No byte-order conversion is done below
+            // the PAL.
 
             // Per-call Montgomery constant from the curve prime (like
             // ecdh_derive). `mont_result` is transient scratch consumed

--- a/fw/plat/uno/fw/pal/src/crypto/ecc.rs
+++ b/fw/plat/uno/fw/pal/src/crypto/ecc.rs
@@ -252,19 +252,21 @@ impl HsmEcc for UnoHsmPal {
         }
         let prime_le = curve_prime_le(pka_curve);
 
-        // Allocate the per-call PKA scratch (LE hash, curve prime, and the
-        // Montgomery-constant result) from a scoped heap so it is released as
-        // soon as the verify completes rather than living for the whole IO. A
-        // single IO that verifies several signatures (e.g. cert-chain
-        // validation) would otherwise accumulate this scratch and can exhaust
-        // the DMA pool.
+        // Allocate the per-call PKA scratch (curve prime + transient
+        // Montgomery-constant scratch) from a scoped heap so it is released
+        // as soon as the verify completes rather than living for the whole
+        // IO. A single IO that verifies several signatures (e.g. cert-chain
+        // validation) would otherwise accumulate this scratch and can
+        // exhaust the DMA pool.
         self.alloc_scoped_async(io, async |scope| {
             // The digest arrives PKA-native little-endian (the DDI handler asks
             // `hash(.., big_endian = false)` for it); pub_key and signature
             // likewise arrive LE via the host DDI serde. No byte-order
             // conversion is done below the PAL.
 
-            // Per-call Montgomery constant from the curve prime (like ecdh_derive).
+            // Per-call Montgomery constant from the curve prime (like
+            // ecdh_derive). `mont_result` is transient scratch consumed
+            // internally by the driver's verify; it is not surfaced back.
             let prime = scope.dma_alloc(prime_le.len())?;
             prime.copy_from_slice(prime_le);
             let mont_result = scope.dma_alloc(prime_le.len())?;

--- a/fw/plat/uno/fw/pal/src/crypto/ecc.rs
+++ b/fw/plat/uno/fw/pal/src/crypto/ecc.rs
@@ -29,9 +29,9 @@ use azihsm_fw_hsm_pal_traits::HsmError;
 use azihsm_fw_hsm_pal_traits::HsmIo;
 use azihsm_fw_hsm_pal_traits::HsmResult;
 use azihsm_fw_hsm_pal_traits::HsmScopedAlloc;
+use azihsm_fw_uno_drivers_upka::UpkaEccCurve;
 use azihsm_fw_uno_drivers_upka::hash_size;
 use azihsm_fw_uno_drivers_upka::hsm_point_size;
-use azihsm_fw_uno_drivers_upka::UpkaEccCurve;
 
 use crate::UnoHsmPal;
 


### PR DESCRIPTION
## Summary

Fixes two issues introduced by the EstablishCredential DDI bring-up PR (#515). Based directly on `main` (independent of the NSSR PR #530).

### 1. ECC endianness: make the PAL strictly PKA little-endian
The establish-credential work performed ECDH/ECDSA byte-order conversion *below* the PAL. That is wrong for two reasons:
- It incurs a perf hit when ECDH is called directly from the host, and
- it prevents leveraging the host-side pre/post encode/decode path.

This change makes the uno ECC PAL strictly PKA-LE native (no reversals in `ecc_verify`/`ecdh_derive`), turns the std driver into an LE adapter, and moves all byte-order conversion (LE↔BE) into the DDI handlers where it belongs:
- `establish_credential.rs`: POTA verify uses `hash(true)` + full-digest `reverse()`; ECDH secret reversed LE→BE before HKDF.
- `open_session.rs`: ECDH secret reversed before HKDF.
- `x509-chain/validate.rs`: digest reversed for the LE-native verify.

Note: SHA `big_endian=false` is a per-word byte-swap, **not** a full-digest reversal — so ECDSA verify uses `hash(true)` then a full `reverse()`.

### 2. Document the UPKA `prime`/`mont_result` scratch
Documents the previously-undocumented `prime` and `mont_result` parameters on the UPKA `ecc_verify`/`ecdh_derive` engine + driver APIs, and clarifies that the command itself computes and consumes the Montgomery constant as an internal PKA setup step (`mont_result` is transient scratch, never surfaced to the caller). Docs only — no logic change.

## Validation
- **std emu suite**: 452 passed / 178 failed — **identical set before/after** (zero regressions; the 178 are all pre-existing unrelated failures).
- **EVB hardware**: `test_open_session_no_cert_chain` **passes** (exercises both `ecdh_derive` and `ecc_verify` via establish + open session on real PKA hardware).

## Notes
- Prime→DTCM and code-bloat reduction were evaluated and dropped: the curve primes are only 148 B (0.07% of the image); the real weight is async `mbor::dispatch`/`establish_credential` monomorphization, out of scope for this fix.

