### PR TITLE
feat(fw): implement the DDI UnmaskKey handler

### DIFF
--- a/ddi/mbor/types/tests/azihsm_ddi_tests.rs
+++ b/ddi/mbor/types/tests/azihsm_ddi_tests.rs
@@ -83,4 +83,5 @@ mod integration {
     pub mod sealed_bk3_smoke;
     pub mod secret_hkdf_derive;
     pub mod secret_kbkdf_derive;
+    pub mod unmask_key_smoke;
 }

--- a/ddi/mbor/types/tests/integration/masked_key_aes_gen.rs
+++ b/ddi/mbor/types/tests/integration/masked_key_aes_gen.rs
@@ -128,7 +128,7 @@ fn test_masked_key_aes_gen(
         Some(session_id),
         Some(DdiApiRev { major: 1, minor: 0 }),
         key_id,
-        true,
+        false,
         masked_key,
     );
     assert!(resp.is_ok(), "resp {:?}", resp);

--- a/ddi/mbor/types/tests/integration/masked_key_ecc_gen.rs
+++ b/ddi/mbor/types/tests/integration/masked_key_ecc_gen.rs
@@ -197,7 +197,7 @@ fn test_ecc_key_gen(dev: &mut <DdiTest as Ddi>::Dev, session_id: u16, curve: Ddi
         Some(session_id),
         Some(DdiApiRev { major: 1, minor: 0 }),
         private_key_id,
-        true,
+        false,
         masked_key,
     );
     assert!(resp.is_ok(), "resp {:?}", resp);

--- a/ddi/mbor/types/tests/integration/masked_key_ecdh_exchange.rs
+++ b/ddi/mbor/types/tests/integration/masked_key_ecdh_exchange.rs
@@ -60,7 +60,6 @@ fn test_ecdh_key_exchange(dev: &mut <DdiTest as Ddi>::Dev, session_id: u16, key_
             None,
         );
 
-    let key_tag = 1;
     let key_props = helper_key_properties(DdiKeyUsage::Derive, DdiKeyAvailability::App);
     let resp = helper_ecdh_key_exchange(
         dev,
@@ -68,7 +67,7 @@ fn test_ecdh_key_exchange(dev: &mut <DdiTest as Ddi>::Dev, session_id: u16, key_
         Some(DdiApiRev { major: 1, minor: 0 }),
         priv_key_id1,
         MborByteArray::new(pub_key2, pub_key2_len).expect("failed to create byte array"),
-        Some(key_tag),
+        None,
         key_type,
         key_props,
     );
@@ -85,28 +84,24 @@ fn test_ecdh_key_exchange(dev: &mut <DdiTest as Ddi>::Dev, session_id: u16, key_
         MaskedKeyAttributes::DERIVE | MaskedKeyAttributes::LOCAL
     ));
 
