### PR TITLE
feat(mbor): implement AttestKey command handler

### DIFF
--- a/ddi/mbor/types/tests/azihsm_ddi_tests.rs
+++ b/ddi/mbor/types/tests/azihsm_ddi_tests.rs
@@ -12,6 +12,7 @@ mod integration {
     pub mod aes_xts_bulk_stress;
     pub mod aes_xts_encrypt_decrypt;
     pub mod attest_key;
+    pub mod attest_key_smoke;
     pub mod change_pin;
     pub mod close_session;
     pub mod close_session_smoke;

--- a/ddi/mbor/types/tests/integration/attest_key.rs
+++ b/ddi/mbor/types/tests/integration/attest_key.rs
@@ -711,8 +711,136 @@ fn test_attest_secret_key() {
     );
 }
 
+/// Attest a derived AES key and assert it reports as an on-device
+/// *generated* (not imported) symmetric key with an empty public key.
+///
+/// Shared by the HKDF- and KBKDF-derived AES attestation tests: both
+/// derive an AES key on-device, so the report must show `is_generated`
+/// (parity with the derived HMAC / secret keys and the simulator).
+fn assert_derived_aes_attestation(
+    dev: &mut <DdiTest as Ddi>::Dev,
+    session_id: u16,
+    aes_key_id: u16,
+) {
+    let report_data = [3u8; REPORT_DATA_SIZE];
+    let result = helper_attest_key_cmd(
+        dev,
+        Some(session_id),
+        Some(DdiApiRev { major: 1, minor: 0 }),
+        report_data,
+        aes_key_id,
+    );
+    assert!(result.is_ok(), "result {:?}", result);
+    let resp = result.unwrap();
+    let report = resp.data.report.data_take();
+    let report_len = resp.data.report.len();
+    assert!(report_len <= TAGGED_COSE_SIGN1_OBJECT_MAX_SIZE);
+
+    let cert_chain = helper_get_cert_chain(dev);
+    assert!(helper_verify_cert_chain(&cert_chain).is_ok());
+    let report_payload = verify_report(&report, &cert_chain);
+
+    assert_eq!(report_payload.report_data, report_data);
+
+    let keyflags: KeyFlags = report_payload.flags.into();
+    // Derived on-device → attested as generated, never imported.
+    assert!(!keyflags.is_imported());
+    assert!(keyflags.is_generated());
+    // App availability → not a session key.
+    assert!(!keyflags.is_session_key());
+    assert!(keyflags.can_encrypt());
+    assert!(keyflags.can_decrypt());
+    assert!(!keyflags.can_sign());
+    assert!(!keyflags.can_verify());
+    assert!(!keyflags.can_wrap());
+    assert!(!keyflags.can_unwrap());
+    assert!(!keyflags.can_derive());
+
+    // Symmetric key → empty COSE_Key.
+    assert_eq!(report_payload.public_key_size, 0);
+    for byte in report_payload.public_key.iter() {
+        assert_eq!(*byte, 0);
+    }
+}
+
+#[test]
+fn test_attest_hkdf_derived_aes_key() {
+    ddi_dev_test(
+        common_setup,
+        common_cleanup,
+        |dev, _ddi, _path, session_id| {
+            // TODO: remove once virtual device supports cert chain ddi commands
+            let device_kind = get_device_kind(dev);
+            if device_kind != DdiDeviceKind::Physical {
+                tracing::debug!("Skipped test_attest_hkdf_derived_aes_key for virtual device");
+                return;
+            }
+
+            // Derive an AES-256 key on-device via ECDH + HKDF.
+            let (secret_key_id, _) = create_ecdh_secrets(session_id, dev, DdiKeyType::Secret256);
+            let key_props =
+                helper_key_properties(DdiKeyUsage::EncryptDecrypt, DdiKeyAvailability::App);
+            let resp = helper_hkdf_derive(
+                dev,
+                Some(session_id),
+                Some(DdiApiRev { major: 1, minor: 0 }),
+                secret_key_id,
+                DdiHashAlgorithm::Sha256,
+                None,
+                None,
+                DdiKeyType::Aes256,
+                None,
+                key_props,
+                Default::default(),
+            );
+            assert!(resp.is_ok(), "resp {:?}", resp);
+            let aes_key_id = resp.unwrap().data.key_id;
+
+            assert_derived_aes_attestation(dev, session_id, aes_key_id);
+        },
+    );
+}
+
+#[test]
+fn test_attest_kbkdf_derived_aes_key() {
+    ddi_dev_test(
+        common_setup,
+        common_cleanup,
+        |dev, _ddi, _path, session_id| {
+            // TODO: remove once virtual device supports cert chain ddi commands
+            let device_kind = get_device_kind(dev);
+            if device_kind != DdiDeviceKind::Physical {
+                tracing::debug!("Skipped test_attest_kbkdf_derived_aes_key for virtual device");
+                return;
+            }
+
+            // Derive an AES-256 key on-device via ECDH + KBKDF.
+            let (secret_key_id, _) = create_ecdh_secrets(session_id, dev, DdiKeyType::Secret256);
+            let key_props =
+                helper_key_properties(DdiKeyUsage::EncryptDecrypt, DdiKeyAvailability::App);
+            let resp = helper_kbkdf_derive(
+                dev,
+                Some(session_id),
+                Some(DdiApiRev { major: 1, minor: 0 }),
+                secret_key_id,
+                DdiHashAlgorithm::Sha256,
+                None,
+                None,
+                DdiKeyType::Aes256,
+                None,
+                key_props,
+                Default::default(),
+            );
+            assert!(resp.is_ok(), "resp {:?}", resp);
+            let aes_key_id = resp.unwrap().data.key_id;
+
+            assert_derived_aes_attestation(dev, session_id, aes_key_id);
+        },
+    );
+}
+
 /// Helper function to get certificate chain
