### PR TITLE
feat(fw): return masked-key envelopes from key create/derive handlers

### DIFF
--- a/ddi/mbor/types/tests/integration/aes_generate_smoke.rs
+++ b/ddi/mbor/types/tests/integration/aes_generate_smoke.rs
@@ -3,9 +3,9 @@
 
 //! AesGenerateKey smoke tests for the emu backend.
 //!
-//! - Happy path: generate an AES-128 encrypt/decrypt key in an open
-//!   session and confirm the response carries a non-zero `key_id`
-//!   and the expected (empty placeholder) masked-key envelope.
+//! - Happy path: generate an AES-128/192/256 encrypt/decrypt key in an
+//!   open session and confirm the response carries a non-zero `key_id`
+//!   and a populated masked-key envelope (randomized IV).
 //! - Without a session: rejected by the host-side dev validator
 //!   before the request reaches firmware.
 
@@ -24,25 +24,52 @@ fn test_aes_generate_smoke() {
         common_setup,
         common_cleanup,
         |dev, _ddi, _path, session_id| {
-            let key_props =
-                helper_key_properties(DdiKeyUsage::EncryptDecrypt, DdiKeyAvailability::App);
-            let resp = helper_aes_generate(
-                dev,
-                Some(session_id),
-                Some(DdiApiRev { major: 1, minor: 0 }),
+            // Every AES key size must import cleanly and return a
+            // populated masked-key envelope.
+            for key_size in [
                 DdiAesKeySize::Aes128,
-                None,
-                key_props,
-            )
-            .unwrap();
+                DdiAesKeySize::Aes192,
+                DdiAesKeySize::Aes256,
+            ] {
+                let key_props =
+                    helper_key_properties(DdiKeyUsage::EncryptDecrypt, DdiKeyAvailability::App);
+                let resp = helper_aes_generate(
+                    dev,
+                    Some(session_id),
+                    Some(DdiApiRev { major: 1, minor: 0 }),
+                    key_size,
+                    None,
+                    key_props,
+                )
+                .unwrap();
 
-            assert_eq!(resp.hdr.op, DdiOp::AesGenerateKey);
-            assert_eq!(resp.hdr.status, DdiStatus::Success);
-            assert_ne!(resp.data.key_id, 0, "key_id must be non-zero");
-            assert!(
-                resp.data.bulk_key_id.is_none(),
-                "non-bulk AES request must carry bulk_key_id = None"
-            );
+                assert_eq!(resp.hdr.op, DdiOp::AesGenerateKey);
+                assert_eq!(resp.hdr.status, DdiStatus::Success);
+                assert_ne!(resp.data.key_id, 0, "key_id must be non-zero");
+                assert!(
+                    resp.data.bulk_key_id.is_none(),
+                    "non-bulk AES request must carry bulk_key_id = None"
+                );
+
+                // The generated key is returned as a populated masked-key
+                // envelope with a randomized IV and the requested attributes.
+                assert!(
+                    !resp.data.masked_key.as_slice().is_empty(),
+                    "masked_key must be populated for {key_size:?}",
+                );
+                assert!(
+                    verify_iv_not_default_from_masked_key(resp.data.masked_key.as_slice())
+                        .unwrap_or(false),
+                    "masked_key IV must be randomized for {key_size:?}",
+                );
+                assert!(
+                    verify_masked_key_attributes(
+                        resp.data.masked_key.as_slice(),
+                        MaskedKeyAttributes::ENCRYPT | MaskedKeyAttributes::DECRYPT
+                    ),
+                    "masked_key attributes must include ENCRYPT|DECRYPT for {key_size:?}",
+                );
+            }
         },
     );
 }

--- a/ddi/mbor/types/tests/integration/common.rs
+++ b/ddi/mbor/types/tests/integration/common.rs
@@ -832,10 +832,8 @@ pub fn get_unwrapping_key(
         }
         assert!(resp.is_ok(), "resp {:?}", resp);
         let resp = resp.unwrap();
-        // The sim (mock) backend returns a populated masked-key
-        // envelope; the emu backend defers firmware-side masking and
-        // emits an empty placeholder for now, so only assert off-emu.
-        #[cfg(not(feature = "emu"))]
+        // Both the sim (mock) and emu (firmware) backends now return a
+        // populated masked-key envelope for the unwrapping key.
         assert!(!resp.data.masked_key.is_empty());
 
         return (

--- a/ddi/mbor/types/tests/integration/ecc_generate_smoke.rs
+++ b/ddi/mbor/types/tests/integration/ecc_generate_smoke.rs
@@ -3,9 +3,10 @@
 
 //! EccGenerateKeyPair smoke tests for the emu backend.
 //!
-//! - Happy path: generate a P-256 sign/verify key in an open session
-//!   and confirm the response carries a non-zero `private_key_id`
-//!   and a non-empty public key.
+//! - Happy path: generate a P-256/384/521 sign/verify key in an open
+//!   session and confirm the response carries a non-zero
+//!   `private_key_id`, a non-empty public key, and a populated
+//!   masked-key envelope (randomized IV).
 //! - Without a session: rejected by the host-side dev validator
 //!   before the request reaches firmware.
 
@@ -24,27 +25,51 @@ fn test_ecc_generate_smoke() {
         common_setup,
         common_cleanup,
         |dev, _ddi, _path, session_id| {
-            let key_props = helper_key_properties(DdiKeyUsage::SignVerify, DdiKeyAvailability::App);
-            let resp = helper_ecc_generate_key_pair(
-                dev,
-                Some(session_id),
-                Some(DdiApiRev { major: 1, minor: 0 }),
-                DdiEccCurve::P256,
-                None,
-                key_props,
-            )
-            .unwrap();
+            // Every curve must generate cleanly and return a non-empty
+            // public key plus a populated masked-key envelope.
+            for curve in [DdiEccCurve::P256, DdiEccCurve::P384, DdiEccCurve::P521] {
+                let key_props =
+                    helper_key_properties(DdiKeyUsage::SignVerify, DdiKeyAvailability::App);
+                let resp = helper_ecc_generate_key_pair(
+                    dev,
+                    Some(session_id),
+                    Some(DdiApiRev { major: 1, minor: 0 }),
+                    curve,
+                    None,
+                    key_props,
+                )
+                .unwrap();
 
-            assert_eq!(resp.hdr.op, DdiOp::EccGenerateKeyPair);
-            assert_eq!(resp.hdr.status, DdiStatus::Success);
-            assert_ne!(
-                resp.data.private_key_id, 0,
-                "private_key_id must be non-zero"
-            );
-            assert!(
-                !resp.data.pub_key.der.as_slice().is_empty(),
-                "public key bytes must be non-empty"
-            );
+                assert_eq!(resp.hdr.op, DdiOp::EccGenerateKeyPair);
+                assert_eq!(resp.hdr.status, DdiStatus::Success);
+                assert_ne!(
+                    resp.data.private_key_id, 0,
+                    "private_key_id must be non-zero for {curve:?}",
+                );
+                assert!(
+                    !resp.data.pub_key.der.as_slice().is_empty(),
+                    "public key bytes must be non-empty for {curve:?}",
+                );
+
+                // The generated private key is returned as a populated
+                // masked-key envelope with a randomized IV.
+                assert!(
+                    !resp.data.masked_key.as_slice().is_empty(),
+                    "masked_key must be populated for {curve:?}",
+                );
+                assert!(
+                    verify_iv_not_default_from_masked_key(resp.data.masked_key.as_slice())
+                        .unwrap_or(false),
+                    "masked_key IV must be randomized for {curve:?}",
+                );
+                assert!(
+                    verify_masked_key_attributes(
+                        resp.data.masked_key.as_slice(),
+                        MaskedKeyAttributes::SIGN | MaskedKeyAttributes::VERIFY
+                    ),
+                    "masked_key attributes must include SIGN|VERIFY for {curve:?}",
+                );
+            }
         },
     );
 }