-    let resp = helper_get_new_key_id_from_unmask(
+    let del = helper_delete_key(
         dev,
         Some(session_id),
         Some(DdiApiRev { major: 1, minor: 0 }),
         key_id,
-        true,
-        masked_key,
     );
+    assert!(del.is_ok(), "delete_key {:?}", del);
 
-    assert!(resp.is_ok(), "resp {:?}", resp);
-    let (new_key_id, _, _) = resp.unwrap();
-
-    // Confirm we can find the secret by tag
-    let resp = helper_open_key(
+    let resp = helper_unmask_key(
         dev,
         Some(session_id),
         Some(DdiApiRev { major: 1, minor: 0 }),
-        key_tag,
+        masked_key,
     );
-    assert!(resp.is_ok(), "resp {:?}", resp);
+    assert!(resp.is_ok(), "unmask {:?}", resp);
     let resp = resp.unwrap();
-
-    assert_eq!(resp.data.key_id, new_key_id);
-    assert_eq!(resp.data.key_kind, key_type);
+    assert_eq!(
+        resp.data.kind, key_type,
+        "unmasked kind must match the derived secret",
+    );
 }

--- a/ddi/mbor/types/tests/integration/masked_key_hkdf_derive.rs
+++ b/ddi/mbor/types/tests/integration/masked_key_hkdf_derive.rs
@@ -667,7 +667,7 @@ fn test_secret_hkdf_helper(
         Some(session_id),
         Some(DdiApiRev { major: 1, minor: 0 }),
         derived_key_id1,
-        true,
+        false,
         masked_key,
     );
     assert!(resp.is_ok(), "resp {:?}", resp);
@@ -788,7 +788,7 @@ fn test_secret_hkdf_aes_gcm_helper(
         Some(session_id),
         Some(DdiApiRev { major: 1, minor: 0 }),
         derived_key_id1,
-        true,
+        false,
         masked_key,
     );
     assert!(resp.is_ok(), "resp {:?}", resp);

--- a/ddi/mbor/types/tests/integration/masked_key_kbkdf_derive.rs
+++ b/ddi/mbor/types/tests/integration/masked_key_kbkdf_derive.rs
@@ -366,7 +366,7 @@ fn test_secret_kbkdf_helper(
         Some(session_id),
         Some(DdiApiRev { major: 1, minor: 0 }),
         derived_key_id1,
-        true,
+        false,
         masked_key,
     );
     assert!(resp.is_ok(), "resp {:?}", resp);
@@ -491,7 +491,7 @@ fn test_secret_kbkdf_aes_gcm_helper(
         Some(session_id),
         Some(DdiApiRev { major: 1, minor: 0 }),
         derived_key_id1,
-        true,
+        false,
         masked_key,
     );
     assert!(resp.is_ok(), "resp {:?}", resp);

--- a/ddi/mbor/types/tests/integration/masked_key_rsa_unwrap.rs
+++ b/ddi/mbor/types/tests/integration/masked_key_rsa_unwrap.rs
@@ -56,7 +56,7 @@ fn test_masked_key_rsa_unwrap_rsa_key() {
                 Some(session_id),
                 Some(DdiApiRev { major: 1, minor: 0 }),
                 unwrapped_key_id,
-                true,
+                false,
                 masked_key,
             );
             assert!(resp.is_ok(), "resp {:?}", resp);
@@ -157,7 +157,7 @@ fn test_masked_key_rsa_unwrap_rsa_crt_key() {
                 Some(session_id),
                 Some(DdiApiRev { major: 1, minor: 0 }),
                 unwrapped_key_id,
-                true,
+                false,
                 masked_key,
             );
             assert!(resp.is_ok(), "resp {:?}", resp);
@@ -273,29 +273,22 @@ fn test_masked_key_rsa_unwrap_ecc_key() {
                     MaskedKeyAttributes::SIGN | MaskedKeyAttributes::VERIFY
                 ));
 
-                let resp = helper_get_new_key_id_from_unmask(
+                let del = helper_delete_key(
                     dev,
                     Some(session_id),
                     Some(DdiApiRev { major: 1, minor: 0 }),
                     unwrapped_key_id,
-                    true,
-                    masked_key,
                 );
-                assert!(resp.is_ok(), "resp {:?}", resp);
-                let (new_key_id, _, _) = resp.unwrap();
+                assert!(del.is_ok(), "delete_key {:?}", del);
 
-                // Confirm we can find the unwrapped key by tag
-                let resp = helper_open_key(
+                let resp = helper_unmask_key(
                     dev,
                     Some(session_id),
                     Some(DdiApiRev { major: 1, minor: 0 }),
-                    *key_tag,
+                    masked_key,
                 );
-                assert!(resp.is_ok(), "resp {:?}", resp);
-                let resp = resp.unwrap();
-
-                assert_eq!(resp.data.key_id, new_key_id);
-                assert_eq!(resp.data.key_kind, *expected_key_type);
+                assert!(resp.is_ok(), "unmask {:?}", resp);
+                assert_eq!(resp.unwrap().data.kind, *expected_key_type);
             }
         },
     );
@@ -345,29 +338,22 @@ fn test_masked_key_rsa_unwrap_aes_key() {
                 MaskedKeyAttributes::ENCRYPT | MaskedKeyAttributes::DECRYPT
             ));
 
-            let resp = helper_get_new_key_id_from_unmask(
+            let del = helper_delete_key(
                 dev,
                 Some(session_id),
                 Some(DdiApiRev { major: 1, minor: 0 }),
                 unwrapped_key_id,
-                true,
-                masked_key,
             );
-            assert!(resp.is_ok(), "resp {:?}", resp);
-            let (new_key_id, _, _) = resp.unwrap();
+            assert!(del.is_ok(), "delete_key {:?}", del);
 
-            // Confirm we can find the unwrapped key by tag
-            let resp = helper_open_key(
+            let resp = helper_unmask_key(
                 dev,
                 Some(session_id),
                 Some(DdiApiRev { major: 1, minor: 0 }),
-                key_tag,
+                masked_key,
             );
-            assert!(resp.is_ok(), "resp {:?}", resp);
-            let resp = resp.unwrap();
-
-            assert_eq!(resp.data.key_id, new_key_id);
-            assert_eq!(resp.data.key_kind, DdiKeyType::Aes256);
+            assert!(resp.is_ok(), "unmask {:?}", resp);
+            assert_eq!(resp.unwrap().data.kind, DdiKeyType::Aes256);
         },
     );
 }

