### PR TITLE
[build] refactor workflows to utilize matrix strategy on os

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -16,9 +16,13 @@ env:
 
 jobs:
 
-  coverage_ubuntu:
+  coverage:
+    name: coverage (${{ matrix.os }})
+    strategy:
+      matrix:
+        os: [ubuntu-24.04, windows-2025-vs2026]
 
-    runs-on: ubuntu-24.04
+    runs-on: ${{ matrix.os }}
 
     defaults:
       run:
@@ -27,43 +31,9 @@ jobs:
     steps:
     - uses: actions/checkout@v6
     - uses: ./.github/actions/ubuntu-setup
-    - name: Run all mock tests with code coverage
-      id: test-mock-coverage
-      run: cargo xtask precheck --coverage --skip-clean --exclude provider-integration-tests-cli --exclude provider-integration-tests-capi -F mock --profile ci-mock
-      continue-on-error: true
-    - name: Run resiliency fault injection tests with code coverage
-      id: test-res-fault
-      run: cargo xtask precheck --coverage --skip-clean -p azihsm_api_tests -F mock,res-test -E 'test(resiliency::fault_injection::)' --profile ci-mock-res
-      continue-on-error: true
-    - name: Generate nextest report
-      id: nextest-report
-      run: cargo xtask precheck --nextest-report
-    - name: Code Coverage Summary Report
-      if: ${{ steps.test-mock-coverage.outcome == 'success' && steps.test-res-fault.outcome == 'success' }}
-      run: cargo xtask precheck --coverage-report
-    - name: Upload coverage report
-      if: ${{ steps.test-mock-coverage.outcome == 'success' && steps.test-res-fault.outcome == 'success' }}
-      uses: actions/upload-artifact@v7
-      with:
-        name: coverage-report-ubuntu
-        path: ./target/reports/
-    - name: Fail if any tests failed
-      if: ${{ steps.test-mock-coverage.outcome == 'failure' || steps.test-res-fault.outcome == 'failure' }}
-      run: |
-        echo "One or more tests failed."
-        exit 1
-
-  coverage_windows:
-
-    runs-on: windows-2025-vs2026
-
-    defaults:
-      run:
-        working-directory: .
-
-    steps:
-    - uses: actions/checkout@v6
+      if: matrix.os == 'ubuntu-24.04'
     - uses: ./.github/actions/windows-setup
+      if: matrix.os == 'windows-2025-vs2026'
     - name: Run all mock tests with code coverage
       id: test-mock-coverage
       run: cargo xtask precheck --coverage --skip-clean --exclude provider-integration-tests-cli --exclude provider-integration-tests-capi -F mock --profile ci-mock
@@ -82,7 +52,7 @@ jobs:
       if: ${{ steps.test-mock-coverage.outcome == 'success' && steps.test-res-fault.outcome == 'success' }}
       uses: actions/upload-artifact@v7
       with:
-        name: coverage-report-windows
+        name: coverage-report-${{ matrix.os }}
         path: ./target/reports/
     - name: Fail if any tests failed
       if: ${{ steps.test-mock-coverage.outcome == 'failure' || steps.test-res-fault.outcome == 'failure' }}

--- a/.github/workflows/create_new_cache.yml
+++ b/.github/workflows/create_new_cache.yml
@@ -10,31 +10,13 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  create_new_cache_ubuntu:
+  create_new_cache:
+    name: create_new_cache (${{ matrix.os }})
+    strategy:
+      matrix:
+        os: [ubuntu-24.04, windows-2025-vs2026]
 
-    runs-on: ubuntu-24.04
-
-    defaults:
-      run:
-        working-directory: .
-
-    steps:
-    - uses: actions/checkout@v6
-    - name: Run Setup
-      run: cargo xtask precheck --setup
-    - name: Save Cargo cache
-      uses: actions/cache/save@v5
-      with:
-        path: |
-          ~/.cargo/bin/
-          ~/.cargo/registry/index/
-          ~/.cargo/registry/cache/
-          ~/.cargo/git/db/
-        key: ${{ runner.os }}-cargo-${{ github.sha }}
-
-  create_new_cache_windows:
-
-    runs-on: windows-2025-vs2026
+    runs-on: ${{ matrix.os }}
 
     defaults:
       run:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -15,9 +15,13 @@ env:
   CACHE_KEY_ID: 84f8acac52412db91407ab9f85776987da17d42f
 
 jobs:
-  build_ubuntu:
+  build:
+    name: build (${{ matrix.os }})
+    strategy:
+      matrix:
+        os: [ubuntu-24.04, windows-2025-vs2026]
 
-    runs-on: ubuntu-24.04
+    runs-on: ${{ matrix.os }}
 
     defaults:
       run:
@@ -27,11 +31,15 @@ jobs:
     - uses: actions/checkout@v6
     - uses: ./.github/actions/ubuntu-setup
       id: ubuntu-setup