--- a/ddi/mbor/types/tests/integration/ecdh_smoke.rs
+++ b/ddi/mbor/types/tests/integration/ecdh_smoke.rs
@@ -57,6 +57,25 @@ fn test_ecdh_key_exchange_smoke() {
             assert_eq!(resp1.hdr.status, DdiStatus::Success);
             assert_ne!(resp1.data.key_id, 0);
 
+            // The derived shared secret is returned as a populated
+            // masked-key envelope with a randomized IV.
+            assert!(
+                !resp1.data.masked_key.as_slice().is_empty(),
+                "ECDH masked_key must be populated"
+            );
+            assert!(
+                verify_iv_not_default_from_masked_key(resp1.data.masked_key.as_slice())
+                    .unwrap_or(false),
+                "ECDH masked_key IV must be randomized",
+            );
+            assert!(
+                verify_masked_key_attributes(
+                    resp1.data.masked_key.as_slice(),
+                    MaskedKeyAttributes::DERIVE
+                ),
+                "ECDH masked_key attributes must include DERIVE",
+            );
+
             // Side B: derive Secret256 from (priv2, pub1).  Both sides
             // must succeed; the fact that both ECDH operations produce
             // a vault entry is the firmware-side smoke contract — the

--- a/ddi/mbor/types/tests/integration/get_unwrapping_key_smoke.rs
+++ b/ddi/mbor/types/tests/integration/get_unwrapping_key_smoke.rs
@@ -4,11 +4,10 @@
 //! GetUnwrappingKey smoke tests.
 //!
 //! - Happy path: with an open session, the command returns an RSA-2048
-//!   public key and a vault key id.  We intentionally do *not* assert
-//!   on `masked_key` — the firmware emits an empty placeholder until
-//!   vault-key masking is wired up — nor on the exact `key_id` value,
-//!   which is an opaque handle (the sim backend legitimately assigns
-//!   `0`).
+//!   public key, a vault key id, and a populated masked-key envelope
+//!   (the partition unwrapping key, masked for host re-import).  We do
+//!   not assert on the exact `key_id` value, which is an opaque handle
+//!   (the sim backend legitimately assigns `0`).
 //! - Stability: two calls on the same partition return the same key id
 //!   and public-key bytes — the key is partition-cached and lazily
 //!   generated on first use.
@@ -48,6 +47,25 @@ fn test_get_unwrapping_key_smoke() {
                 resp.data.pub_key.key_kind,
                 DdiKeyType::Rsa2kPublic,
                 "unwrap key must be RSA-2048"
+            );
+
+            // The unwrapping key is returned as a populated masked-key
+            // envelope with a randomized IV, for host re-import.
+            assert!(
+                !resp.data.masked_key.as_slice().is_empty(),
+                "unwrap masked_key must be populated"
+            );
+            assert!(
+                verify_iv_not_default_from_masked_key(resp.data.masked_key.as_slice())
+                    .unwrap_or(false),
+                "unwrap masked_key IV must be randomized",
+            );
+            assert!(
+                verify_masked_key_attributes(
+                    resp.data.masked_key.as_slice(),
+                    MaskedKeyAttributes::UNWRAP
+                ),
+                "unwrap masked_key attributes must include UNWRAP",
             );
         },
     );

--- a/ddi/mbor/types/tests/integration/hkdf_smoke.rs
+++ b/ddi/mbor/types/tests/integration/hkdf_smoke.rs
@@ -56,11 +56,30 @@ fn test_hkdf_aes_derive_smoke() {
                     None,
                 )
                 .expect("HKDF AES-256 derive should succeed")
-                .data
-                .key_id
             };
