### PR TITLE
Azihsm PSK Change API 

### DIFF
--- a/api/lib/src/ddi/mod.rs
+++ b/api/lib/src/ddi/mod.rs
@@ -98,15 +98,17 @@ impl From<DdiError> for HsmError {
 
 pub(crate) type HsmKeyHandle = u32;
 
-/// Maximum size, in bytes, of the `pta_csr` buffer written by the
-/// partition-provisioning `part_init` command. Owned by the API layer
-/// but pinned to the TBOR wire-schema bound so the two cannot drift.
-pub const PTA_CSR_MAX_LEN: usize = azihsm_ddi_tbor_types::PTA_CSR_MAX_LEN;
+/// Size, in bytes, of the `part_final` `local_mk_backup` envelope.
+pub use azihsm_ddi_tbor_types::LOCAL_MK_BACKUP_LEN;
+/// Maximum size, in bytes, of the `part_init` `pta_csr` buffer.
+pub use azihsm_ddi_tbor_types::PTA_CSR_MAX_LEN;
+/// Maximum size, in bytes, of the `part_init` `pta_report` buffer.
+pub use azihsm_ddi_tbor_types::PTA_REPORT_MAX_LEN;
 
-/// Maximum size, in bytes, of the `pta_report` buffer written by the
-/// partition-provisioning `part_init` command. Owned by the API layer
-/// but pinned to the TBOR wire-schema bound so the two cannot drift.
-pub const PTA_REPORT_MAX_LEN: usize = azihsm_ddi_tbor_types::PTA_REPORT_MAX_LEN;
+// Pin the shared-module `PSK_LEN` (defined in `shared_types`, which is
+// shared with the native crate) to the wire-schema value so the two
+// cannot drift.
+const _: () = assert!(crate::PSK_LEN == azihsm_ddi_tbor_types::PSK_LEN);
 
 /// Extracts the key ID from a packed HSM key handle.
 ///

--- a/api/lib/src/ddi/mod.rs
+++ b/api/lib/src/ddi/mod.rs
@@ -100,6 +100,8 @@ pub(crate) type HsmKeyHandle = u32;
 
 /// Size, in bytes, of the `part_final` `local_mk_backup` envelope.
 pub use azihsm_ddi_tbor_types::LOCAL_MK_BACKUP_LEN;
+/// Maximum number of certificates in a `part_final` PTA chain.
+pub use azihsm_ddi_tbor_types::MAX_CERTS;
 /// Maximum size, in bytes, of the `part_init` `pta_csr` buffer.
 pub use azihsm_ddi_tbor_types::PTA_CSR_MAX_LEN;
 /// Maximum size, in bytes, of the `part_init` `pta_report` buffer.

--- a/api/lib/src/ddi/session_ex.rs
+++ b/api/lib/src/ddi/session_ex.rs
@@ -202,13 +202,14 @@ pub(crate) fn open_session_ex(
     partition: &HsmPartition,
     rev: HsmApiRev,
     psk_id: u8,
+    psk: Option<&[u8; crate::PSK_LEN]>,
     session_type: HsmSessionExType,
 ) -> HsmResult<OpenSessionExResult> {
     // Convert the API-layer session type to the wire-level `SessionType`
     // here in the DDI layer, so the public API surface never handles the
     // DDI wire type.
     let session_type: SessionType = session_type.try_into()?;
-    let pending = open_session_ex_init(partition, rev, psk_id, session_type)?;
+    let pending = open_session_ex_init(partition, rev, psk_id, psk, session_type)?;
     open_session_ex_finish(partition, pending)
 }
 
@@ -220,8 +221,8 @@ pub(crate) fn open_session_ex(
 /// response, and verifies the Phase-1 confirm MAC. Returns a
 /// [`PendingHandshake`] for [`open_session_ex_finish`] to consume.
 ///
-/// Uses the partition default PSK for `psk_id` (CO = 0, CU = 1); PSK
-/// rotation is out of scope for now.
+/// Uses the caller-supplied PSK when present, otherwise the partition
+/// default PSK for `psk_id` (CO = 0, CU = 1).
 ///
 /// `rev` is the negotiated API revision selected by the caller
 /// ([`open_session_ex`]); it is used for the `pk_hsm` cert-chain
@@ -237,6 +238,7 @@ fn open_session_ex_init(
     partition: &HsmPartition,
     rev: HsmApiRev,
     psk_id: u8,
+    psk: Option<&[u8; crate::PSK_LEN]>,
     session_type: SessionType,
 ) -> HsmResult<PendingHandshake> {
     let inner = partition.inner().read();
@@ -266,7 +268,12 @@ fn open_session_ex_init(
     // Derive the 48-byte HPKE `exported` secret, then verify the FW's
     // Phase-1 confirm MAC binds the negotiated role/type/suite.
     let info = build_hpke_info(psk_id, session_type.to_u8(), suite_id);
-    let psk = default_psk(psk_id)?;
+    // Use the caller-supplied PSK when present, else the partition
+    // default PSK for the role (required before the default is rotated).
+    let psk: &[u8; crate::PSK_LEN] = match psk {
+        Some(p) => p,
+        None => default_psk(psk_id)?,
+    };
     let exported = Zeroizing::new(receive_exported(
         &eph.sk,
         &eph.pk,
@@ -364,6 +371,72 @@ fn open_session_ex_finish(
     })
 }
 
+/// Issue `PskChange` (opcode `0x06`) on the active session.
+///
+/// Seals `new_psk` under the session `param_key` (AAD-bound to the
+/// session id via [`build_psk_change_aad`]) and ships it as the
+/// `psk_envelope`. The firmware rotates the PSK slot implied by the
+/// session role (CO session → CO slot, CU session → CU slot); the
+/// request carries no slot-selection field.
+///
+/// # Arguments
+///
+/// * `partition` - The HSM partition handle.
+/// * `session_id` - The active session id this request binds to.
+/// * `param_key` - The session's per-session AES wrap key used to seal
+///   the new PSK.
+/// * `new_psk` - The 32-byte replacement PSK ([`crate::PSK_LEN`]).
+///
+/// # Errors
+///
+/// Propagates [`HsmError::InternalError`] on an RNG / AEAD seal failure
+/// and surfaces DDI/device failures from the round-trip.
+pub(crate) fn psk_change(
+    partition: &HsmPartition,
+    session_id: u16,
+    param_key: &AesKey,
+    new_psk: &[u8; crate::PSK_LEN],
+) -> HsmResult<()> {
+    let aad = build_psk_change_aad(session_id);
+    let iv = Rng::rand_vec(12).map_err(|_| HsmError::InternalError)?;
+
+    // First pass sizes the output buffer; second pass writes the sealed
+    // envelope into it.
+    let total = azihsm_crypto::aead_envelope::seal(
+        azihsm_crypto::aead_envelope::AeadAlg::AesGcm256,
+        param_key,
+        &iv,
+        &aad,
+        new_psk,
+        None,
+    )
+    .map_err(|_| HsmError::InternalError)?;
+    let mut envelope = vec![0u8; total];
+    let written = azihsm_crypto::aead_envelope::seal(
+        azihsm_crypto::aead_envelope::AeadAlg::AesGcm256,
+        param_key,
+        &iv,
+        &aad,
+        new_psk,
+        Some(&mut envelope),
+    )
+    .map_err(|_| HsmError::InternalError)?;
+    envelope.truncate(written);
+
+    let req = TborPskChangeReq {
+        session_id,
+        psk_envelope: envelope,
+    };
+
+    let inner = partition.inner().read();
+    let dev = inner.dev();
+    let mut cookie = None;
+    let _resp: TborPskChangeResp = dev
+        .exec_op_tbor(&req, None, &mut cookie)
+        .map_err(HsmError::from)?;
+    Ok(())
+}
+
 /// Closes an active TBOR security-domain session — `CloseSession`
 /// (opcode `0x12`).
 ///
@@ -444,7 +517,7 @@ mod tests {
         let part = fresh_emu_partition();
         let rev = part.inner().read().api_rev();
 
-        let pending = open_session_ex_init(&part, rev, psk_id, session_type)
+        let pending = open_session_ex_init(&part, rev, psk_id, None, session_type)
             .expect("phase 1 (open_session_ex_init) should succeed against emu");
         assert_eq!(
             pending.psk_id, psk_id,
@@ -496,7 +569,7 @@ mod tests {
         let _guard = EMU_LOCK.lock();
         let part = fresh_emu_partition();
         let rev = part.inner().read().api_rev();
-        let result = open_session_ex_init(&part, rev, 2, SessionType::Authenticated);
+        let result = open_session_ex_init(&part, rev, 2, None, SessionType::Authenticated);
         assert!(
             result.is_err(),
             "unknown psk_id must not produce a pending handshake"

--- a/api/lib/src/lib.rs
+++ b/api/lib/src/lib.rs
@@ -13,6 +13,7 @@ pub mod traits;
 
 pub use algo::*;
 pub use ddi::LOCAL_MK_BACKUP_LEN;
+pub use ddi::MAX_CERTS;
 pub use ddi::PTA_CSR_MAX_LEN;
 pub use ddi::PTA_REPORT_MAX_LEN;
 pub use error::*;

--- a/api/lib/src/lib.rs
+++ b/api/lib/src/lib.rs
@@ -12,6 +12,7 @@ mod shared_types;
 pub mod traits;
 
 pub use algo::*;
+pub use ddi::LOCAL_MK_BACKUP_LEN;
 pub use ddi::PTA_CSR_MAX_LEN;
 pub use ddi::PTA_REPORT_MAX_LEN;
 pub use error::*;

--- a/api/lib/src/partition.rs
+++ b/api/lib/src/partition.rs
@@ -574,16 +574,17 @@ impl HsmPartition {
     /// # Arguments
     ///
     /// * `api_rev` - The negotiated API revision.
-    /// * `psk_id` - PSK identity selecting the role (0 = CO, 1 = CU).
+    /// * `psk` - PSK credential: the role slot plus an optional
+    ///   caller-supplied PSK (`None` selects the partition default PSK).
     /// * `session_type` - Channel integrity profile to pin.
     #[instrument(skip_all, err, fields(path = self.path().as_str()))]
     pub fn open_session_ex(
         &self,
         api_rev: HsmApiRev,
-        psk_id: u8,
+        psk: HsmSessionPsk<'_>,
         session_type: HsmSessionExType,
     ) -> HsmResult<HsmSession> {
-        let result = ddi::open_session_ex(self, api_rev, psk_id, session_type)?;
+        let result = ddi::open_session_ex(self, api_rev, psk.psk_id as u8, psk.psk, session_type)?;
         Ok(HsmSession::new_ex(api_rev, self.clone(), result))
     }
 

--- a/api/lib/src/session.rs
+++ b/api/lib/src/session.rs
@@ -135,6 +135,24 @@ impl HsmSession {
         self.inner.write().set_bmk_session(bmk_session);
     }
 
+    /// Issues TBOR `PskChange` (opcode `0x06`) on this session.
+    ///
+    /// Rotates this session's own partition PSK to `new_psk`, sealed
+    /// under the session `param_key`. The slot is implied by the session
+    /// role (CO session → CO, CU session → CU). Required once on a fresh
+    /// partition to move past the default-PSK gate before provisioning.
+    /// Only valid on a V2 session; a V1 session returns
+    /// [`HsmError::InvalidSession`].
+    pub fn change_psk(&self, new_psk: &[u8; PSK_LEN]) -> HsmResult<()> {
+        let inner = self.inner.read();
+        match &inner.kind {
+            SessionKind::Ver2 { param_key, .. } => {
+                ddi::psk_change(&inner.partition, inner.id, param_key, new_psk)
+            }
+            SessionKind::Ver1 { .. } => Err(HsmError::InvalidSession),
+        }
+    }
+
     /// Issues TBOR `PartInit` (opcode `0x07`) on this CO session.
     ///
     /// Seals `mach_seed` under the session `param_key` and ships it

--- a/api/lib/src/shared_types.rs
+++ b/api/lib/src/shared_types.rs
@@ -188,6 +188,55 @@ pub enum HsmSessionExType {
     Authenticated = 1,
 }
 
+/// Length, in bytes, of a partition PSK (Pre-Shared Key). This module is
+/// shared with the native crate (which does not depend on the wire-types
+/// crate), so the value is a literal here and pinned to the wire-schema
+/// `PSK_LEN` by a static assert in the DDI layer.
+pub const PSK_LEN: usize = 32;
+
+/// Partition PSK slot for a security-domain (TBOR) session, selecting
+/// which PSK the handshake authenticates with. The `#[repr(u8)]`
+/// discriminant is the wire `psk_id`.
+#[repr(u8)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HsmPskId {
+    /// Crypto Officer — PSK slot 0.
+    CO = 0,
+    /// Crypto User — PSK slot 1.
+    CU = 1,
+}
+
+/// PSK credential for opening a security-domain session: the PSK slot
+/// and, optionally, the caller's PSK.
+///
+/// When `psk` is `None`, the partition **default** PSK for the slot is
+/// used — required for the first session, before the default PSK is
+/// rotated. After rotation, pass the rotated secret via `psk`.
+#[derive(Debug, Clone, Copy)]
+pub struct HsmSessionPsk<'a> {
+    /// PSK slot this session authenticates as.
+    pub psk_id: HsmPskId,
+    /// Caller-supplied PSK (exactly [`PSK_LEN`] bytes); `None` selects
+    /// the partition default PSK for the slot.
+    pub psk: Option<&'a [u8; PSK_LEN]>,
+}
+
+impl<'a> HsmSessionPsk<'a> {
+    /// Opens the given slot with the partition **default** PSK — used
+    /// for the first session, before the default PSK is rotated.
+    pub fn new(psk_id: HsmPskId) -> Self {
+        Self { psk_id, psk: None }
+    }
+
+    /// Opens the given slot with a caller-supplied (rotated) PSK.
+    pub fn with_psk(psk_id: HsmPskId, psk: &'a [u8; PSK_LEN]) -> Self {
+        Self {
+            psk_id,
+            psk: Some(psk),
+        }
+    }
+}
+
 /// Result of a security-domain partition-provisioning (`part_init_ex`)
 /// command: the artifacts the device returns after initializing a
 /// partition's security domain.

--- a/api/native/cbindgen.toml
+++ b/api/native/cbindgen.toml
@@ -49,7 +49,9 @@ include = [
   "AzihsmResiliencyConfig",
   "AzihsmResiliencyLockOps",
   "AzihsmResiliencyStorageOps",
+  "AzihsmSessExPartFinalParams",
   "AzihsmSessExPartInitParams",
+  "AzihsmSessionPsk",
   "HsmEccCurve",
   "HsmError",
   "HsmKeyClass",
@@ -100,10 +102,12 @@ item_types = ["constants", "enums", "functions", "structs", "typedefs"]
 "AzihsmResiliencyConfig" = "azihsm_resiliency_config"
 "AzihsmResiliencyLockOps" = "azihsm_resiliency_lock_ops"
 "AzihsmResiliencyStorageOps" = "azihsm_resiliency_storage_ops"
+"AzihsmSessExPartFinalParams" = "azihsm_sess_ex_part_final_params"
 "AzihsmSessExPartInitParams" = "azihsm_sess_ex_part_init_params"
 "AzihsmSessionExType" = "azihsm_session_ex_type"
 "AzihsmSessionProp" = "azihsm_session_prop"
 "AzihsmSessionPropId" = "azihsm_session_prop_id"
+"AzihsmSessionPsk" = "azihsm_session_psk"
 "AzihsmStatus" = "azihsm_status"
 "AzihsmStr" = "azihsm_str"
 "AzihsmWideChar" = "azihsm_char"

--- a/api/native/doc/chapter_09_sd.md
+++ b/api/native/doc/chapter_09_sd.md
@@ -10,9 +10,11 @@ provisioning command in this chapter.
 Open a security-domain session to the device.
 
 The session uses the API revision that was selected when the partition was
-opened with [`azihsm_part_open`](#azihsm_part_open). `psk` selects the role
-slot and (optionally) the PSK — when its `psk` buffer is NULL the partition
-default PSK for the slot is used. The `session_type` selects the channel
+opened with [`azihsm_part_open`](#azihsm_part_open). `psk` must be a non-NULL
+pointer to an [`azihsm_session_psk`](#azihsm_session_psk) selecting the role
+slot; only its inner `psk` buffer may be NULL, which selects the partition
+default PSK for the slot. A NULL `psk` pointer is rejected with
+`AZIHSM_STATUS_INVALID_ARGUMENT`. The `session_type` selects the channel
 integrity profile pinned for the session (see
 [azihsm_session_ex_type](#azihsm_session_ex_type)), and a handle to the new
 session is returned.
@@ -31,7 +33,7 @@ azihsm_status azihsm_sess_ex_open(
  | Parameter         | Name                                                | Description                                    |
  | ----------------- | --------------------------------------------------- | ---------------------------------------------- |
  | [in] dev_handle   | [azihsm_handle](#azihsm_handle)                     | partition handle                               |
- | [in] psk          | const azihsm_session_psk *                          | PSK slot + optional PSK (NULL buffer = default)|
+ | [in] psk          | const azihsm_session_psk *                          | PSK credential (non-NULL); inner `psk` buffer NULL = default |
  | [in] session_type | [azihsm_session_ex_type](#azihsm_session_ex_type)   | channel integrity profile to pin               |
  | [out] sess_handle | [azihsm_handle *](#azihsm_handle)                   | new security-domain session handle      &nbsp; |
 

--- a/api/native/doc/chapter_09_sd.md
+++ b/api/native/doc/chapter_09_sd.md
@@ -10,14 +10,17 @@ provisioning command in this chapter.
 Open a security-domain session to the device.
 
 The session uses the API revision that was selected when the partition was
-opened with [`azihsm_part_open`](#azihsm_part_open). The `session_type`
-selects the channel integrity profile pinned for the session (see
+opened with [`azihsm_part_open`](#azihsm_part_open). `psk` selects the role
+slot and (optionally) the PSK — when its `psk` buffer is NULL the partition
+default PSK for the slot is used. The `session_type` selects the channel
+integrity profile pinned for the session (see
 [azihsm_session_ex_type](#azihsm_session_ex_type)), and a handle to the new
 session is returned.
 
 ```cpp
 azihsm_status azihsm_sess_ex_open(
     azihsm_handle dev_handle,
+    const azihsm_session_psk *psk,
     azihsm_session_ex_type session_type,
     azihsm_handle *sess_handle
     );
@@ -28,6 +31,7 @@ azihsm_status azihsm_sess_ex_open(
  | Parameter         | Name                                                | Description                                    |
  | ----------------- | --------------------------------------------------- | ---------------------------------------------- |
  | [in] dev_handle   | [azihsm_handle](#azihsm_handle)                     | partition handle                               |
+ | [in] psk          | const azihsm_session_psk *                          | PSK slot + optional PSK (NULL buffer = default)|
  | [in] session_type | [azihsm_session_ex_type](#azihsm_session_ex_type)   | channel integrity profile to pin               |
  | [out] sess_handle | [azihsm_handle *](#azihsm_handle)                   | new security-domain session handle      &nbsp; |
 

--- a/api/native/doc/chapter_09_sd.md
+++ b/api/native/doc/chapter_09_sd.md
@@ -39,6 +39,27 @@ azihsm_status azihsm_sess_ex_open(
 
 `AZIHSM_STATUS_SUCCESS` on success, error code otherwise
 
+### azihsm_session_psk
+
+PSK credential for [`azihsm_sess_ex_open`](#azihsm_sess_ex_open): the PSK
+slot plus an optional caller-supplied PSK. When the `psk` buffer is NULL,
+the partition **default** PSK for the slot is used — required for the first
+session, before the default is rotated via
+[`azihsm_sess_ex_psk_change`](#azihsm_sess_ex_psk_change). After rotation,
+point `psk` at the rotated 32-byte secret.
+
+```cpp
+struct azihsm_session_psk {
+    uint8_t psk_id;
+    const struct azihsm_buffer *psk;
+};
+```
+
+ | Field  | Name                             | Description                                        |
+ | ------ | -------------------------------- | -------------------------------------------------- |
+ | psk_id | uint8_t                          | PSK slot: 0 = Crypto Officer, 1 = Crypto User      |
+ | psk    | [azihsm_buffer*](#azihsm_buffer) | optional PSK (exactly 32 bytes); NULL = default PSK |
+
 ## azihsm_sess_ex_part_init
 
 Provision a partition's security domain over a security-domain session.
@@ -113,3 +134,95 @@ struct azihsm_sess_ex_part_init_params {
  | pota_thumbprint   | [azihsm_buffer*](#azihsm_buffer) | POTA public-key thumbprint               |
  | sata_thumbprint   | [azihsm_buffer*](#azihsm_buffer) | SATA public-key thumbprint               |
  | sapota_thumbprint | [azihsm_buffer*](#azihsm_buffer) | optional SAPOTA thumbprint (may be NULL) |
+
+## azihsm_sess_ex_part_final
+
+Finalize a partition's security domain over a security-domain session.
+
+Completes provisioning started by
+[`azihsm_sess_ex_part_init`](#azihsm_sess_ex_part_init): re-supplies the
+unified partition policy and the PTA certificate chain (leaf to root),
+optionally restoring a prior `local_mk` backup, and returns the current
+`local_mk` backup envelope the firmware produced.
+
+The inputs are grouped into an
+[`azihsm_sess_ex_part_final_params`](#azihsm_sess_ex_part_final_params)
+structure. `local_mk_backup` is a caller-provided output buffer with the
+same capacity/length contract and two-call size-probe behavior as the
+`azihsm_sess_ex_part_init` outputs: an undersized buffer (or a NULL `ptr`
+with `len == 0`) is rejected with `AZIHSM_STATUS_BUFFER_TOO_SMALL` and
+`len` set to the maximum **before** the partition is finalized. A NULL
+`ptr` with a non-zero `len` is rejected with
+`AZIHSM_STATUS_INVALID_ARGUMENT`.
+
+```cpp
+azihsm_status azihsm_sess_ex_part_final(
+    azihsm_handle sess_handle,
+    const struct azihsm_sess_ex_part_final_params *params,
+    struct azihsm_buffer *local_mk_backup
+    );
+```
+
+**Parameters**
+
+ | Parameter                 | Name                                                                      | Description                                  |
+ | ------------------------- | ------------------------------------------------------------------------- | -------------------------------------------- |
+ | [in] sess_handle          | [azihsm_handle](#azihsm_handle)                                           | security-domain session handle               |
+ | [in] params               | [azihsm_sess_ex_part_final_params*](#azihsm_sess_ex_part_final_params)     | finalization input buffers                   |
+ | [in, out] local_mk_backup | [azihsm_buffer *](#azihsm_buffer)                                         | output buffer for the local_mk backup &nbsp; |
+
+**Returns**
+
+`AZIHSM_STATUS_SUCCESS` on success, error code otherwise
+
+### azihsm_sess_ex_part_final_params
+
+Finalization input buffers for
+[`azihsm_sess_ex_part_final`](#azihsm_sess_ex_part_final). `pta_cert_chain`
+points to an array of `pta_cert_chain_len` [azihsm_buffer](#azihsm_buffer)s,
+each holding one DER-encoded PTA certificate (leaf to root; at most
+`MAX_CERTS`). `prev_local_mk_backup` is optional and may be NULL to omit it.
+
+```cpp
+struct azihsm_sess_ex_part_final_params {
+    const struct azihsm_buffer *part_policy;
+    const struct azihsm_buffer *pta_cert_chain;
+    uint32_t pta_cert_chain_len;
+    const struct azihsm_buffer *prev_local_mk_backup;
+};
+```
+
+ | Field                | Name                             | Description                                     |
+ | -------------------- | -------------------------------- | ----------------------------------------------- |
+ | part_policy          | [azihsm_buffer*](#azihsm_buffer) | unified partition policy (must match part_init) |
+ | pta_cert_chain       | [azihsm_buffer*](#azihsm_buffer) | array of DER PTA certificates (leaf to root)    |
+ | pta_cert_chain_len   | uint32_t                         | number of certificates in the chain             |
+ | prev_local_mk_backup | [azihsm_buffer*](#azihsm_buffer) | optional prior local_mk backup (may be NULL)    |
+
+## azihsm_sess_ex_psk_change
+
+Rotate the calling session's own partition PSK.
+
+Replaces the PSK of the slot implied by the session role (CO session → CO,
+CU session → CU) with `new_psk`, sealed under the session key. This is
+required **once** on a fresh partition to move past the default-PSK gate
+before provisioning, and may also be used later to re-rotate. `new_psk`
+must be exactly 32 bytes.
+
+```cpp
+azihsm_status azihsm_sess_ex_psk_change(
+    azihsm_handle sess_handle,
+    const struct azihsm_buffer *new_psk
+    );
+```
+
+**Parameters**
+
+ | Parameter        | Name                              | Description                              |
+ | ---------------- | --------------------------------- | ---------------------------------------- |
+ | [in] sess_handle | [azihsm_handle](#azihsm_handle)   | security-domain session handle           |
+ | [in] new_psk     | [azihsm_buffer *](#azihsm_buffer) | new PSK buffer (exactly 32 bytes) &nbsp; |
+
+**Returns**
+
+`AZIHSM_STATUS_SUCCESS` on success, error code otherwise

--- a/api/native/src/session_ex.rs
+++ b/api/native/src/session_ex.rs
@@ -308,22 +308,24 @@ pub unsafe extern "C" fn azihsm_sess_ex_part_final(
         let prev_local_mk_backup = buffer_to_optional_slice(params.prev_local_mk_backup)?;
 
         // Build the PTA cert chain (borrowing, not copying) from the C
-        // array of `azihsm_buffer`s.
+        // array of `azihsm_buffer`s. Reject an empty or oversized chain
+        // up front so a bogus `pta_cert_chain_len` cannot trigger an
+        // unbounded allocation ahead of the `part_final_ex` validation;
+        // the firmware accepts at most `MAX_CERTS` certificates.
         let chain_len = params.pta_cert_chain_len as usize;
-        let certs: Vec<api::HsmCert<'_>> = if chain_len == 0 {
-            Vec::new()
-        } else {
-            validate_ptr(params.pta_cert_chain)?;
-            // SAFETY: the caller guarantees `pta_cert_chain` points to
-            // `chain_len` valid `azihsm_buffer`s (documented above).
-            let raw = unsafe { std::slice::from_raw_parts(params.pta_cert_chain, chain_len) };
-            let mut certs = Vec::with_capacity(chain_len);
-            for buf in raw {
-                let der: &[u8] = buf.try_into()?;
-                certs.push(api::HsmCert { cert: der });
-            }
-            certs
-        };
+        if chain_len == 0 || chain_len > api::MAX_CERTS {
+            Err(AzihsmStatus::InvalidArgument)?;
+        }
+        validate_ptr(params.pta_cert_chain)?;
+        // SAFETY: the caller guarantees `pta_cert_chain` points to
+        // `chain_len` valid `azihsm_buffer`s (documented above), and
+        // `chain_len` is bounded by `MAX_CERTS` above.
+        let raw = unsafe { std::slice::from_raw_parts(params.pta_cert_chain, chain_len) };
+        let mut certs: Vec<api::HsmCert<'_>> = Vec::with_capacity(chain_len);
+        for buf in raw {
+            let der: &[u8] = buf.try_into()?;
+            certs.push(api::HsmCert { cert: der });
+        }
 
         // Validate the output buffer up-front against the fixed
         // wire-schema bound so the partition is not finalized when the

--- a/api/native/src/session_ex.rs
+++ b/api/native/src/session_ex.rs
@@ -9,14 +9,33 @@
 
 use super::*;
 
+/// PSK credential for opening a security-domain session.
+///
+/// Pairs the PSK slot with an optional caller-supplied PSK. When `psk`
+/// is NULL, the partition **default** PSK for the slot is used — required
+/// for the first session, before the default is rotated via
+/// `azihsm_sess_ex_psk_change`. After rotation, point `psk` at the
+/// rotated secret.
+#[repr(C)]
+pub struct AzihsmSessionPsk {
+    /// PSK slot: 0 = Crypto Officer, 1 = Crypto User.
+    pub psk_id: u8,
+    /// Optional PSK buffer (exactly `PSK_LEN` bytes); NULL selects the
+    /// partition default PSK for the slot.
+    pub psk: *const AzihsmBuffer,
+}
+
 /// @brief Open a security-domain session to the device
 ///
 /// Opens a security-domain session using the API revision negotiated when
 /// the partition was opened, and returns a handle to the resulting
-/// session. `session_type` selects the channel integrity profile pinned
-/// for the session.
+/// session. `psk` selects the role slot and (optionally) the PSK, and
+/// `session_type` selects the channel integrity profile pinned for the
+/// session.
 ///
 /// @param[in] dev_handle Handle to the HSM partition
+/// @param[in] psk PSK credential — slot plus optional PSK
+///            (see `azihsm_session_psk`)
 /// @param[in] session_type Channel integrity profile to pin for the session
 /// @param[out] sess_handle Pointer to the session handle to be allocated
 ///
@@ -25,26 +44,45 @@ use super::*;
 /// # Safety
 ///
 /// - `dev_handle` must be a valid partition handle.
+/// - `psk` must be a valid pointer to an `azihsm_session_psk` whose `psk`
+///   field is NULL or a valid `azihsm_buffer` holding exactly `PSK_LEN`
+///   bytes.
 /// - `sess_handle` must be a valid pointer to memory where the session handle
 ///   will be written.
 #[unsafe(no_mangle)]
 #[allow(unsafe_code)]
 pub unsafe extern "C" fn azihsm_sess_ex_open(
     dev_handle: AzihsmHandle,
+    psk: *const AzihsmSessionPsk,
     session_type: AzihsmSessionExType,
     sess_handle: *mut AzihsmHandle,
 ) -> AzihsmStatus {
     abi_boundary(|| {
         validate_ptr(sess_handle)?;
 
+        let psk = deref_ptr(psk)?;
+        let psk_id = match psk.psk_id {
+            0 => api::HsmPskId::CO,
+            1 => api::HsmPskId::CU,
+            _ => Err(AzihsmStatus::InvalidArgument)?,
+        };
+        // NULL `psk` buffer selects the partition default PSK; otherwise
+        // the caller-supplied PSK must be exactly `PSK_LEN` bytes.
+        let session_psk = match buffer_to_optional_slice(psk.psk)? {
+            Some(bytes) => {
+                let key: &[u8; api::PSK_LEN] = bytes
+                    .try_into()
+                    .map_err(|_| AzihsmStatus::InvalidArgument)?;
+                api::HsmSessionPsk::with_psk(psk_id, key)
+            }
+            None => api::HsmSessionPsk::new(psk_id),
+        };
+
         // Get the partition from the handle
         let partition = &api::HsmPartition::try_from(dev_handle)?;
-        // PSK id selecting the role (0 = CO, 1 = CU). Hardcoded to CO for
-        // now; role selection is not yet exposed on this entry point.
-        let psk_id = 0;
         let session = Box::new(partition.open_session_ex(
             partition.api_rev(),
-            psk_id,
+            session_psk,
             api::HsmSessionExType::from(session_type),
         )?);
 
@@ -195,6 +233,144 @@ pub unsafe extern "C" fn azihsm_sess_ex_part_init(
 
         copy_to_buffer(pta_csr, &result.pta_csr)?;
         copy_to_buffer(pta_report, &result.pta_report)?;
+
+        Ok(())
+    })
+}
+
+/// Input buffers for [`azihsm_sess_ex_part_final`].
+///
+/// Groups the security-domain finalization inputs into a single struct so
+/// the call site does not pass them as separate arguments. `pta_cert_chain`
+/// points to an array of `pta_cert_chain_len` `azihsm_buffer`s, each holding
+/// one DER-encoded PTA certificate (leaf to root). `prev_local_mk_backup` is
+/// optional and may be NULL to omit it.
+#[repr(C)]
+pub struct AzihsmSessExPartFinalParams {
+    /// Unified partition policy image buffer, re-supplied for `POTAPubKey`
+    /// recovery; must match the policy given to `part_init`.
+    pub part_policy: *const AzihsmBuffer,
+    /// Pointer to an array of `pta_cert_chain_len` `azihsm_buffer`s, each a
+    /// DER-encoded PTA certificate (leaf to root).
+    pub pta_cert_chain: *const AzihsmBuffer,
+    /// Number of certificates in `pta_cert_chain`.
+    pub pta_cert_chain_len: u32,
+    /// Optional previous `local_mk` backup envelope to restore; NULL to omit.
+    pub prev_local_mk_backup: *const AzihsmBuffer,
+}
+
+/// @brief Finalize a partition's security domain
+///
+/// Completes provisioning started by `azihsm_sess_ex_part_init`: re-supplies
+/// the unified partition policy and the PTA certificate chain (leaf to root),
+/// optionally restoring a prior `local_mk` backup, and returns the current
+/// `local_mk` backup envelope the firmware produced.
+///
+/// @param[in] sess_handle Handle to the security-domain session
+/// @param[in] params Finalization input buffers
+///            (see `azihsm_sess_ex_part_final_params`)
+/// @param[in,out] local_mk_backup Output buffer for the `local_mk` backup
+///                envelope. On input `len` is the capacity; on success it is
+///                set to the number of bytes written. If the buffer is too
+///                small (or `ptr` is NULL with `len == 0`), `len` is set to
+///                the maximum possible output size and
+///                `AZIHSM_STATUS_BUFFER_TOO_SMALL` is returned **before** the
+///                partition is finalized, so the standard two-call probe
+///                (call once with a zero-length buffer to learn the required
+///                capacity, then retry) is safe for this one-shot command. A
+///                NULL `ptr` with a non-zero `len` is rejected with
+///                `AZIHSM_STATUS_INVALID_ARGUMENT`.
+///
+/// @return `AzihsmStatus` indicating the result of the operation
+///
+/// # Safety
+///
+/// - `sess_handle` must be a valid security-domain session handle.
+/// - `params` must be a valid pointer to an `azihsm_sess_ex_part_final_params`
+///   whose `part_policy` is a valid `azihsm_buffer` pointer, whose
+///   `pta_cert_chain` points to `pta_cert_chain_len` valid `azihsm_buffer`s,
+///   and whose `prev_local_mk_backup` is NULL or a valid `azihsm_buffer`
+///   pointer.
+/// - `local_mk_backup` must be a valid pointer to an `azihsm_buffer` with
+///   writable backing storage of the advertised length.
+#[unsafe(no_mangle)]
+#[allow(unsafe_code)]
+pub unsafe extern "C" fn azihsm_sess_ex_part_final(
+    sess_handle: AzihsmHandle,
+    params: *const AzihsmSessExPartFinalParams,
+    local_mk_backup: *mut AzihsmBuffer,
+) -> AzihsmStatus {
+    abi_boundary(|| {
+        let session = api::HsmSession::try_from(sess_handle)?;
+        let params = deref_ptr(params)?;
+
+        let part_policy: &[u8] = deref_ptr(params.part_policy)?.try_into()?;
+        let prev_local_mk_backup = buffer_to_optional_slice(params.prev_local_mk_backup)?;
+
+        // Build the PTA cert chain (borrowing, not copying) from the C
+        // array of `azihsm_buffer`s.
+        let chain_len = params.pta_cert_chain_len as usize;
+        let certs: Vec<api::HsmCert<'_>> = if chain_len == 0 {
+            Vec::new()
+        } else {
+            validate_ptr(params.pta_cert_chain)?;
+            // SAFETY: the caller guarantees `pta_cert_chain` points to
+            // `chain_len` valid `azihsm_buffer`s (documented above).
+            let raw = unsafe { std::slice::from_raw_parts(params.pta_cert_chain, chain_len) };
+            let mut certs = Vec::with_capacity(chain_len);
+            for buf in raw {
+                let der: &[u8] = buf.try_into()?;
+                certs.push(api::HsmCert { cert: der });
+            }
+            certs
+        };
+
+        // Validate the output buffer up-front against the fixed
+        // wire-schema bound so the partition is not finalized when the
+        // buffer is too small.
+        validate_ptr(local_mk_backup)?;
+        let local_mk_backup = deref_mut_ptr(local_mk_backup)?;
+        validate_output_buffer(local_mk_backup, api::LOCAL_MK_BACKUP_LEN)?;
+
+        let result = session.part_final_ex(part_policy, &certs, prev_local_mk_backup)?;
+
+        copy_to_buffer(local_mk_backup, &result.local_mk_backup)?;
+
+        Ok(())
+    })
+}
+
+/// @brief Rotate the calling session's partition PSK
+///
+/// Replaces the PSK of the slot implied by the session role (CO session
+/// → CO, CU session → CU) with `new_psk`, sealed under the session key.
+/// Required once on a fresh partition to move past the default-PSK gate
+/// before provisioning.
+///
+/// @param[in] sess_handle Handle to the security-domain session
+/// @param[in] new_psk New PSK buffer; must be exactly `PSK_LEN` (32 B)
+///
+/// @return `AzihsmStatus` indicating the result of the operation
+///
+/// # Safety
+///
+/// - `sess_handle` must be a valid security-domain session handle.
+/// - `new_psk` must be a valid pointer to an `azihsm_buffer` whose
+///   backing storage holds exactly `PSK_LEN` bytes.
+#[unsafe(no_mangle)]
+#[allow(unsafe_code)]
+pub unsafe extern "C" fn azihsm_sess_ex_psk_change(
+    sess_handle: AzihsmHandle,
+    new_psk: *const AzihsmBuffer,
+) -> AzihsmStatus {
+    abi_boundary(|| {
+        let session = api::HsmSession::try_from(sess_handle)?;
+        let new_psk: &[u8] = deref_ptr(new_psk)?.try_into()?;
+        let new_psk: &[u8; api::PSK_LEN] = new_psk
+            .try_into()
+            .map_err(|_| AzihsmStatus::InvalidArgument)?;
+
+        session.change_psk(new_psk)?;
 
         Ok(())
     })

--- a/api/tests/cpp/session_ex_tests.cpp
+++ b/api/tests/cpp/session_ex_tests.cpp
@@ -146,6 +146,83 @@ TEST_F(azihsm_sess_ex, open_invalid_partition_handle)
     });
 }
 
+// A NULL `psk` credential pointer is rejected before any device round-trip.
+TEST_F(azihsm_sess_ex, open_null_psk)
+{
+    part_list_.for_each_part([](std::vector<azihsm_char> &path) {
+        azihsm_handle part_handle = open_reset_partition(path);
+        if (part_handle == 0)
+        {
+            return;
+        }
+        auto part_guard =
+            scope_guard::make_scope_exit([&part_handle] { azihsm_part_close(part_handle); });
+
+        azihsm_handle sess_handle = 0;
+        auto err = azihsm_sess_ex_open(
+            part_handle,
+            nullptr,
+            AZIHSM_SESSION_EX_TYPE_AUTHENTICATED,
+            &sess_handle
+        );
+
+        ASSERT_EQ(err, AZIHSM_STATUS_INVALID_ARGUMENT);
+    });
+}
+
+// An unknown `psk_id` (neither CO = 0 nor CU = 1) is rejected.
+TEST_F(azihsm_sess_ex, open_invalid_psk_id)
+{
+    part_list_.for_each_part([](std::vector<azihsm_char> &path) {
+        azihsm_handle part_handle = open_reset_partition(path);
+        if (part_handle == 0)
+        {
+            return;
+        }
+        auto part_guard =
+            scope_guard::make_scope_exit([&part_handle] { azihsm_part_close(part_handle); });
+
+        azihsm_handle sess_handle = 0;
+        azihsm_session_psk psk{ 2, nullptr }; // 2 is neither CO nor CU
+        auto err = azihsm_sess_ex_open(
+            part_handle,
+            &psk,
+            AZIHSM_SESSION_EX_TYPE_AUTHENTICATED,
+            &sess_handle
+        );
+
+        ASSERT_EQ(err, AZIHSM_STATUS_INVALID_ARGUMENT);
+    });
+}
+
+// A caller-supplied PSK buffer of the wrong length (not `PSK_LEN`) is rejected.
+TEST_F(azihsm_sess_ex, open_wrong_length_psk)
+{
+    part_list_.for_each_part([](std::vector<azihsm_char> &path) {
+        azihsm_handle part_handle = open_reset_partition(path);
+        if (part_handle == 0)
+        {
+            return;
+        }
+        auto part_guard =
+            scope_guard::make_scope_exit([&part_handle] { azihsm_part_close(part_handle); });
+
+        azihsm_handle sess_handle = 0;
+        // 16 bytes: a valid buffer but the wrong length (PSK is 32 bytes).
+        std::vector<uint8_t> short_psk(16, 0);
+        azihsm_buffer psk_buf{ short_psk.data(), static_cast<uint32_t>(short_psk.size()) };
+        azihsm_session_psk psk{ 0, &psk_buf };
+        auto err = azihsm_sess_ex_open(
+            part_handle,
+            &psk,
+            AZIHSM_SESSION_EX_TYPE_AUTHENTICATED,
+            &sess_handle
+        );
+
+        ASSERT_EQ(err, AZIHSM_STATUS_INVALID_ARGUMENT);
+    });
+}
+
 // The `azihsm_sess_ex_part_init` tests below need a live security-domain
 // session, which requires the two-phase TBOR HPKE handshake implemented only by
 // the emu (in-process firmware) backend. They exercise the ABI-boundary

--- a/api/tests/cpp/session_ex_tests.cpp
+++ b/api/tests/cpp/session_ex_tests.cpp
@@ -57,8 +57,13 @@ class azihsm_sess_ex : public ::testing::Test
     static azihsm_handle open_sd_session(azihsm_handle part_handle)
     {
         azihsm_handle sess_handle = 0;
-        auto err =
-            azihsm_sess_ex_open(part_handle, AZIHSM_SESSION_EX_TYPE_AUTHENTICATED, &sess_handle);
+        azihsm_session_psk psk{ 0, nullptr };
+        auto err = azihsm_sess_ex_open(
+            part_handle,
+            &psk,
+            AZIHSM_SESSION_EX_TYPE_AUTHENTICATED,
+            &sess_handle
+        );
         if (err != AZIHSM_STATUS_SUCCESS || sess_handle == 0)
         {
             ADD_FAILURE() << "azihsm_sess_ex_open failed: " << err;
@@ -85,8 +90,13 @@ TEST_F(azihsm_sess_ex, open_and_close)
             scope_guard::make_scope_exit([&part_handle] { azihsm_part_close(part_handle); });
 
         azihsm_handle sess_handle = 0;
-        auto err =
-            azihsm_sess_ex_open(part_handle, AZIHSM_SESSION_EX_TYPE_AUTHENTICATED, &sess_handle);
+        azihsm_session_psk psk{ 0, nullptr };
+        auto err = azihsm_sess_ex_open(
+            part_handle,
+            &psk,
+            AZIHSM_SESSION_EX_TYPE_AUTHENTICATED,
+            &sess_handle
+        );
 
         ASSERT_EQ(err, AZIHSM_STATUS_SUCCESS);
         ASSERT_NE(sess_handle, 0);
@@ -109,7 +119,9 @@ TEST_F(azihsm_sess_ex, open_null_sess_handle)
         auto part_guard =
             scope_guard::make_scope_exit([&part_handle] { azihsm_part_close(part_handle); });
 
-        auto err = azihsm_sess_ex_open(part_handle, AZIHSM_SESSION_EX_TYPE_AUTHENTICATED, nullptr);
+        azihsm_session_psk psk{ 0, nullptr };
+        auto err =
+            azihsm_sess_ex_open(part_handle, &psk, AZIHSM_SESSION_EX_TYPE_AUTHENTICATED, nullptr);
 
         ASSERT_EQ(err, AZIHSM_STATUS_INVALID_ARGUMENT);
     });
@@ -122,8 +134,13 @@ TEST_F(azihsm_sess_ex, open_invalid_partition_handle)
 
         azihsm_handle sess_handle = 0;
 
-        auto err =
-            azihsm_sess_ex_open(bad_handle, AZIHSM_SESSION_EX_TYPE_AUTHENTICATED, &sess_handle);
+        azihsm_session_psk psk{ 0, nullptr };
+        auto err = azihsm_sess_ex_open(
+            bad_handle,
+            &psk,
+            AZIHSM_SESSION_EX_TYPE_AUTHENTICATED,
+            &sess_handle
+        );
 
         ASSERT_EQ(err, AZIHSM_STATUS_INVALID_HANDLE);
     });

--- a/api/tests/src/emu_helpers.rs
+++ b/api/tests/src/emu_helpers.rs
@@ -12,11 +12,6 @@
 use azihsm_api::*;
 use parking_lot::Mutex;
 
-/// PSK id selecting the Crypto Officer role.
-pub(crate) const CO: u8 = 0;
-/// PSK id selecting the Crypto User role.
-pub(crate) const CU: u8 = 1;
-
 /// Serialises tests against the process-global FW emulator singleton.
 /// `cargo-nextest` runs each test in its own process, but this keeps a
 /// plain `cargo test` (single process, multi-threaded) correct too.
@@ -45,6 +40,10 @@ pub(crate) fn fresh_emu_partition() -> (HsmPartition, HsmApiRev) {
 /// `part_final_ex`).
 pub(crate) fn fresh_co_session() -> HsmSession {
     let (part, rev) = fresh_emu_partition();
-    part.open_session_ex(rev, CO, HsmSessionExType::Authenticated)
-        .expect("open CO session")
+    part.open_session_ex(
+        rev,
+        HsmSessionPsk::new(HsmPskId::CO),
+        HsmSessionExType::Authenticated,
+    )
+    .expect("open CO session")
 }

--- a/api/tests/src/session_ex_tests.rs
+++ b/api/tests/src/session_ex_tests.rs
@@ -21,7 +21,11 @@ fn open_session_ex_co_authenticated() {
     let (part, rev) = fresh_emu_partition();
 
     let session = part
-        .open_session_ex(rev, CO, HsmSessionExType::Authenticated)
+        .open_session_ex(
+            rev,
+            HsmSessionPsk::new(HsmPskId::CO),
+            HsmSessionExType::Authenticated,
+        )
         .expect("CO/Authenticated open_session_ex should succeed against emu");
 
     // The V2 session must carry the negotiated api revision through.
@@ -40,7 +44,11 @@ fn open_session_ex_cu_plaintext() {
     let (part, rev) = fresh_emu_partition();
 
     let session = part
-        .open_session_ex(rev, CU, HsmSessionExType::PlainText)
+        .open_session_ex(
+            rev,
+            HsmSessionPsk::new(HsmPskId::CU),
+            HsmSessionExType::PlainText,
+        )
         .expect("CU/PlainText open_session_ex should succeed against emu");
 
     let sess_rev = session.api_rev();
@@ -51,14 +59,47 @@ fn open_session_ex_cu_plaintext() {
     );
 }
 
-/// Negative path: an unknown `psk_id` (neither CO nor CU) is rejected by
-/// the FW during Phase 1.
+/// PSK-rotation round trip: after rotating the CO PSK from the default,
+/// the partition accepts the new secret and rejects the default — the
+/// full `change_psk` + optional-PSK-`open_session_ex` flow end to end.
 #[test]
-fn open_session_ex_rejects_unknown_psk_id() {
+fn change_psk_rotates_co_psk() {
     let _guard = EMU_LOCK.lock();
     let (part, rev) = fresh_emu_partition();
 
-    let result = part.open_session_ex(rev, 2, HsmSessionExType::Authenticated);
+    // A non-default replacement CO PSK.
+    let new_psk = [0x5Au8; PSK_LEN];
 
-    assert!(result.is_err(), "unknown psk_id must not yield a session");
+    // Open with the default CO PSK, rotate it, then close the session.
+    {
+        let session = part
+            .open_session_ex(
+                rev,
+                HsmSessionPsk::new(HsmPskId::CO),
+                HsmSessionExType::Authenticated,
+            )
+            .expect("open with the default CO PSK");
+        session
+            .change_psk(&new_psk)
+            .expect("rotate the CO PSK to the new secret");
+    }
+
+    // Reopening with the rotated secret must now succeed.
+    part.open_session_ex(
+        rev,
+        HsmSessionPsk::with_psk(HsmPskId::CO, &new_psk),
+        HsmSessionExType::Authenticated,
+    )
+    .expect("open with the rotated CO PSK should succeed");
+
+    // Reopening with the (now stale) default CO PSK must be rejected.
+    let stale = part.open_session_ex(
+        rev,
+        HsmSessionPsk::new(HsmPskId::CO),
+        HsmSessionExType::Authenticated,
+    );
+    assert!(
+        stale.is_err(),
+        "the default CO PSK must be rejected after rotation",
+    );
 }


### PR DESCRIPTION
This pull request introduces support for caller-supplied PSKs (Pre-Shared Keys) for security-domain session establishment, enables PSK rotation, and updates the API surface and documentation accordingly. The most important changes are the addition of a new PSK credential struct, the ability to rotate PSKs, and the refactoring of session APIs to support these features.

**API and Struct Changes:**

* Added the `HsmSessionPsk` struct and `HsmPskId` enum to represent a PSK slot and an optional caller-supplied PSK, allowing sessions to be opened either with the partition default PSK or a provided PSK (`api/lib/src/shared_types.rs`, `api/native/src/session_ex.rs`). [[1]](diffhunk://#diff-85a29a7bdf800dd335c8a2fa339d4244b61fd802b282ceb10834b86454698f95R191-R239) [[2]](diffhunk://#diff-232c2f139edf33114268a3c3d42395b58de503817fab05f4d50a5caa4c049490R12-R38)
* Refactored the session open APIs (`open_session_ex` and related functions) to accept the new `HsmSessionPsk` struct, propagating this change through the Rust and C FFI layers (`api/lib/src/partition.rs`, `api/lib/src/ddi/session_ex.rs`, `api/native/src/session_ex.rs`). [[1]](diffhunk://#diff-d2f3978011de3fd9c7f4ef179ad254ab7905ac147cc889b800ac2969c972e5dbL577-R587) [[2]](diffhunk://#diff-ede908b3c99c406aa50881552e4b183e7d64876453102d511176262302fd3b58R205-R212) [[3]](diffhunk://#diff-232c2f139edf33114268a3c3d42395b58de503817fab05f4d50a5caa4c049490R47-R85) [[4]](diffhunk://#diff-565b71c0317062acfa948978344423a48027bff4b1521697226e22fe5560716aR52-R54) [[5]](diffhunk://#diff-565b71c0317062acfa948978344423a48027bff4b1521697226e22fe5560716aR105-R110)

**PSK Rotation Support:**

* Added the `psk_change` function and a corresponding `change_psk` method on `HsmSession`, allowing the partition PSK to be rotated securely during an active session (`api/lib/src/ddi/session_ex.rs`, `api/lib/src/session.rs`). [[1]](diffhunk://#diff-ede908b3c99c406aa50881552e4b183e7d64876453102d511176262302fd3b58R374-R439) [[2]](diffhunk://#diff-e581060cd3ba888831dfe31d9189175deeee6536648d05ba1f61f75be4ae0170R138-R155)

**Wire Schema and Constant Synchronization:**

* Ensured that PSK length constants are defined in a single place and statically asserted to match the wire schema, preventing drift between API and wire types (`api/lib/src/ddi/mod.rs`, `api/lib/src/shared_types.rs`). [[1]](diffhunk://#diff-aa73978ea399a03e712ad1dac59b39fd7b83569a4ae011196a323d3852f38e73L101-R111) [[2]](diffhunk://#diff-85a29a7bdf800dd335c8a2fa339d4244b61fd802b282ceb10834b86454698f95R191-R239)

**Documentation and Bindings:**

* Updated the C API documentation and FFI bindings to reflect the new `AzihsmSessionPsk` struct and the updated session opening semantics, including parameter tables and usage notes (`api/native/doc/chapter_09_sd.md`, `api/native/src/session_ex.rs`, `api/native/cbindgen.toml`). [[1]](diffhunk://#diff-114b039b60c9d947a36f8557f713014a18950dd39a5ec4c92a116a1d6d17eaccL13-R23) [[2]](diffhunk://#diff-114b039b60c9d947a36f8557f713014a18950dd39a5ec4c92a116a1d6d17eaccR34) [[3]](diffhunk://#diff-565b71c0317062acfa948978344423a48027bff4b1521697226e22fe5560716aR52-R54) [[4]](diffhunk://#diff-565b71c0317062acfa948978344423a48027bff4b1521697226e22fe5560716aR105-R110) [[5]](diffhunk://#diff-232c2f139edf33114268a3c3d42395b58de503817fab05f4d50a5caa4c049490R12-R38)

**Testing and Internal Refactoring:**

* Updated tests and internal function signatures to use the new PSK credential struct and semantics, ensuring that both default and caller-supplied PSKs are handled correctly (`api/lib/src/ddi/session_ex.rs`). [[1]](diffhunk://#diff-ede908b3c99c406aa50881552e4b183e7d64876453102d511176262302fd3b58L447-R520) [[2]](diffhunk://#diff-ede908b3c99c406aa50881552e4b183e7d64876453102d511176262302fd3b58L499-R572)

These changes collectively enable robust, flexible PSK management for security-domain sessions, supporting both initial provisioning (with default PSKs) and secure PSK rotation.