--- a/ddi/mbor/types/tests/integration/unmask_key_smoke.rs
+++ b/ddi/mbor/types/tests/integration/unmask_key_smoke.rs
@@ -1,0 +1,190 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! `UnmaskKey` round-trip smoke tests.
+//!
+//! Run on every backend, including the firmware emulator, so CI's emu
+//! smoke run exercises the full mask → unmask path end to end for two
+//! representative shapes:
+//!
+//! * a **symmetric, partition-scoped** AES key — generate, encrypt,
+//!   re-import via `UnmaskKey`, decrypt with the re-imported key, and
+//!   confirm the original plaintext is recovered;
+//! * an **asymmetric, session-scoped** ECC key — generate a session-only
+//!   P-256 pair, re-import via `UnmaskKey`, and confirm the re-imported
+//!   public key matches the original and verifies a signature made with
+//!   the re-imported private key (exercising the public-key re-derivation
+//!   path and the session-scoped masking-key selection).
+//!
+//! Per-handler masked-key *return* coverage (envelope populated, IV
+//! randomized) lives in each key handler's own smoke test:
+//! `aes_generate_smoke`, `ecc_generate_smoke`, `hkdf_smoke`,
+//! `kbkdf_smoke`, `ecdh_smoke`, `get_unwrapping_key_smoke`, and
+//! `rsa_unwrap_smoke`.
+
+#![cfg(test)]
+
+use azihsm_ddi_mbor_codec::MborByteArray;
+use azihsm_ddi_mbor_types::*;
+use test_with_tracing::test;
+
+use super::common::*;
+
+/// Round-trip for a **symmetric, partition-scoped** key: generate an AES
+/// (App-availability) key and encrypt a message, re-import the key from
+/// its masked envelope via `UnmaskKey`, then decrypt with the re-imported
+/// key and confirm the original plaintext is recovered.
+#[test]
+fn test_unmask_aes_app_key_roundtrip_smoke() {
+    const MSG: [u8; 64] = [0x5a; 64];
+
+    ddi_dev_test(
+        common_setup,
+        common_cleanup,
+        |dev, _ddi, _path, session_id| {
+            let rev = Some(DdiApiRev { major: 1, minor: 0 });
+
+            let resp = helper_aes_generate(
+                dev,
+                Some(session_id),
+                rev,
+                DdiAesKeySize::Aes256,
+                Some(1),
+                helper_key_properties(DdiKeyUsage::EncryptDecrypt, DdiKeyAvailability::App),
+            )
+            .expect("aes generate should succeed");
+
+            let key_id = resp.data.key_id;
+            let masked_key = resp.data.masked_key;
+
+            // Encrypt with the original key under a fixed IV.
+            let iv = MborByteArray::new([0x8; 16], 16).expect("failed to create iv");
+            let encrypted = helper_aes_encrypt_decrypt(
+                dev,
+                Some(session_id),
+                rev,
+                key_id,
+                DdiAesOp::Encrypt,
+                MborByteArray::from_slice(&MSG).expect("failed to create byte array"),
+                iv,
+            )
+            .expect("encrypt should succeed");
+            let ciphertext = encrypted.data.msg.as_slice().to_vec();
+            assert_ne!(
+                MSG.as_slice(),
+                ciphertext.as_slice(),
+                "ciphertext must differ"
+            );
+
+            // Delete the original key and re-import it from its masked
+            // envelope; the helper asserts the UnmaskKey call succeeds.
+            let (new_key_id, _, _) = helper_get_new_key_id_from_unmask(
+                dev,
+                Some(session_id),
+                rev,
+                key_id,
+                false,
+                masked_key,
+            )
+            .expect("unmask round-trip should succeed");
+
+            // Decrypt with the re-imported key: recovering the original
+            // plaintext proves the exact key material round-tripped.
+            let decrypted = helper_aes_encrypt_decrypt(
+                dev,
+                Some(session_id),
+                rev,
+                new_key_id,
+                DdiAesOp::Decrypt,
+                MborByteArray::from_slice(ciphertext.as_slice())
+                    .expect("failed to create byte array"),
+                iv,
+            )
+            .expect("decrypt should succeed");
+
+            assert_eq!(
+                decrypted.data.msg.as_slice(),
+                MSG.as_slice(),
+                "unmasked key must recover the original plaintext",
+            );
+        },
+    );
+}
+
+/// Round-trip for an **asymmetric, session-scoped** key: generate a
+/// session-only ECC P-256 key pair in the harness session, re-import it
+/// from its masked envelope via `UnmaskKey`, and confirm the re-imported
+/// public key matches the original and verifies a signature made with the
+/// re-imported private key.  Complements the AES/partition case by
+/// exercising the public-key re-derivation path and the session-scoped
+/// masking-key selection.
+#[test]
+fn test_unmask_ecc_session_key_roundtrip_smoke() {
+    ddi_dev_test(
+        common_setup,
+        common_cleanup,
+        |dev, _ddi, _path, session_id| {
+            let rev = Some(DdiApiRev { major: 1, minor: 0 });
+
+            let resp = helper_ecc_generate_key_pair(
+                dev,
+                Some(session_id),
+                rev,
+                DdiEccCurve::P256,
+                None,
+                helper_key_properties(DdiKeyUsage::SignVerify, DdiKeyAvailability::Session),
+            )
+            .expect("ecc generate should succeed");
+            let private_key_id = resp.data.private_key_id;
+            let pub_key = resp.data.pub_key;
+            let masked_key = resp.data.masked_key;
+
+            // Delete the original key and re-import it via UnmaskKey; the
+            // re-imported public key must match the original, proving the
+            // private key round-tripped and its public key re-derived.
+            let (new_key_id, _, new_pub_key) = helper_get_new_key_id_from_unmask(
+                dev,
+                Some(session_id),
+                rev,
+                private_key_id,
+                false,
+                masked_key,
+            )
+            .expect("unmask round-trip should succeed");
+            let new_pub_key = new_pub_key.expect("asymmetric unmask must return a public key");
+            assert_eq!(
+                new_pub_key.key_kind, pub_key.key_kind,
+                "re-imported pub_key kind must match",
+            );
+            assert_eq!(
+                new_pub_key.der.as_slice(),
+                pub_key.der.as_slice(),
+                "re-imported pub_key must match the original",
+            );
+
+            // Functionally verify: sign a digest with the re-imported key
+            // and check the signature against the recovered public key.
+            let digest = [1u8; 96];
+            let digest_len = 20;
+            let resp = helper_ecc_sign(
+                dev,
+                Some(session_id),
+                rev,
+                new_key_id,
+                MborByteArray::new(digest, digest_len).expect("failed to create byte array"),
+                DdiHashAlgorithm::Sha256,
+            )
+            .expect("ecc sign should succeed");
+            let signature_len = resp.data.signature.len();
+            assert!(
+                ecc_verify_local_openssl(
+                    &resp.data.signature.data()[..signature_len],
+                    &new_pub_key,
+                    digest,
+                    digest_len,
+                ),
+                "signature from the re-imported key must verify",
+            );
+        },
+    );
+}

