### PR TITLE
feat(fw): re-mask the re-imported key into the UnmaskKey response

### DIFF
--- a/ddi/mbor/types/tests/integration/unmask_key_smoke.rs
+++ b/ddi/mbor/types/tests/integration/unmask_key_smoke.rs
@@ -4,17 +4,25 @@
 //! `UnmaskKey` round-trip smoke tests.
 //!
 //! Run on every backend, including the firmware emulator, so CI's emu
-//! smoke run exercises the full mask → unmask path end to end for two
+//! smoke run exercises the full mask → unmask path end to end for three
 //! representative shapes:
 //!
 //! * a **symmetric, partition-scoped** AES key — generate, encrypt,
-//!   re-import via `UnmaskKey`, decrypt with the re-imported key, and
-//!   confirm the original plaintext is recovered;
+//!   re-import via `UnmaskKey`, then re-import *again* from the fresh
+//!   envelope `UnmaskKey` itself returns, and confirm decrypting with the
+//!   twice-round-tripped key recovers the original plaintext;
 //! * an **asymmetric, session-scoped** ECC key — generate a session-only
-//!   P-256 pair, re-import via `UnmaskKey`, and confirm the re-imported
-//!   public key matches the original and verifies a signature made with
-//!   the re-imported private key (exercising the public-key re-derivation
-//!   path and the session-scoped masking-key selection).
+//!   P-256 pair, re-import via `UnmaskKey` and again from the envelope it
+//!   returns, and confirm the re-imported public key matches the original
+//!   and verifies a signature made with the re-imported private key
+//!   (exercising the public-key re-derivation path, the session-scoped
+//!   masking-key selection, and the re-mask of the returned envelope);
+//! * a **large asymmetric, partition-scoped** RSA-4096 CRT key — import via
+//!   `RsaUnwrap`, then 10× delete and re-import it from the fresh envelope
+//!   each `UnmaskKey` returns, confirming a raw `RsaModExp` output and the
+//!   re-derived public key stay bit-identical every round and the metadata
+//!   is preserved (exercising the DMA-tight in-place re-mask of the largest
+//!   key type).
 //!
 //! Per-handler masked-key *return* coverage (envelope populated, IV
 //! randomized) lives in each key handler's own smoke test:
@@ -76,20 +84,31 @@ fn test_unmask_aes_app_key_roundtrip_smoke() {
                 "ciphertext must differ"
             );
 
-            // Delete the original key and re-import it from its masked
-            // envelope; the helper asserts the UnmaskKey call succeeds.
-            let (new_key_id, _, _) = helper_get_new_key_id_from_unmask(
-                dev,
-                Some(session_id),
-                rev,
-                key_id,
-                false,
-                masked_key,
-            )
-            .expect("unmask round-trip should succeed");
+            // Re-import twice: first from the generate envelope, then from
+            // the *re-masked* envelope UnmaskKey itself returns, deleting the
+            // prior key each time.  Decrypting with the twice-round-tripped
+            // key proves the returned envelope carries the exact key material.
+            assert!(
+                helper_delete_key(dev, Some(session_id), rev, key_id).is_ok(),
+                "delete original key",
+            );
+            let resp = helper_unmask_key(dev, Some(session_id), rev, masked_key)
+                .expect("unmask (generate envelope) should succeed");
+            assert_eq!(resp.data.kind, DdiKeyType::Aes256);
+            let key_id_2 = resp.data.key_id;
+            let masked_key_2 = resp.data.masked_key;
 