-            let key1 = derive(dev, secret1);
-            let key2 = derive(dev, secret2);
+            let resp1 = derive(dev, secret1);
+
+            // The derived key is returned as a populated masked-key
+            // envelope with a randomized IV.
+            assert!(
+                !resp1.data.masked_key.as_slice().is_empty(),
+                "HKDF AES-256 masked_key must be populated"
+            );
+            assert!(
+                verify_iv_not_default_from_masked_key(resp1.data.masked_key.as_slice())
+                    .unwrap_or(false),
+                "HKDF AES-256 masked_key IV must be randomized",
+            );
+            assert!(
+                verify_masked_key_attributes(
+                    resp1.data.masked_key.as_slice(),
+                    MaskedKeyAttributes::ENCRYPT | MaskedKeyAttributes::DECRYPT
+                ),
+                "HKDF AES-256 masked_key attributes must include ENCRYPT|DECRYPT",
+            );
+
+            let key1 = resp1.data.key_id;
+            let key2 = derive(dev, secret2).data.key_id;
 
             // Encrypt with key1, decrypt with key2 — recovers the input
             // iff both derivations produced the same usable AES key.
@@ -140,6 +159,22 @@ fn test_hkdf_hmac_derive_smoke() {
                 let resp = resp.unwrap();
                 assert_eq!(resp.hdr.op, DdiOp::HkdfDerive);
                 assert_eq!(resp.hdr.status, DdiStatus::Success);
+                assert!(
+                    !resp.data.masked_key.as_slice().is_empty(),
+                    "HKDF {key_type:?} masked_key must be populated",
+                );
+                assert!(
+                    verify_iv_not_default_from_masked_key(resp.data.masked_key.as_slice())
+                        .unwrap_or(false),
+                    "HKDF {key_type:?} masked_key IV must be randomized",
+                );
+                assert!(
+                    verify_masked_key_attributes(
+                        resp.data.masked_key.as_slice(),
+                        MaskedKeyAttributes::SIGN | MaskedKeyAttributes::VERIFY
+                    ),
+                    "HKDF {key_type:?} masked_key attributes must include SIGN|VERIFY",
+                );
             }
         },
     );
@@ -170,6 +205,22 @@ fn test_hkdf_var_hmac_derive_smoke() {
                 let resp = resp.unwrap();
                 assert_eq!(resp.hdr.op, DdiOp::HkdfDerive);
                 assert_eq!(resp.hdr.status, DdiStatus::Success);
+                assert!(
+                    !resp.data.masked_key.as_slice().is_empty(),
+                    "HKDF {key_type:?} len {key_len} masked_key must be populated",
+                );
+                assert!(
+                    verify_iv_not_default_from_masked_key(resp.data.masked_key.as_slice())
+                        .unwrap_or(false),
+                    "HKDF {key_type:?} len {key_len} masked_key IV must be randomized",
+                );
+                assert!(
+                    verify_masked_key_attributes(
+                        resp.data.masked_key.as_slice(),
+                        MaskedKeyAttributes::SIGN | MaskedKeyAttributes::VERIFY
+                    ),
+                    "HKDF {key_type:?} len {key_len} masked_key attrs must include SIGN|VERIFY",
+                );
             }
         },
     );

--- a/ddi/mbor/types/tests/integration/kbkdf_smoke.rs
+++ b/ddi/mbor/types/tests/integration/kbkdf_smoke.rs
@@ -56,11 +56,30 @@ fn test_kbkdf_aes_derive_smoke() {
                     None,
                 )
                 .expect("KBKDF AES-256 derive should succeed")
-                .data
-                .key_id
             };
-            let key1 = derive(dev, secret1);
-            let key2 = derive(dev, secret2);
+            let resp1 = derive(dev, secret1);
+
+            // The derived key is returned as a populated masked-key
+            // envelope with a randomized IV.
+            assert!(
+                !resp1.data.masked_key.as_slice().is_empty(),
+                "KBKDF AES-256 masked_key must be populated"
+            );
+            assert!(
+                verify_iv_not_default_from_masked_key(resp1.data.masked_key.as_slice())
+                    .unwrap_or(false),
+                "KBKDF AES-256 masked_key IV must be randomized",
+            );
+            assert!(
+                verify_masked_key_attributes(
+                    resp1.data.masked_key.as_slice(),
+                    MaskedKeyAttributes::ENCRYPT | MaskedKeyAttributes::DECRYPT
+                ),
+                "KBKDF AES-256 masked_key attributes must include ENCRYPT|DECRYPT",
+            );
+
+            let key1 = resp1.data.key_id;
+            let key2 = derive(dev, secret2).data.key_id;
 
             // Encrypt with key1, decrypt with key2 — recovers the input
             // iff both derivations produced the same usable AES key.
@@ -140,6 +159,22 @@ fn test_kbkdf_hmac_derive_smoke() {
                 let resp = resp.unwrap();
                 assert_eq!(resp.hdr.op, DdiOp::KbkdfCounterHmacDerive);
                 assert_eq!(resp.hdr.status, DdiStatus::Success);
+                assert!(
+                    !resp.data.masked_key.as_slice().is_empty(),
+                    "KBKDF {key_type:?} masked_key must be populated",
+                );
+                assert!(
+                    verify_iv_not_default_from_masked_key(resp.data.masked_key.as_slice())
+                        .unwrap_or(false),
+                    "KBKDF {key_type:?} masked_key IV must be randomized",
+                );
+                assert!(
+                    verify_masked_key_attributes(
+                        resp.data.masked_key.as_slice(),
+                        MaskedKeyAttributes::SIGN | MaskedKeyAttributes::VERIFY
+                    ),
+                    "KBKDF {key_type:?} masked_key attributes must include SIGN|VERIFY",
+                );
             }
         },
     );
@@ -170,6 +205,22 @@ fn test_kbkdf_var_hmac_derive_smoke() {
                 let resp = resp.unwrap();
                 assert_eq!(resp.hdr.op, DdiOp::KbkdfCounterHmacDerive);
                 assert_eq!(resp.hdr.status, DdiStatus::Success);
+                assert!(
+                    !resp.data.masked_key.as_slice().is_empty(),
+                    "KBKDF {key_type:?} len {key_len} masked_key must be populated",
+                );
+                assert!(
+                    verify_iv_not_default_from_masked_key(resp.data.masked_key.as_slice())
+                        .unwrap_or(false),
+                    "KBKDF {key_type:?} len {key_len} masked_key IV must be randomized",
+                );
+                assert!(
+                    verify_masked_key_attributes(
+                        resp.data.masked_key.as_slice(),
+                        MaskedKeyAttributes::SIGN | MaskedKeyAttributes::VERIFY
+                    ),
+                    "KBKDF {key_type:?} len {key_len} masked_key attrs must include SIGN|VERIFY",
+                );
             }
         },
     );