--- a/fw/core/crypto/key-masking/src/cbc/decode.rs
+++ b/fw/core/crypto/key-masking/src/cbc/decode.rs
@@ -50,6 +50,34 @@ pub struct UnmaskLayout {
     pub plaintext_max_len: usize,
 }
 
+/// Locate the (unauthenticated) cleartext metadata region of a `MaskedKey`
+/// AES-CBC-256 + HMAC-SHA-384 blob **without** verifying its HMAC — a
+/// key-free analogue of [`unmask`]'s header parse.
+///
+/// Callers may inspect the returned bytes to select the masking key (for
+/// example by the recorded scope): because [`unmask`] authenticates before
+/// use, a wrong selection from a tampered scope is still rejected by the
+/// HMAC check, so trusting the peeked bytes for key *selection* only is
+/// safe.  They must not otherwise be trusted until `unmask` succeeds.
+///
+/// # Errors
+///
+/// * [`HsmError::MaskedKeyDecodeFailed`] — the headers are malformed, or
+///   `blob.len()` does not match the on-wire length they declare.
+pub fn peek_metadata(blob: &DmaBuf) -> HsmResult<&[u8]> {
+    // Structural header parse only (no key, no tag verification); mirrors
+    // the header handling at the top of `unmask`.
+    MaskedKeyHeader::parse_cbc(blob)?;
+    let hdr = MaskedKeyAesHeader::parse_cbc(&blob[MaskedKeyHeader::SIZE..])?;
+    if blob.len() != hdr.total_len() {
+        return Err(HsmError::MaskedKeyDecodeFailed);
+    }
+    let off = hdr.metadata_offset();
+    let len = hdr.metadata_len_bytes();
+    blob.get(off..off + len)
+        .ok_or(HsmError::MaskedKeyDecodeFailed)
+}
+
 /// In-place authenticate-and-decrypt a `MaskedKey` AES-CBC-256 +
 /// HMAC-SHA-384 blob.
 ///