-            // Decrypt with the re-imported key: recovering the original
-            // plaintext proves the exact key material round-tripped.
+            assert!(
+                helper_delete_key(dev, Some(session_id), rev, key_id_2).is_ok(),
+                "delete first re-imported key",
+            );
+            let resp = helper_unmask_key(dev, Some(session_id), rev, masked_key_2)
+                .expect("unmask (re-masked envelope) should succeed");
+            assert_eq!(resp.data.kind, DdiKeyType::Aes256);
+            let new_key_id = resp.data.key_id;
+
+            // Decrypt with the twice-round-tripped key: recovering the
+            // original plaintext proves the exact key material round-tripped.
             let decrypted = helper_aes_encrypt_decrypt(
                 dev,
                 Some(session_id),
@@ -139,19 +158,41 @@ fn test_unmask_ecc_session_key_roundtrip_smoke() {
             let pub_key = resp.data.pub_key;
             let masked_key = resp.data.masked_key;
 
-            // Delete the original key and re-import it via UnmaskKey; the
-            // re-imported public key must match the original, proving the
-            // private key round-tripped and its public key re-derived.
-            let (new_key_id, _, new_pub_key) = helper_get_new_key_id_from_unmask(
-                dev,
-                Some(session_id),
-                rev,
-                private_key_id,
-                false,
-                masked_key,
-            )
-            .expect("unmask round-trip should succeed");
-            let new_pub_key = new_pub_key.expect("asymmetric unmask must return a public key");
+            // Re-import twice: first from the generate envelope, then from
+            // the *re-masked* envelope UnmaskKey returns, deleting the prior
+            // (session-scoped) key each time.  The re-imported public key must
+            // match the original throughout, proving the private key
+            // round-trips through the session-scoped re-mask and its public
+            // key re-derives.
+            assert!(
+                helper_delete_key(dev, Some(session_id), rev, private_key_id).is_ok(),
+                "delete original key",
+            );
+            let resp = helper_unmask_key(dev, Some(session_id), rev, masked_key)
+                .expect("unmask (generate envelope) should succeed");
+            let key_id_2 = resp.data.key_id;
+            let masked_key_2 = resp.data.masked_key;
+            let pub_2 = resp
+                .data
+                .pub_key
+                .expect("asymmetric unmask must return a public key");
+            assert_eq!(
+                pub_2.der.as_slice(),
+                pub_key.der.as_slice(),
+                "re-imported pub_key must match the original",
+            );
+
+            assert!(
+                helper_delete_key(dev, Some(session_id), rev, key_id_2).is_ok(),
+                "delete first re-imported key",
+            );
+            let resp = helper_unmask_key(dev, Some(session_id), rev, masked_key_2)
+                .expect("unmask (re-masked envelope) should succeed");
+            let new_key_id = resp.data.key_id;
+            let new_pub_key = resp
+                .data
+                .pub_key
+                .expect("asymmetric unmask must return a public key");
             assert_eq!(
                 new_pub_key.key_kind, pub_key.key_kind,
                 "re-imported pub_key kind must match",
@@ -159,7 +200,7 @@ fn test_unmask_ecc_session_key_roundtrip_smoke() {
             assert_eq!(
                 new_pub_key.der.as_slice(),
                 pub_key.der.as_slice(),
-                "re-imported pub_key must match the original",
+                "re-imported pub_key must match the original after re-mask",
             );
 
             // Functionally verify: sign a digest with the re-imported key
@@ -185,6 +226,196 @@ fn test_unmask_ecc_session_key_roundtrip_smoke() {
                 ),
                 "signature from the re-imported key must verify",
             );
+        },
+    );
+}
+
+/// Round-trip for the **largest asymmetric, partition-scoped** key across
+/// *repeated* re-masks: import an RSA-4096 CRT private key via `RsaUnwrap`,
+/// then 10× delete it and re-import it via `UnmaskKey`, each round feeding
+/// back the fresh envelope the previous `UnmaskKey` returned.  Because the
+/// same fixed input is fed to every raw `RsaModExp`, the exponentiation
+/// output — and the re-derived public key — must be bit-identical on every
+/// round iff the private key survives unchanged, and the masked-key metadata
+/// (type, attributes, label, length) must be preserved through every mask /
+/// re-mask cycle.  Guards the DMA-tight in-place re-mask of the largest key.
+#[test]
+fn test_unmask_rsa_4k_crt_reunmask_roundtrip_smoke() {
+    ddi_dev_test(
+        common_setup,
+        common_cleanup,
+        |dev, _ddi, _path, session_id| {
+            let rev = Some(DdiApiRev { major: 1, minor: 0 });
+            // Non-empty label to prove label preservation across re-masks.
+            let label_bytes: &[u8] = b"rsa4k-crt-role";
+
+            // --- Import an RSA-4096 CRT private key via RsaUnwrap. ---
+            let (unwrap_key_id, unwrap_pub_key_der, _) = get_unwrapping_key(dev, session_id);
+            let wrapped = wrap_data(unwrap_pub_key_der, TEST_RSA_4K_PRIVATE_KEY.as_slice());
+            let mut der = [0u8; 3072];
+            der[..wrapped.len()].copy_from_slice(&wrapped);
+            let der_len = wrapped.len();
+
+            let resp = helper_rsa_unwrap(
+                dev,
+                Some(session_id),
+                rev,
+                unwrap_key_id,
+                MborByteArray::new(der, der_len).expect("failed to create byte array"),
+                DdiKeyClass::RsaCrt,
+                DdiRsaCryptoPadding::Oaep,
+                DdiHashAlgorithm::Sha256,
+                None,
+                helper_key_properties_with_label(
+                    DdiKeyUsage::EncryptDecrypt,
+                    DdiKeyAvailability::App,
+                    MborByteArray::from_slice(label_bytes).expect("failed to create label"),
+                ),
+            )
+            .expect("rsa_unwrap");
+            assert_eq!(resp.data.kind, DdiKeyType::Rsa4kPrivateCrt);
+            // Baseline captured from the unwrap: key id, envelope, public key,
+            // metadata, and the raw mod-exp output.  Every subsequent unmask of
+            // the (re-masked) envelope must reproduce these exactly.
+            let mut current_key = resp.data.key_id;
+            let mut current_env = resp.data.masked_key;
+            let base_pub = resp.data.pub_key.expect("unwrap must return a public key");
+            let base_pub_kind = base_pub.key_kind;
+            let base_pub_der = base_pub.der.as_slice().to_vec();
+            let base_meta =
+                extract_metadata_from_masked_key(current_env.as_slice()).expect("M1 metadata");
+            let base_key_type = base_meta.key_type;
+            let base_attrs = base_meta.key_attributes.clone();
+            let base_label = base_meta.key_label.as_slice().to_vec();
+            let base_key_len = base_meta.key_length;
+
+            // Fixed mod-exp input reused for every key so the raw private-key
+            // exponentiation output must match iff the key material is preserved.
+            let orig_x = [0x1u8; 512];
+            let data_len = 190;
+            let y_vec = rsa_encrypt_local_openssl(
+                &TEST_RSA_4K_PUBLIC_KEY,
+                &orig_x,
+                data_len,
+                DdiRsaCryptoPadding::Oaep,
+                Some(DdiHashAlgorithm::Sha256),
+            );
+            let mut y = [0u8; 512];
+            y[..y_vec.len()].copy_from_slice(y_vec.as_slice());
+            let y_arr = MborByteArray::new(y, y_vec.len()).expect("failed to create byte array");
+
+            let mod_exp_raw = |key_id: u16| -> MborByteArray<512> {
+                helper_rsa_mod_exp(
+                    dev,
+                    Some(session_id),
+                    rev,
+                    key_id,
+                    y_arr,
+                    DdiRsaOpType::Decrypt,
+                )
+                .expect("rsa mod-exp")
+                .data
+                .x
+            };
+            let base_x = mod_exp_raw(current_key);
+
+            // Sanity: the raw output OAEP-decodes back to the original data.
+            let mut padded = [0u8; 512];
+            let x_len = base_x.len();
+            padded[..x_len].copy_from_slice(&base_x.data()[..x_len]);
+            let decoded = RsaEncoding::decode_oaep(
+                &mut padded[..x_len],
+                None,
+                4096 / 8,
+                RsaDigestKind::Sha256,
+                crypto_sha256,
+            )
+            .expect("oaep decode");
+            assert_eq!(orig_x[..data_len], decoded[..]);
+
+            // The firmware embeds the caller's label into the envelope; the sim
+            // (mock) backend does not model labels, so assert the exact value on
+            // every backend except the sim.
+            #[cfg(not(feature = "mock"))]
+            assert_eq!(
+                base_meta.key_label.as_slice(),
+                label_bytes,
+                "label not carried into the unwrap envelope"
+            );
+
+            // Re-import the key from its own envelope 10 times, each round
+            // feeding back the fresh envelope the previous UnmaskKey returned.
+            // The firmware re-masks on every call (fresh IV) so the envelope
+            // differs byte-wise each round, yet the recovered key never changes
+            // — proven by identical raw mod-exp and public key — and the
+            // metadata (type, attributes, label, length) is preserved.
+            for round in 0..10 {
+                assert!(
+                    helper_delete_key(dev, Some(session_id), rev, current_key).is_ok(),
+                    "delete key (round {round})"
+                );
+                let resp = helper_unmask_key(dev, Some(session_id), rev, current_env);
+                assert!(resp.is_ok(), "unmask (round {round}): {resp:?}");
+                let resp = resp.unwrap();
+                assert_eq!(
+                    resp.data.kind,
+                    DdiKeyType::Rsa4kPrivateCrt,
+                    "kind changed (round {round})"
+                );
+                let new_key = resp.data.key_id;
+                let new_env = resp.data.masked_key;
+                let new_pub = resp.data.pub_key.expect("unmask must return a public key");
+                let new_meta =
+                    extract_metadata_from_masked_key(new_env.as_slice()).expect("metadata");
+
+                // Key material preserved: raw mod-exp + public key are identical.
+                assert_eq!(
+                    mod_exp_raw(new_key).as_slice(),
+                    base_x.as_slice(),
+                    "mod-exp changed (round {round})"
+                );
+                assert_eq!(
+                    new_pub.key_kind, base_pub_kind,
+                    "pub key kind changed (round {round})"
+                );
+                assert_eq!(
+                    new_pub.der.as_slice(),
+                    base_pub_der.as_slice(),
+                    "pub key changed (round {round})"
+                );
+
+                // Key properties + label preserved through the mask / re-mask.
+                assert_eq!(
+                    new_meta.key_type, base_key_type,
+                    "key_type changed (round {round})"
+                );
+                assert_eq!(
+                    new_meta.key_attributes, base_attrs,
+                    "attributes changed (round {round})"
+                );
+                assert_eq!(
+                    new_meta.key_label.as_slice(),
+                    base_label.as_slice(),
+                    "label changed (round {round})"
+                );
+                assert_eq!(
+                    new_meta.key_length, base_key_len,
+                    "key_length changed (round {round})"
+                );
+
+                // The firmware re-masks (fresh IV) rather than echoing, so each
+                // envelope differs byte-wise from the one it unmasked; the sim
+                // (mock) echoes the input, so this holds on every backend but it.
+                #[cfg(not(feature = "mock"))]
+                assert_ne!(
+                    new_env.as_slice(),
+                    current_env.as_slice(),
+                    "envelope must be a fresh re-mask (round {round})"
+                );
+
+                current_key = new_key;
+                current_env = new_env;
+            }
         },
     );
 }

