### PR TITLE
feat(mbor-derive): support Optional fields in frame/reserve codegen

### DIFF
--- a/fw/core/ddi/mbor/derive/Cargo.toml
+++ b/fw/core/ddi/mbor/derive/Cargo.toml
@@ -17,5 +17,13 @@ proc-macro2.workspace = true
 quote.workspace = true
 syn.workspace = true
 
+[dev-dependencies]
+azihsm_fw_ddi_mbor.workspace = true
+azihsm_fw_hsm_pal_traits.workspace = true
+
+[[test]]
+name = "frame_optional"
+path = "tests/frame_optional.rs"
+
 [lints]
 workspace = true

--- a/fw/core/ddi/mbor/derive/src/frame.rs
+++ b/fw/core/ddi/mbor/derive/src/frame.rs
@@ -48,12 +48,28 @@ pub(crate) fn struct_frame(ddi: &DdiStruct) -> syn::Result<proc_macro2::TokenStr
     let params_ident = format_ident!("{}FrameParams", ident);
     let layout_ident = format_ident!("{}Layout", ident);
 
-    // FrameParams needs lifetime parameters when Normal (non-frame)
-    // fields carry borrowed data (e.g., `DdiTargetKeyProperties<'a>`).
-    let params_needs_lifetime = ddi
-        .fields
-        .iter()
-        .any(|f| !f.opt && !f.frame && f.kind == DdiStructFieldKind::Normal && has_lifetime(&f.ty));
+    // `FrameParams` needs the struct's lifetime when any field carried *by
+    // value* there borrows data. A field is carried by value in
+    // `FrameParams` when it is optional (any kind — threaded through as its
+    // own `Option<T>`, e.g. `Option<DdiPublicKey<'a>>` or `Option<&'a [u8]>`)
+    // or a non-frame `Normal`/`Array` field (e.g. `DdiTargetKeyProperties<'a>`).
+    // Reserved fields never contribute a lifetime: a non-optional slice
+    // becomes a `usize` length, and a `#[ddi(frame)]` child becomes a
+    // lifetime-free child `FrameParams`.
+    let params_needs_lifetime = ddi.fields.iter().any(|f| {
+        let by_value = f.opt
+            || (!f.frame
+                && matches!(
+                    f.kind,
+                    DdiStructFieldKind::Normal | DdiStructFieldKind::Array
+                ));
+        by_value && has_lifetime(&f.ty)
+    });
+
+    // A struct with any optional field is a top-level response frame, never
+    // a nested `#[ddi(frame)]` child (whose fields must all be present), so
+    // it does not implement `MborFrameable`.
+    let has_optional_field = ddi.fields.iter().any(|f| f.opt);
     let lifetimes = &ddi.lifetimes;
     let params_lifetimes = if params_needs_lifetime {
         lifetimes.clone()
@@ -103,10 +119,14 @@ pub(crate) fn struct_frame(ddi: &DdiStruct) -> syn::Result<proc_macro2::TokenStr
     let params_fields = ddi
         .fields
         .iter()
-        .filter(|f| !f.opt)
         .map(|f| {
             let name = &f.ident;
-            if f.frame {
+            if f.opt {
+                // By-value optional field (never reserved): carried as its
+                // own `Option<T>` type and encoded only when present.
+                let ty = &f.ty;
+                quote! { pub #name: #ty }
+            } else if f.frame {
                 let ty = strip_lifetime(&f.ty);
                 quote! {
                     pub #name: <#ty as azihsm_fw_ddi_mbor::MborFrameable>::FrameParams
@@ -130,10 +150,12 @@ pub(crate) fn struct_frame(ddi: &DdiStruct) -> syn::Result<proc_macro2::TokenStr
     let frame_params = ddi
         .fields
         .iter()
-        .filter(|f| !f.opt)
         .map(|f| {
             let name = &f.ident;
-            if f.frame {
+            if f.opt {
+                let ty = &f.ty;
+                quote! { #name: #ty }
+            } else if f.frame {
                 let ty = strip_lifetime(&f.ty);
                 quote! {
                     #name: <#ty as azihsm_fw_ddi_mbor::MborFrameable>::FrameParams
@@ -154,11 +176,21 @@ pub(crate) fn struct_frame(ddi: &DdiStruct) -> syn::Result<proc_macro2::TokenStr
         .collect::<Vec<_>>();
 
     // ── frame() body ──────────────────────────────────────────────────
-    let field_cnt = ddi.fields.iter().filter(|f| !f.opt).count();
+    // The map entry count is resolved at runtime: start from the total
+    // field count and drop one for every `None` optional (mirroring the
+    // normal `MborEncode` path). Reserved fields are always non-optional
+    // and always present.
+    let field_cnt = ddi.fields.len();
+    let enc_cnt = {
+        let checks = ddi.fields.iter().filter(|f| f.opt).map(|f| {
+            let name = &f.ident;
+            quote! { if #name.is_none() { cnt -= 1; } }
+        });
+        quote! { #(#checks)* }
+    };
     let frame_body = ddi
         .fields
         .iter()
-        .filter(|f| !f.opt)
         .map(frame_encode_field)
         .collect::<Vec<_>>();
 
@@ -167,7 +199,6 @@ pub(crate) fn struct_frame(ddi: &DdiStruct) -> syn::Result<proc_macro2::TokenStr
     let reserve_body = ddi
         .fields
         .iter()
-        .filter(|f| !f.opt)
         .map(reserve_encode_field)
         .collect::<Vec<_>>();
 
@@ -217,7 +248,7 @@ pub(crate) fn struct_frame(ddi: &DdiStruct) -> syn::Result<proc_macro2::TokenStr
     // Structs whose FrameParams need lifetimes (because they have Normal
     // fields with borrowed data) cannot implement MborFrameable — they
     // are top-level response structs, not nested frame children.
-    let frameable_impl = if params_needs_lifetime {
+    let frameable_impl = if params_needs_lifetime || has_optional_field {
         quote! {}
     } else {
         let frameable_destructure = ddi
@@ -315,7 +346,8 @@ pub(crate) fn struct_frame(ddi: &DdiStruct) -> syn::Result<proc_macro2::TokenStr
             ) -> Result<#frame_ident<'a>, azihsm_fw_ddi_mbor::MborEncodeError> {
                 use azihsm_fw_ddi_mbor::MborEncode;
 
-                let cnt = #field_cnt as azihsm_fw_ddi_mbor::MborId;
+                let mut cnt = #field_cnt as azihsm_fw_ddi_mbor::MborId;
+                #enc_cnt
                 azihsm_fw_ddi_mbor::MborMap(cnt).mbor_encode(encoder)?;
 
                 #(#frame_body)*
@@ -335,7 +367,8 @@ pub(crate) fn struct_frame(ddi: &DdiStruct) -> syn::Result<proc_macro2::TokenStr
             ) -> Result<#layout_ident, azihsm_fw_ddi_mbor::MborEncodeError> {
                 use azihsm_fw_ddi_mbor::MborEncode;
 
-                let cnt = #field_cnt as azihsm_fw_ddi_mbor::MborId;
+                let mut cnt = #field_cnt as azihsm_fw_ddi_mbor::MborId;
+                #enc_cnt
                 azihsm_fw_ddi_mbor::MborMap(cnt).mbor_encode(encoder)?;
 
                 #(#reserve_body)*
@@ -392,10 +425,79 @@ pub(crate) fn struct_frame(ddi: &DdiStruct) -> syn::Result<proc_macro2::TokenStr
     })
 }
 
+/// Generate the encode body for a **by-value optional field**, shared by the
+/// frame and reserve paths.
+///
+/// Optional fields are never reserved (see [`is_frameable_field`]), so both
+/// paths encode the value inline and identically. The `if let Some(name) =
+/// name` binding moves the inner value out of the `Option<T>` param, so
+/// `name` is the owned `T` — for a slice that is `&[u8]` (encoded via
+/// [`MborByteSlice`]/[`MborPaddedByteSlice`], **not** `T::mbor_encode`), for
+/// an array `[u8; N]`, and for a primitive/struct the value itself. This
+/// mirrors [`crate::encode::encode_value`] so `frame`/`reserve` produce
+/// byte-identical output to `MborEncode`.
+fn opt_encode_field(f: &DdiStructField) -> proc_macro2::TokenStream {
+    let id = f.id;
+    let name = &f.ident;
+
+    let value_encode = match f.kind {
+        DdiStructFieldKind::Slice => {
+            // Validate length like `encode.rs`, then encode: fixed-size
+            // (`len`) slices are unpadded; variable-size (`max_len` or
+            // unbounded) slices are padded to 4-byte alignment.
+            let len_check = if let Some(exact) = f.len {
+                quote! {
+                    if #name.len() != #exact {
+                        return Err(azihsm_fw_ddi_mbor::MborEncodeError::InvalidLen);
+                    }
+                }
+            } else if let Some(max) = f.max_len {
+                quote! {
+                    if #name.len() > #max {
+                        return Err(azihsm_fw_ddi_mbor::MborEncodeError::InvalidLen);
+                    }
+                }
+            } else {
+                quote! {}
+            };
+            let encode = if f.len.is_some() {
+                quote! { azihsm_fw_ddi_mbor::MborByteSlice(#name).mbor_encode(encoder)?; }
+            } else {
+                quote! {
+                    let pad = azihsm_fw_ddi_mbor::pad4(encoder.position() as u32 + 3) as u8;
+                    azihsm_fw_ddi_mbor::MborPaddedByteSlice(#name, pad).mbor_encode(encoder)?;
+                }
+            };
+            quote! {
+                #len_check
+                #encode
+            }
+        }
+        DdiStructFieldKind::Array => {
+            quote! { azihsm_fw_ddi_mbor::MborByteSlice(&#name).mbor_encode(encoder)?; }
+        }
+        DdiStructFieldKind::Normal => {
+            quote! { #name.mbor_encode(encoder)?; }
+        }
+    };
+
+    quote! {
+        if let Some(#name) = #name {
+            (#id).mbor_encode(encoder)?;
+            #value_encode
+        }
+    }
+}
+
 /// Generate the frame encode body for a single non-optional field.
 fn frame_encode_field(f: &DdiStructField) -> proc_macro2::TokenStream {
     let id = f.id;
     let name = &f.ident;
+
+    if f.opt {
+        // By-value optional field: emit the map entry only when present.
+        return opt_encode_field(f);
+    }
 
     if f.frame {
         // Nested frame: delegate to child's MborFrameable::mbor_frame.
@@ -448,6 +550,11 @@ fn frame_encode_field(f: &DdiStructField) -> proc_macro2::TokenStream {
 fn reserve_encode_field(f: &DdiStructField) -> proc_macro2::TokenStream {
     let id = f.id;
     let name = &f.ident;
+
+    if f.opt {
+        // By-value optional field (never reserved): emit only when present.
+        return opt_encode_field(f);
+    }
 
     if f.frame {
         let ty = strip_lifetime(&f.ty);
@@ -526,14 +633,18 @@ fn strip_lifetime(ty: &syn::Type) -> proc_macro2::TokenStream {
     }
 }
 
-/// Returns `true` if a type contains any lifetime parameter.
+/// Returns `true` if a type contains any lifetime parameter, recursing
+/// into nested generic type arguments (so e.g. `Option<DdiPublicKey<'a>>`
+/// is detected, not just a directly-applied `Foo<'a>`).
 fn has_lifetime(ty: &syn::Type) -> bool {
     match ty {
         syn::Type::Path(type_path) => type_path.path.segments.iter().any(|seg| {
             if let syn::PathArguments::AngleBracketed(args) = &seg.arguments {
-                args.args
-                    .iter()
-                    .any(|arg| matches!(arg, syn::GenericArgument::Lifetime(_)))
+                args.args.iter().any(|arg| match arg {
+                    syn::GenericArgument::Lifetime(_) => true,
+                    syn::GenericArgument::Type(inner) => has_lifetime(inner),
+                    _ => false,
+                })
             } else {
                 false
             }

--- a/fw/core/ddi/mbor/derive/tests/frame_optional.rs
+++ b/fw/core/ddi/mbor/derive/tests/frame_optional.rs
@@ -1,0 +1,243 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Integration test for the `#[derive(Ddi)]` `frame()` / `reserve()`
+//! codegen's **by-value `Option` field** support.
+//!
+//! Uses dummy structs that mirror a real response shape — fixed fields,
+//! optional by-value fields (a primitive, a borrowed struct, and a borrowed
+//! slice, so the `Option<T<'a>>` / `Option<&'a [u8]>` lifetime handling is
+//! exercised), and a reserved trailing byte-slice. For every Some/None
+//! combination of the optionals, **both** the `reserve()` + `from_layout()`
+//! path and the `frame()` path (plus fill) must produce byte-identical output
+//! to the canonical [`MborEncode`] of the same struct — proving the derive
+//! resolves the runtime map count and emits each optional entry correctly,
+//! and that `frame`/`reserve` pad identically to `MborEncode`.
+//!
+//! [`OptSliceOnly`] additionally guards the case where the *only* borrowed
+//! by-value field is an `Option<&'a [u8]>`: `params_needs_lifetime` must keep
+//! `'a` on the generated `FrameParams` or the code won't compile.
+
+#![allow(unsafe_code, clippy::unwrap_used)]
+
+use azihsm_fw_ddi_mbor::MborEncode;
+use azihsm_fw_ddi_mbor::MborEncoder;
+use azihsm_fw_ddi_mbor_derive::Ddi;
+use azihsm_fw_hsm_pal_traits::DmaBuf;
+
+/// A nested struct with a borrowed field, used below as an *optional*
+/// by-value field so the codegen's `Option<T<'a>>` lifetime handling is
+/// exercised.
+#[derive(Ddi)]
+#[ddi(map)]
+struct Inner<'a> {
+    #[ddi(id = 1, max_len = 32)]
+    data: &'a [u8],
+    #[ddi(id = 2)]
+    tag: u8,
+}
+
+/// Fixed fields + optional by-value fields (primitive, borrowed struct, and
+/// borrowed slice) + a reserved trailing byte-slice.
+#[derive(Ddi)]
+#[ddi(map)]
+struct Resp<'a> {
+    #[ddi(id = 1)]
+    a: u16,
+    #[ddi(id = 2)]
+    inner: Option<Inner<'a>>,
+    #[ddi(id = 3)]
+    b: Option<u16>,
+    #[ddi(id = 4)]
+    c: u8,
+    #[ddi(id = 5, max_len = 32)]
+    opt_slice: Option<&'a [u8]>,
+    #[ddi(id = 6, max_len = 64)]
+    tail: &'a [u8],
+}
+
+/// Regression guard for the exact reviewer scenario: a frameable struct whose
+/// *only* borrowed by-value field is an optional slice (`Option<&'a [u8]>`).
+/// The fixed field and the reserved `tail` slice contribute no lifetime on
+/// their own (a non-optional slice reserves as a `usize` length). Before the
+/// fix, `params_needs_lifetime` skipped `Slice`-kind fields, so `FrameParams`
+/// was emitted without `'a` while still carrying `s: Option<&'a [u8]>` — which
+/// failed to compile. If that regresses, this file no longer compiles.
+#[derive(Ddi)]
+#[ddi(map)]
+struct OptSliceOnly<'a> {
+    #[ddi(id = 1)]
+    x: u16,
+    #[ddi(id = 2, max_len = 32)]
+    s: Option<&'a [u8]>,
+    #[ddi(id = 3, max_len = 64)]
+    tail: &'a [u8],
+}
+
+/// Brand a `&mut [u8]` as `&mut DmaBuf` — safe in tests (no DMA hw).
+fn dma(buf: &mut [u8]) -> &mut DmaBuf {
+    // SAFETY: tests only read/write the bytes; no DMA engine is involved.
+    unsafe { DmaBuf::from_raw_mut(buf) }
+}
+
+fn assert_reserve_matches_encode(with_inner: bool, with_b: bool, with_slice: bool) {
+    const DATA: [u8; 5] = [0xde, 0xad, 0xbe, 0xef, 0x01];
+    const SLICE: [u8; 6] = [0x11, 0x22, 0x33, 0x44, 0x55, 0x66];
+    const TAIL: [u8; 20] = [0xab; 20];
+    let a = 0x1234u16;
+    let c = 0x5u8;
+    let b = with_b.then_some(0x9abcu16);
+    // An optional *slice* field (kind == Slice) carried by value — the case
+    // that requires `params_needs_lifetime` to look past Normal/Array so the
+    // generated `FrameParams` keeps its `'a`.
+    let opt_slice = with_slice.then_some(&SLICE[..]);
+
+    // ── Canonical path: `MborEncode` the whole struct. ──
+    let mut buf_a = [0u8; 128];
+    let len_a = {
+        let inner = with_inner.then_some(Inner {
+            data: &DATA,
+            tag: 7,
+        });
+        let resp = Resp {
+            a,
+            inner,
+            b,
+            c,
+            opt_slice,
+            tail: &TAIL,
+        };
+        let mut enc = MborEncoder::new(&mut buf_a);
+        resp.mbor_encode(&mut enc).unwrap();
+        enc.position()
+    };
+
+    // ── Reserve path: `reserve` + `from_layout` + fill `tail`. ──
+    let mut buf_b = [0u8; 128];
+    let len_b = {
+        let inner = with_inner.then_some(Inner {
+            data: &DATA,
+            tag: 7,
+        });
+        let (pos, layout) = {
+            let mut enc = MborEncoder::new(&mut buf_b);
+            let layout = Resp::reserve(&mut enc, a, inner, b, c, opt_slice, TAIL.len()).unwrap();
+            (enc.position(), layout)
+        };
+        let frame = Resp::from_layout(dma(&mut buf_b), &layout);
+        frame.tail.copy_from_slice(&TAIL);
+        pos
+    };
+
+    // ── Frame path: `frame` writes the structure and hands back the
+    //    reserved `tail` slice directly (no separate `from_layout`). The
+    //    encoder position is the final length, captured before filling —
+    //    the returned frame borrows the buffer, not the encoder (see
+    //    `get_sealed_bk3.rs`). ──
+    let mut buf_c = [0u8; 128];
+    let len_c = {
+        let inner = with_inner.then_some(Inner {
+            data: &DATA,
+            tag: 7,
+        });
+        let mut enc = MborEncoder::new(&mut buf_c);
+        let frame = Resp::frame(&mut enc, a, inner, b, c, opt_slice, TAIL.len()).unwrap();
+        let pos = enc.position();
+        frame.tail.copy_from_slice(&TAIL);
+        pos
+    };
+
+    assert_eq!(
+        len_a, len_b,
+        "reserve length mismatch (inner={with_inner}, b={with_b})",
+    );
+    assert_eq!(
+        buf_a[..len_a],
+        buf_b[..len_b],
+        "reserve bytes mismatch (inner={with_inner}, b={with_b})",
+    );
+    assert_eq!(
+        len_a, len_c,
+        "frame length mismatch (inner={with_inner}, b={with_b})",
+    );
+    assert_eq!(
+        buf_a[..len_a],
+        buf_c[..len_c],
+        "frame bytes mismatch (inner={with_inner}, b={with_b})",
+    );
+}
+
+#[test]
+fn reserve_matches_encode_all_optional_combinations() {
+    for with_inner in [false, true] {
+        for with_b in [false, true] {
+            for with_slice in [false, true] {
+                assert_reserve_matches_encode(with_inner, with_b, with_slice);
+            }
+        }
+    }
+}
+
+/// The reviewer's case at runtime: an optional-slice-only struct must produce
+/// the same bytes as `MborEncode` via **both** the `reserve` + `from_layout`
+/// path and the `frame` path, for both `Some` and `None`. (Compiling this
+/// test at all is the primary regression guard.)
+#[test]
+fn opt_slice_only_reserve_matches_encode() {
+    const S: [u8; 4] = [0x11, 0x22, 0x33, 0x44];
+    const TAIL: [u8; 8] = [0xcd; 8];
+    for s in [None, Some(&S[..])] {
+        let mut buf_a = [0u8; 64];
+        let len_a = {
+            let resp = OptSliceOnly {
+                x: 0x77,
+                s,
+                tail: &TAIL,
+            };
+            let mut enc = MborEncoder::new(&mut buf_a);
+            resp.mbor_encode(&mut enc).unwrap();
+            enc.position()
+        };
+
+        let mut buf_b = [0u8; 64];
+        let len_b = {
+            let (pos, layout) = {
+                let mut enc = MborEncoder::new(&mut buf_b);
+                let layout = OptSliceOnly::reserve(&mut enc, 0x77, s, TAIL.len()).unwrap();
+                (enc.position(), layout)
+            };
+            let frame = OptSliceOnly::from_layout(dma(&mut buf_b), &layout);
+            frame.tail.copy_from_slice(&TAIL);
+            pos
+        };
+
+        let mut buf_c = [0u8; 64];
+        let len_c = {
+            let mut enc = MborEncoder::new(&mut buf_c);
+            let frame = OptSliceOnly::frame(&mut enc, 0x77, s, TAIL.len()).unwrap();
+            let pos = enc.position();
+            frame.tail.copy_from_slice(&TAIL);
+            pos
+        };
+
+        assert_eq!(
+            len_a,
+            len_b,
+            "reserve length mismatch (s={:?})",
+            s.is_some()
+        );
+        assert_eq!(
+            buf_a[..len_a],
+            buf_b[..len_b],
+            "reserve bytes mismatch (s={:?})",
+            s.is_some(),
+        );
+        assert_eq!(len_a, len_c, "frame length mismatch (s={:?})", s.is_some());
+        assert_eq!(
+            buf_a[..len_a],
+            buf_c[..len_c],
+            "frame bytes mismatch (s={:?})",
+            s.is_some(),
+        );
+    }
+}


### PR DESCRIPTION
The frame()/reserve() codegen for #[derive(Ddi)] response structs previously dropped every Option field: optionals were filtered out of FrameParams, the map entry count, and the encode bodies. A response struct with optional fields (e.g. an optional pub_key/bulk_key_id alongside a reserved trailing byte-slice) would therefore encode an incorrect map.

Teach the codegen to carry by-value Optional (Normal/Array) fields:
- include them in FrameParams / positional params as their Option<T>,
- resolve the map entry count at runtime (start from the field count and drop one per None, mirroring the normal MborEncode path),
- emit each optional entry only when Some, in both frame() and reserve().

Reserved fields (byte slices and #[ddi(frame)] children) stay non-optional. has_lifetime now recurses into nested generic arguments so Option<Foo<'a>> correctly makes FrameParams borrow 'a, and a struct with any optional field skips the MborFrameable impl (it is a top-level response frame, not a nested child).

Adds a derive-crate integration test (dummy structs mixing an optional primitive, an optional borrowed struct, and a reserved trailing slice) asserting reserve()+fill is byte-identical to the canonical MborEncode for every Some/None combination of the optionals.

Additive: no existing reserve-using struct has optional fields, so their generated code is unchanged.