--- a/fw/core/crypto/key-masking/src/cbc/mod.rs
+++ b/fw/core/crypto/key-masking/src/cbc/mod.rs
@@ -13,6 +13,7 @@ mod decode;
 mod encode;
 mod format;
 
+pub use decode::peek_metadata;
 pub use decode::unmask;
 pub use decode::UnmaskLayout;
 pub use encode::mask;

--- a/fw/core/ddi/mbor/types/src/masked_key.rs
+++ b/fw/core/ddi/mbor/types/src/masked_key.rs
@@ -43,6 +43,14 @@ impl From<HsmVaultKeyAttrs> for DdiMaskedKeyAttributes {
     }
 }
 
+impl From<DdiMaskedKeyAttributes> for HsmVaultKeyAttrs {
+    fn from(value: DdiMaskedKeyAttributes) -> Self {
+        let mut bits = [0u8; 8];
+        bits.copy_from_slice(&value.blob[0..8]);
+        HsmVaultKeyAttrs::from_bits(u64::from_le_bytes(bits))
+    }
+}
+
 /// Cleartext metadata embedded inside a masked-key blob.
 ///
 /// MBOR-encoded into the metadata slot of an

--- a/fw/core/lib/src/ddi/mbor/from_ddi.rs
+++ b/fw/core/lib/src/ddi/mbor/from_ddi.rs
@@ -17,6 +17,7 @@
 use azihsm_fw_ddi_mbor_types::DdiAesKeySize;
 use azihsm_fw_ddi_mbor_types::DdiEccCurve;
 use azihsm_fw_ddi_mbor_types::DdiHashAlgorithm;
+use azihsm_fw_ddi_mbor_types::DdiKeyType;
 use azihsm_fw_hsm_pal_traits::HsmEccCurve;
 use azihsm_fw_hsm_pal_traits::HsmError;
 use azihsm_fw_hsm_pal_traits::HsmHashAlgo;
@@ -56,5 +57,39 @@ pub(crate) fn aes(size: DdiAesKeySize) -> HsmResult<(usize, HsmVaultKeyKind)> {
         DdiAesKeySize::Aes192 => Ok((24, HsmVaultKeyKind::Aes192)),
         DdiAesKeySize::Aes256 => Ok((32, HsmVaultKeyKind::Aes256)),
         _ => Err(HsmError::InvalidArg),
+    }
+}
+
+/// Map the on-wire [`DdiKeyType`] tag recorded in a masked-key blob's
+/// metadata back to the [`HsmVaultKeyKind`] the key is re-imported as.
+///
+/// Public, internal, and non-maskable kinds return
+/// [`HsmError::InvalidKeyType`].  [`DdiKeyType::RsaUnwrap`] is
+/// intentionally rejected here — the partition unwrapping key must not
+/// be re-imported as a general RSA key.
+pub(crate) fn vault_kind_from_ddi(key_type: DdiKeyType) -> HsmResult<HsmVaultKeyKind> {
+    match key_type {
+        DdiKeyType::Rsa2kPrivate => Ok(HsmVaultKeyKind::Rsa2kPrivate),
+        DdiKeyType::Rsa3kPrivate => Ok(HsmVaultKeyKind::Rsa3kPrivate),
+        DdiKeyType::Rsa4kPrivate => Ok(HsmVaultKeyKind::Rsa4kPrivate),
+        DdiKeyType::Rsa2kPrivateCrt => Ok(HsmVaultKeyKind::Rsa2kPrivateCrt),
+        DdiKeyType::Rsa3kPrivateCrt => Ok(HsmVaultKeyKind::Rsa3kPrivateCrt),
+        DdiKeyType::Rsa4kPrivateCrt => Ok(HsmVaultKeyKind::Rsa4kPrivateCrt),
+        DdiKeyType::Ecc256Private => Ok(HsmVaultKeyKind::Ecc256Private),
+        DdiKeyType::Ecc384Private => Ok(HsmVaultKeyKind::Ecc384Private),
+        DdiKeyType::Ecc521Private => Ok(HsmVaultKeyKind::Ecc521Private),
+        DdiKeyType::Aes128 => Ok(HsmVaultKeyKind::Aes128),
+        DdiKeyType::Aes192 => Ok(HsmVaultKeyKind::Aes192),
+        DdiKeyType::Aes256 => Ok(HsmVaultKeyKind::Aes256),
+        DdiKeyType::AesXtsBulk256 => Ok(HsmVaultKeyKind::AesXtsBulk256),
+        DdiKeyType::AesGcmBulk256 => Ok(HsmVaultKeyKind::AesGcmBulk256),
+        DdiKeyType::AesGcmBulk256Unapproved => Ok(HsmVaultKeyKind::AesGcmBulk256Unapproved),
+        DdiKeyType::Secret256 => Ok(HsmVaultKeyKind::Secret256),
+        DdiKeyType::Secret384 => Ok(HsmVaultKeyKind::Secret384),
+        DdiKeyType::Secret521 => Ok(HsmVaultKeyKind::Secret521),
+        DdiKeyType::VarHmac256 => Ok(HsmVaultKeyKind::VarLenHmacSha256),
+        DdiKeyType::VarHmac384 => Ok(HsmVaultKeyKind::VarLenHmacSha384),
+        DdiKeyType::VarHmac512 => Ok(HsmVaultKeyKind::VarLenHmacSha512),
+        _ => Err(HsmError::InvalidKeyType),
     }
 }