--- a/fw/core/lib/src/ddi/mbor/unmask_key.rs
+++ b/fw/core/lib/src/ddi/mbor/unmask_key.rs
@@ -14,7 +14,17 @@
 //! is safe: a tampered scope selects the wrong key, and because [`unmask`]
 //! verifies the HMAC before decrypting, the mismatch is rejected without
 //! touching the ciphertext.
+//!
+//! The response carries a **fresh** masked-key envelope of the re-imported
+//! key — the key re-masked under the current scope's masking key, recording
+//! the current SVN, but preserving the original key type, attributes, and
+//! label.  The input blob is not echoed back: its masking key / SVN may
+//! have rolled since it was produced, so the host persists this fresh
+//! envelope to keep the key re-importable.  Like the other key-producing
+//! handlers, the envelope is written in place into the reserved response
+//! slot to stay within the per-IO DMA budget.
 
+use azihsm_fw_core_crypto_key_masking::cbc::mask;
 use azihsm_fw_core_crypto_key_masking::cbc::peek_metadata;
 use azihsm_fw_core_crypto_key_masking::cbc::unmask;
 use azihsm_fw_ddi_mbor::MborDecode;
@@ -45,7 +55,7 @@ pub(crate) async fn unmask_key<'p, P: HsmPal>(
     // to try, which is self-correcting (a tampered scope picks the wrong
     // key and the HMAC check rejects it).  Derived as owned values so the
     // blob borrow is released before `unmask` takes it mutably.