+      if: matrix.os == 'ubuntu-24.04'
+    - uses: ./.github/actions/windows-setup
+      id: windows-setup
+      if: matrix.os == 'windows-2025-vs2026'
     - name: Install nightly rustfmt
-      if: steps.ubuntu-setup.outputs.cache-hit == 'true'
+      if: ${{ (matrix.os == 'ubuntu-24.04' && steps.ubuntu-setup.outputs.cache-hit == 'true') || (matrix.os == 'windows-2025-vs2026' && steps.windows-setup.outputs.cache-hit == 'true') }}
       run: cargo xtask rustup-component-add --component rustfmt --toolchain nightly
     - name: Install clippy
-      if: steps.ubuntu-setup.outputs.cache-hit == 'true'
+      if: ${{ (matrix.os == 'ubuntu-24.04' && steps.ubuntu-setup.outputs.cache-hit == 'true') || (matrix.os == 'windows-2025-vs2026' && steps.windows-setup.outputs.cache-hit == 'true') }}
       run: cargo xtask rustup-component-add --component clippy
     - name: Run Copyright
       run: cargo xtask precheck --copyright
@@ -42,9 +50,13 @@ jobs:
     - name: Cargo Clippy
       run: cargo xtask precheck --clippy
 
-  test_ubuntu_mock:
+  test_mock:
+    name: test_mock (${{ matrix.os }})
+    strategy:
+      matrix:
+        os: [ubuntu-24.04, windows-2025-vs2026]
 
-    runs-on: ubuntu-24.04
+    runs-on: ${{ matrix.os }}
 
     defaults:
       run:
@@ -53,6 +65,9 @@ jobs:
     steps:
     - uses: actions/checkout@v6
     - uses: ./.github/actions/ubuntu-setup
+      if: matrix.os == 'ubuntu-24.04'
+    - uses: ./.github/actions/windows-setup
+      if: matrix.os == 'windows-2025-vs2026'
     - name: Run all mock tests (except azihsm_api_tests)
       id: test-mock
       run: cargo xtask precheck --nextest --exclude azihsm_api_tests --exclude provider-integration-tests-cli --exclude provider-integration-tests-capi -F mock --profile ci-mock
@@ -66,9 +81,13 @@ jobs:
         echo "One or more tests failed."
         exit 1
 
-  test_ubuntu_api:
+  test_api:
+    name: test_api (${{ matrix.os }})
+    strategy:
+      matrix:
+        os: [ubuntu-24.04, windows-2025-vs2026]
 
-    runs-on: ubuntu-24.04
+    runs-on: ${{ matrix.os }}
 
     defaults:
       run:
@@ -77,6 +96,9 @@ jobs:
     steps:
     - uses: actions/checkout@v6
     - uses: ./.github/actions/ubuntu-setup
+      if: matrix.os == 'ubuntu-24.04'
+    - uses: ./.github/actions/windows-setup
+      if: matrix.os == 'windows-2025-vs2026'
     - name: Run azihsm_api_tests
       id: test-api
       run: cargo xtask precheck --nextest -p azihsm_api_tests -F mock --profile ci-api
@@ -90,9 +112,13 @@ jobs:
         echo "One or more tests failed."
         exit 1
 
-  test_ubuntu_misc:
+  test_misc:
+    name: test_misc (${{ matrix.os }})
+    strategy:
+      matrix:
+        os: [ubuntu-24.04, windows-2025-vs2026]
 
-    runs-on: ubuntu-24.04
+    runs-on: ${{ matrix.os }}
 
     defaults:
       run:
@@ -101,16 +127,22 @@ jobs:
     steps:
     - uses: actions/checkout@v6
     - uses: ./.github/actions/ubuntu-setup
+      if: matrix.os == 'ubuntu-24.04'
+    - uses: ./.github/actions/windows-setup
+      if: matrix.os == 'windows-2025-vs2026'
     - name: SDK Run all mock tests table-4
       id: test-mock-table-4
+      if: matrix.os == 'ubuntu-24.04'
       run: cargo xtask precheck --nextest -p azihsm_ddi_mbor_types -F mock,table-4 --profile ci-mock-table-4
       continue-on-error: true
     - name: SDK Run all mock tests table-64
       id: test-mock-table-64
+      if: matrix.os == 'ubuntu-24.04'
       run: cargo xtask precheck --nextest -p azihsm_ddi_mbor_types -F mock,table-64 --profile ci-mock-table-64
       continue-on-error: true
     - name: SDK Run TBOR types tests against emu backend
       id: test-tbor-emu
+      if: matrix.os == 'ubuntu-24.04'
       run: cargo xtask precheck --nextest -p azihsm_ddi_tbor_types -F emu --profile ci-tbor-emu
       continue-on-error: true
     - name: Run resiliency fault injection tests
@@ -126,9 +158,13 @@ jobs:
         echo "One or more tests failed."
         exit 1
 
-  test_ubuntu_smoke:
+  test_smoke:
+    name: test_smoke (${{ matrix.os }})
+    strategy:
+      matrix:
+        os: [ubuntu-24.04, windows-2025-vs2026]
 