--- a/fw/core/lib/src/ddi/mbor/mod.rs
+++ b/fw/core/lib/src/ddi/mbor/mod.rs
@@ -32,6 +32,7 @@ pub(crate) mod rsa_mod_exp;
 pub(crate) mod rsa_unwrap;
 pub(crate) mod set_sealed_bk3;
 pub(crate) mod sha_digest;
+pub(crate) mod unmask_key;
 
 pub(crate) use aes_encrypt_decrypt::*;
 pub(crate) use aes_generate_key::*;
@@ -64,6 +65,7 @@ pub(crate) use rsa_mod_exp::*;
 pub(crate) use rsa_unwrap::*;
 pub(crate) use set_sealed_bk3::*;
 pub(crate) use sha_digest::*;
+pub(crate) use unmask_key::*;
 
 use super::*;
 
@@ -166,6 +168,7 @@ pub(crate) async fn dispatch<'p, P: HsmPal>(
         DdiOp::GetSessionEncryptionKey => get_session_encryption_key(pal, io, decoder, hdr).await,
         DdiOp::GetUnwrappingKey => get_unwrapping_key(pal, io, decoder, hdr).await,
         DdiOp::RsaUnwrap => rsa_unwrap(pal, io, decoder, hdr).await,
+        DdiOp::UnmaskKey => unmask_key(pal, io, decoder, hdr).await,
         DdiOp::GetSealedBk3 => get_sealed_bk3(pal, io, decoder, hdr),
         DdiOp::SetSealedBk3 => set_sealed_bk3(pal, io, decoder, hdr),
         DdiOp::InitBk3 => init_bk3(pal, io, decoder, hdr).await,