-    let (key_type, kind, attrs, key_len) = {
+    let (key_type, kind, attrs, key_len, key_label) = {
         let meta = peek_metadata(body.masked_key)?;
         let meta_buf = pal.dma_alloc(io, meta.len())?;
         meta_buf.copy_from_slice(meta);
@@ -61,38 +71,62 @@ pub(crate) async fn unmask_key<'p, P: HsmPal>(
 
         let kind = super::from_ddi::vault_kind_from_ddi(metadata.key_type)?;
         let attrs: HsmVaultKeyAttrs = metadata.key_attributes.into();
-        (metadata.key_type, kind, attrs, metadata.key_length as usize)
+
+        // Copy the caller's key label out of the metadata scratch (the
+        // scratch outlives this block but the borrow does not) so the
+        // re-mask below can preserve it verbatim in the fresh envelope.
+        let key_label = pal.dma_alloc(io, metadata.key_label.len())?;
+        key_label.copy_from_slice(metadata.key_label);
+
+        (
+            metadata.key_type,
+            kind,
+            attrs,
+            metadata.key_length as usize,
+            key_label,
+        )
     };
 
-    // Authenticate-then-decrypt in place under the scope's masking key: the
-    // per-session masking key for session-scoped keys, the partition
-    // masking key (MK) otherwise.  A wrong key (tampered scope) or a
-    // tampered blob fails the HMAC here without leaking plaintext.
-    let layout = if attrs.session() {
-        let session_mk = pal.session_masking_key(io, HsmSessId::from(sess_id))?;
-        unmask(pal, io, session_mk, body.masked_key).await?
-    } else {
-        let mk_id = crate::part_state::part_mk_key_id(pal, io)?;
-        let part_mk = pal.vault_key(io, mk_id)?;
-        unmask(pal, io, part_mk, body.masked_key).await?
-    };
+    // Authenticate-then-decrypt in place, copy out the primary key
+    // material, and import it into the vault — all inside an allocation
+    // scope so the (multi-KB for RSA) import scratch is freed before the
+    // response frame is built.  Only the owned vault key id escapes; the
+    // committed key is read back from vault storage below.  The masking key
+    // is the per-session masking key for session-scoped keys, the partition
+    // masking key (MK) otherwise; a wrong key (tampered scope) or tampered
+    // blob fails the HMAC in `unmask` without leaking plaintext.
+    let key_id = pal
+        .alloc_scoped_async(io, async |_scope| -> HsmResult<HsmKeyId> {
+            let layout = if attrs.session() {
+                let session_mk = pal.session_masking_key(io, HsmSessId::from(sess_id))?;
+                unmask(pal, io, session_mk, body.masked_key).await?
+            } else {
+                let mk_id = crate::part_state::part_mk_key_id(pal, io)?;
+                let part_mk = pal.vault_key(io, mk_id)?;
+                unmask(pal, io, part_mk, body.masked_key).await?
+            };
 
-    // Copy the primary key material (plaintext prefix) into a fresh
-    // vault-import scratch buffer.  For ECC the trailing public point is
-    // ignored here; the private scalar alone re-derives it on import.
-    let key_buf = pal.dma_alloc(io, key_len)?;
-    key_buf.copy_from_slice(
-        &body.masked_key[layout.plaintext_offset..layout.plaintext_offset + key_len],
-    );
+            // Copy the primary key material (plaintext prefix) into a fresh
+            // vault-import scratch buffer.  For ECC the trailing public
+            // point is ignored here; the private scalar re-derives it.
+            let key_buf = pal.dma_alloc(io, key_len)?;
+            key_buf.copy_from_slice(
+                &body.masked_key[layout.plaintext_offset..layout.plaintext_offset + key_len],
+            );
 
-    let session_binding = attrs.session().then_some(HsmSessId::from(sess_id));
-    let key_id: u16 = pal
-        .vault_key_create(io, key_buf, kind, session_binding, attrs)
-        .await?
-        .into();
+            let session_binding = attrs.session().then_some(HsmSessId::from(sess_id));
+            pal.vault_key_create(io, key_buf, kind, session_binding, attrs)
+                .await
+        })
+        .await?;
+
+    // The import scratch is freed.  Read the committed key back (from vault
+    // storage, not the per-IO arena) to drive both the public-key
+    // re-derivation and the fresh masked envelope.
+    let priv_blob = pal.vault_key(io, key_id)?;
 
     // Asymmetric kinds return their public key, re-derived from the
-    // imported private key so the host recovers the full keypair (this
+    // committed private key so the host recovers the full keypair (this
     // also avoids trusting any untrusted trailing bytes in the blob).
     let pub_spec = match kind {
         HsmVaultKeyKind::Ecc256Private => Some((false, DdiKeyType::Ecc256Public)),
@@ -109,35 +143,74 @@ pub(crate) async fn unmask_key<'p, P: HsmPal>(
         }
         _ => None,
     };
