### PR TITLE
test(ddi): make attest_masked_key round-trips emu-compatible

### DIFF
--- a/ddi/mbor/types/tests/integration/attest_key.rs
+++ b/ddi/mbor/types/tests/integration/attest_key.rs
@@ -1159,7 +1159,7 @@ fn test_attest_rsa_der_import(
         Some(session_id),
         Some(DdiApiRev { major: 1, minor: 0 }),
         key_id_priv,
-        true,
+        false,
         masked_key,
     );
     assert!(resp.is_ok(), "resp {:?}", resp);


### PR DESCRIPTION
The six test_attest_masked_key_rsa_* tests failed on the emulator. The shared test_attest_rsa_der_import helper passed try_to_unmask_first=true to helper_get_new_key_id_from_unmask, which asserts that unmasking a key whose key_tag still exists fails. That duplicate-tag rejection is a sim-only behavior; the emu firmware allows the re-import, so the assertion tripped. AttestKey itself already works on emu (the first attestation in the flow passes), so flip the flag to false, matching the emu-compatible masked-key round-trips elsewhere (aes_gen, ecc_gen, hkdf/kbkdf, rsa_unwrap).

emu DDI suite (azihsm_ddi_mbor_types --features emu): attest_key is now 16/16, and the full suite is 515/577 pass (up from 509 — the remaining 62 failures are unrelated emu-unsupported areas: session mgmt, live migration, cert chain, RSA input-limit, and ECDH/session invalid-key negatives). Also passes on mock; clippy -D warnings, fmt, and copyright are clean.