--- a/fw/core/lib/src/ddi/mbor/aes_generate_key.rs
+++ b/fw/core/lib/src/ddi/mbor/aes_generate_key.rs
@@ -51,24 +51,40 @@ pub(crate) async fn aes_generate_key<'p, P: HsmPal>(
 
     // Store in the vault, session-scoped iff requested.
     let session_binding = attrs.session().then_some(HsmSessId::from(sess_id));
-    let key_id: u16 = pal
+    let key_handle = pal
         .vault_key_create(io, key_buf, vault_kind, session_binding, attrs)
-        .await?
-        .into();
+        .await?;
+    let key_id: u16 = key_handle.into();
 
-    // Build the response.  `masked_key` is the host's opaque
-    // re-import blob; firmware-side masking against the session BK is
-    // pending the corresponding `UnmaskKey` handler — emit an empty
-    // placeholder for now so the response is wire-valid.  `bulk_key_id`
-    // is reserved for the AES-XTS / AES-GCM bulk variants which this
-    // handler rejects; non-bulk keys always report `None`.
+    // Build the host's opaque re-import blob: envelope the freshly
+    // stored key under the per-session masking key (session-scoped
+    // keys) or the partition masking key (persistent keys).  The key
+    // is read back from the vault so the masked bytes match the bytes
+    // the host will re-import.  `bulk_key_id` is reserved for the
+    // AES-XTS / AES-GCM bulk variants which this handler rejects;
+    // non-bulk keys always report `None`.
+    let plaintext = pal.vault_key(io, key_handle)?;
+    let masked_key = super::masking::mask_blob(
+        pal,
+        io,
+        HsmSessId::from(sess_id),
+        super::masking::MaskSpec {
+            attrs,
+            key_type: super::from_pal::vault_kind_ddi(vault_kind)?,
+            key_label: body.key_properties.key_label,
+            key_length: plaintext.len() as u16,
+        },
+        plaintext,
+    )
+    .await?;
+
     let resp = pal.dma_alloc_var(io, |buf| {
         super::encode_resp(
             &super::success_hdr_sess(hdr, DdiOp::AesGenerateKey, sess_id),
             &DdiAesGenerateKeyResp {
                 key_id,
                 bulk_key_id: None,
-                masked_key: &[],
+                masked_key,
             },
             buf,
         )

--- a/fw/core/lib/src/ddi/mbor/ecc_generate_key_pair.rs
+++ b/fw/core/lib/src/ddi/mbor/ecc_generate_key_pair.rs
@@ -10,6 +10,7 @@
 //! the public key plus an opaque masked-key envelope the host may
 //! re-import on a future session.
 
+use azihsm_fw_core_crypto_key_masking::cbc::mask;
 use azihsm_fw_ddi_mbor_types::ecc_generate_key_pair::DdiEccGenerateKeyPairReq;
 use azihsm_fw_ddi_mbor_types::ecc_generate_key_pair::DdiEccGenerateKeyPairResp;
 
@@ -88,10 +89,25 @@ pub(crate) async fn ecc_generate_key_pair<'p, P: HsmPal>(
         .await?
         .into();
 
-    // Build the response.  `masked_key` is the host's opaque
-    // re-import blob; firmware-side masking against the session BK is
-    // pending the corresponding `UnmaskKey` handler — emit an empty
-    // placeholder for now so the response is wire-valid.
+    // Build the host's re-import blob.  ECC envelopes the private-key
+    // blob followed by the public point so the unmask path can restore
+    // both; `key_length` records the private-key length so the importer
+    // can split the plaintext.  Session-scoped keys use the session
+    // masking key; persistent keys use the partition masking key (`MK`).
+    let key_plain = pal.dma_alloc(io, priv_len + pub_len)?;
+    key_plain[..priv_len].copy_from_slice(&priv_key[..priv_len]);
+    key_plain[priv_len..priv_len + pub_len].copy_from_slice(&pub_key[..pub_len]);
+    let masking_key =
+        super::masking::resolve_masking_key(pal, io, HsmSessId::from(sess_id), attrs.session())?;
+    let metadata = super::masking::masked_metadata(
+        pal,
+        super::from_pal::vault_kind_ddi(vault_kind)?,
+        attrs,
+        body.key_properties.key_label,
+        priv_len as u16,
+    )?;
+    let masked_len = mask(pal, io, masking_key, &key_plain[..], &metadata, None).await?;
+
     let (resp, layout) = pal.dma_alloc_var_with(io, |buf| {
         let mut encoder = super::encode_resp_hdr(
             &super::success_hdr_sess(hdr, DdiOp::EccGenerateKeyPair, sess_id),
@@ -104,7 +120,7 @@ pub(crate) async fn ecc_generate_key_pair<'p, P: HsmPal>(
                 raw_len: pub_len,
                 key_kind: super::from_pal::ecc_public_ddi(pal_curve),
             },
-            0, /* masked_key length — empty placeholder */
+            masked_len,
         )?;
         Ok((encoder.position(), layout))
     })?;
@@ -113,6 +129,19 @@ pub(crate) async fn ecc_generate_key_pair<'p, P: HsmPal>(
     // PAL already emitted the public key in wire format (LE + P-521
     // padding), so copy directly without further reordering.
     frame.pub_key.raw.copy_from_slice(&pub_key[..pub_len]);
+
+    // `mask` requires `out[..total_len]` to be zero on entry; zero the
+    // reserved slot before filling it with the envelope.
+    frame.masked_key.fill(0);
+    mask(
+        pal,
+        io,
+        masking_key,
+        &key_plain[..],
+        &metadata,
+        Some(frame.masked_key),
+    )
+    .await?;
 
     Ok(resp)
 }

