### PR TITLE
feat(tbor): implement SdCreateRemoteBackup command

### DIFF
--- a/ddi/tbor/types/src/policy.rs
+++ b/ddi/tbor/types/src/policy.rs
@@ -12,23 +12,24 @@
 //!
 //! Layout discipline:
 //!
-//! * Every multi-byte scalar is stored as a little-endian byte array
-//!   native `#[repr(C)]` `u16` (alignment-2); a trailing `_reserved`
-//!   byte pads [`PartPolicy`] to an even, padding-free size. All
-//!   supported targets are little-endian, so the in-memory image equals
-//!   the wire image. The firmware copies the policy out of the wire
-//!   buffer (`try_read_from_bytes`), so no buffer-alignment plumbing is
-//!   needed.
+//! * Every multi-byte scalar is stored as an alignment-1 little-endian
+//!   [`U16`], so every type here — and [`PartPolicy`] as a whole — is
+//!   alignment-1 / [`Unaligned`]. A trailing `_reserved` byte pads
+//!   [`PartPolicy`] to an even, padding-free size. The firmware borrows
+//!   the policy zero-copy from the wire buffer (`try_ref_from_bytes`),
+//!   so no buffer-alignment plumbing is needed.
 //! * `#[repr(C)]` + zerocopy [`TryFromBytes`] / [`IntoBytes`] /
-//!   [`Immutable`] / [`KnownLayout`] derives reject any padding /
-//!   alignment drift at compile time.
+//!   [`Immutable`] / [`KnownLayout`] / [`Unaligned`] derives reject any
+//!   padding / alignment drift at compile time.
 
 use bitfield_struct::bitfield;
 use open_enum::open_enum;
+use zerocopy::little_endian::U16;
 use zerocopy::Immutable;
 use zerocopy::IntoBytes;
 use zerocopy::KnownLayout;
 use zerocopy::TryFromBytes;
+use zerocopy::Unaligned;
 
 /// Maximum key length for [`PolicyPubKey::data`] (bytes).
 ///
@@ -63,7 +64,9 @@ pub enum PolicyKeyKind {
 /// Two-byte policy version (`major.minor`).
 ///
 /// Layout (alignment 1, size 2 B): `major(1) ‖ minor(1)`.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, TryFromBytes, IntoBytes, Immutable, KnownLayout)]
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, TryFromBytes, IntoBytes, Immutable, KnownLayout, Unaligned,
+)]
 #[repr(C)]
 pub struct PolicyVer {
     /// Major version number.  Must equal [`POLICY_VERSION_MAJOR`].
@@ -75,20 +78,57 @@ pub struct PolicyVer {
 
 /// POTA public key embedded in [`PartPolicy`].
 ///
-/// Layout (alignment 2, size 100 B): `kind(2 LE) ‖ len(2 LE) ‖ data(96)`.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, TryFromBytes, IntoBytes, Immutable, KnownLayout)]
+/// Layout (alignment 1, size 100 B): `kind(2 LE) ‖ len(2 LE) ‖ data(96)`.
+///
+/// `kind` and `len` are stored as alignment-1 little-endian [`U16`] so
+/// the whole struct (and [`PartPolicy`]) is [`Unaligned`] and can be
+/// borrowed zero-copy from an arbitrarily-aligned wire buffer; read them
+/// through [`kind`](Self::kind) / [`len`](Self::len).
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, TryFromBytes, IntoBytes, Immutable, KnownLayout, Unaligned,
+)]
 #[repr(C)]
 pub struct PolicyPubKey {
-    /// [`PolicyKeyKind`] discriminant. Native, little-endian on all
-    /// supported targets (open-enum newtype over `u16`).
-    pub kind: PolicyKeyKind,
+    /// [`PolicyKeyKind`] discriminant, little-endian.  Read via
+    /// [`kind`](Self::kind).
+    kind: U16,
 
-    /// Active prefix length of `data` (`0..=POLICY_MAX_KEY_LEN`).
-    /// For `Ecc384` must equal [`POLICY_MAX_KEY_LEN`].
-    pub len: u16,
+    /// Active prefix length of `data` (`0..=POLICY_MAX_KEY_LEN`),
+    /// little-endian.  Read via [`len`](Self::len).  For `Ecc384` must
+    /// equal [`POLICY_MAX_KEY_LEN`].
+    len: U16,
 
-    /// Key bytes; only the first `len` bytes are meaningful.
+    /// Key bytes; only the first `len()` bytes are meaningful.
     pub data: [u8; POLICY_MAX_KEY_LEN],
+}
+
+impl PolicyPubKey {
+    /// Construct a key slot from its raw discriminant, length, and data.
+    pub const fn new(kind: PolicyKeyKind, len: u16, data: [u8; POLICY_MAX_KEY_LEN]) -> Self {
+        Self {
+            kind: U16::new(kind.0),
+            len: U16::new(len),
+            data,
+        }
+    }
+
+    /// The [`PolicyKeyKind`] discriminant.
+    #[inline]
+    pub fn kind(&self) -> PolicyKeyKind {
+        PolicyKeyKind(self.kind.get())
+    }
+
+    /// Active prefix length of [`data`](Self::data).
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.len.get() as usize
+    }
+
+    /// `true` iff the key slot is absent (`len == 0`).
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.len.get() == 0
+    }
 }
 
 /// Boolean policy flags, packed into a single byte (alignment 1).