--- a/fw/core/lib/src/ddi/mbor/unmask_key.rs
+++ b/fw/core/lib/src/ddi/mbor/unmask_key.rs
@@ -1,0 +1,143 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! DDI UnmaskKey command handler.
+//!
+//! Inverse of the masking (return) side ([`masking`](super::masking)):
+//! recover a host-held masked-key blob and re-import the key into the
+//! partition vault, returning the new vault key id.
+//!
+//! The blob is an AES-CBC-256 + HMAC-SHA-384 envelope.  Its scope is read
+//! from the cleartext (MAC-covered) metadata to select the masking key —
+//! the per-session masking key for session-scoped keys, the partition
+//! masking key (`MK`) otherwise.  Reading the scope before authenticating
+//! is safe: a tampered scope selects the wrong key, and because [`unmask`]
+//! verifies the HMAC before decrypting, the mismatch is rejected without
+//! touching the ciphertext.
+
+use azihsm_fw_core_crypto_key_masking::cbc::peek_metadata;
+use azihsm_fw_core_crypto_key_masking::cbc::unmask;
+use azihsm_fw_ddi_mbor::MborDecode;
+use azihsm_fw_ddi_mbor::MborDecoder;
+use azihsm_fw_ddi_mbor_types::masked_key::DdiMaskedKeyMetadata;
+use azihsm_fw_ddi_mbor_types::unmask_key::DdiUnmaskKeyReq;
+use azihsm_fw_ddi_mbor_types::unmask_key::DdiUnmaskKeyResp;
+use azihsm_fw_ddi_mbor_types::DdiKeyType;
+use azihsm_fw_ddi_mbor_types::DdiPublicKey;
+
+use super::*;
+
+/// Handle `DdiUnmaskKeyCmd`.
+pub(crate) async fn unmask_key<'p, P: HsmPal>(
+    pal: &'p P,
+    io: &impl HsmIo,
+    decoder: &mut DdiDecoder<'_>,
+    hdr: &DdiReqHdr,
+) -> HsmResult<&'p DmaBuf> {
+    let sess_id = hdr.sess_id.ok_or(HsmError::SessionExpected)?;
+    let body: DdiUnmaskKeyReq = decoder.decode_data()?;
+
+    // Decode the blob's cleartext (MAC-covered) metadata WITHOUT the
+    // masking key: its recorded scope selects which masking key the blob
+    // was enveloped under, and its `key_type` / length drive the
+    // re-import.  These values are only *acted on* after `unmask` (below)
+    // verifies the HMAC; the peek trusts nothing except to pick which key
+    // to try, which is self-correcting (a tampered scope picks the wrong
+    // key and the HMAC check rejects it).  Derived as owned values so the
+    // blob borrow is released before `unmask` takes it mutably.
+    let (key_type, kind, attrs, key_len) = {
+        let meta = peek_metadata(body.masked_key)?;
+        let meta_buf = pal.dma_alloc(io, meta.len())?;
+        meta_buf.copy_from_slice(meta);
+        let mut dec = MborDecoder::new(meta_buf);
+        let metadata = DdiMaskedKeyMetadata::mbor_decode(&mut dec)
+            .map_err(|_| HsmError::MaskedKeyDecodeFailed)?;
+
+        // The partition unwrapping key is tagged `RsaUnwrap` and must
+        // not be re-imported as a general key.
+        if metadata.key_type == DdiKeyType::RsaUnwrap {
+            return Err(HsmError::InvalidKeyType);
+        }
+
+        let kind = super::from_ddi::vault_kind_from_ddi(metadata.key_type)?;
+        let attrs: HsmVaultKeyAttrs = metadata.key_attributes.into();
+        (metadata.key_type, kind, attrs, metadata.key_length as usize)
+    };
+
+    // Authenticate-then-decrypt in place under the scope's masking key: the
+    // per-session masking key for session-scoped keys, the partition
+    // masking key (MK) otherwise.  A wrong key (tampered scope) or a
+    // tampered blob fails the HMAC here without leaking plaintext.
+    let layout = if attrs.session() {
+        let session_mk = pal.session_masking_key(io, HsmSessId::from(sess_id))?;
+        unmask(pal, io, session_mk, body.masked_key).await?
+    } else {
+        let mk_id = crate::part_state::part_mk_key_id(pal, io)?;
+        let part_mk = pal.vault_key(io, mk_id)?;
+        unmask(pal, io, part_mk, body.masked_key).await?
+    };
+
+    // Copy the primary key material (plaintext prefix) into a fresh
+    // vault-import scratch buffer.  For ECC the trailing public point is
+    // ignored here; the private scalar alone re-derives it on import.
+    let key_buf = pal.dma_alloc(io, key_len)?;
+    key_buf.copy_from_slice(
+        &body.masked_key[layout.plaintext_offset..layout.plaintext_offset + key_len],
+    );
+
+    let session_binding = attrs.session().then_some(HsmSessId::from(sess_id));
+    let key_id: u16 = pal
+        .vault_key_create(io, key_buf, kind, session_binding, attrs)
+        .await?
+        .into();
+
+    // Asymmetric kinds return their public key, re-derived from the
+    // imported private key so the host recovers the full keypair (this
+    // also avoids trusting any untrusted trailing bytes in the blob).
+    let pub_spec = match kind {
+        HsmVaultKeyKind::Ecc256Private => Some((false, DdiKeyType::Ecc256Public)),
+        HsmVaultKeyKind::Ecc384Private => Some((false, DdiKeyType::Ecc384Public)),
+        HsmVaultKeyKind::Ecc521Private => Some((false, DdiKeyType::Ecc521Public)),
+        HsmVaultKeyKind::Rsa2kPrivate | HsmVaultKeyKind::Rsa2kPrivateCrt => {
+            Some((true, DdiKeyType::Rsa2kPublic))
+        }
+        HsmVaultKeyKind::Rsa3kPrivate | HsmVaultKeyKind::Rsa3kPrivateCrt => {
+            Some((true, DdiKeyType::Rsa3kPublic))
+        }
+        HsmVaultKeyKind::Rsa4kPrivate | HsmVaultKeyKind::Rsa4kPrivateCrt => {
+            Some((true, DdiKeyType::Rsa4kPublic))
+        }
+        _ => None,
+    };
+    let pub_out = if let Some((is_rsa, pub_kind)) = pub_spec {
+        let pub_len = if is_rsa {
+            pal.rsa_priv_pub_key(io, key_buf, None)?
+        } else {
+            pal.ecc_priv_pub_key(io, key_buf, None).await?
+        };
+        let pub_buf = pal.dma_alloc(io, pub_len)?;
+        if is_rsa {
+            pal.rsa_priv_pub_key(io, key_buf, Some(pub_buf))?;
+        } else {
+            pal.ecc_priv_pub_key(io, key_buf, Some(pub_buf)).await?;
+        }
+        Some((pub_buf, pub_kind))
+    } else {
+        None
+    };
+
+    let resp = pal.dma_alloc_var(io, |buf| {
+        super::encode_resp(
+            &super::success_hdr_sess(hdr, DdiOp::UnmaskKey, sess_id),
+            &DdiUnmaskKeyResp {
+                key_id,
+                pub_key: pub_out.map(|(raw, key_kind)| DdiPublicKey { raw, key_kind }),
+                bulk_key_id: None,
+                kind: key_type,
+                masked_key: &[],
+            },
+            buf,
+        )
+    })?;
+    Ok(resp)
+}