--- a/fw/core/lib/src/ddi/mbor/ecdh_key_exchange.rs
+++ b/fw/core/lib/src/ddi/mbor/ecdh_key_exchange.rs
@@ -75,10 +75,8 @@ pub(crate) async fn ecdh_key_exchange<'p, P: HsmPal>(
     )
     .await?;
 
-    // RAII vault entry — rolls back if response encoding below
-    // fails.  `masked_key` is the host's opaque re-import blob;
-    // firmware-side masking is pending the `UnmaskKey` handler, so
-    // we emit an empty placeholder for wire validity.
+    // Commit the derived shared secret to the vault, session-scoped
+    // iff requested.
     let key_id: u16 = pal
         .vault_key_create(
             io,
@@ -90,13 +88,25 @@ pub(crate) async fn ecdh_key_exchange<'p, P: HsmPal>(
         .await?
         .into();
 
+    // Envelope the derived shared secret into the host's re-import blob.
+    let masked_key = super::masking::mask_blob(
+        pal,
+        io,
+        HsmSessId::from(sess_id),
+        super::masking::MaskSpec {
+            attrs: target_attrs,
+            key_type: super::from_pal::ecdh_secret_ddi(curve),
+            key_label: body.key_properties.key_label,
+            key_length: secret.len() as u16,
+        },
+        &secret[..],
+    )
+    .await?;
+
     let resp = pal.dma_alloc_var(io, |buf| {
         super::encode_resp(
             &super::success_hdr_sess(hdr, DdiOp::EcdhKeyExchange, sess_id),
-            &DdiEcdhKeyExchangeResp {
-                key_id,
-                masked_key: &[],
-            },
+            &DdiEcdhKeyExchangeResp { key_id, masked_key },
             buf,
         )
     })?;

--- a/fw/core/lib/src/ddi/mbor/from_pal.rs
+++ b/fw/core/lib/src/ddi/mbor/from_pal.rs
@@ -80,6 +80,42 @@ pub(crate) fn rsa_key(kind: HsmVaultKeyKind) -> HsmResult<HsmRsaKey> {
     }
 }
 
+/// Map a vault key kind to the on-wire [`DdiKeyType`] tag recorded in
+/// a masked-key blob's metadata.  Only the kinds that a key-creating
+/// or key-importing handler can mask are accepted; public, internal,
+/// and session-schedule kinds return [`HsmError::InvalidKeyType`].
+///
+/// The unwrapping key is an RSA private key in the vault but is
+/// tagged `RsaUnwrap` in its masked metadata by the
+/// [`get_unwrapping_key`](super::get_unwrapping_key) handler, which
+/// passes that type explicitly rather than going through this map.
+pub(crate) fn vault_kind_ddi(kind: HsmVaultKeyKind) -> HsmResult<DdiKeyType> {
+    match kind {
+        HsmVaultKeyKind::Rsa2kPrivate => Ok(DdiKeyType::Rsa2kPrivate),
+        HsmVaultKeyKind::Rsa3kPrivate => Ok(DdiKeyType::Rsa3kPrivate),
+        HsmVaultKeyKind::Rsa4kPrivate => Ok(DdiKeyType::Rsa4kPrivate),
+        HsmVaultKeyKind::Rsa2kPrivateCrt => Ok(DdiKeyType::Rsa2kPrivateCrt),
+        HsmVaultKeyKind::Rsa3kPrivateCrt => Ok(DdiKeyType::Rsa3kPrivateCrt),
+        HsmVaultKeyKind::Rsa4kPrivateCrt => Ok(DdiKeyType::Rsa4kPrivateCrt),
+        HsmVaultKeyKind::Ecc256Private => Ok(DdiKeyType::Ecc256Private),
+        HsmVaultKeyKind::Ecc384Private => Ok(DdiKeyType::Ecc384Private),
+        HsmVaultKeyKind::Ecc521Private => Ok(DdiKeyType::Ecc521Private),
+        HsmVaultKeyKind::Aes128 => Ok(DdiKeyType::Aes128),
+        HsmVaultKeyKind::Aes192 => Ok(DdiKeyType::Aes192),
+        HsmVaultKeyKind::Aes256 => Ok(DdiKeyType::Aes256),
+        HsmVaultKeyKind::AesXtsBulk256 => Ok(DdiKeyType::AesXtsBulk256),
+        HsmVaultKeyKind::AesGcmBulk256 => Ok(DdiKeyType::AesGcmBulk256),
+        HsmVaultKeyKind::AesGcmBulk256Unapproved => Ok(DdiKeyType::AesGcmBulk256Unapproved),
+        HsmVaultKeyKind::Secret256 => Ok(DdiKeyType::Secret256),
+        HsmVaultKeyKind::Secret384 => Ok(DdiKeyType::Secret384),
+        HsmVaultKeyKind::Secret521 => Ok(DdiKeyType::Secret521),
+        HsmVaultKeyKind::VarLenHmacSha256 => Ok(DdiKeyType::VarHmac256),
+        HsmVaultKeyKind::VarLenHmacSha384 => Ok(DdiKeyType::VarHmac384),
+        HsmVaultKeyKind::VarLenHmacSha512 => Ok(DdiKeyType::VarHmac512),
+        _ => Err(HsmError::InvalidKeyType),
+    }
+}
+
 // ── HsmEccCurve → … ───────────────────────────────────────────────
 
 /// Map a [`HsmEccCurve`] to its private ECC vault kind.

--- a/fw/core/lib/src/ddi/mbor/get_unwrapping_key.rs
+++ b/fw/core/lib/src/ddi/mbor/get_unwrapping_key.rs
@@ -21,6 +21,7 @@
 //! key is cached: it is derived from the vault
 //! private key on demand (matching the reference firmware).
 
+use azihsm_fw_core_crypto_key_masking::cbc::mask;
 use azihsm_fw_ddi_mbor_types::get_unwrapping_key::DdiGetUnwrappingKeyReq;
 use azihsm_fw_ddi_mbor_types::get_unwrapping_key::DdiGetUnwrappingKeyResp;
 use azihsm_fw_ddi_mbor_types::DdiPublicKeyFrameParams;