-    runs-on: ubuntu-24.04
+    runs-on: ${{ matrix.os }}
 
     defaults:
       run:
@@ -137,129 +173,9 @@ jobs:
     steps:
     - uses: actions/checkout@v6
     - uses: ./.github/actions/ubuntu-setup
-    - name: Run emu smoke tests
-      id: test-emu-smoke
-      run: cargo xtask precheck --nextest --package azihsm_ddi_mbor_types --features emu --test azihsm_ddi_tests --filter smoke --profile ci-emu-smoke
-      continue-on-error: true
-    - name: Generate nextest report
-      id: nextest-report
-      run: cargo xtask precheck --nextest-report
-    - name: Fail if any tests failed
-      if: ${{ steps.test-emu-smoke.outcome == 'failure' }}
-      run: |
-        echo "One or more tests failed."
-        exit 1
-
-  build_windows:
-
-    runs-on: windows-2025-vs2026
-
-    defaults:
-      run:
-        working-directory: .
-
-    steps:
-    - uses: actions/checkout@v6
+      if: matrix.os == 'ubuntu-24.04'
     - uses: ./.github/actions/windows-setup
-      id: windows-setup
-    - name: Install nightly rustfmt
-      if: steps.windows-setup.outputs.cache-hit == 'true'
-      run: cargo xtask rustup-component-add --component rustfmt --toolchain nightly
-    - name: Install clippy
-      if: steps.windows-setup.outputs.cache-hit == 'true'
-      run: cargo xtask rustup-component-add --component clippy
-    - name: Run Copyright
-      run: cargo xtask precheck --copyright
-    - name: Run Audit
-      run: cargo xtask precheck --audit
-    - name: Cargo format
-      run: cargo xtask precheck --fmt
-    - name: Cargo Clippy
-      run: cargo xtask precheck --clippy
-
-  test_windows_mock:
-
-    runs-on: windows-2025-vs2026
-
-    defaults:
-      run:
-        working-directory: .
-
-    steps:
-    - uses: actions/checkout@v6
-    - uses: ./.github/actions/windows-setup
-    - name: Run all mock tests (except azihsm_api_tests)
-      id: test-mock
-      run: cargo xtask precheck --nextest --exclude azihsm_api_tests --exclude provider-integration-tests-cli --exclude provider-integration-tests-capi -F mock --profile ci-mock
-      continue-on-error: true
-    - name: Generate nextest report
-      id: nextest-report
-      run: cargo xtask precheck --nextest-report
-    - name: Fail if any tests failed
-      if: ${{ steps.test-mock.outcome == 'failure' }}
-      run: |
-        echo "One or more tests failed."
-        exit 1
-
-  test_windows_api:
-
-    runs-on: windows-2025-vs2026
-
-    defaults:
-      run:
-        working-directory: .
-
-    steps:
-    - uses: actions/checkout@v6
-    - uses: ./.github/actions/windows-setup
-    - name: Run azihsm_api_tests
-      id: test-api
-      run: cargo xtask precheck --nextest -p azihsm_api_tests -F mock --profile ci-api
-      continue-on-error: true
-    - name: Generate nextest report
-      id: nextest-report
-      run: cargo xtask precheck --nextest-report
-    - name: Fail if any tests failed
-      if: ${{ steps.test-api.outcome == 'failure' }}
-      run: |
-        echo "One or more tests failed."
-        exit 1
-
-  test_windows_misc:
-
-    runs-on: windows-2025-vs2026
-
-    defaults:
-      run:
-        working-directory: .
-
-    steps:
-    - uses: actions/checkout@v6
-    - uses: ./.github/actions/windows-setup
-    - name: Run resiliency fault injection tests
-      id: test-res-fault
-      run: cargo xtask precheck --nextest -p azihsm_api_tests -F mock,res-test -E 'test(resiliency::fault_injection::)' --profile ci-mock-res
-      continue-on-error: true
-    - name: Generate nextest report
-      id: nextest-report
-      run: cargo xtask precheck --nextest-report
-    - name: Fail if any tests failed
-      if: ${{ steps.test-res-fault.outcome == 'failure' }}
-      run: |
-        echo "One or more tests failed."
-        exit 1
-
-  test_windows_smoke:
-
-    runs-on: windows-2025-vs2026
-
-    defaults:
-      run:
-        working-directory: .
-
-    steps:
-    - uses: actions/checkout@v6
-    - uses: ./.github/actions/windows-setup
+      if: matrix.os == 'windows-2025-vs2026'
     - name: Run emu smoke tests
       id: test-emu-smoke
       run: cargo xtask precheck --nextest --package azihsm_ddi_mbor_types --features emu --test azihsm_ddi_tests --filter smoke --profile ci-emu-smoke


### PR DESCRIPTION
This change updates every workflow that is currently using duplicate logic in multiple jobs to handle testing across multiple OSes to instead use a matrix strategy containing a dimension for OS so that jobs can share OS-independent steps where applicable.