-    let pub_out = if let Some((is_rsa, pub_kind)) = pub_spec {
+    let pub_key = if let Some((is_rsa, pub_kind)) = pub_spec {
         let pub_len = if is_rsa {
-            pal.rsa_priv_pub_key(io, key_buf, None)?
+            pal.rsa_priv_pub_key(io, priv_blob, None)?
         } else {
-            pal.ecc_priv_pub_key(io, key_buf, None).await?
+            pal.ecc_priv_pub_key(io, priv_blob, None).await?
         };
         let pub_buf = pal.dma_alloc(io, pub_len)?;
         if is_rsa {
-            pal.rsa_priv_pub_key(io, key_buf, Some(pub_buf))?;
+            pal.rsa_priv_pub_key(io, priv_blob, Some(pub_buf))?;
         } else {
-            pal.ecc_priv_pub_key(io, key_buf, Some(pub_buf)).await?;
+            pal.ecc_priv_pub_key(io, priv_blob, Some(pub_buf)).await?;
         }
-        Some((pub_buf, pub_kind))
+        Some(DdiPublicKey {
+            raw: pub_buf,
+            key_kind: pub_kind,
+        })
     } else {
         None
     };
 
-    let resp = pal.dma_alloc_var(io, |buf| {
-        super::encode_resp(
+    // Re-mask the re-imported key under the *current* scope's masking key,
+    // preserving the original key type, attributes, and label but recording
+    // the current SVN via [`masked_metadata`](super::masking::masked_metadata).
+    // The original blob is deliberately NOT echoed: the masking key / SVN may
+    // have rolled since it was produced, so the host must persist this fresh
+    // envelope to stay re-importable.  The envelope is written straight into
+    // the reserved `masked_key` response region — no scratch buffer, no copy —
+    // keeping the largest RSA-4096 keys within the per-IO DMA budget.
+    let masking_key =
+        super::masking::resolve_masking_key(pal, io, HsmSessId::from(sess_id), attrs.session())?;
+    let metadata = super::masking::masked_metadata(
+        pal,
+        key_type,
+        attrs,
+        &key_label[..],
+        priv_blob.len() as u16,
+    )?;
+    let masked_len = mask(pal, io, masking_key, priv_blob, &metadata, None).await?;
+
+    let (resp, layout) = pal.dma_alloc_var_with(io, |buf| {
+        let mut encoder = super::encode_resp_hdr(
             &super::success_hdr_sess(hdr, DdiOp::UnmaskKey, sess_id),
-            &DdiUnmaskKeyResp {
-                key_id,
-                pub_key: pub_out.map(|(raw, key_kind)| DdiPublicKey { raw, key_kind }),
-                bulk_key_id: None,
-                kind: key_type,
-                masked_key: &[],
-            },
             buf,
-        )
+        )?;
+        let layout = DdiUnmaskKeyResp::reserve(
+            &mut encoder,
+            u16::from(key_id),
+            pub_key,
+            None,
+            key_type,
+            masked_len,
+        )?;
+        Ok((encoder.position(), layout))
     })?;
+
+    // `mask` requires `out[..total_len]` zeroed on entry; the encoder does
+    // not zero the reserved slot, so clear it before filling.
+    let frame = DdiUnmaskKeyResp::from_layout(resp, &layout);
+    frame.masked_key.fill(0);
+    mask(
+        pal,
+        io,
+        masking_key,
+        priv_blob,
+        &metadata,
+        Some(frame.masked_key),
+    )
+    .await?;
+
     Ok(resp)
 }


### PR DESCRIPTION
The DDI UnmaskKey handler returned an empty `masked_key`, so a host could not re-persist a key it had just re-imported. Mirror the reference firmware (and the RsaUnwrap handler): after re-importing the key, re-mask it under the current scope's masking key — recording the current SVN and preserving the original key type, attributes, and label — and write the fresh envelope in place into the reserved response slot. The input blob is not echoed because the masking key / SVN may have rolled since it was produced.

The import runs in an allocation scope so the multi-KB RSA scratch is freed before the response is framed; the committed key is then read back from vault storage to drive both the public-key re-derivation and the in-place envelope. This keeps RSA-4096-CRT within the per-IO DMA budget.

Tests (unmask_key_smoke, run on emu in CI's smoke gate):
- strengthen the AES-partition and ECC-session round-trips to re-unmask the returned envelope, covering the session-scoped masking-key selection;
- add test_unmask_rsa_4k_crt_reunmask_roundtrip_smoke: import an RSA-4096-CRT key, then 10x re-import it from the fresh envelope each UnmaskKey returns, asserting the raw RsaModExp output, the re-derived public key, and the masked-key metadata are identical every round. Firmware-only invariants (label embedding, fresh-IV re-mask) are gated to non-mock backends because the sim echoes the input blob.