### PR DESCRIPTION
Add the UnmaskKey command handler — the inverse of the masked-key (return) path: recover a host-held masked-key blob and re-import the key into the partition vault, returning the new vault key id (and, for the asymmetric kinds, the re-derived wire public key).

The blob is an AES-CBC-256 + HMAC-SHA-384 envelope.  The handler reads the blob's cleartext (MAC-covered) metadata to select the masking key by its recorded scope — the per-session masking key for session-scoped keys, the partition masking key (MK) otherwise — then authenticates-then- decrypts in place under it.  Selecting the key from the pre-authentication scope is safe: a tampered scope picks the wrong key and `unmask`'s HMAC check rejects it before touching the ciphertext (mirrors the sim's `is_session_only_masked_key` and the TBOR `peek_metadata` path).  A new `cbc::peek_metadata` exposes the unauthenticated metadata region without the masking key.

After authentication the handler maps the recorded `DdiKeyType` back to a vault kind (`from_ddi::vault_kind_from_ddi`; the internal `RsaUnwrap` tag is rejected), reconstructs the vault attributes, and creates the vault key from the plaintext prefix.  Asymmetric kinds re-derive their public key from the imported private key so the host recovers the full keypair without trusting trailing blob bytes.

Wires the handler into the MBOR dispatch (`DdiOp::UnmaskKey`) and adds the `DdiMaskedKeyAttributes -> HsmVaultKeyAttrs` conversion used to rebuild the vault attributes on re-import.

The masked-key unmask round-trip tests are made emu-compatible without losing coverage:
- the AES / ECC / HKDF / KBKDF gen suites drop the sim-only "unmask-while-present must fail" pre-check (`try_to_unmask_first=false`), since the emu firmware re-imports a key even when it still exists;
- the ECDH-exchange and RsaUnwrap suites verify the round-trip via the UnmaskKey response directly (delete original -> unmask -> assert kind) instead of a named-key OpenKey-by-tag lookup (not implemented on emu), so they no longer need a key tag.

Tested:
- unmask_key_smoke round-trips: 2/2 pass on emu and 2/2 on mock — a symmetric partition-scoped AES key (encrypt -> unmask -> decrypt) and an asymmetric session-scoped ECC key (public-key re-derivation + sign / verify), covering both masking-key-selection branches.
- full DDI emu suite (azihsm_ddi_tests): 635 run, 508 passed, 127 failed — 0 regressions vs main, and 37 pre-existing masked-key unmask round-trips (AES / ECC / ECDH / HKDF / KBKDF / RsaUnwrap) now pass.  The remaining failures are emu-unsupported paths (AES-XTS/GCM bulk, OpenKey) handled separately.