@@ -57,9 +58,22 @@ pub(crate) async fn get_unwrapping_key<'p, P: HsmPal>(
     let priv_key = pal.vault_key(io, key_id)?;
     let pub_len = pal.rsa_priv_pub_key(io, priv_key, None)?;
 
-    // `masked_key` is the host's opaque re-import blob; firmware-side
-    // masking is pending the corresponding unmask path — emit an empty
-    // placeholder for now so the response is wire-valid.
+    // Envelope the unwrapping key for host re-import.  It is a
+    // partition-scoped key, so it is masked under the partition masking
+    // key (`MK`) and tagged `RsaUnwrap` so the unmask path can refuse
+    // to re-import it as a general RSA key.
+    let attrs = pal.vault_key_attrs(io, key_id)?;
+    let masking_key =
+        super::masking::resolve_masking_key(pal, io, HsmSessId::from(sess_id), false)?;
+    let metadata = super::masking::masked_metadata(
+        pal,
+        DdiKeyType::RsaUnwrap,
+        attrs,
+        &[],
+        priv_key.len() as u16,
+    )?;
+    let masked_len = mask(pal, io, masking_key, priv_key, &metadata, None).await?;
+
     let (resp, layout) = pal.dma_alloc_var_with(io, |buf| {
         let mut encoder = super::encode_resp_hdr(
             &super::success_hdr_sess(hdr, DdiOp::GetUnwrappingKey, sess_id),
@@ -72,7 +86,7 @@ pub(crate) async fn get_unwrapping_key<'p, P: HsmPal>(
                 raw_len: pub_len,
                 key_kind: DdiKeyType::Rsa2kPublic,
             },
-            0, /* masked_key length — empty placeholder */
+            masked_len,
         )?;
         Ok((encoder.position(), layout))
     })?;
@@ -85,6 +99,19 @@ pub(crate) async fn get_unwrapping_key<'p, P: HsmPal>(
     if actual_pub_len != pub_len {
         return Err(HsmError::InvalidArg);
     }
+
+    // `mask` requires `out[..total_len]` to be zero on entry; zero the
+    // reserved slot before filling it with the envelope.
+    frame.masked_key.fill(0);
+    mask(
+        pal,
+        io,
+        masking_key,
+        priv_key,
+        &metadata,
+        Some(frame.masked_key),
+    )
+    .await?;
 
     Ok(resp)
 }

--- a/fw/core/lib/src/ddi/mbor/hkdf_derive.rs
+++ b/fw/core/lib/src/ddi/mbor/hkdf_derive.rs
@@ -77,10 +77,7 @@ pub(crate) async fn hkdf_derive<'p, P: HsmPal>(
     pal.hkdf_expand(io, algo, prk, body.info.as_deref(), out)
         .await?;
 