@@ -104,7 +144,7 @@ pub struct PolicyPubKey {
 /// contract "reserved bits MUST be zero" is enforced separately by
 /// [`PolicyFlags::is_valid`].
 #[bitfield(u8)]
-#[derive(PartialEq, Eq, TryFromBytes, IntoBytes, Immutable, KnownLayout)]
+#[derive(PartialEq, Eq, TryFromBytes, IntoBytes, Immutable, KnownLayout, Unaligned)]
 pub struct PolicyFlags {
     /// Bit 0: include the First Mutable Composite Device Identity
     /// (CDI-FMC) in key derivations.
@@ -158,7 +198,7 @@ impl PolicyFlags {
 /// peer-cloning flags).  Pubkey slots that are not in use carry
 /// `len = 0` (see [`PolicyPubKey`]).
 ///
-/// Layout (alignment 2, size 484 B):
+/// Layout (alignment 1, size 484 B):
 ///
 /// | Field                 | Offset | Size |
 /// |-----------------------|--------|------|
@@ -171,7 +211,9 @@ impl PolicyFlags {
 /// | `flags`               | 418    | 1    |
 /// | `info`                | 419    | 64   |
 /// | `_reserved`           | 483    | 1    |
-#[derive(Debug, Clone, PartialEq, Eq, TryFromBytes, IntoBytes, Immutable, KnownLayout)]
+#[derive(
+    Debug, Clone, PartialEq, Eq, TryFromBytes, IntoBytes, Immutable, KnownLayout, Unaligned,
+)]
 #[repr(C)]
 pub struct PartPolicy {
     /// Policy version (major.minor).
@@ -205,7 +247,7 @@ pub struct PartPolicy {
     pub info: [u8; POLICY_INFO_LEN],
 
     /// Reserved padding byte (MUST be zero) that rounds the struct to an
-    /// even, alignment-2-clean size with no implicit padding.
+    /// even size with no implicit padding.
     pub _reserved: u8,
 }
 
@@ -214,11 +256,8 @@ impl PartPolicy {
     /// default for owned request structs (the contained byte arrays are
     /// larger than 32 B, so `#[derive(Default)]` is unavailable).
     pub const fn zeroed() -> Self {
-        const ZERO_KEY: PolicyPubKey = PolicyPubKey {
-            kind: PolicyKeyKind(0),
-            len: 0,
-            data: [0; POLICY_MAX_KEY_LEN],
-        };
+        const ZERO_KEY: PolicyPubKey =
+            PolicyPubKey::new(PolicyKeyKind(0), 0, [0; POLICY_MAX_KEY_LEN]);
         Self {
             version: PolicyVer { major: 0, minor: 0 },
             pota_pub_key: ZERO_KEY,
@@ -243,9 +282,9 @@ impl Default for PartPolicy {
 pub const PART_POLICY_LEN: usize = core::mem::size_of::<PartPolicy>();
 
 const _: () = assert!(PART_POLICY_LEN == 484);
-const _: () = assert!(core::mem::align_of::<PartPolicy>() == 2);
+const _: () = assert!(core::mem::align_of::<PartPolicy>() == 1);
 const _: () = assert!(core::mem::size_of::<PolicyPubKey>() == 100);
-const _: () = assert!(core::mem::align_of::<PolicyPubKey>() == 2);
+const _: () = assert!(core::mem::align_of::<PolicyPubKey>() == 1);
 const _: () = assert!(core::mem::size_of::<PolicyVer>() == 2);
 const _: () = assert!(core::mem::size_of::<PolicyFlags>() == 1);
 
@@ -256,7 +295,7 @@ mod tests {
     #[test]
     fn layout_is_pinned() {
         assert_eq!(PART_POLICY_LEN, 484);
-        assert_eq!(core::mem::align_of::<PartPolicy>(), 2);
+        assert_eq!(core::mem::align_of::<PartPolicy>(), 1);
     }
 
     #[test]

--- a/ddi/tbor/types/src/sd_create_remote_backup.rs
+++ b/ddi/tbor/types/src/sd_create_remote_backup.rs
@@ -19,31 +19,41 @@ use alloc::vec::Vec;
 
 use crate::evidence::ReportDescriptor;
 use crate::policy::PartPolicy;
+use crate::sd_sealing_key_gen::MASKED_SEALING_KEY_LEN;
 use crate::tbor;
 use crate::CertDescriptor;
 
 /// TBOR opcode for `SdCreateRemoteBackup`.
 pub const TBOR_OP_SD_CREATE_REMOTE_BACKUP: u8 = 0x0A;
 
-/// Exact on-the-wire length of the masked security-domain blob (a masked
-/// BKS3).  Mirrors
-/// `azihsm_fw_ddi_tbor_types::sd_create_remote_backup::MASKED_SD_LEN`; the
-/// firmware schema is the length authority.
+/// Exact on-the-wire length of a **masked** security-domain blob (a
+/// masked BKS3).  Retained as the shared length authority for the rest
+/// of the Security-Domain backup family (`SdReseal`, `SdRestore*`), which
+/// re-export it; **this** command's response is an HPKE-Auth seal sized
+/// by [`POK_REMOTE_BACKUP_LEN`].
 pub const MASKED_SD_LEN: usize = 180;
+
+/// Exact on-the-wire length of the remote partition-owner-key backup (an
+/// HPKE-Auth seal of BKS3: `enc(97) ‖ ct(64)`).  Mirrors
+/// `azihsm_fw_ddi_tbor_types::sd_create_remote_backup::
+/// POK_REMOTE_BACKUP_LEN`; the firmware schema is the length authority.
+pub const POK_REMOTE_BACKUP_LEN: usize = 161;
 
 /// Host-facing TBOR `SdCreateRemoteBackup` request.
 #[tbor(opcode = TBOR_OP_SD_CREATE_REMOTE_BACKUP, session_ctrl = in_session)]
-#[derive(Debug, Default, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TborSdCreateRemoteBackupReq {
     /// CO session id this request is bound to.  Cross-checked against the
     /// SQE-carried session id by the dispatcher.
     #[tbor(session_id)]
     pub session_id: u16,
 
-    /// Sender key id (`KeyId`, inline TOC entry type 1) the masked
-    /// security domain is wrapped under.
-    #[tbor(key_id)]
-    pub sender_key: u16,
+    /// The sender's masked SD-sealing key (from `SdSealingKeyGen`),
+    /// exactly [`MASKED_SEALING_KEY_LEN`] (180 B).  Unmasked on-device to
+    /// recover the sender's private ECDH key.  A fixed-length `[u8; N]`
+    /// field (a `min_len == max_len` buffer): the array type is the host
+    /// derive's exact-length form, mirroring the firmware `len = 180`.
+    pub masked_sealing_key: [u8; MASKED_SEALING_KEY_LEN],
 
     /// Receiver manufacturer certificate-chain descriptors.  Flattened
     /// from the firmware `receiver_evidence` field group (first of its
@@ -69,12 +79,14 @@ pub struct TborSdCreateRemoteBackupReq {
 
 /// Host-facing TBOR `SdCreateRemoteBackup` response.
 #[tbor(response)]
-#[derive(Debug, Default, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct TborSdCreateRemoteBackupResp {
-    /// Remote partition-owner-key backup, a masked BKS3 (exactly
-    /// [`MASKED_SD_LEN`] = 180 B on the wire; the firmware schema is the
-    /// length authority).
-    pub pok_remote_backup: Vec<u8>,
+    /// Remote partition-owner-key backup: an HPKE-Auth seal of BKS3
+    /// (exactly [`POK_REMOTE_BACKUP_LEN`] = 161 B on the wire; the
+    /// firmware schema is the length authority).  A fixed-length `[u8; N]`
+    /// field so host decode enforces the exact length — rejecting any
+    /// malformed frame — instead of allocating from the encoded length.
+    pub pok_remote_backup: [u8; POK_REMOTE_BACKUP_LEN],
 }
 
 #[cfg(test)]
@@ -87,9 +99,12 @@ mod tests {
     fn request_encodes_session_and_policy() {
         let req = TborSdCreateRemoteBackupReq {
             session_id: 9,
-            sender_key: 0x1234,
+            masked_sealing_key: [0u8; MASKED_SEALING_KEY_LEN],
+            receiver_mfgr_cert_chain: Vec::new(),
+            receiver_owner_cert_chain: Vec::new(),
+            receiver_part_owner_cert_chain: Vec::new(),
+            receiver_report: ReportDescriptor::default(),
             policy: PartPolicy::zeroed(),
-            ..Default::default()
         };
 
         let mut buf = [0u8; 1024];

--- a/ddi/tbor/types/tests/commands/mod.rs
+++ b/ddi/tbor/types/tests/commands/mod.rs
@@ -15,6 +15,7 @@ pub mod part_final;
 pub mod part_info;
 pub mod part_init;
 pub mod psk_change;
+pub mod sd_create_remote_backup;
 pub mod sd_sealing_key_gen;
 pub mod session_close;
 pub mod unexpected_toc_type;

--- a/ddi/tbor/types/tests/commands/sd_create_remote_backup.rs
+++ b/ddi/tbor/types/tests/commands/sd_create_remote_backup.rs
@@ -1,0 +1,432 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Integration tests for the TBOR `SdCreateRemoteBackup` command.
+//!
+//! `SdCreateRemoteBackup` seals a fresh BKS3 to a receiver's SD sealing
+//! public key (recovered from the receiver's `KeyReport`, carried out of
+//! band) authenticated by the sender's masked SD sealing key, returning a
+//! 161-byte HPKE-Auth remote backup.  Nothing is persisted.
+//!
+//! These tests run a **self-backup** (sender == receiver): one partition
+//! mints an SD sealing key, attests it via `KeyReport`, then seals to its
+//! own attested public key.  This exercises the full path — the OOB SGL
+//! transport, the COSE_Key `RcvrPub` extraction, the sealing-key unmask,
+//! and the HPKE-Auth seal — without a second device.
+//!
+//! Coverage:
+//! * Happy path — a 161-byte, non-zero `pok_remote_backup`; each call
+//!   re-randomizes BKS3, so two backups differ.
+//! * Missing OOB evidence → `InvalidArg`.
+//! * Policy that does not name this partition as the backing partition
+//!   (`backup_part_id` / `backup_part_pub_key` absent) → `InvalidArg`.
+
+#![cfg(feature = "emu")]
+
+use azihsm_ddi_tbor_types::tbor_int::U16;
+use azihsm_ddi_tbor_types::CertDescriptor;
+use azihsm_ddi_tbor_types::PartPolicy;
+use azihsm_ddi_tbor_types::PolicyKeyKind;
+use azihsm_ddi_tbor_types::ReportDescriptor;
+use azihsm_ddi_tbor_types::TborKeyReportReq;
+use azihsm_ddi_tbor_types::TborPartInfoReq;
+use azihsm_ddi_tbor_types::TborSdCreateRemoteBackupReq;
+use azihsm_ddi_tbor_types::TborSdSealingKeyGenReq;
+use azihsm_ddi_tbor_types::TborStatus;
+use azihsm_ddi_tbor_types::KEY_REPORT_DATA_LEN;
+use azihsm_ddi_tbor_types::PART_POLICY_LEN;
+use azihsm_ddi_tbor_types::POK_REMOTE_BACKUP_LEN;
+use azihsm_ddi_tbor_types::POLICY_MAX_KEY_LEN;
+use zerocopy::TryFromBytes;
+
+use crate::commands::part_init::bootstrap_rotated_co;
+use crate::commands::part_init::known_good_part_policy;
+use crate::commands::part_init::mach_seed;
+use crate::commands::part_init::part_policy_with_pota;
+use crate::commands::part_init::pota_thumbprint;
+use crate::commands::part_init::ROTATED_CO_PSK;
+use crate::commands::sd_sealing_key_gen::finalized_co_session;
+use crate::harness::x509_fixture::make_chain;
+use crate::harness::x509_fixture::make_pta_chain;
+use crate::harness::x509_fixture::pta_pub_from_csr;
+use crate::harness::x509_fixture::CaKey;
+use crate::harness::x509_fixture::GeneratedChain;
+use crate::harness::x509_fixture::RAW_PUB_LEN;
+use crate::harness::SessionHandshake;
+use crate::harness::TestCtx;
+
+/// `KeyScope::Local` discriminant (wire mirror of the firmware
+/// `HsmKeyScope`).
+const SCOPE_LOCAL: u8 = 0b011;
+
+/// Byte offset of the SATA public-key **data** inside the 484-byte
+/// `PartPolicy` image: `sata_pub_key` starts at 102 (`kind(2) ‖ len(2) ‖
+/// data(96)`), so the raw `X ‖ Y` coordinates begin at 106.
+const OFF_SATA_PUB_KEY_DATA: usize = 106;
+
+/// Byte offsets of the backing-partition fields inside the 484-byte
+/// `PartPolicy` image (mirror of `fw/core/ddi/tbor/types/src/policy.rs`).
+const OFF_BACKUP_PART_ID: usize = 302;
+const OFF_BACKUP_PART_PUB_KEY: usize = 318;
+const BACKUP_PART_ID_LEN: usize = 16;
+
+/// Build a policy naming **this** partition as the backing partition
+/// (`backup_part_id = PID`, `backup_part_pub_key = PID public key`) and
+/// anchoring the security domain to `sata_pub` (raw `X ‖ Y`, big-endian).
+///
+/// The caller learns the PID / PID public key from `PartInfo` (before
+/// `PartInit`); the SATA key is a synthetic trust anchor the test also
+/// uses to sign the partition-owner certificate chain.
+fn backing_part_policy(
+    pid: &[u8],
+    pid_pub: &[u8],
+    sata_pub: &[u8; RAW_PUB_LEN],
+    pota_pub: &[u8; RAW_PUB_LEN],
+) -> [u8; PART_POLICY_LEN] {
+    // Anchor the policy to a real POTA key so `PartFinal` can validate a
+    // PTA certificate chain against it.
+    let mut bytes = part_policy_with_pota(pota_pub);
+
+    // Overwrite the placeholder SATA key with the test anchor's real
+    // P-384 public coordinates (kind / len already Ecc384 / 96).
+    bytes[OFF_SATA_PUB_KEY_DATA..OFF_SATA_PUB_KEY_DATA + RAW_PUB_LEN].copy_from_slice(sata_pub);
+
+    bytes[OFF_BACKUP_PART_ID..OFF_BACKUP_PART_ID + BACKUP_PART_ID_LEN].copy_from_slice(pid);
+
+    // backup_part_pub_key = { kind: Ecc384 (LE), len: 96 (LE), data }.
+    let off = OFF_BACKUP_PART_PUB_KEY;
+    bytes[off..off + 2].copy_from_slice(&PolicyKeyKind::Ecc384.0.to_le_bytes());
+    bytes[off + 2..off + 4].copy_from_slice(&(POLICY_MAX_KEY_LEN as u16).to_le_bytes());
+    bytes[off + 4..off + 4 + POLICY_MAX_KEY_LEN].copy_from_slice(pid_pub);
+
+    bytes
+}
+
+/// Drive `PartInit → PartFinal` with a backing-partition policy anchored
+/// to `sata_key` and return the live CO session, the exact policy image
+/// (needed verbatim by `SdCreateRemoteBackup` for the `policy_hash`
+/// re-check), and the partition-identity (PID) public key that every
+/// evidence leaf certificate must carry.
+fn finalized_backing_session(
+    ctx: &TestCtx,
+    sata_key: &CaKey,
+) -> (SessionHandshake, [u8; PART_POLICY_LEN], [u8; RAW_PUB_LEN]) {
+    let session = bootstrap_rotated_co(ctx, &ROTATED_CO_PSK);
+
+    // PID / PID public key are materialized before PartInit.
+    let info = ctx.tbor(&TborPartInfoReq::new()).expect("PartInfo");
+    let mut pid_pub = [0u8; RAW_PUB_LEN];
+    pid_pub.copy_from_slice(&info.pid_pub_key);
+
+    // POTA anchor for the PTA certificate chain `PartFinal` validates.
+    let pota = CaKey::generate();
+    let policy = backing_part_policy(
+        &info.pid,
+        &info.pid_pub_key,
+        &sata_key.raw_pub(),
+        &pota.raw_pub(),
+    );
+
+    let init = ctx
+        .part_init(&session, &mach_seed(), &policy, &pota_thumbprint())
+        .expect("PartInit");
+    let chain = make_pta_chain(&pota, &pta_pub_from_csr(&init.pta_csr));
+    ctx.part_final(&session, &policy, &[], &chain.der_items())
+        .expect("PartFinal");
+
+    (session, policy, pid_pub)
+}
+
+/// Mint an SD sealing key and attest it, returning
+/// `(masked_sealing_key, key_report_bytes)`.  In the self-backup tests
+/// this key is both the sender's authentication key and (via its report)
+/// the receiver's `RcvrPub` source; the report is signed by the PID key.
+fn masked_key_and_report(ctx: &TestCtx, session_id: u16) -> (Vec<u8>, Vec<u8>) {
+    let seal = ctx
+        .tbor(&TborSdSealingKeyGenReq {
+            session_id,
+            scope: SCOPE_LOCAL,
+        })
+        .expect("SdSealingKeyGen");
+    let masked = seal.masked_key.to_vec();
+
+    let report = ctx
+        .tbor(&TborKeyReportReq {
+            session_id,
+            masked_key: masked.clone(),
+            report_data: [0u8; KEY_REPORT_DATA_LEN],
+        })
+        .expect("KeyReport")
+        .report;
+
+    (masked, report)
+}
+
+/// Receiver attestation evidence: the OOB items (three cert chains then
+/// the report, in index order) plus the descriptors referencing them.
+struct ReceiverEvidence {
+    /// OOB SGL items in index order: `[mfgr root, mfgr leaf, owner root,
+    /// owner leaf, part-owner root, part-owner leaf, report]`.
+    oob_items: Vec<Vec<u8>>,
+    mfgr: Vec<CertDescriptor>,
+    owner: Vec<CertDescriptor>,
+    part_owner: Vec<CertDescriptor>,
+    report: ReportDescriptor,
+}
+
+impl ReceiverEvidence {
+    /// Borrow the OOB items as the `&[&[u8]]` slice `tbor_oob` expects.
+    fn oob(&self) -> Vec<&[u8]> {
+        self.oob_items.iter().map(Vec::as_slice).collect()
+    }
+}
+
+/// Append `der` as the next OOB item and return a descriptor for it.
+fn push_item(items: &mut Vec<Vec<u8>>, der: &[u8]) -> CertDescriptor {
+    let index = items.len() as u8;
+    items.push(der.to_vec());
+    CertDescriptor {
+        index,
+        length: U16::new(der.len() as u16),
+    }
+}
+
+/// Assemble receiver evidence from three explicit chains plus the report,
+/// laying the DER items out in the OOB page in index order.
+fn evidence_from_chains(
+    mfgr: &GeneratedChain,
+    owner: &GeneratedChain,
+    part_owner: &GeneratedChain,
+    report: &[u8],
+) -> ReceiverEvidence {
+    let mut items = Vec::new();
+    let mfgr_desc = vec![
+        push_item(&mut items, &mfgr.root_der),
+        push_item(&mut items, &mfgr.leaf_der),
+    ];
+    let owner_desc = vec![
+        push_item(&mut items, &owner.root_der),
+        push_item(&mut items, &owner.leaf_der),
+    ];
+    let part_owner_desc = vec![
+        push_item(&mut items, &part_owner.root_der),
+        push_item(&mut items, &part_owner.leaf_der),
+    ];
+    let report_desc = push_item(&mut items, report);
+
+    ReceiverEvidence {
+        oob_items: items,
+        mfgr: mfgr_desc,
+        owner: owner_desc,
+        part_owner: part_owner_desc,
+        report: ReportDescriptor {
+            index: report_desc.index,
+            length: report_desc.length,
+        },
+    }
+}
+
+/// Build the three-chain receiver evidence for `pid_pub`: manufacturer and
+/// owner chains rooted at fresh CAs, and a partition-owner chain rooted at
+/// the policy `sata_key`.  Every leaf certifies `pid_pub` (the report
+/// signer), so all three share one leaf key.
+fn build_receiver_evidence(
+    pid_pub: &[u8; RAW_PUB_LEN],
+    sata_key: &CaKey,
+    report: &[u8],
+) -> ReceiverEvidence {
+    let mfgr = make_chain(&CaKey::generate(), pid_pub);
+    let owner = make_chain(&CaKey::generate(), pid_pub);
+    let part_owner = make_chain(sata_key, pid_pub);
+    evidence_from_chains(&mfgr, &owner, &part_owner, report)
+}
+
+/// Assemble a `SdCreateRemoteBackup` request carrying the three receiver
+/// certificate chains and the attestation-report descriptor.
+fn backup_request(
+    session_id: u16,
+    masked_sealing_key: Vec<u8>,
+    evidence: &ReceiverEvidence,
+    policy: &[u8; PART_POLICY_LEN],
+) -> TborSdCreateRemoteBackupReq {
+    TborSdCreateRemoteBackupReq {
+        session_id,
+        masked_sealing_key: masked_sealing_key
+            .as_slice()
+            .try_into()
+            .expect("masked sealing key is exactly MASKED_SEALING_KEY_LEN bytes"),
+        receiver_mfgr_cert_chain: evidence.mfgr.clone(),
+        receiver_owner_cert_chain: evidence.owner.clone(),
+        receiver_part_owner_cert_chain: evidence.part_owner.clone(),
+        receiver_report: evidence.report,
+        policy: PartPolicy::try_read_from_bytes(policy).expect("policy image is canonical"),
+    }
+}
+
+/// Minimal evidence (one report OOB item, empty cert chains) for reject
+/// tests that fail **before** evidence validation — missing OOB page, or a
+/// policy whose backing-partition binding is rejected first.
+fn dummy_evidence(report: &[u8]) -> ReceiverEvidence {
+    ReceiverEvidence {
+        oob_items: vec![report.to_vec()],
+        mfgr: Vec::new(),
+        owner: Vec::new(),
+        part_owner: Vec::new(),
+        report: ReportDescriptor {
+            index: 0,
+            length: U16::new(report.len() as u16),
+        },
+    }
+}
+
+#[test]
+fn sd_create_remote_backup_roundtrip_emu() {
+    let ctx = TestCtx::new();
+    let sata_key = CaKey::generate();
+    let (session, policy, pid_pub) = finalized_backing_session(&ctx, &sata_key);
+    let (masked, report) = masked_key_and_report(&ctx, session.session_id);
+    let evidence = build_receiver_evidence(&pid_pub, &sata_key, &report);
+
+    let req = backup_request(session.session_id, masked, &evidence, &policy);
+    let resp = ctx
+        .tbor_oob(&req, &evidence.oob())
+        .expect("SdCreateRemoteBackup roundtrip");
+
+    // HPKE-Auth seal: enc(97) ‖ ct(64) = 161 B, non-zero.
+    assert_eq!(resp.pok_remote_backup.len(), POK_REMOTE_BACKUP_LEN);
+    assert!(
+        resp.pok_remote_backup.iter().any(|&b| b != 0),
+        "pok_remote_backup must not be all-zero",
+    );
+}
+
+#[test]
+fn sd_create_remote_backup_rerandomizes_bks3_emu() {
+    let ctx = TestCtx::new();
+    let sata_key = CaKey::generate();
+    let (session, policy, pid_pub) = finalized_backing_session(&ctx, &sata_key);
+    let (masked, report) = masked_key_and_report(&ctx, session.session_id);
+    let evidence = build_receiver_evidence(&pid_pub, &sata_key, &report);
+
+    let req = backup_request(session.session_id, masked, &evidence, &policy);
+    let first = ctx.tbor_oob(&req, &evidence.oob()).expect("first backup");
+    let second = ctx.tbor_oob(&req, &evidence.oob()).expect("second backup");
+
+    // Fresh BKS3 + fresh HPKE ephemeral each call → distinct backups.
+    assert_ne!(
+        first.pok_remote_backup, second.pok_remote_backup,
+        "each backup must re-randomize BKS3 and the HPKE encapsulation",
+    );
+}
+
+#[test]
+fn sd_create_remote_backup_rejects_missing_oob_emu() {
+    let ctx = TestCtx::new();
+    let sata_key = CaKey::generate();
+    let (session, policy, _pid_pub) = finalized_backing_session(&ctx, &sata_key);
+    let (masked, report) = masked_key_and_report(&ctx, session.session_id);
+
+    // The receiver evidence descriptors reference OOB items, but no OOB
+    // page is supplied → the handler rejects before any crypto.
+    let evidence = dummy_evidence(&report);
+    let req = backup_request(session.session_id, masked, &evidence, &policy);
+    ctx.expect_fw_reject(&req, TborStatus::InvalidArg);
+}
+
+#[test]
+fn sd_create_remote_backup_rejects_non_backing_policy_emu() {
+    let ctx = TestCtx::new();
+
+    // `finalized_co_session` binds `known_good_part_policy` — POTA/SATA
+    // populated but the backing-partition fields left absent.  The policy
+    // hash re-check passes (same policy), but the backing-partition
+    // identity binding fails (before any evidence validation) because
+    // `backup_part_id` / `backup_part_pub_key` do not name this partition.
+    let session = finalized_co_session(&ctx);
+    let (masked, report) = masked_key_and_report(&ctx, session.session_id);
+
+    let policy = known_good_part_policy();
+    let evidence = dummy_evidence(&report);
+    let req = backup_request(session.session_id, masked, &evidence, &policy);
+    ctx.expect_fw_reject_oob(&req, &evidence.oob(), TborStatus::InvalidArg);
+}
+
+/// Flip the final byte of a DER/COSE blob — corrupts the trailing ECDSA
+/// signature value without disturbing the outer length-prefixed structure.
+fn flip_last_byte(mut bytes: Vec<u8>) -> Vec<u8> {
+    let n = bytes.len();
+    bytes[n - 1] ^= 0xFF;
+    bytes
+}
+
+#[test]
+fn sd_create_remote_backup_rejects_wrong_sata_anchor_emu() {
+    let ctx = TestCtx::new();
+    let sata_key = CaKey::generate();
+    let (session, policy, pid_pub) = finalized_backing_session(&ctx, &sata_key);
+    let (masked, report) = masked_key_and_report(&ctx, session.session_id);
+
+    // The partition-owner chain is internally valid but rooted at a CA the
+    // policy SATA key does not match → the anchor binding (req 3) fails.
+    let mfgr = make_chain(&CaKey::generate(), &pid_pub);
+    let owner = make_chain(&CaKey::generate(), &pid_pub);
+    let part_owner = make_chain(&CaKey::generate(), &pid_pub);
+    let evidence = evidence_from_chains(&mfgr, &owner, &part_owner, &report);
+
+    let req = backup_request(session.session_id, masked, &evidence, &policy);
+    ctx.expect_fw_reject_oob(&req, &evidence.oob(), TborStatus::InvalidArg);
+}
+
+#[test]
+fn sd_create_remote_backup_rejects_leaf_key_mismatch_emu() {
+    let ctx = TestCtx::new();
+    let sata_key = CaKey::generate();
+    let (session, policy, pid_pub) = finalized_backing_session(&ctx, &sata_key);
+    let (masked, report) = masked_key_and_report(&ctx, session.session_id);
+
+    // The owner chain certifies a *different* leaf key, so the three chains
+    // do not agree on a single leaf (req 4) → reject.
+    let other_pub = CaKey::generate().raw_pub();
+    let mfgr = make_chain(&CaKey::generate(), &pid_pub);
+    let owner = make_chain(&CaKey::generate(), &other_pub);
+    let part_owner = make_chain(&sata_key, &pid_pub);
+    let evidence = evidence_from_chains(&mfgr, &owner, &part_owner, &report);
+
+    let req = backup_request(session.session_id, masked, &evidence, &policy);
+    ctx.expect_fw_reject_oob(&req, &evidence.oob(), TborStatus::InvalidArg);
+}
+
+#[test]
+fn sd_create_remote_backup_rejects_tampered_cert_sig_emu() {
+    let ctx = TestCtx::new();
+    let sata_key = CaKey::generate();
+    let (session, policy, pid_pub) = finalized_backing_session(&ctx, &sata_key);
+    let (masked, report) = masked_key_and_report(&ctx, session.session_id);
+
+    // Corrupt the partition-owner leaf's signature: the chain is structurally
+    // valid but the leaf's ECDSA signature no longer verifies (req 1).
+    let mfgr = make_chain(&CaKey::generate(), &pid_pub);
+    let owner = make_chain(&CaKey::generate(), &pid_pub);
+    let mut part_owner = make_chain(&sata_key, &pid_pub);
+    part_owner.leaf_der = flip_last_byte(part_owner.leaf_der);
+    let evidence = evidence_from_chains(&mfgr, &owner, &part_owner, &report);
+
+    let req = backup_request(session.session_id, masked, &evidence, &policy);
+    ctx.expect_fw_reject_oob(&req, &evidence.oob(), TborStatus::X509SignatureInvalid);
+}
+
+#[test]
+fn sd_create_remote_backup_rejects_tampered_report_emu() {
+    let ctx = TestCtx::new();
+    let sata_key = CaKey::generate();
+    let (session, policy, pid_pub) = finalized_backing_session(&ctx, &sata_key);
+    let (masked, report) = masked_key_and_report(&ctx, session.session_id);
+
+    // All three chains are valid and share the leaf key, but the report's
+    // signature no longer verifies against that leaf key (req 5).
+    let tampered_report = flip_last_byte(report);
+    let evidence = build_receiver_evidence(&pid_pub, &sata_key, &tampered_report);
+
+    let req = backup_request(session.session_id, masked, &evidence, &policy);
+    ctx.expect_fw_reject_oob(&req, &evidence.oob(), TborStatus::InvalidArg);
+}

--- a/ddi/tbor/types/tests/harness/ctx.rs
+++ b/ddi/tbor/types/tests/harness/ctx.rs
@@ -99,6 +99,18 @@ impl TestCtx {
         self.dev.exec_op_tbor(req, None, &mut cookie)
     }
 
+    /// Issue an `OP_TBOR` request carrying out-of-band SGL items.
+    ///
+    /// Each slice in `oob_items` becomes one NVMe SGL Data Block
+    /// descriptor the emulator writes into a 4-KiB descriptor page; the
+    /// firmware indexes them by position (see the OOB transport). Used by
+    /// commands whose bulk evidence rides outside the 4-KiB request
+    /// buffer (e.g. `SdCreateRemoteBackup`'s receiver `KeyReport`).
+    pub fn tbor_oob<R: TborOpReq>(&self, req: &R, oob_items: &[&[u8]]) -> DdiResult<R::OpResp> {
+        let mut cookie = None;
+        self.dev.exec_op_tbor(req, Some(oob_items), &mut cookie)
+    }
+
     /// Issue `req`, assert the FW dispatcher rejected it with exactly
     /// `expected`, and return the matched [`DdiError`] for any further
     /// caller-side inspection.
@@ -115,6 +127,30 @@ impl TestCtx {
         match self.tbor(req) {
             Ok(resp) => panic!(
                 "expected FW reject {expected:?} (0x{:08X}), got Ok({resp:?})",
+                expected.0,
+            ),
+            Err(err) => {
+                assert_fw_rejects(&err, expected);
+                err
+            }
+        }
+    }
+
+    /// [`Self::expect_fw_reject`] for a request carrying out-of-band SGL
+    /// items (see [`Self::tbor_oob`]).
+    #[track_caller]
+    pub fn expect_fw_reject_oob<R: TborOpReq>(
+        &self,
+        req: &R,
+        oob_items: &[&[u8]],
+        expected: TborStatus,
+    ) -> DdiError
+    where
+        R::OpResp: core::fmt::Debug,
+    {
+        match self.tbor_oob(req, oob_items) {
+            Ok(_resp) => panic!(
+                "expected FW reject {expected:?} (0x{:08X}), got unexpected success",
                 expected.0,
             ),
             Err(err) => {

--- a/ddi/tbor/types/tests/harness/x509_fixture.rs
+++ b/ddi/tbor/types/tests/harness/x509_fixture.rs
@@ -14,6 +14,8 @@
 
 use azihsm_crypto::x509_builder::cert_builder;
 use azihsm_crypto::x509_builder::cert_builder::IntermediateCertParams;
+use azihsm_crypto::x509_builder::cert_builder::KeyUsage;
+use azihsm_crypto::x509_builder::cert_builder::LeafCertParams;
 use azihsm_crypto::x509_builder::cert_builder::RootCertParams;
 use azihsm_crypto::x509_builder::cert_builder::CN_LEN;
 use azihsm_crypto::x509_builder::cert_builder::SN_LEN;
@@ -37,6 +39,8 @@ const ROOT_CN: &str = "AZIHSM POTA Root CA";
 const ROOT_SN: &str = "POTAROOT1";
 const PTA_CN: &str = "AZIHSM PTA Intermediate CA";
 const PTA_SN: &str = "PTAINT001";
+const LEAF_CN: &str = "AZIHSM Evidence Leaf";
+const LEAF_SN: &str = "EVLEAF001";
 
 /// A synthetic P-384 CA key (e.g. a policy POTA trust anchor) that can
 /// sign certificates and expose its public key.
@@ -201,6 +205,71 @@ pub fn make_pta_chain(pota_ca: &CaKey, pta_pub_sec1: &[u8; SEC1_PUB_LEN]) -> Pta
     }
 }
 
+/// Build an **end-entity** leaf certificate whose subject public key is
+/// `leaf_pub_sec1` (e.g. an attestation-report signer's key), signed by
+/// `issuer` (a self-signed CA).  Unlike [`build_pta_intermediate`], the
+/// leaf is `cA=false` with `digitalSignature` key usage.
+pub fn build_leaf(leaf_pub_sec1: &[u8; SEC1_PUB_LEN], issuer: &CaKey) -> Vec<u8> {
+    let params = LeafCertParams {
+        public_key: leaf_pub_sec1,
+        serial_number: &serial(3),
+        not_before: NOT_BEFORE,
+        not_after: NOT_AFTER,
+        subject_cn: LEAF_CN,
+        subject_sn: LEAF_SN,
+        issuer_cn: ROOT_CN,
+        issuer_sn: ROOT_SN,
+        subject_key_id: &sha1_ski(leaf_pub_sec1),
+        authority_key_id: &issuer.ski(),
+        key_usage: KeyUsage::DIGITAL_SIGNATURE,
+    };
+
+    let mut tbs = azihsm_crypto::x509_builder::leaf_cert::TBS_TEMPLATE;
+    patch_tbs_leaf(&mut tbs, &params);
+    let (r, s) = issuer.sign(&tbs);
+
+    let mut out = vec![0u8; 1024];
+    let len = cert_builder::build_leaf_cert(&params, &r, &s, &mut out).expect("leaf cert");
+    out.truncate(len);
+    out
+}
+
+/// A generated root→leaf attestation-evidence chain, DER-encoded.
+///
+/// `root_der` is a self-signed CA certificate; `leaf_der` is an
+/// end-entity certificate signed by the root whose subject public key is
+/// the caller-supplied report-signer key.
+pub struct GeneratedChain {
+    /// Self-signed root CA certificate (DER).
+    pub root_der: Vec<u8>,
+    /// End-entity leaf certificate carrying the report-signer key (DER).
+    pub leaf_der: Vec<u8>,
+}
+
+impl GeneratedChain {
+    /// The chain's certificate DERs in root → leaf order.
+    pub fn der_items(&self) -> [&[u8]; 2] {
+        [self.root_der.as_slice(), self.leaf_der.as_slice()]
+    }
+}
+
+/// Build a root→leaf chain: a self-signed root CA (`ca`) certifying an
+/// end-entity leaf that carries `leaf_pub_raw` (raw `X ‖ Y`, the report
+/// signer's public key).
+///
+/// Pass a caller-controlled `ca` (e.g. the SATA anchor key) when the chain
+/// must be anchored to a known public key; otherwise use a fresh
+/// [`CaKey::generate`].
+pub fn make_chain(ca: &CaKey, leaf_pub_raw: &[u8; RAW_PUB_LEN]) -> GeneratedChain {
+    let mut leaf_sec1 = [0u8; SEC1_PUB_LEN];
+    leaf_sec1[0] = 0x04;
+    leaf_sec1[1..].copy_from_slice(leaf_pub_raw);
+    GeneratedChain {
+        root_der: build_root(ca),
+        leaf_der: build_leaf(&leaf_sec1, ca),
+    }
+}
+
 /// Extract the SEC1 public key (`0x04 ‖ X ‖ Y`, 97 bytes) from a DER
 /// PKCS#10 CSR, parsed structurally per
 /// [RFC 2986](https://datatracker.ietf.org/doc/html/rfc2986):
@@ -296,4 +365,24 @@ fn patch_tbs_intermediate(tbs: &mut [u8], params: &IntermediateCertParams<'_>) {
     tbs[AUTHORITY_KEY_ID_OFFSET..AUTHORITY_KEY_ID_OFFSET + 20]
         .copy_from_slice(params.authority_key_id);
     tbs[PATH_LEN_OFFSET] = params.path_len;
+}
+
+fn patch_tbs_leaf(tbs: &mut [u8], params: &LeafCertParams<'_>) {
+    use azihsm_crypto::x509_builder::leaf_cert::*;
+    let s_cn = pad_cn(params.subject_cn);
+    let i_cn = pad_cn(params.issuer_cn);
+    let s_sn = pad_sn(params.subject_sn);
+    let i_sn = pad_sn(params.issuer_sn);
+    tbs[PUBLIC_KEY_OFFSET..PUBLIC_KEY_OFFSET + 97].copy_from_slice(params.public_key);
+    tbs[SERIAL_NUMBER_OFFSET..SERIAL_NUMBER_OFFSET + 20].copy_from_slice(params.serial_number);
+    tbs[NOT_BEFORE_OFFSET..NOT_BEFORE_OFFSET + 15].copy_from_slice(params.not_before);
+    tbs[NOT_AFTER_OFFSET..NOT_AFTER_OFFSET + 15].copy_from_slice(params.not_after);
+    tbs[ISSUER_CN_OFFSET..ISSUER_CN_OFFSET + CN_LEN].copy_from_slice(&i_cn);
+    tbs[SUBJECT_CN_OFFSET..SUBJECT_CN_OFFSET + CN_LEN].copy_from_slice(&s_cn);
+    tbs[ISSUER_SN_OFFSET..ISSUER_SN_OFFSET + SN_LEN].copy_from_slice(&i_sn);
+    tbs[SUBJECT_SN_OFFSET..SUBJECT_SN_OFFSET + SN_LEN].copy_from_slice(&s_sn);
+    tbs[SUBJECT_KEY_ID_OFFSET..SUBJECT_KEY_ID_OFFSET + 20].copy_from_slice(params.subject_key_id);
+    tbs[AUTHORITY_KEY_ID_OFFSET..AUTHORITY_KEY_ID_OFFSET + 20]
+        .copy_from_slice(params.authority_key_id);
+    tbs[KEY_USAGE_OFFSET..KEY_USAGE_OFFSET + 2].copy_from_slice(&params.key_usage.to_bytes());
 }

--- a/docs/tbor-ddi/README.md
+++ b/docs/tbor-ddi/README.md
@@ -58,7 +58,7 @@ single `none` TOC placeholder and no typed body fields.
 | `0x07` | `PartInit` | InSession | [`commands/part_init.md`](./commands/part_init.md) |
 | `0x08` | `PartFinal` | InSession | [`commands/part_final.md`](./commands/part_final.md) |
 | `0x09` | `SdSealingKeyGen` | InSession | [`commands/sd_sealing_key_gen.md`](./commands/sd_sealing_key_gen.md) |
-| `0x0A` | `SdCreateRemoteBackup` (schema-only) | InSession | [`commands/sd_create_remote_backup.md`](./commands/sd_create_remote_backup.md) |
+| `0x0A` | `SdCreateRemoteBackup` | InSession | [`commands/sd_create_remote_backup.md`](./commands/sd_create_remote_backup.md) |
 | `0x0B` | `SdResealBackup` (schema-only) | InSession | [`commands/sd_reseal_backup.md`](./commands/sd_reseal_backup.md) |
 | `0x0C` | `SdRestoreRemoteBackup` (schema-only) | InSession | [`commands/sd_restore_remote_backup.md`](./commands/sd_restore_remote_backup.md) |
 | `0x0D` | `SdRestoreLocalBackup` (schema-only) | InSession | [`commands/sd_restore_local_backup.md`](./commands/sd_restore_local_backup.md) |

--- a/docs/tbor-ddi/commands/sd_create_remote_backup.md
+++ b/docs/tbor-ddi/commands/sd_create_remote_backup.md
@@ -5,14 +5,27 @@ Licensed under the MIT License.
 
 # SdCreateRemoteBackup (Opcode 0x0A)
 
-**Handler:** _Not yet landed — wire schema only._
+**Handler:** `fw/core/lib/src/ddi/tbor/sd_create_remote_backup.rs`
 **Session:** InSession (Crypto Officer)
 
 ## Description
 
-Creates a new security domain under the active session's partition from
-the caller-supplied unified `PartPolicy`, returning the remote
-partition-owner-key backup (`pok_remote_backup`).
+Creates a security-domain **remote backup**: a fresh 48-byte BKS3
+HPKE-Auth-sealed to the *receiver's* SD sealing public key (`RcvrPub`,
+recovered from the receiver's `KeyReport` carried out of band) and
+authenticated by the *sender's* SD sealing private key (`SndrPriv`,
+recovered by unmasking `masked_sealing_key`).  Maps to manticore
+`CreateSD`, reduced to its remote-backup output.
+
+The command is **stateless** — nothing is persisted (no vault writes, no
+undo log). It requires an `Initialized` partition whose bound policy
+names this partition as the backing partition.
+
+The receiver attestation **evidence** is validated on-device
+([`verify_evidence`](../../../fw/core/evidence/src/lib.rs)): the three
+certificate chains (manufacturer / owner / partition-owner) are verified,
+the partition-owner chain is anchored to the policy SATA key, and the
+attested COSE_Key is recovered as `RcvrPub`.
 
 ## Request
 
@@ -24,23 +37,27 @@ variable-length data section.
 | Offset | Field | Type | Description |
 |---|---|---|---|
 | 4  | `session_id` | `session_id` (inline) | CO session this request is bound to; cross-checked against the SQE-carried session id. |
-| 8  | `sender_key` | `key_id` (inline) | Sender key id (`KeyId`, TOC entry type 1). |
+| 8  | `masked_sealing_key` | `buffer` (fixed 180 B) | Sender's masked SD-sealing key (the `masked_key` from `SdSealingKeyGen`), unmasked on-device to recover `SndrPriv`. `MASKED_SEALING_KEY_LEN` (180 B). |
 | 12 | `mfgr_cert_chain` | `buffer` (typed `&[CertDescriptor]`) | Manufacturer certificate-chain descriptors (from the `Evidence` field group). |
 | 16 | `owner_cert_chain` | `buffer` (typed `&[CertDescriptor]`) | Owner certificate-chain descriptors. |
 | 20 | `part_owner_cert_chain` | `buffer` (typed `&[CertDescriptor]`) | Partition-owner certificate-chain descriptors. |
-| 24 | `evidence` | `buffer` (single `&ReportDescriptor`, 4 B) | Attestation-report (COSE_Sign1) descriptor. |
-| 28 | `policy` | `buffer` (fixed 484 B) | Caller-asserted unified `PartPolicy` describing the security domain to create. Length pinned to `PART_POLICY_LEN` (484 B); a wrong length is rejected at decode. |
+| 24 | `evidence` | `buffer` (single `&ReportDescriptor`, 3 B) | Receiver attestation-report (COSE_Sign1) descriptor. |
+| 28 | `policy` | `buffer` (fixed 484 B) | Caller-asserted unified `PartPolicy`. Must match the policy bound at `PartInit` (`SHA-384` re-check) and name this partition as the backing partition (`backup_part_id` = PID, `backup_part_pub_key` = PID public key). Length pinned to `PART_POLICY_LEN` (484 B). |
 
 The four `mfgr_cert_chain` … `evidence` entries are spliced in by the
 shared [`Evidence`](../../../fw/core/ddi/tbor/types/src/evidence.rs)
-field group; the certificate-chain DER bytes and the COSE_Sign1 report
-travel **out of band**, referenced by these `(offset, length)`
-descriptors.
+field group.  Each descriptor is `{ index: u8, length: U16 }`: `index`
+selects a 16-byte NVMe SGL Data Block descriptor in the **out-of-band**
+SGL page (SQE `oob_prp`/`oob_len`), and `length` is the byte count of the
+referenced payload.  All three certificate chains **and** the `evidence`
+(receiver `KeyReport`) descriptor are consumed: the chains are validated
+and the report's COSE_Key is recovered as `RcvrPub`.
 
 ### Data section
 
-Carries the packed cert-chain / report descriptors and the 484-byte
-`policy` image.
+Carries the 180-byte `masked_sealing_key`, the packed cert-chain / report
+descriptors, and the 484-byte `policy` image.  The referenced evidence
+payloads (the receiver `KeyReport`) travel out of band.
 
 ## Response
 
@@ -51,21 +68,26 @@ section.
 
 | Offset | Field | Type | Description |
 |---|---|---|---|
-| 8 | `pok_remote_backup` | `buffer` (fixed 180 B) | Remote partition-owner-key backup, a masked BKS3: an AEAD-GCM-256 envelope (`header(8) ‖ iv(12) ‖ aad(96) ‖ pt(48) ‖ tag(16)`) = `MASKED_SD_LEN` (180 B). |
+| 8 | `pok_remote_backup` | `buffer` (fixed 161 B) | Remote partition-owner-key backup: an HPKE-Auth seal of BKS3 under `DHKemP384Sha384AesGcm256`, `enc(97) ‖ ct(64)` = `POK_REMOTE_BACKUP_LEN` (161 B). |
 
 ### Data section
 
-Carries the 180-byte `pok_remote_backup` blob.
+Carries the 161-byte `pok_remote_backup` seal.
 
 ## Errors
 
 | Error | Cause |
 |---|---|
-| `TborInvalidFixedLength` | `policy` is not exactly 484 B (rejected at decode before the handler runs) |
-| `SessionNotFound` | `session_id` does not refer to an allocated slot |
-| `DdiDecodeFailed` | Malformed request body |
+| `TborInvalidFixedLength` | `masked_sealing_key` (180 B) or `policy` (484 B) is the wrong length (rejected at decode before the handler runs) |
+| `InvalidArg` | Not `Initialized`; missing out-of-band evidence; policy hash mismatch; or the policy does not name this partition as the backing partition |
+| `InvalidPermissions` | Not a Crypto-Officer session |
+| `UnsupportedKeyScope` | The masked sealing key's scope has no provisioned masking key |
+| `UnsupportedKeyType` | The unmasked key is not an `SdSealing` key |
+| `SessionNotFound` | `session_id` does not refer to an `Active` slot |
 
 ## See also
 
 - Wire encoding: [TBOR specification](../../../fw/core/ddi/tbor/docs/spec.md)
 - Wire schema: `fw/core/ddi/tbor/types/src/sd_create_remote_backup.rs`
+- Sender flow: [`SdSealingKeyGen`](sd_sealing_key_gen.md) → [`KeyReport`](key_report.md) → `SdCreateRemoteBackup`
+

--- a/fw/core/crypto/key-masking/src/aead/decode.rs
+++ b/fw/core/crypto/key-masking/src/aead/decode.rs
@@ -52,8 +52,11 @@ pub struct UnmaskedView<'a> {
     pub key_label: &'a [u8],
 
     /// Recovered target-key bytes (decrypted in place inside the
-    /// caller's `blob`).
-    pub target_key: &'a [u8],
+    /// caller's `blob`).  Borrows the `blob` buffer directly (a
+    /// [`DmaBuf`] sub-view of the decrypted payload region), so callers
+    /// that forward the key to another PAL/crypto verb needing a
+    /// `&DmaBuf` can pass it through without an intermediate copy.
+    pub target_key: &'a DmaBuf,
 }
 
 /// In-place unmask: parse, authenticate, decrypt, and validate a

--- a/fw/core/ddi/tbor/types/src/policy.rs
+++ b/fw/core/ddi/tbor/types/src/policy.rs
@@ -14,27 +14,28 @@
 //!
 //! Layout discipline:
 //!
-//! * Multi-byte scalars use native `#[repr(C)]` integer fields (`u16`).
-//!   The struct is therefore alignment-2; a trailing `_reserved` byte
-//!   pads [`PartPolicy`] to an even size so there is no implicit padding
-//!   (zerocopy `IntoBytes` rejects padding).  All supported targets are
-//!   little-endian, so the in-memory image equals the wire image.
-//! * Because the struct is alignment-2, it is **not** overlaid on the
-//!   (arbitrarily-aligned) wire buffer; the firmware parser copies it
-//!   out with `try_read_from_bytes`, so no buffer-alignment plumbing is
-//!   needed.
+//! * Multi-byte scalars use alignment-1 little-endian [`U16`]
+//!   fields, so every type here — and [`PartPolicy`] as a whole — is
+//!   alignment-1 / [`Unaligned`].  A trailing `_reserved` byte pads
+//!   [`PartPolicy`] to an even size so there is no implicit padding
+//!   (zerocopy `IntoBytes` rejects padding).
+//! * Because the struct is [`Unaligned`], the firmware parser borrows it
+//!   zero-copy from the (arbitrarily-aligned) wire buffer with
+//!   `try_ref_from_bytes` — no copy, no buffer-alignment plumbing.
 //! * `#[repr(C)]` + zerocopy [`TryFromBytes`] / [`IntoBytes`] /
-//!   [`Immutable`] / [`KnownLayout`] derives reject any padding /
-//!   alignment drift at compile time.
+//!   [`Immutable`] / [`KnownLayout`] / [`Unaligned`] derives reject any
+//!   padding / alignment drift at compile time.
 //! * The `const _: () = assert!(...)` blocks at the bottom pin
 //!   absolute byte sizes as a belt-and-braces check.
 
 use bitfield_struct::bitfield;
 use open_enum::open_enum;
+use zerocopy::little_endian::U16;
 use zerocopy::Immutable;
 use zerocopy::IntoBytes;
 use zerocopy::KnownLayout;
 use zerocopy::TryFromBytes;
+use zerocopy::Unaligned;
 
 /// Maximum key length for [`PolicyPubKey::data`] (bytes).
 ///
@@ -70,7 +71,7 @@ pub enum PolicyKeyKind {
 /// Two-byte policy version (`major.minor`).
 ///
 /// Layout (alignment 1, size 2 B): `major(1) ‖ minor(1)`.
-#[derive(Debug, TryFromBytes, IntoBytes, Immutable, KnownLayout)]
+#[derive(Debug, TryFromBytes, IntoBytes, Immutable, KnownLayout, Unaligned)]
 #[repr(C)]
 pub struct PolicyVer {
     /// Major version number.  Must equal [`POLICY_VERSION_MAJOR`].
@@ -82,20 +83,46 @@ pub struct PolicyVer {
 
 /// POTA public key embedded in [`PartPolicy`].
 ///
-/// Layout (alignment 2, size 100 B): `kind(2 LE) ‖ len(2 LE) ‖ data(96)`.
-#[derive(Debug, TryFromBytes, IntoBytes, Immutable, KnownLayout)]
+/// Layout (alignment 1, size 100 B): `kind(2 LE) ‖ len(2 LE) ‖ data(96)`.
+///
+/// `kind` and `len` are stored as alignment-1 little-endian [`U16`] so
+/// the whole struct (and [`PartPolicy`]) is [`Unaligned`] and can be
+/// borrowed zero-copy from an arbitrarily-aligned wire buffer; read them
+/// through [`kind`](Self::kind) / [`len`](Self::len).
+#[derive(Debug, TryFromBytes, IntoBytes, Immutable, KnownLayout, Unaligned)]
 #[repr(C)]
 pub struct PolicyPubKey {
-    /// [`PolicyKeyKind`] discriminant. Native, little-endian on all
-    /// supported targets (open-enum newtype over `u16`).
-    pub kind: PolicyKeyKind,
+    /// [`PolicyKeyKind`] discriminant, little-endian.  Read via
+    /// [`kind`](Self::kind).
+    kind: U16,
 
-    /// Active prefix length of `data` (`0..=POLICY_MAX_KEY_LEN`).
-    /// For `Ecc384` must equal [`POLICY_MAX_KEY_LEN`].
-    pub len: u16,
+    /// Active prefix length of `data` (`0..=POLICY_MAX_KEY_LEN`),
+    /// little-endian.  Read via [`len`](Self::len).  For `Ecc384` must
+    /// equal [`POLICY_MAX_KEY_LEN`].
+    len: U16,
 
-    /// Key bytes; only the first `len` bytes are meaningful.
+    /// Key bytes; only the first `len()` bytes are meaningful.
     pub data: [u8; POLICY_MAX_KEY_LEN],
+}
+
+impl PolicyPubKey {
+    /// The [`PolicyKeyKind`] discriminant.
+    #[inline]
+    pub fn kind(&self) -> PolicyKeyKind {
+        PolicyKeyKind(self.kind.get())
+    }
+
+    /// Active prefix length of [`data`](Self::data).
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.len.get() as usize
+    }
+
+    /// `true` iff the key slot is absent (`len == 0`).
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.len.get() == 0
+    }
 }
 
 /// Boolean policy flags, packed into a single byte (alignment 1).
@@ -111,7 +138,7 @@ pub struct PolicyPubKey {
 /// contract "reserved bits MUST be zero" is enforced separately by
 /// [`PolicyFlags::is_valid`].
 #[bitfield(u8)]
-#[derive(PartialEq, Eq, TryFromBytes, IntoBytes, Immutable, KnownLayout)]
+#[derive(PartialEq, Eq, TryFromBytes, IntoBytes, Immutable, KnownLayout, Unaligned)]
 pub struct PolicyFlags {
     /// Bit 0: include the First Mutable Composite Device Identity
     /// (CDI-FMC) in key derivations.
@@ -166,7 +193,7 @@ impl PolicyFlags {
 /// security-domain policy type.  Pubkey slots that are not in use carry
 /// `len = 0` (see [`PolicyPubKey`]).
 ///
-/// Layout (alignment 2, size 484 B):
+/// Layout (alignment 1, size 484 B):
 ///
 /// | Field                 | Offset | Size |
 /// |-----------------------|--------|------|
@@ -181,12 +208,11 @@ impl PolicyFlags {
 /// | `_reserved`           | 483    | 1    |
 ///
 /// The trailing `_reserved` byte pads the struct to an even length so
-/// the alignment-2 `#[repr(C)]` layout has no implicit padding (required
-/// for the zerocopy `IntoBytes` derive).  Because the struct is
-/// alignment-2 it is copied out of the wire buffer
-/// (`try_read_from_bytes`) rather than overlaid, so no buffer-alignment
-/// attribute is required on the `part_policy` field.
-#[derive(Debug, TryFromBytes, IntoBytes, Immutable, KnownLayout)]
+/// the `#[repr(C)]` layout has no implicit padding (required for the
+/// zerocopy `IntoBytes` derive).  Every field is alignment-1, so the
+/// struct is [`Unaligned`] and can be borrowed zero-copy from an
+/// arbitrarily-aligned wire buffer (`try_ref_from_bytes`) with no copy.
+#[derive(Debug, TryFromBytes, IntoBytes, Immutable, KnownLayout, Unaligned)]
 #[repr(C)]
 pub struct PartPolicy {
     /// Policy version (major.minor).
@@ -233,9 +259,9 @@ pub struct PartPolicy {
 pub const PART_POLICY_LEN: usize = core::mem::size_of::<PartPolicy>();
 
 const _: () = assert!(PART_POLICY_LEN == 484);
-const _: () = assert!(core::mem::align_of::<PartPolicy>() == 2);
+const _: () = assert!(core::mem::align_of::<PartPolicy>() == 1);
 const _: () = assert!(core::mem::size_of::<PolicyPubKey>() == 100);
-const _: () = assert!(core::mem::align_of::<PolicyPubKey>() == 2);
+const _: () = assert!(core::mem::align_of::<PolicyPubKey>() == 1);
 const _: () = assert!(core::mem::size_of::<PolicyVer>() == 2);
 const _: () = assert!(core::mem::size_of::<PolicyFlags>() == 1);
 
@@ -290,10 +316,10 @@ mod tests {
         let policy = PartPolicy::try_read_from_bytes(&bytes).expect("parse");
         assert_eq!(policy.version.major, 1);
         assert_eq!(policy.version.minor, 0);
-        assert_eq!(policy.pota_pub_key.kind, PolicyKeyKind::Ecc384);
-        assert_eq!(policy.pota_pub_key.len, 96);
-        assert_eq!(policy.sata_pub_key.len, 96);
-        assert_eq!(policy.sapota_pub_key.len, 96);
+        assert_eq!(policy.pota_pub_key.kind(), PolicyKeyKind::Ecc384);
+        assert_eq!(policy.pota_pub_key.len(), 96);
+        assert_eq!(policy.sata_pub_key.len(), 96);
+        assert_eq!(policy.sapota_pub_key.len(), 96);
         assert!(policy.backup_part_id.iter().all(|&b| b == 0xCD));
         assert!(policy.flags.include_fmc_cdi());
         assert!(!policy.flags.require_trusted_sa_key());

--- a/fw/core/ddi/tbor/types/src/sd_create_remote_backup.rs
+++ b/fw/core/ddi/tbor/types/src/sd_create_remote_backup.rs
@@ -13,26 +13,33 @@
 //! * `session_id` — TOC-carried CO session id; cross-checked against the
 //!   SQE-carried session id by the dispatcher (parity with the other
 //!   in-session commands).
-//! * `sender_key` — sender key id ([`KeyId`](azihsm_fw_ddi_tbor_api::KeyId),
-//!   TOC entry type 1) the masked security domain is wrapped under.
+//! * `masked_sealing_key` — the sender's masked SD-sealing key (the
+//!   `masked_key` returned by
+//!   [`SdSealingKeyGen`](crate::sd_sealing_key_gen)), exactly
+//!   [`MASKED_SEALING_KEY_LEN`] (180 B).  Unmasked on-device to recover
+//!   the sender's private ECDH key (`SndrPriv`); never a vault handle.
 //! * `receiver_evidence` — receiver side-band attestation evidence
 //!   ([`Evidence`](crate::evidence::Evidence) field group: manufacturer /
-//!   owner / partition-owner certificate chains plus the attestation
-//!   report).
+//!   owner / partition-owner certificate-chain descriptors plus the
+//!   attestation-report descriptor).  The report descriptor indexes the
+//!   receiver's `KeyReport` in the out-of-band SGL page; its COSE_Key
+//!   supplies the recipient public key (`RcvrPub`).
 //! * `policy` — the unified [`PartPolicy`] describing the security domain
 //!   to create.  Length pinned to [`PART_POLICY_LEN`] (484 B).
 //!
 //! Output:
 //!
-//! * `pok_remote_backup` — the remote partition-owner-key backup (a
-//!   masked BKS3), exactly [`MASKED_SD_LEN`] (180 B): an AEAD-GCM-256
-//!   masked-key envelope whose plaintext is the 48-byte BKS3 and whose
-//!   AAD is the 96-byte `MaskedKeyMetadata`.
+//! * `pok_remote_backup` — the remote partition-owner-key backup: an
+//!   **HPKE-Auth seal** of the fresh 48-byte BKS3 to `RcvrPub` with
+//!   `SndrPriv` as the sender-authentication key, exactly
+//!   [`POK_REMOTE_BACKUP_LEN`] (161 B) = `enc(97) ‖ ct(64)` under the
+//!   `DHKemP384Sha384AesGcm256` suite.
 
 use azihsm_fw_ddi_tbor_api::tbor;
 
 use crate::evidence::*;
 pub use crate::policy::PART_POLICY_LEN;
+pub use crate::sd_sealing_key_gen::MASKED_SEALING_KEY_LEN;
 
 /// TBOR opcode for `SdCreateRemoteBackup`.
 pub const TBOR_OP_SD_CREATE_REMOTE_BACKUP: u8 = 0x0A;
@@ -42,14 +49,32 @@ pub const TBOR_OP_SD_CREATE_REMOTE_BACKUP: u8 = 0x0A;
 // against the canonical value here.
 const _: () = assert!(PART_POLICY_LEN == 484);
 
-/// Exact on-the-wire length of the masked security-domain blob.
+// `masked_sealing_key` is spelled out as `180` on the field (the derive
+// needs an integer literal) and pinned against the canonical
+// `MASKED_SEALING_KEY_LEN` here.
+const _: () = assert!(MASKED_SEALING_KEY_LEN == 180);
+
+/// Exact on-the-wire length of a **masked** security-domain blob (a
+/// masked BKS3): an AEAD-GCM-256 masked-key envelope
+/// (`header(8) ‖ iv(12) ‖ aad(96) ‖ pt(48) ‖ tag(16)`) whose plaintext
+/// is the 48-byte BKS3 and whose AAD is the 96-byte `MaskedKeyMetadata`.
 ///
-/// Sized as a masked BKS3: an AEAD-GCM-256 masked-key envelope
-/// (`header(8) ‖ iv(12) ‖ aad(96) ‖ pt(48) ‖ tag(16)`) where the
-/// plaintext is the 48-byte BKS3 and the AAD is the 96-byte
-/// `MaskedKeyMetadata`.
+/// Retained here as the shared length authority for the rest of the
+/// Security-Domain backup family (`SdReseal`, `SdRestore*`,
+/// `SdCreatePeerBackup`), which re-export it.  **This command's**
+/// response is an HPKE-Auth seal sized by [`POK_REMOTE_BACKUP_LEN`], not
+/// a masked blob.
 pub const MASKED_SD_LEN: usize = 8 + 12 + 96 + 48 + 16;
 const _: () = assert!(MASKED_SD_LEN == 180);
+
+/// Exact on-the-wire length of the remote partition-owner-key backup.
+///
+/// An HPKE-Auth seal under `DHKemP384Sha384AesGcm256`: the encapsulated
+/// key `enc` (P-384 SEC1 uncompressed, 97 B) followed by the AEAD
+/// ciphertext `ct` over the 48-byte BKS3 plus the 16-byte GCM tag
+/// (`48 + 16 = 64`).
+pub const POK_REMOTE_BACKUP_LEN: usize = 97 + (48 + 16);
+const _: () = assert!(POK_REMOTE_BACKUP_LEN == 161);
 
 /// `SdCreateRemoteBackup` request schema.
 #[tbor(opcode = 0x0A)]
@@ -60,14 +85,25 @@ pub struct TborSdCreateRemoteBackupReq<'a> {
     #[tbor(session_id)]
     pub session_id: SessionId,
 
-    /// The sender key id.
-    #[tbor(key_id)]
-    pub sender_key: KeyId,
+    /// The sender's masked SD-sealing key (from `SdSealingKeyGen`),
+    /// exactly [`MASKED_SEALING_KEY_LEN`] (180 B).  Unmasked on-device to
+    /// recover `SndrPriv`.
+    ///
+    /// Marked `#[tbor(mutable)]` so the FW handler can AEAD-open (unmask)
+    /// the blob **in place** in the request buffer via
+    /// [`decode_mut`](TborSdCreateRemoteBackupReq::decode_mut), avoiding a
+    /// scratch copy.  The `#[tbor(include)]` evidence group that follows is
+    /// omitted from the generated `ViewMut` (its accessors remain on the
+    /// shared [`decode`](TborSdCreateRemoteBackupReq::decode) view), so the
+    /// handler reads evidence via `decode` and unmasks via `decode_mut`.
+    #[tbor(buffer, len = 180, mutable)]
+    pub masked_sealing_key: &'a [u8],
 
     /// Side-band attestation evidence (manufacturer / owner /
-    /// partition-owner certificate chains plus the attestation report).
-    /// Spliced in as the [`Evidence`](crate::evidence::Evidence) field
-    /// group's four TOC entries.
+    /// partition-owner certificate-chain descriptors plus the attestation
+    /// report descriptor).  Spliced in as the
+    /// [`Evidence`](crate::evidence::Evidence) field group's four TOC
+    /// entries.
     #[tbor(include)]
     pub receiver_evidence: Evidence<'a>,
 
@@ -82,9 +118,9 @@ pub struct TborSdCreateRemoteBackupReq<'a> {
 /// `SdCreateRemoteBackup` response schema.
 #[tbor(response)]
 pub struct TborSdCreateRemoteBackupResp<'a> {
-    /// Remote partition-owner-key backup (a masked BKS3).  Always exactly
-    /// [`MASKED_SD_LEN`] (180 B).
-    #[tbor(buffer, len = 180)]
+    /// Remote partition-owner-key backup (an HPKE-Auth seal of BKS3).
+    /// Always exactly [`POK_REMOTE_BACKUP_LEN`] (161 B).
+    #[tbor(buffer, len = 161)]
     pub pok_remote_backup: &'a [u8],
 }
 
@@ -92,27 +128,27 @@ pub struct TborSdCreateRemoteBackupResp<'a> {
 mod tests {
     #![allow(clippy::unwrap_used)]
 
-    use azihsm_fw_ddi_tbor_api::KeyId;
     use azihsm_fw_ddi_tbor_api::SessionId;
 
     use super::*;
 
     #[test]
-    fn masked_sd_len_matches_masked_bks3_envelope() {
-        // header(8) + iv(12) + meta-aad(96) + bks3(48) + tag(16).
-        const _: () = assert!(MASKED_SD_LEN == 180);
-        assert_eq!(MASKED_SD_LEN, 180);
+    fn pok_remote_backup_len_matches_hpke_auth_seal() {
+        // enc(97) + ct(BKS3 48 + GCM tag 16 = 64).
+        const _: () = assert!(POK_REMOTE_BACKUP_LEN == 161);
+        assert_eq!(POK_REMOTE_BACKUP_LEN, 161);
     }
 
     #[test]
-    fn request_round_trips_policy() {
+    fn request_round_trips_masked_key_and_policy() {
+        let masked = [0u8; MASKED_SEALING_KEY_LEN];
         let policy = [0u8; PART_POLICY_LEN];
         let cert = CertDescriptor {
             index: 0,
             length: crate::tbor_int::U16::new(8),
         };
         let report = ReportDescriptor {
-            index: 1,
+            index: 8,
             length: crate::tbor_int::U16::new(16),
         };
         let chain = [cert];
@@ -121,7 +157,7 @@ mod tests {
             .unwrap()
             .session_id(SessionId(7))
             .unwrap()
-            .sender_key(KeyId(0x5678))
+            .masked_sealing_key(&masked)
             .unwrap()
             .receiver_evidence(|e| {
                 e.mfgr_cert_chain(&chain)?
@@ -133,18 +169,19 @@ mod tests {
             .policy(&policy)
             .unwrap()
             .finish();
+        assert_eq!(frame.masked_sealing_key().len(), MASKED_SEALING_KEY_LEN);
         assert_eq!(frame.policy().len(), PART_POLICY_LEN);
     }
 
     #[test]
     fn response_round_trips_pok_remote_backup() {
-        let masked = [0xABu8; MASKED_SD_LEN];
+        let sealed = [0xABu8; POK_REMOTE_BACKUP_LEN];
         let mut buf = [0u8; 512];
         let frame = TborSdCreateRemoteBackupResp::encode(&mut buf, 0, true)
             .unwrap()
-            .pok_remote_backup(&masked)
+            .pok_remote_backup(&sealed)
             .unwrap()
             .finish();
-        assert_eq!(frame.pok_remote_backup().len(), MASKED_SD_LEN);
+        assert_eq!(frame.pok_remote_backup().len(), POK_REMOTE_BACKUP_LEN);
     }
 }

--- a/fw/core/lib/Cargo.toml
+++ b/fw/core/lib/Cargo.toml
@@ -18,6 +18,7 @@ azihsm_fw_core_crypto_key_masking.workspace = true
 azihsm_fw_core_crypto_key_report.workspace = true
 azihsm_fw_core_crypto_x509_builder.workspace = true
 azihsm_fw_core_crypto_x509_chain.workspace = true
+azihsm_fw_core_evidence.workspace = true
 azihsm_fw_ddi_mbor = { features = ["trusted-encode"], workspace = true }
 azihsm_fw_ddi_mbor_api.workspace = true
 azihsm_fw_ddi_mbor_types.workspace = true

--- a/fw/core/lib/src/ddi/tbor/mod.rs
+++ b/fw/core/lib/src/ddi/tbor/mod.rs
@@ -28,6 +28,7 @@ pub mod part_info;
 pub mod part_init;
 pub mod policy;
 pub(crate) mod psk_change;
+pub(crate) mod sd_create_remote_backup;
 pub(crate) mod sd_sealing_key_gen;
 pub(crate) mod session_close;
 pub(crate) mod session_open_finish;
@@ -109,6 +110,13 @@ pub(crate) mod opcode {
     /// masking key (nothing is persisted on-device) plus the public key.
     /// See [`super::sd_sealing_key_gen`].
     pub(crate) const SD_SEALING_KEY_GEN: u8 = 0x09;
+
+    /// `SdCreateRemoteBackup` — create a security-domain remote backup:
+    /// a fresh BKS3 HPKE-Auth-sealed to the receiver's SD sealing public
+    /// key (from its `KeyReport`, carried out of band) and authenticated
+    /// by the sender's masked SD sealing key.  See
+    /// [`super::sd_create_remote_backup`].
+    pub(crate) const SD_CREATE_REMOTE_BACKUP: u8 = 0x0A;
 
     /// `KeyReport` — attest a masked key: unmask it, derive its public
     /// component on-device, and return a PID-signed COSE_Sign1
@@ -231,6 +239,9 @@ pub(crate) async fn dispatch<'p, P: HsmPal>(
         opcode::PART_FINAL => part_final::handle(pal, io, req_buf, oob, undo).await,
         opcode::PART_INFO => part_info::handle(pal, io, req_buf),
         opcode::SD_SEALING_KEY_GEN => sd_sealing_key_gen::handle(pal, io, req_buf).await,
+        opcode::SD_CREATE_REMOTE_BACKUP => {
+            sd_create_remote_backup::handle(pal, io, req_buf, oob).await
+        }
         opcode::KEY_REPORT => key_report::handle(pal, io, req_buf).await,
         _ => Err(HsmError::UnsupportedCmd),
     }
@@ -252,6 +263,7 @@ fn is_known_opcode(opcode: u8) -> bool {
             | opcode::PART_FINAL
             | opcode::PART_INFO
             | opcode::SD_SEALING_KEY_GEN
+            | opcode::SD_CREATE_REMOTE_BACKUP
             | opcode::KEY_REPORT
     )
 }
@@ -280,6 +292,7 @@ fn is_in_session(opcode: u8) -> bool {
         | opcode::PART_INIT
         | opcode::PART_FINAL
         | opcode::SD_SEALING_KEY_GEN
+        | opcode::SD_CREATE_REMOTE_BACKUP
         | opcode::KEY_REPORT => true,
         // Default-deny: any future opcode is treated as in-session
         // until classified, so the default-PSK gate applies to it.
@@ -316,6 +329,7 @@ fn needs_session_id_cross_check(opcode: u8) -> bool {
         | opcode::PART_INIT
         | opcode::PART_FINAL
         | opcode::SD_SEALING_KEY_GEN
+        | opcode::SD_CREATE_REMOTE_BACKUP
         | opcode::KEY_REPORT => true,
         _ => true,
     }
@@ -403,6 +417,7 @@ mod tests {
             opcode::PART_INFO,
             opcode::PART_FINAL,
             opcode::SD_SEALING_KEY_GEN,
+            opcode::SD_CREATE_REMOTE_BACKUP,
             opcode::KEY_REPORT,
         ] {
             assert!(is_known_opcode(op), "{op:#04x} should be known");

--- a/fw/core/lib/src/ddi/tbor/part_final.rs
+++ b/fw/core/lib/src/ddi/tbor/part_final.rs
@@ -137,7 +137,7 @@ pub(crate) async fn handle<'p, P: HsmPal>(
         // Trust gate: walk the supplied PTA certificate chain, proving it
         // chains to the policy `POTAPubKey` and that its terminal (PTA)
         // certificate carries this partition's PTA key.
-        validate_pta_chain(pal, io, alloc, oob, req.cert_descriptors, &policy).await?;
+        validate_pta_chain(pal, io, alloc, oob, req.cert_descriptors, policy).await?;
 
         // Platform identity that binds the masking keys / backup
         // envelope: SVN (BKS1 lineage) and owner-seed id (BKS2 lineage).
@@ -347,7 +347,7 @@ async fn derive_local_bmk<'a, P: HsmPal>(
 
 /// Verify `SHA-384(part_policy)` equals the partition's stored
 /// `policy_hash` (bound at `PartInit`).
-async fn verify_policy_hash<P: HsmPal>(
+pub(crate) async fn verify_policy_hash<P: HsmPal>(
     pal: &P,
     io: &impl HsmIo,
     alloc: &impl HsmScopedAlloc,

--- a/fw/core/lib/src/ddi/tbor/policy.rs
+++ b/fw/core/lib/src/ddi/tbor/policy.rs
@@ -57,8 +57,8 @@ const ECC384_KEY_LEN: usize = POLICY_MAX_KEY_LEN;
 /// describe a well-formed Ecc384 key.  When `required` is `true`,
 /// the slot must always be a well-formed Ecc384 key.
 fn validate_pubkey(key: &PolicyPubKey, required: bool) -> HsmResult<()> {
-    let kind = key.kind;
-    let key_len = key.len as usize;
+    let kind = key.kind();
+    let key_len = key.len();
 
     if !required && key_len == 0 {
         return Ok(());
@@ -75,20 +75,22 @@ fn validate_pubkey(key: &PolicyPubKey, required: bool) -> HsmResult<()> {
     Ok(())
 }
 
-/// Parse and validate a [`PART_POLICY_LEN`]-byte `PartPolicy`
-/// resident in DMA-eligible memory.
+/// Validate a [`PART_POLICY_LEN`]-byte `PartPolicy` resident in
+/// DMA-eligible memory and return a **zero-copy** [`PartPolicy`] view
+/// borrowing `buf`.
 ///
-/// Returns an **owned**, naturally-aligned [`PartPolicy`] copied out of
-/// `buf` (the struct is alignment-2, so it cannot be safely overlaid on
-/// an arbitrarily-aligned wire buffer).  Downstream code that needs the
-/// raw bytes for hashing or persistence keeps the original `&DmaBuf` and
-/// threads it into the next DMA primitive.
-pub fn from_bytes(buf: &DmaBuf) -> HsmResult<PartPolicy> {
+/// `PartPolicy` is [`Unaligned`](zerocopy::Unaligned), so it is borrowed
+/// directly from the (arbitrarily-aligned) wire buffer with
+/// `try_ref_from_bytes` — no copy.  The returned reference borrows `buf`
+/// for its lifetime; callers that also need the raw bytes for hashing or
+/// persistence keep the same `&DmaBuf` and thread it into the next DMA
+/// primitive.
+pub fn from_bytes(buf: &DmaBuf) -> HsmResult<&PartPolicy> {
     if buf.len() != PART_POLICY_LEN {
         return Err(HsmError::InvalidArg);
     }
 
-    let this = PartPolicy::try_read_from_bytes(buf).map_err(|_| HsmError::InvalidArg)?;
+    let this = PartPolicy::try_ref_from_bytes(buf).map_err(|_| HsmError::InvalidArg)?;
 
     if this.version.major != POLICY_VERSION_MAJOR {
         return Err(HsmError::InvalidArg);

--- a/fw/core/lib/src/ddi/tbor/sd_create_remote_backup.rs
+++ b/fw/core/lib/src/ddi/tbor/sd_create_remote_backup.rs
@@ -1,0 +1,311 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! TBOR `SdCreateRemoteBackup` handler.
+//!
+//! Creates a security-domain **remote backup**: a fresh 48-byte BKS3
+//! HPKE-Auth-sealed to the *receiver's* SD sealing public key
+//! (`RcvrPub`), authenticated by the *sender's* SD sealing private key
+//! (`SndrPriv`).  Maps to manticore `CreateSD`, reduced to its remote
+//! backup output.
+//!
+//! Flow:
+//!
+//! 1. Decode the request; gate to a Crypto-Officer, `Active` session on
+//!    an `Initialized` partition (parity with `SdSealingKeyGen` /
+//!    `KeyReport`).
+//! 2. Bind the caller-supplied [`PartPolicy`] to the one fixed at
+//!    `PartInit` (`SHA-384(policy) == policy_hash`), validate it, and
+//!    verify it names this partition as the backing partition
+//!    (`backup_part_id == PID`, `backup_part_pub_key == PID pubkey`;
+//!    the caller populated both from `PartInfo` before `PartInit`).
+//! 3. Copy the receiver's `KeyReport` and its supporting certificate
+//!    chains from the out-of-band SGL page and validate the attestation
+//!    **evidence** via [`verify_evidence`]: the three cert chains
+//!    (manufacturer / owner / partition-owner) are verified and the
+//!    partition-owner chain is anchored to the policy SATA key; the
+//!    attested COSE_Key is then recovered as `RcvrPub`.
+//! 4. Unmask the sender's `masked_sealing_key` to recover `SndrPriv`
+//!    (must be an [`SdSealing`](HsmVaultKeyKind::SdSealing) key) and
+//!    derive `SndrPub` on-device.
+//! 5. Generate a fresh BKS3 and HPKE-Auth-seal it to `RcvrPub` under the
+//!    `DHKemP384Sha384AesGcm256` suite, returning
+//!    `pok_remote_backup = enc ‖ ct` (161 B).  BKS3 and `SndrPriv` are
+//!    zeroized before returning.
+//!
+//! **Stateless:** nothing is persisted, no vault writes, no undo log —
+//! the same shape as `KeyReport` / `SdSealingKeyGen`.
+//!
+//! This command is **Crypto-Officer-only**.
+//!
+//! [`PartPolicy`]: super::policy
+
+use azihsm_fw_core_crypto_hpke::seal;
+use azihsm_fw_core_crypto_hpke::AuthParams;
+use azihsm_fw_core_crypto_hpke::HpkeSealConfig;
+use azihsm_fw_core_crypto_hpke::HpkeSuite;
+use azihsm_fw_core_crypto_key_masking::aead::peek_metadata;
+use azihsm_fw_core_crypto_key_masking::aead::unmask;
+use azihsm_fw_core_evidence::verify_evidence;
+use azihsm_fw_core_evidence::EvidenceRefs;
+use azihsm_fw_core_evidence::TrustAnchors;
+use azihsm_fw_ddi_tbor_types::policy::PartPolicy;
+use azihsm_fw_ddi_tbor_types::policy::PolicyKeyKind;
+use azihsm_fw_ddi_tbor_types::policy::POLICY_MAX_KEY_LEN;
+use azihsm_fw_ddi_tbor_types::TborSdCreateRemoteBackupReq;
+use azihsm_fw_ddi_tbor_types::TborSdCreateRemoteBackupResp;
+use azihsm_fw_ddi_tbor_types::POK_REMOTE_BACKUP_LEN;
+use azihsm_fw_hsm_oob::OobPtr;
+use azihsm_fw_hsm_pal_traits::DmaBuf;
+use azihsm_fw_hsm_pal_traits::HsmEccCurve;
+use azihsm_fw_hsm_pal_traits::HsmError;
+use azihsm_fw_hsm_pal_traits::HsmIo;
+use azihsm_fw_hsm_pal_traits::HsmPal;
+use azihsm_fw_hsm_pal_traits::HsmResult;
+use azihsm_fw_hsm_pal_traits::HsmScopedAlloc;
+use azihsm_fw_hsm_pal_traits::HsmSessId;
+use azihsm_fw_hsm_pal_traits::HsmVaultKeyKind;
+use azihsm_fw_hsm_pal_traits::PartState;
+
+use super::masking_key_id_for_scope;
+use super::part_final::verify_policy_hash;
+use super::validate_crypto_officer_active_session;
+use crate::part_state;
+
+/// NIST curve for the SD sealing keys and the remote-backup HPKE seal.
+const SD_CURVE: HsmEccCurve = HsmEccCurve::P384;
+
+/// HPKE ciphersuite for the remote-backup seal.
+const HPKE_SUITE: HpkeSuite = HpkeSuite::DHKemP384Sha384AesGcm256;
+
+/// Length of the fresh BKS3 sealed into the remote backup.
+const BKS3_LEN: usize = 48;
+
+/// SEC1 uncompressed point tag (`0x04 ‖ X ‖ Y`).
+const SEC1_UNCOMPRESSED: u8 = 0x04;
+
+/// Verify the policy names **this** partition as the backing partition.
+///
+/// `backup_part_id` must equal the partition PID and `backup_part_pub_key`
+/// must equal its PID public key (raw P-384 `X ‖ Y`, 96 B).  Both policy
+/// fields were populated by the caller from `PartInfo` before `PartInit`
+/// (same `part_state` source), so this is a direct byte comparison — no
+/// endianness conversion.
+fn verify_backing_partition<P: HsmPal>(
+    pal: &P,
+    io: &impl HsmIo,
+    policy: &PartPolicy,
+) -> HsmResult<()> {
+    let pid = part_state::part_id(pal, io)?;
+    if pid[..] != policy.backup_part_id[..] {
+        return Err(HsmError::InvalidArg);
+    }
+
+    let key = &policy.backup_part_pub_key;
+    if key.kind() != PolicyKeyKind::Ecc384 || key.len() != POLICY_MAX_KEY_LEN {
+        return Err(HsmError::InvalidArg);
+    }
+    let pid_pub = part_state::part_id_pub_key(pal, io)?;
+    if pid_pub[..] != key.data[..] {
+        return Err(HsmError::InvalidArg);
+    }
+    Ok(())
+}
+
+/// Handle a TBOR `SdCreateRemoteBackup` request.
+///
+/// No partition lock or undo log is required: the command **persists
+/// nothing** — it validates evidence, unmasks the caller-supplied sealing
+/// key, and returns a freshly sealed backup.  It makes no observable state
+/// change, so a concurrently-dispatched command (IOs run in a task pool
+/// and interleave at await points) can neither observe it half-done nor
+/// require its rollback on failure.
+pub(crate) async fn handle<'p, P: HsmPal>(
+    pal: &'p P,
+    io: &impl HsmIo,
+    req_buf: &mut DmaBuf,
+    oob: Option<OobPtr>,
+) -> HsmResult<&'p DmaBuf> {
+    // Session/state gating + masking-key routing use only the shared
+    // `decode` view.  Confine that borrow to this block so the request
+    // buffer can be borrowed mutably later to unmask the sealing key in
+    // place.  `mk_key_id` is `Copy`, so it outlives the view.
+    let mk_key_id = {
+        let req = TborSdCreateRemoteBackupReq::decode(&*req_buf)?;
+        let sess_id = HsmSessId::from(u16::from(req.session_id()));
+        validate_crypto_officer_active_session(pal, io, sess_id)?;
+
+        // The SD masking keys / policy hash are provisioned by `PartFinal`,
+        // so the partition must be finalized (`Initialized`).
+        if part_state::part_state(pal, io)? != PartState::Initialized {
+            return Err(HsmError::InvalidArg);
+        }
+
+        // Route the masked sealing key to its masking key via the
+        // cleartext, tag-bound metadata (before unmasking).
+        let scope = peek_metadata(req.masked_sealing_key())?
+            .usage_flags()
+            .scope();
+        masking_key_id_for_scope(pal, io, scope)?
+    };
+
+    // The receiver attestation evidence — three certificate chains
+    // (manufacturer / owner / partition-owner) plus a COSE_Sign1 report —
+    // is mandatory side-band data carried in the out-of-band SGL page.
+    let oob = oob.ok_or(HsmError::InvalidArg)?;
+
+    // Allocate the fixed-size response backup in the IO scope so it
+    // survives the crypto scratch allocator's reset.
+    let pok = pal.dma_alloc(io, POK_REMOTE_BACKUP_LEN)?;
+
+    pal.alloc_scoped_async(io, async |alloc| -> HsmResult<()> {
+        // `pk_r` (the attested `RcvrPub`) is recovered by the evidence
+        // check in phase 1 and consumed by the seal in phase 2, so it is
+        // allocated up front to span both phases.  `coord` is likewise
+        // reused for the `SndrPub` (`pk_s`) buffer below.
+        let coord = SD_CURVE.priv_key_len();
+        let pk_r = alloc.dma_alloc(1 + 2 * coord)?;
+
+        // ── Phase 1: policy binding + receiver evidence (shared view) ──
+        // Everything that reads the `receiver_evidence` field group goes
+        // through the shared `decode` view (the group is intentionally
+        // absent from `ViewMut`).  The borrow is confined to this block so
+        // the sealing key can be unmasked in place afterwards.
+        {
+            let req = TborSdCreateRemoteBackupReq::decode(&*req_buf)?;
+
+            // The re-supplied policy must match the one bound at `PartInit`.
+            let policy = req.policy();
+            verify_policy_hash(pal, io, alloc, policy).await?;
+            let part_policy = super::policy::from_bytes(policy)?;
+
+            // SD-policy identity binding (manticore `CreateSD` step a): the
+            // policy names this partition as the backing partition.  The
+            // caller populated `backup_part_id` / `backup_part_pub_key`
+            // from `PartInfo` (available in `Initializing`, before
+            // `PartInit`), so they must equal this partition's PID and PID
+            // public key.
+            verify_backing_partition(pal, io, part_policy)?;
+
+            // Validate all three certificate chains, bind the
+            // partition-owner chain to the policy SATA anchor, require one
+            // shared leaf key across the chains, and confirm that leaf key
+            // endorses the attestation report — then recover the attested
+            // `RcvrPub` into `pk_r`.
+            let sata = &part_policy.sata_pub_key;
+            if sata.kind() != PolicyKeyKind::Ecc384 || sata.len() != POLICY_MAX_KEY_LEN {
+                return Err(HsmError::InvalidArg);
+            }
+            let evidence = req.receiver_evidence();
+            verify_evidence(
+                pal,
+                io,
+                &oob,
+                &EvidenceRefs {
+                    mfgr_chain: evidence.mfgr_cert_chain(),
+                    owner_chain: evidence.owner_cert_chain(),
+                    part_owner_chain: evidence.part_owner_cert_chain(),
+                    report: evidence.evidence(),
+                },
+                &TrustAnchors {
+                    sata: &sata.data[..POLICY_MAX_KEY_LEN],
+                },
+                pk_r,
+            )
+            .await?;
+        }
+
+        // ── Phase 2: unmask SndrPriv in place, derive SndrPub, and
+        // HPKE-Auth seal a fresh BKS3 to RcvrPub.  `unmask` decrypts the
+        // sealing key in place in the request buffer and BKS3 is fresh
+        // secret material; scope rewind does not clear DMA memory, so both
+        // are scrubbed on EVERY exit path below.  The crypto runs in an
+        // inner scope so `SndrPriv`'s borrow of the request buffer ends
+        // before it is re-borrowed mutably to wipe the decrypted region.
+        let crypto_res = async {
+            let sndr_priv = {
+                let req_mut = TborSdCreateRemoteBackupReq::decode_mut(req_buf)?;
+                let masking_key = pal.vault_key(io, mk_key_id)?;
+                let view = unmask(pal, io, masking_key, req_mut.masked_sealing_key).await?;
+                if !matches!(view.key_kind, HsmVaultKeyKind::SdSealing) {
+                    return Err(HsmError::UnsupportedKeyType);
+                }
+                view.target_key
+            };
+
+            // Sender public key (SndrPub) in SEC1 BE, derived on-device
+            // from the recovered private key.  The PAL emits wire-LE
+            // `X ‖ Y` directly into the coordinate region of `pk_s`;
+            // reversing each coordinate in place then yields SEC1
+            // `0x04 ‖ X_be ‖ Y_be` with no separate scratch buffer or copy.
+            let pk_s = alloc.dma_alloc(1 + 2 * coord)?;
+            pal.ecc_pub_from_priv(io, SD_CURVE, sndr_priv, &mut pk_s[1..1 + 2 * coord])
+                .await?;
+            pk_s[0] = SEC1_UNCOMPRESSED;
+            pk_s[1..1 + coord].reverse();
+            pk_s[1 + coord..1 + 2 * coord].reverse();
+
+            // ── Fresh BKS3 + HPKE-Auth seal to RcvrPub ───────────────
+            let bks3 = alloc.dma_alloc(BKS3_LEN)?;
+            pal.rng_fill_bytes(io, bks3)?;
+
+            let cfg = HpkeSealConfig::auth(
+                HPKE_SUITE,
+                pk_r,
+                &[],
+                &[],
+                AuthParams {
+                    sk_s: sndr_priv,
+                    pk_s,
+                },
+            );
+
+            // Size query, then split the fixed response buffer into the
+            // `enc` and `ct` regions the seal writes.
+            let seal_res = async {
+                let sizes = seal(pal, io, &cfg, bks3, None, None, alloc).await?;
+                if sizes.enc_len + sizes.ct_len != POK_REMOTE_BACKUP_LEN {
+                    return Err(HsmError::InternalError);
+                }
+                let (enc, ct) = pok.split_at_mut(sizes.enc_len);
+                seal(pal, io, &cfg, bks3, Some(enc), Some(ct), alloc).await?;
+                Ok::<(), HsmError>(())
+            }
+            .await;
+
+            // Wipe the fresh BKS3 on both success and failure before the
+            // borrow of the request buffer (via `SndrPriv`) is released.
+            bks3.zeroize();
+            seal_res
+        }
+        .await;
+
+        // Scrub the in-place-decrypted SndrPriv from the request buffer on
+        // every path (success, unsupported-kind, or seal failure) — the
+        // borrow held by `SndrPriv` has now ended.
+        if let Ok(req_mut) = TborSdCreateRemoteBackupReq::decode_mut(req_buf) {
+            req_mut.masked_sealing_key.zeroize();
+        }
+        crypto_res?;
+
+        Ok(())
+    })
+    .await?;
+
+    encode_response(pal, io, pok)
+}
+
+/// Encode the `SdCreateRemoteBackup` response around the sealed backup.
+fn encode_response<'p, P: HsmPal>(
+    pal: &'p P,
+    io: &impl HsmIo,
+    pok: &DmaBuf,
+) -> HsmResult<&'p DmaBuf> {
+    let resp = pal.dma_alloc_var(io, |buf| {
+        let frame = TborSdCreateRemoteBackupResp::encode(buf, 0, false)?
+            .pok_remote_backup(pok)?
+            .finish();
+        Ok(frame.as_bytes().len())
+    })?;
+    Ok(resp)
+}

--- a/fw/core/lib/src/op.rs
+++ b/fw/core/lib/src/op.rs
@@ -262,6 +262,7 @@ impl SessionCtrl {
             | opcode::PART_INIT
             | opcode::PART_FINAL
             | opcode::SD_SEALING_KEY_GEN
+            | opcode::SD_CREATE_REMOTE_BACKUP
             | opcode::KEY_REPORT => Self::InSession,
             opcode::SESSION_CLOSE => Self::Close,
             _ => Self::NoSession,

--- a/fw/plat/uno/fw/crates/key_vault/src/tests.rs
+++ b/fw/plat/uno/fw/crates/key_vault/src/tests.rs
@@ -155,6 +155,15 @@ impl HsmGdmaController for FakeGdma {
     ) -> HsmResult<()> {
         unimplemented!("vault does not use host copies")
     }
+    async fn copy_mem_from_host_raw(
+        &self,
+        _io: &impl HsmIo,
+        _desc: &[u8; 16],
+        _dst: &mut DmaBuf,
+        _prp: bool,
+    ) -> HsmResult<()> {
+        unimplemented!("vault does not use host copies")
+    }
     async fn copy_mem_to_host(
         &self,
         _io: &impl HsmIo,


### PR DESCRIPTION
## Summary

Implements the TBOR **`SdCreateRemoteBackup`** command (manticore `CreateSD`): the sender HPKE-Auth-seals a fresh security-domain backup key (`BKS3`) to a receiver partition's attested public key.

Handler flow (`fw/core/lib/src/ddi/tbor/sd_create_remote_backup.rs`):
1. Gate CO-only / `Active` session / `Initialized` partition.
2. Verify the re-supplied `PartPolicy` against the `PartInit`-bound hash, and that it names **this** partition as the backing partition.
3. Validate the receiver attestation **evidence** (manufacturer / owner / partition-owner cert chains + COSE_Sign1 report, transported out-of-band) via the `evidence` crate, anchored to the policy SATA key; recover `RcvrPub` from the report's COSE_Key.
4. Unmask the sender's masked SD-sealing key in place to recover `SndrPriv`; derive `SndrPub`.
5. Generate a fresh 48-byte `BKS3` and `HpkeSealConfig::auth`-seal it to `RcvrPub` → the fixed **161-byte** `pok_remote_backup` (`enc(97) ‖ ct(64)`, `DHKemP384Sha384AesGcm256`). Stateless — persists nothing.

Schema: `sender_key` → `masked_sealing_key`; response `pok_remote_backup` 180 → 161. `UnmaskedView.target_key` now borrows the decrypted blob as `&DmaBuf` (zero-copy forward); `verify_policy_hash` is `pub(crate)`.

## Zero-copy / task-storage reductions

- **`PartPolicy` is now `Unaligned`.** `PolicyPubKey.kind/len` are stored as alignment-1 little-endian `U16` (read via `kind()`/`len()`), so `policy::from_bytes` returns a **zero-copy `&PartPolicy`** borrowed from the wire `DmaBuf` (`try_ref_from_bytes`) instead of copying an owned 484-byte value. The wire/hash image is byte-identical, so persistence, `verify_policy_hash`, and the host mirror are unaffected. Because the policy no longer lives by value across the handlers' `await` points, the 484-byte struct leaves the futures in the uno embassy task pool (`part_init`, `part_final`, `sd_create_remote_backup`): **uno `.bss` shrinks ~15 KB, `.text` unchanged.**
- **`SndrPub` derived in place** — the PAL writes wire-LE `X‖Y` straight into `pk_s`'s coordinate region, reversed in place to SEC1 BE, eliminating a scratch buffer + copies.

## Tests

Extends the cross-platform `azihsm_crypto` x509 fixture with end-entity evidence-chain helpers (`build_leaf`/`make_chain`) and adds **8 emu tests**: happy-path roundtrip, `BKS3` re-randomization, and reject paths (missing OOB, non-backing policy, wrong SATA anchor, leaf-key mismatch, tampered cert signature, tampered report).

## Validation

- fw core + uno firmware build; `clippy -D warnings` (root + uno workspaces); nightly rustfmt; copyright — all clean.
- Full tbor emu suite **86/86**; fw-types **36/36** (incl. policy byte round-trips); mock build + sim/MBOR build green.