-fn helper_get_cert_chain(dev: &mut <DdiTest as Ddi>::Dev) -> Vec<Vec<u8>> {
+pub(crate) fn helper_get_cert_chain(dev: &mut <DdiTest as Ddi>::Dev) -> Vec<Vec<u8>> {
     tracing::debug!("Getting certificate chain");
     // Gets the cert chain
     // 1. Gets the number of certs in the cert chain using DDI command GetCertChainInfo command
@@ -779,7 +907,7 @@ fn import_rsa_key(dev: &mut <DdiTest as Ddi>::Dev, session_id: u16) -> (u16, Vec
 }
 
 /// Helper function to verify the report
-fn verify_report(report: &[u8], cert_chain: &[Vec<u8>]) -> KeyAttestationReport {
+pub(crate) fn verify_report(report: &[u8], cert_chain: &[Vec<u8>]) -> KeyAttestationReport {
     tracing::debug!("Verifying report");
     tracing::debug!(?report, ?cert_chain, "Dumping report and certificate chain");
 
@@ -868,12 +996,12 @@ fn decode_report_payload(payload: &[u8]) -> KeyAttestationReport {
 }
 
 #[derive(Debug, PartialEq, PartialOrd)]
-enum CoseKey {
+pub(crate) enum CoseKey {
     RsaPublic { n: Vec<u8>, e: Vec<u8> },
     EccPublic { crv: i8, x: Vec<u8>, y: Vec<u8> },
 }
 
-fn decode_cose_key(data: &[u8]) -> CoseKey {
+pub(crate) fn decode_cose_key(data: &[u8]) -> CoseKey {
     let mut decoder = minicbor::Decoder::new(data);
 
     let result = decoder.map();
@@ -958,7 +1086,7 @@ fn decode_cose_key(data: &[u8]) -> CoseKey {
 }
 
 // Helper function to strip out leading zeros from a public key coordinate.
-fn normalized_key(key: &[u8]) -> Vec<u8> {
+pub(crate) fn normalized_key(key: &[u8]) -> Vec<u8> {
     let mut normalized_key = key.to_vec();
     while normalized_key.len() > 1 && normalized_key[0] == 0 {
         normalized_key.remove(0);

--- a/ddi/mbor/types/tests/integration/attest_key_smoke.rs
+++ b/ddi/mbor/types/tests/integration/attest_key_smoke.rs
@@ -1,0 +1,84 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! AttestKey smoke test for the emu backend.
+//!
+//! Exercises the firmware `AttestKey` handler end-to-end: generate an ECC
+//! key, attest it, verify the ES384/PID-signed COSE_Sign1 report against
+//! the partition cert chain, and confirm the attested public key
+//! round-trips. Named `*smoke*` so the smoke-filtered emu CI runs it.
+
+#![cfg(test)]
+
+use azihsm_crypto::*;
+use azihsm_ddi_mbor_test_helpers::*;
+use azihsm_ddi_mbor_types::*;
+use test_with_tracing::test;
+
+use super::attest_key::decode_cose_key;
+use super::attest_key::helper_get_cert_chain;
+use super::attest_key::normalized_key;
+use super::attest_key::verify_report;
+use super::attest_key::CoseKey;
+use super::common::*;
+
+#[test]
+fn test_attest_ecc_key_smoke() {
+    ddi_dev_test(
+        common_setup,
+        common_cleanup,
+        |dev, _ddi, _path, session_id| {
+            // The cert-chain verification path requires a physical/emu
+            // device; skip on backends that don't support it.
+            let device_kind = get_device_kind(dev);
+            if device_kind != DdiDeviceKind::Physical {
+                tracing::debug!("Skipped test_attest_ecc_key_smoke for virtual device");
+                return;
+            }
+
+            let (private_key_id, pub_key_der, _) = ecc_gen_key_mcr(
+                dev,
+                DdiEccCurve::P256,
+                None,
+                Some(session_id),
+                DdiKeyUsage::SignVerify,
+            );
+
+            let report_data = [7u8; REPORT_DATA_SIZE];
+            let resp = helper_attest_key_cmd(
+                dev,
+                Some(session_id),
+                Some(DdiApiRev { major: 1, minor: 0 }),
+                report_data,
+                private_key_id,
+            )
+            .expect("AttestKey must succeed for an ECC key");
+
+            let report = resp.data.report.data_take();
+            let report_len = resp.data.report.len();
+            assert!(report_len <= TAGGED_COSE_SIGN1_OBJECT_MAX_SIZE);
+
+            // The report must verify (ES384) against the PID key in the
+            // partition cert chain.
+            let cert_chain = helper_get_cert_chain(dev);
+            assert!(helper_verify_cert_chain(&cert_chain).is_ok());
+            let report_payload = verify_report(&report, &cert_chain);
+
+            assert_eq!(report_payload.report_data, report_data);
+
+            // The attested public key round-trips against the generated key.
+            let attested_key = decode_cose_key(
+                &report_payload.public_key[..report_payload.public_key_size.into()],
+            );
+            let ecc_pub =
+                EccPublicKey::from_bytes(&pub_key_der.der.data()[..pub_key_der.der.len()]).unwrap();
+            let CoseKey::EccPublic { crv, x, y } = attested_key else {
+                panic!("Should be CoseKey::EccPublic")
+            };
+            let (expected_x, expected_y) = ecc_pub.coord_vec().unwrap();
+            assert_eq!(normalized_key(&x), normalized_key(&expected_x));
+            assert_eq!(normalized_key(&y), normalized_key(&expected_y));
+            assert_eq!(crv, 1 /* P-256 */);
+        },
+    );
+}

--- a/fw/core/lib/src/ddi/mbor/attest_key.rs
+++ b/fw/core/lib/src/ddi/mbor/attest_key.rs
@@ -1,0 +1,210 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! DDI `AttestKey` command handler.
+//!
+//! Within an open session, produce a tagged COSE_Sign1 key-attestation
+//! report over a vault key identified by `key_id`, and return it. The
+//! report is signed **ES384 by the partition-identity (PID) key** — the
+//! same signer the firmware uses for the other key-attestation reports.
+//!
+//! ECC-private and RSA-private keys embed their public component in the
+//! report as an RFC 9052 COSE_Key. Every other kind (symmetric / bulk /
+//! HMAC / secret, or any key with no public component) is still
+//! attestable, but carries an **empty** COSE_Key (`public_key_size == 0`)
+//! — matching the reference firmware and simulator.
+//!
+//! Deriving the ECC / RSA public component uses the PAL's
+//! `ecc_priv_pub_key` / `rsa_priv_pub_key`. These are implemented on the
+//! std PAL (and exercised by the emu tests); on the Uno PAL they are still
+//! stubs pending PKA bring-up, so ECC / RSA attestation returns
+//! `UnsupportedCmd` on Uno hardware until those methods land. Symmetric
+//! attestation (empty COSE_Key) needs no public-key derivation and works
+//! on any PAL.
+//!
+//! The command **persists nothing** — it reads the attested key, derives
+//! its public component, and returns a signed report. No RSA verification
+//! is performed anywhere: the report signature is always ES384 over the
+//! PID key regardless of the attested key type.
+//!
+//! ## Endianness
+//!
+//! The attested key's public coordinates / modulus are baked into the
+//! opaque signed `report` byte array, which the MBOR wire layer does not
+//! convert. The PAL emits public keys in wire-LE, so this handler reverses
+//! each component to **big-endian** before building the COSE_Key (RFC 9052
+//! uses big-endian). Typed MBOR fields would instead rely on the wire
+//! layer's `pre_encode`/`post_decode`; the report is the exception because
+//! it is a signed opaque blob.
+
+use azihsm_fw_core_crypto_key_report::key_report;
+use azihsm_fw_core_crypto_key_report::AttestedPubKey;
+use azihsm_fw_core_crypto_key_report::KeyFlags;
+use azihsm_fw_core_crypto_key_report::KeyReportParams;
+use azihsm_fw_core_crypto_key_report::APP_UUID_LEN;
+use azihsm_fw_ddi_mbor_types::attest_key::DdiAttestKeyReq;
+use azihsm_fw_ddi_mbor_types::attest_key::DdiAttestKeyResp;
+
+use super::*;
+
+/// Translate the attested key's vault attributes into report [`KeyFlags`].
+fn key_flags_from_attrs(attrs: HsmVaultKeyAttrs) -> KeyFlags {
+    KeyFlags::new()
+        .with_is_imported(!attrs.local())
+        .with_is_session_key(attrs.session())
+        .with_is_generated(attrs.local())
+        .with_can_encrypt(attrs.encrypt())
+        .with_can_decrypt(attrs.decrypt())
+        .with_can_sign(attrs.sign())
+        .with_can_verify(attrs.verify())
+        .with_can_wrap(attrs.wrap())
+        .with_can_unwrap(attrs.unwrap())
+        .with_can_derive(attrs.derive())
+}
+
+/// Reverse-copy `src` into `dst[..src.len()]` (wire-LE → big-endian).
+fn reverse_copy(dst: &mut [u8], src: &[u8]) {
+    for (d, s) in dst.iter_mut().zip(src.iter().rev()) {
+        *d = *s;
+    }
+}
+
+/// Handle `DdiAttestKeyCmd`.
+pub(crate) async fn attest_key<'p, P: HsmPal>(
+    pal: &'p P,
+    io: &impl HsmIo,
+    decoder: &mut DdiDecoder<'_>,
+    hdr: &DdiReqHdr,
+) -> HsmResult<&'p DmaBuf> {
+    let body: DdiAttestKeyReq = decoder.decode_data()?;
+    let sess_id = hdr.sess_id.ok_or(HsmError::SessionExpected)?;
+    let key_id = HsmKeyId::from(body.key_id);
+
+    // Attested key metadata → report flags.
+    let kind = pal.vault_key_kind(io, key_id)?;
+    let attrs = pal.vault_key_attrs(io, key_id)?;
+    let flags: u32 = key_flags_from_attrs(attrs).into();
+
+    // `report_data` borrows directly from the decoded request buffer — no
+    // copy; `key_report` validates its exact `REPORT_DATA_LEN` length.
+    //
+    // `app_uuid` / `vm_launch_id` are IO-lifetime allocations: they feed
+    // both `key_report` passes, so they must live outside any scoped
+    // allocator whose bump-mark reset could overlap the response buffer.
+    let app_uuid = pal.dma_alloc(io, APP_UUID_LEN)?;
+    app_uuid.copy_from_slice(&crate::session::session_app_id(
+        pal,
+        io,
+        HsmSessId::from(sess_id),
+    )?);
+
+    let vm_launch_id = crate::part_state::part_vm_launch_guid(pal, io)?;
+
+    // Derive the attested key's public component in big-endian COSE form.
+    // The private key material is fetched only in the ECC/RSA arms; the
+    // symmetric path has no public component and never touches it.
+    let key = if let Ok(curve) = super::from_pal::ecc_curve(kind) {
+        let priv_key = pal.vault_key(io, key_id)?;
+        let coord_raw = curve.priv_key_len();
+        let coord_wire = curve.wire_coord_len();
+        let wire_len = curve.wire_pub_key_len();
+        let pub_le = pal.dma_alloc(io, wire_len)?;
+        // The serialize pass must write the full wire key; a short write
+        // would leave stale DMA bytes in the tail of `pub_le` that must not
+        // be baked into the report — treat any mismatch as a PAL fault.
+        if pal
+            .ecc_priv_pub_key(io, priv_key, Some(&mut *pub_le))
+            .await?
+            != wire_len
+        {
+            return Err(HsmError::InternalError);
+        }
+        let x_be = pal.dma_alloc(io, coord_raw)?;
+        let y_be = pal.dma_alloc(io, coord_raw)?;
+        reverse_copy(x_be, &pub_le[..coord_raw]);
+        reverse_copy(y_be, &pub_le[coord_wire..coord_wire + coord_raw]);
+        AttestedPubKey::Ecc {
+            curve,
+            x: x_be,
+            y: y_be,
+        }
+    } else if let Ok(rsa) = super::from_pal::rsa_key(kind) {
+        let priv_key = pal.vault_key(io, key_id)?;
+        let mod_len = rsa.modulus_len();
+        // The PAL emits the RSA public key as wire-LE `n_le || e_le`, where
+        // `e_le` is a fixed 4-byte little-endian exponent, so the wire is
+        // exactly `mod_len + RSA_PUB_EXP_LEN`. Any other length means the
+        // PAL and our modulus-kind mapping disagree — a PAL/internal fault,
+        // not a caller error.
+        const RSA_PUB_EXP_LEN: usize = 4;
+        let wire = mod_len + RSA_PUB_EXP_LEN;
+        if pal.rsa_priv_pub_key(io, priv_key, None)? != wire {
+            return Err(HsmError::InternalError);
+        }
+        let pub_le = pal.dma_alloc(io, wire)?;
+        // The serialize pass must write exactly the queried length; a
+        // shorter write would leave stale bytes in the tail of `pub_le`.
+        if pal.rsa_priv_pub_key(io, priv_key, Some(&mut *pub_le))? != wire {
+            return Err(HsmError::InternalError);
+        }
+        let n_be = pal.dma_alloc(io, mod_len)?;
+        let e_be = pal.dma_alloc(io, RSA_PUB_EXP_LEN)?;
+        reverse_copy(n_be, &pub_le[..mod_len]);
+        reverse_copy(e_be, &pub_le[mod_len..wire]);
+        AttestedPubKey::Rsa { n: n_be, e: e_be }
+    } else {
+        // Any other kind (symmetric / bulk / HMAC / secret) is attestable
+        // but has no public component: emit an empty COSE_Key, matching the
+        // reference firmware. The report still binds the key's flags and
+        // report_data under the PID signature.
+        AttestedPubKey::Symmetric
+    };
+
+    // Sign the report with the partition-identity (PID) key.
+    let pid_priv = pal.vault_key(io, crate::part_state::part_id_key_id(pal, io)?)?;
+
+    let params = KeyReportParams {
+        key,
+        flags,
+        app_uuid,
+        report_data: body.report_data,
+        vm_launch_id,
+    };
+
+    // Two-pass build: query the exact report size, reserve the response
+    // frame, then build the report straight into the reserved slot
+    // (zero-copy — no intermediate buffer).
+    let report_len = pal
+        .alloc_scoped_async(io, async |a| {
+            key_report(pal, io, a, &params, pid_priv, None).await
+        })
+        .await?;
+    if report_len > DdiAttestKeyResp::MAX_REPORT_SIZE {
+        return Err(HsmError::InternalError);
+    }
+
+    // Reserve the response (header + byte-array framing) sized to the
+    // report.
+    let (resp, layout) = pal.dma_alloc_var_with(io, |buf| {
+        let mut encoder = super::encode_resp_hdr(
+            &super::success_hdr_sess(hdr, DdiOp::AttestKey, sess_id),
+            buf,
+        )?;
+        let layout = DdiAttestKeyResp::reserve(&mut encoder, report_len)?;
+        Ok((encoder.position(), layout))
+    })?;
+    let frame = DdiAttestKeyResp::from_layout(resp, &layout);
+
+    // Build the report directly into the reserved `report` slot.
+    let written = pal
+        .alloc_scoped_async(io, async |a| {
+            key_report(pal, io, a, &params, pid_priv, Some(&mut *frame.report)).await
+        })
+        .await?;
+    // The slot was reserved for exactly `report_len`; refuse to return a
+    // short write — stale DMA bytes would otherwise leak to the host.
+    if written != report_len {
+        return Err(HsmError::InternalError);
+    }
+    Ok(resp)
+}

--- a/fw/core/lib/src/ddi/mbor/hkdf_derive.rs
+++ b/fw/core/lib/src/ddi/mbor/hkdf_derive.rs
@@ -48,8 +48,10 @@ pub(crate) async fn hkdf_derive<'p, P: HsmPal>(
 
     let algo = super::from_ddi::hash(body.hash_algorithm)?;
     let target = super::kdf::resolve_target(body.key_type, body.key_length)?;
+    // A KDF-derived key is created on-device, so `local = true` (it attests
+    // as generated, not imported — parity with the HMAC path and the sim).
     let attrs = match target.class {
-        KdfClass::Aes => super::key_attrs::for_aes(&body.key_properties.key_metadata, false)?,
+        KdfClass::Aes => super::key_attrs::for_aes(&body.key_properties.key_metadata, true)?,
         KdfClass::Hmac => super::key_attrs::for_var_hmac(&body.key_properties.key_metadata)?,
     };
     super::key_attrs::check_session_key_tag(attrs, body.key_tag)?;

--- a/fw/core/lib/src/ddi/mbor/kbkdf_derive.rs
+++ b/fw/core/lib/src/ddi/mbor/kbkdf_derive.rs
@@ -52,8 +52,10 @@ pub(crate) async fn kbkdf_counter_hmac_derive<'p, P: HsmPal>(
 
     let algo = super::from_ddi::hash(body.hash_algorithm)?;
     let target = super::kdf::resolve_target(body.key_type, body.key_length)?;
+    // A KDF-derived key is created on-device, so `local = true` (it attests
+    // as generated, not imported — parity with the HMAC path and the sim).
     let attrs = match target.class {
-        KdfClass::Aes => super::key_attrs::for_aes(&body.key_properties.key_metadata, false)?,
+        KdfClass::Aes => super::key_attrs::for_aes(&body.key_properties.key_metadata, true)?,
         KdfClass::Hmac => super::key_attrs::for_var_hmac(&body.key_properties.key_metadata)?,
     };
     super::key_attrs::check_session_key_tag(attrs, body.key_tag)?;

--- a/fw/core/lib/src/ddi/mbor/key_attrs.rs
+++ b/fw/core/lib/src/ddi/mbor/key_attrs.rs
@@ -8,8 +8,10 @@
 //! `key_metadata` bitflags into the firmware-side vault attribute
 //! set the corresponding key kind is allowed to carry.  All builders
 //! share the same skeleton — exactly one of the five usage flag
-//! groups must be set, `local` reflects PKCS#11 `CKA_LOCAL` (set only for
-//! on-device key *generation*, not derive / import), and `session` is
+//! groups must be set, `local` marks provenance — `true` for keys created
+//! on-device (generated *or* derived), `false` only for imported /
+//! unwrapped keys, matching the attestation report's `is_generated` /
+//! `is_imported` flags — and `session` is
 //! independent — but each
 //! enforces a per-algorithm policy on which usage(s) are valid.
 //!
@@ -77,8 +79,9 @@ pub(crate) fn for_ecc(metadata: &DdiTargetKeyMetadata, local: bool) -> HsmResult
 
 /// Build vault attrs for a non-bulk AES key.
 ///
-/// `local` records provenance: `true` only for a key generated on this device,
-/// `false` for derived and imported / unwrapped keys (e.g. recovered via RsaUnwrap).
+/// `local` records provenance: `true` for a key created on this device
+/// (generated *or* derived), `false` only for imported / unwrapped keys
+/// (e.g. recovered via RsaUnwrap).  The caller passes the right value.
 ///
 /// AES (non-bulk) keys can only carry `EncryptDecrypt`.  Any other
 /// usage flag — sign, verify, derive, wrap, or unwrap — is rejected
@@ -159,15 +162,17 @@ pub(crate) fn for_rsa(metadata: &DdiTargetKeyMetadata, local: bool) -> HsmResult
 
 /// Build vault attrs for an ECDH-derived shared secret.
 ///
-/// The secret is *derived* (ECDH key agreement), so it is never marked
-/// `local` — PKCS#11 sets `CKA_LOCAL` only for on-device key generation.
+/// The secret is created on-device (ECDH key agreement), so it is marked
+/// `local`: the attestation report treats generated *and* on-device-derived
+/// keys as `is_generated` (matching the reference firmware / simulator);
+/// only imported / unwrapped keys are non-`local`.
 ///
 /// Derived secrets are HKDF / KBKDF inputs, so the only valid usage
 /// is `derive` (PKCS#11 `CKA_DERIVE`).  Any other usage is rejected
 /// with [`HsmError::InvalidPermissions`].
 pub(crate) fn for_ecdh_secret(metadata: &DdiTargetKeyMetadata) -> HsmResult<HsmVaultKeyAttrs> {
     validate_pairs(metadata)?;
-    let mut attrs = HsmVaultKeyAttrs::new().with_local(false);
+    let mut attrs = HsmVaultKeyAttrs::new().with_local(true);
 
     let sign_verify = metadata.sign() && metadata.verify();
     let encrypt_decrypt = metadata.encrypt() && metadata.decrypt();
@@ -198,8 +203,10 @@ pub(crate) fn for_ecdh_secret(metadata: &DdiTargetKeyMetadata) -> HsmResult<HsmV
 
 /// Build vault attrs for a derived variable-length HMAC key.
 ///
-/// These keys are *derived* (HKDF / KBKDF), so they are never marked
-/// `local` — PKCS#11 sets `CKA_LOCAL` only for on-device key generation.
+/// These keys are created on-device (HKDF / KBKDF derive), so they are
+/// marked `local`: the attestation report treats generated *and*
+/// on-device-derived keys as `is_generated` (matching the reference
+/// firmware / simulator); only imported / unwrapped keys are non-`local`.
 ///
 /// HMAC keys produced by HKDF / KBKDF can sign / verify MACs or act
 /// as a key-derivation key (`derive`) for a further KDF.  Exactly one
@@ -207,7 +214,7 @@ pub(crate) fn for_ecdh_secret(metadata: &DdiTargetKeyMetadata) -> HsmResult<HsmV
 /// and `unwrap` are rejected with [`HsmError::InvalidPermissions`].
 pub(crate) fn for_var_hmac(metadata: &DdiTargetKeyMetadata) -> HsmResult<HsmVaultKeyAttrs> {
     validate_pairs(metadata)?;
-    let mut attrs = HsmVaultKeyAttrs::new().with_local(false);
+    let mut attrs = HsmVaultKeyAttrs::new().with_local(true);
 
     let sign_verify = metadata.sign() && metadata.verify();
     let encrypt_decrypt = metadata.encrypt() && metadata.decrypt();

--- a/fw/core/lib/src/ddi/mbor/mod.rs
+++ b/fw/core/lib/src/ddi/mbor/mod.rs
@@ -3,6 +3,7 @@
 
 pub(crate) mod aes_encrypt_decrypt;
 pub(crate) mod aes_generate_key;
+pub(crate) mod attest_key;
 pub(crate) mod close_session;
 pub(crate) mod delete_key;
 pub(crate) mod ecc_generate_key_pair;
@@ -33,6 +34,7 @@ pub(crate) mod sha_digest;
 
 pub(crate) use aes_encrypt_decrypt::*;
 pub(crate) use aes_generate_key::*;
+pub(crate) use attest_key::*;
 use azihsm_fw_ddi_mbor::*;
 use azihsm_fw_ddi_mbor_api::DdiDecoder;
 use azihsm_fw_ddi_mbor_api::DdiEncoder;
@@ -178,6 +180,7 @@ pub(crate) async fn dispatch<'p, P: HsmPal>(
         DdiOp::KbkdfCounterHmacDerive => kbkdf_counter_hmac_derive(pal, io, decoder, hdr).await,
         DdiOp::Hmac => hmac(pal, io, decoder, hdr).await,
         DdiOp::RsaModExp => rsa_mod_exp(pal, io, decoder, hdr).await,
+        DdiOp::AttestKey => attest_key(pal, io, decoder, hdr).await,
         _ => Err(HsmError::UnsupportedCmd),
     }?;
     Ok(DispatchResult::from_resp(resp))


### PR DESCRIPTION
## Summary

Implements the MBOR **`AttestKey`** command (`DdiOp::AttestKey` = 1016) in the firmware. Given a vault `key_id` + caller `report_data`, it produces a tagged COSE_Sign1 key-attestation report over that key, **ES384-signed by the partition-identity (PID) key** — the same signer used for the other firmware key-attestation reports.

The wire types (`DdiAttestKeyReq`/`Resp`), opcode, and a comprehensive test file already existed; this PR adds the missing firmware handler + dispatch, plus a derived-key provenance alignment the handler exposed.

## Handler (`fw/core/lib/src/ddi/mbor/attest_key.rs`)

- Attests **ECC-private** (P-256/384/521) and **RSA-private** (2k/3k/4k, plain + CRT) keys — the public component is derived on-device (`ecc_priv_pub_key` / `rsa_priv_pub_key`) and embedded as an RFC 9052 COSE_Key.
- **Symmetric / bulk / HMAC / secret** keys are attestable too, with an empty COSE_Key (matching the reference firmware / simulator).
- **No RSA verification** — the report signature is always ES384 over the PID key; RSA only appears as embedded public material.
- Pure assembly of existing pieces: reuses the `azihsm_fw_core_crypto_key_report` encoder + existing PAL calls. **No new PAL methods, no new crates.**
- Public coordinates / modulus are reversed to big-endian before building the COSE_Key, since they are baked into the opaque signed `report` blob (which the MBOR wire layer does not convert — typed fields rely on `pre_encode`/`post_decode`, the report is the exception).

## Derived-key provenance alignment

The firmware marked on-device-**derived** keys `local=false` (strict PKCS#11 `CKA_LOCAL`), so they attested as *imported*. The simulator/reference and the existing masked-key tests treat them as **created on-device**. Since the **only** firmware reader of `local` is the attestation flag mapping, this PR aligns:

- HKDF/KBKDF-derived **HMAC** (`for_var_hmac`), **ECDH-derived secrets** (`for_ecdh_secret`), and HKDF/KBKDF-derived **AES** (`for_aes(..., true)`) → `local=true`.
- Imported / unwrapped keys (RsaUnwrap) stay non-`local`.

This makes the firmware consistent with the simulator **and** the pre-existing `secret_hkdf_derive` / `secret_kbkdf_derive` / `masked_key_*` tests, which already assert `MaskedKeyAttributes::LOCAL` for derived keys.

## Tests

- **`attest_key_smoke.rs`** — emu-runnable ECC round-trip (verifies the ES384/PID report against the partition cert chain and round-trips the attested key), in a separate `*_smoke.rs` file per convention.
- **`test_attest_hkdf_derived_aes_key`** / **`test_attest_kbkdf_derived_aes_key`** — lock in that derived AES keys attest as *generated* with an empty COSE_Key.

## Validation

- fw core + uno build; clippy `-D warnings`, nightly rustfmt (root + uno), copyright: all clean.
- **emu**: ECC×2, RSA×2, AES, HMAC, secret, HKDF-AES, KBKDF-AES attest tests pass, plus the smoke test.
- **mock** (sim, unaffected by this fw-only change): all attest tests pass.

### Known out-of-scope emu failures (not this handler)
- `test_attest_aes_xts_bulk_key` — AES-XTS not implemented yet.
- 6 `test_attest_masked_key_rsa_*` — emu masked-key placeholder (fail before attest). Both are HW/sim-covered and excluded from the smoke-filtered emu CI.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>