-    // RAII vault entry — rolls back if response encoding below fails.
-    // `masked_key` is the host's opaque re-import blob; firmware-side
-    // masking is pending the `UnmaskKey` handler, so we emit an empty
-    // placeholder for wire validity.
+    // Commit the derived key to the vault, session-scoped iff requested.
     let key_id: u16 = pal
         .vault_key_create(
             io,
@@ -92,12 +89,27 @@ pub(crate) async fn hkdf_derive<'p, P: HsmPal>(
         .await?
         .into();
 
+    // Envelope the derived key into the host's opaque re-import blob.
+    let masked_key = super::masking::mask_blob(
+        pal,
+        io,
+        HsmSessId::from(sess_id),
+        super::masking::MaskSpec {
+            attrs,
+            key_type: super::from_pal::vault_kind_ddi(target.kind)?,
+            key_label: body.key_properties.key_label,
+            key_length: out.len() as u16,
+        },
+        &out[..],
+    )
+    .await?;
+
     let resp = pal.dma_alloc_var(io, |buf| {
         super::encode_resp(
             &super::success_hdr_sess(hdr, DdiOp::HkdfDerive, sess_id),
             &DdiHkdfDeriveResp {
                 key_id,
-                masked_key: &[],
+                masked_key,
                 bulk_key_id: None,
             },
             buf,

--- a/fw/core/lib/src/ddi/mbor/kbkdf_derive.rs
+++ b/fw/core/lib/src/ddi/mbor/kbkdf_derive.rs
@@ -76,10 +76,7 @@ pub(crate) async fn kbkdf_counter_hmac_derive<'p, P: HsmPal>(
         .await?;
     }
 
-    // RAII vault entry — rolls back if response encoding below fails.
-    // `masked_key` is the host's opaque re-import blob; firmware-side
-    // masking is pending the `UnmaskKey` handler, so we emit an empty
-    // placeholder for wire validity.
+    // Commit the derived key to the vault, session-scoped iff requested.
     let key_id: u16 = pal
         .vault_key_create(
             io,
@@ -91,12 +88,27 @@ pub(crate) async fn kbkdf_counter_hmac_derive<'p, P: HsmPal>(
         .await?
         .into();
 
+    // Envelope the derived key into the host's opaque re-import blob.
+    let masked_key = super::masking::mask_blob(
+        pal,
+        io,
+        HsmSessId::from(sess_id),
+        super::masking::MaskSpec {
+            attrs,
+            key_type: super::from_pal::vault_kind_ddi(target.kind)?,
+            key_label: body.key_properties.key_label,
+            key_length: out.len() as u16,
+        },
+        &out[..],
+    )
+    .await?;
+
     let resp = pal.dma_alloc_var(io, |buf| {
         super::encode_resp(
             &super::success_hdr_sess(hdr, DdiOp::KbkdfCounterHmacDerive, sess_id),
             &DdiKbkdfCounterHmacDeriveResp {
                 key_id,
-                masked_key: &[],
+                masked_key,
                 bulk_key_id: None,
             },
             buf,

--- a/fw/core/lib/src/ddi/mbor/masking.rs
+++ b/fw/core/lib/src/ddi/mbor/masking.rs
@@ -1,0 +1,131 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Shared masked-key envelope helpers for key-creating and
+//! key-importing handlers.
+//!
+//! After a handler lands a key in the vault it returns an opaque
+//! `masked_key` blob the host can persist and later re-import.  The
+//! blob is an AES-CBC-256 + HMAC-SHA-384 envelope produced by
+//! [`mask`](azihsm_fw_core_crypto_key_masking::cbc::mask) under a
+//! masking key chosen by scope:
+//!
+//! * **session-scoped** keys are enveloped under the per-session
+//!   masking key, so the blob is only re-importable while that
+//!   session lives;
+//! * **persistent** keys are enveloped under the partition masking
+//!   key (`MK`), so the blob survives across sessions.
+//!
+//! The helpers here factor out the parts every handler shares —
+//! resolving the masking key and assembling the cleartext
+//! [`DdiMaskedKeyMetadata`] — leaving each handler to point its
+//! response's `masked_key` field at the returned slice.
+
+use azihsm_fw_core_crypto_key_masking::cbc::mask;
+use azihsm_fw_ddi_mbor_types::masked_key::DdiMaskedKeyMetadata;
+use azihsm_fw_ddi_mbor_types::DdiKeyType;
+
+use super::*;
+
+/// Resolve the 80-byte masking key for the key being enveloped.
+///
+/// `session_scoped` selects the source: the per-session masking key
+/// (borrowed zero-copy from the session schedule) when set, otherwise
+/// the partition masking key (`MK`) from the vault.
+///
+/// # Errors
+///
+/// - the partition has no `MK` (persistent key requested before
+///   `EstablishCredential`), surfaced by
+///   [`part_mk_key_id`](crate::part_state::part_mk_key_id);
+/// - any error from the session / vault PAL calls.
+pub(crate) fn resolve_masking_key<'p, P: HsmPal>(
+    pal: &'p P,
+    io: &impl HsmIo,
+    sess_id: HsmSessId,
+    session_scoped: bool,
+) -> HsmResult<&'p DmaBuf> {
+    if session_scoped {
+        pal.session_masking_key(io, sess_id)
+    } else {
+        let mk_id = crate::part_state::part_mk_key_id(pal, io)?;
+        pal.vault_key(io, mk_id)
+    }
+}
+
+/// Assemble the cleartext [`DdiMaskedKeyMetadata`] embedded in (and
+/// authenticated by) a masked-key blob.
+///
+/// `key_type` is the on-wire tag the host re-imports the key as
+/// (usually [`from_pal::vault_kind_ddi`](super::from_pal::vault_kind_ddi),
+/// but e.g. [`DdiKeyType::RsaUnwrap`] for the unwrapping key);
+/// `attrs` are the vault attributes to re-apply on import; `key_length`
+/// is the plaintext primary-key length in bytes (for ECC, the
+/// private-scalar length — the public point is recovered from the
+/// curve).
+pub(crate) fn masked_metadata<'a>(
+    pal: &impl HsmPal,
+    key_type: DdiKeyType,
+    attrs: HsmVaultKeyAttrs,
+    key_label: &'a [u8],
+    key_length: u16,
+) -> HsmResult<DdiMaskedKeyMetadata<'a>> {
+    let bks2_id =
+        u16::try_from(crate::part_state::part_owner_svn(pal)).map_err(|_| HsmError::InvalidArg)?;
+    Ok(DdiMaskedKeyMetadata {
+        svn: crate::part_state::part_mfgr_svn(pal),
+        key_type,
+        key_attributes: attrs.into(),
+        // Always-Some on new masking; Option-typed only for backward
+        // compatibility with legacy blobs masked with `None`.
+        bks2_index: Some(bks2_id),
+        rsvd: None,
+        key_label,
+        key_length,
+    })
+}
+
+/// Per-key inputs to [`mask_blob`]: how the masked blob's metadata is
+/// assembled and how the key is later re-imported.
+pub(crate) struct MaskSpec<'a> {
+    /// Vault attributes to re-apply on import; also selects the
+    /// masking key (session vs partition) via
+    /// [`HsmVaultKeyAttrs::session`].
+    pub attrs: HsmVaultKeyAttrs,
+    /// On-wire re-import key-type tag.
+    pub key_type: DdiKeyType,
+    /// Role label embedded in the metadata.
+    pub key_label: &'a [u8],
+    /// Plaintext primary-key length in bytes (for ECC, the
+    /// private-scalar length; the public point is appended to the
+    /// masked `plaintext`).
+    pub key_length: u16,
+}
+
+/// Produce a complete masked-key envelope for `plaintext` into a fresh
+/// DMA buffer and return the written slice.
+///
+/// Resolves the masking key, assembles the metadata, size-queries the
+/// envelope, then fills a zeroed scratch buffer.  Handlers whose
+/// response carries the masked key as an ordinary `&[u8]` field point
+/// that field at the returned slice.
+pub(crate) async fn mask_blob<'p, P: HsmPal>(
+    pal: &'p P,
+    io: &impl HsmIo,
+    sess_id: HsmSessId,
+    spec: MaskSpec<'_>,
+    plaintext: &[u8],
+) -> HsmResult<&'p [u8]> {
+    let masking_key = resolve_masking_key(pal, io, sess_id, spec.attrs.session())?;
+    let metadata = masked_metadata(
+        pal,
+        spec.key_type,
+        spec.attrs,
+        spec.key_label,
+        spec.key_length,
+    )?;
+    let masked_len = mask(pal, io, masking_key, plaintext, &metadata, None).await?;
+    let out = pal.dma_alloc_zeroed(io, masked_len)?;
+    mask(pal, io, masking_key, plaintext, &metadata, Some(out)).await?;
+    Ok(&out[..masked_len])
+}

--- a/fw/core/lib/src/ddi/mbor/mod.rs
+++ b/fw/core/lib/src/ddi/mbor/mod.rs
@@ -25,6 +25,7 @@ pub(crate) mod init_bk3;
 pub(crate) mod kbkdf_derive;
 pub(crate) mod kdf;
 pub(crate) mod key_attrs;
+pub(crate) mod masking;
 pub(crate) mod open_session;
 pub(crate) mod rsa_mod_exp;
 pub(crate) mod rsa_unwrap;

--- a/fw/pal/traits/src/session.rs
+++ b/fw/pal/traits/src/session.rs
@@ -493,6 +493,35 @@ pub trait HsmSessionManager {
     ///   than expected (corruption indicator).
     fn session_param_key(&self, io: &impl HsmIo, id: HsmSessId) -> HsmResult<&DmaBuf>;
 
+    /// Returns a borrowed view of the active session's 80-byte masking
+    /// key (the AES-CBC-256 ‖ HMAC-SHA-384 key installed at session
+    /// creation).
+    ///
+    /// Zero-copy: like [`session_param_key`](Self::session_param_key)
+    /// the returned `&DmaBuf` borrows directly from the PAL's
+    /// session-schedule storage, so in-session key-creating handlers
+    /// can hand it to the masking primitive without an intermediate
+    /// allocation to envelope a session-scoped key into a
+    /// host-re-importable masked-key blob (persistent keys use the
+    /// partition masking key instead).  This hides the schedule blob
+    /// layout from handlers.
+    ///
+    /// # Parameters
+    ///
+    /// - `io` — caller's I/O context (partition scope).
+    /// - `id` — Active session slot.
+    ///
+    /// # Returns
+    ///
+    /// - `Ok(&DmaBuf)` — a sub-view of the schedule blob, exactly
+    ///   [`SESSION_MASKING_KEY_LEN`] bytes long.
+    /// - `Err(HsmError::SessionNotFound)` — `id` does not refer to a
+    ///   live Active session in the caller's partition (slot free,
+    ///   destroyed, or still Pending).
+    /// - `Err(HsmError::InternalError)` — schedule blob is shorter
+    ///   than expected (corruption indicator).
+    fn session_masking_key(&self, io: &impl HsmIo, id: HsmSessId) -> HsmResult<&DmaBuf>;
+
     /// Atomically reserves the session's one-shot "PSK change"
     /// budget.  Each session may successfully consume this budget at
     /// most once.

--- a/fw/plat/std/pal/src/session.rs
+++ b/fw/plat/std/pal/src/session.rs
@@ -266,6 +266,27 @@ impl HsmSessionManager for StdHsmPal {
         Ok(unsafe { DmaBuf::from_raw(key_bytes) })
     }
 
+    fn session_masking_key(&self, io: &impl HsmIo, id: HsmSessId) -> HsmResult<&DmaBuf> {
+        let entry = self.active_part(io.pid())?;
+        let kid = entry.session_table.physical_id(id)?;
+        let blob = entry.vault.key(kid)?;
+        // The masking key follows `api_rev` in a legacy MBOR `Session`
+        // blob, or `api_rev ‖ param_key` in a `SessionEx` (CU/CO) blob;
+        // pick the offset from the blob length so both schedules work.
+        let offset = match blob.len() {
+            SESSION_BLOB_SIZE => SESSION_API_REV_SIZE,
+            SESSION_CU_BLOB_SIZE | SESSION_CU_AUTH_BLOB_SIZE => {
+                SESSION_API_REV_SIZE + SESSION_PARAM_KEY_LEN
+            }
+            _ => return Err(HsmError::InternalError),
+        };
+        let key_bytes = &blob[offset..offset + SESSION_MASKING_KEY_SIZE];
+        // SAFETY: same justification as `session_param_key` — on the
+        // host, any heap byte is reachable; branding the sub-slice as
+        // `DmaBuf` only satisfies the type system.
+        Ok(unsafe { DmaBuf::from_raw(key_bytes) })
+    }
+
     fn session_try_consume_psk_change(&self, io: &impl HsmIo, id: HsmSessId) -> HsmResult<()> {
         let entry = self.active_part_mut(io.pid())?;
         entry.session_table.try_consume_psk_change(id)

--- a/fw/plat/uno/fw/pal/src/session.rs
+++ b/fw/plat/uno/fw/pal/src/session.rs
@@ -327,6 +327,10 @@ impl HsmSessionManager for UnoHsmPal {
             .0)
     }
 
+    fn session_masking_key(&self, _io: &impl HsmIo, _id: HsmSessId) -> HsmResult<&DmaBuf> {
+        Err(HsmError::UnsupportedCmd)
+    }
+
     fn session_try_consume_psk_change(&self, io: &impl HsmIo, id: HsmSessId) -> HsmResult<()> {
         let mut table = SessionStore::partition(io.pid())?;
         table.try_consume_psk_change(id)


### PR DESCRIPTION
The AES/ECC generate, ECDH exchange, HKDF/KBKDF derive, and GetUnwrappingKey handlers previously emitted an empty `masked_key` placeholder, deferring firmware-side masking.  Each handler now envelopes the freshly created/derived key under the per-session masking key (session-scoped keys) or the partition masking key (persistent keys) and returns that blob so the host can persist and later re-import it.

Adds the shared `masking` module (`resolve_masking_key`, `masked_metadata`, `mask_blob`): it resolves the masking key by scope, assembles the cleartext metadata (key type, attributes, label, length), and CBC-masks the vault-read key material into a DMA-allocated blob. Supporting pieces:
- `session_masking_key` PAL method (traits + std + uno) to fetch the per-session masking key.
- `from_pal::vault_kind_ddi` maps a vault key kind to the on-wire `DdiKeyType` recorded in the blob metadata.

Each handler reads the stored key back from the vault (so the masked bytes match what the host re-imports) and frames it into the response's `masked_key` field.  RsaUnwrap masking is handled separately (it needs in-place masking to fit RSA-4K in the DMA budget) and is not included here.

Tests: the AES/ECC generate, ECDH, HKDF, KBKDF, and GetUnwrappingKey smoke tests now assert a populated `masked_key` with the expected metadata/attributes on both the sim and emu backends.