### PR TITLE
feat(fw): reject out-of-range RSA modular-exponentiation input

### DIFF
--- a/fw/plat/std/pal/src/drivers/rsa.rs
+++ b/fw/plat/std/pal/src/drivers/rsa.rs
@@ -47,6 +47,8 @@
 //! On real Cortex-M7 hardware, these operations would be offloaded
 //! to a PKA (Public Key Accelerator) engine via DMA.
 
+use core::cmp::Ordering;
+
 use azihsm_crypto::DecryptOp;
 use azihsm_crypto::EncryptOp;
 use azihsm_crypto::HashAlgo;
@@ -168,11 +170,14 @@ impl StdRsa {
     ///
     /// # Parameters
     /// - `priv_key` — The RSA private key handle.
-    /// - `y` — Input data. Must be exactly the key size in bytes.
+    /// - `y` — Input data, exactly the key size in bytes; its value must
+    ///   satisfy `1 < y < n-1` (FIPS / NIST ACVP).
     /// - `x` — Output buffer for the result. Must be exactly the key
     ///   size in bytes.
     ///
     /// # Errors
+    /// - [`HsmError::InvalidArg`] — `y` is outside the required range
+    ///   `1 < y < n-1`, or its length disagrees with the modulus.
     /// - [`HsmError::RsaDecryptFailed`] — the modular exponentiation failed.
     pub async fn mod_exp_priv(
         &self,
@@ -180,6 +185,13 @@ impl StdRsa {
         y: &[u8],
         x: &mut [u8],
     ) -> HsmResult<()> {
+        // FIPS / NIST ACVP: the input value `m` must satisfy `1 < m < n-1`.
+        // Reject out-of-range inputs with `InvalidArg` before the
+        // exponentiation.  The check lives at the driver level so every
+        // backend enforces it — real PKA hardware compares against the
+        // modulus natively; here it is a software byte compare.
+        reject_out_of_range_mod_exp_input(priv_key, y)?;
+
         let key = priv_key.clone();
         // Wire operands are little-endian; OpenSSL is big-endian.
         let mut y_be = y.to_vec();
@@ -308,6 +320,84 @@ impl StdRsa {
     }
 }
 
+/// Reject an RSA modular-exponentiation input outside the FIPS / NIST
+/// ACVP range `1 < m < n - 1`, where `n` is the private key's modulus.
+///
+/// `m_le` is the little-endian, modulus-length input value.  The modulus
+/// is recovered from the key's derived public key (uniform for CRT and
+/// non-CRT keys).  Returns [`HsmError::InvalidArg`] when the input is out
+/// of range or its length disagrees with the modulus.
+fn reject_out_of_range_mod_exp_input(priv_key: &RsaPrivateKey, m_le: &[u8]) -> HsmResult<()> {
+    /// Largest supported modulus (RSA-4096) in bytes.
+    const MAX_MODULUS_LEN: usize = 512;
+
+    let pubk = priv_key
+        .public_key()
+        .map_err(|_| HsmError::RsaDecryptFailed)?;
+    let n_len = pubk.n(None).map_err(|_| HsmError::RsaDecryptFailed)?;
+    if n_len > MAX_MODULUS_LEN || n_len != m_le.len() {
+        return Err(HsmError::InvalidArg);
+    }
+    // OpenSSL yields the modulus big-endian; reverse to the little-endian
+    // wire order the input uses so the two are compared in the same order.
+    let mut n_be = [0u8; MAX_MODULUS_LEN];
+    pubk.n(Some(&mut n_be[..n_len]))
+        .map_err(|_| HsmError::RsaDecryptFailed)?;
+    let mut n_le = [0u8; MAX_MODULUS_LEN];
+    super::reverse_copy(&mut n_le[..n_len], &n_be[..n_len]);
+
+    if mod_exp_input_in_range(&n_le[..n_len], m_le) {
+        Ok(())
+    } else {
+        Err(HsmError::InvalidArg)
+    }
+}
+
+/// Byte-wise check that the little-endian value `m` satisfies
+/// `1 < m < n - 1`, where `n` is the little-endian modulus of equal
+/// length.
+///
+/// Mirrors the reference firmware's NIST-ACVP input validation: it walks
+/// from the most- to least-significant byte and decides as soon as the
+/// bytes differ, avoiding a general big-integer subtraction (the same
+/// comparison real PKA hardware performs).
+fn mod_exp_input_in_range(n: &[u8], m: &[u8]) -> bool {
+    if n.len() != m.len() || n.is_empty() {
+        return false;
+    }
+    // Whether a more-significant byte of `m` is already non-zero, which
+    // by itself proves `m > 1`.
+    let mut m_gt_one = false;
+    for i in (1..n.len()).rev() {
+        m_gt_one |= m[i] > 0;
+        match n[i].cmp(&m[i]) {
+            Ordering::Greater => {
+                // `m == n - 1` only if the difference is exactly one here
+                // and every lower byte forms the borrow pattern (n's lower
+                // bytes all 0x00, m's all 0xFF).
+                if n[i] - m[i] == 1
+                    && n[..i].iter().all(|&b| b == 0)
+                    && m[..i].iter().all(|&b| b == 0xFF)
+                {
+                    return false;
+                }
+                // `m < n - 1` holds here; valid iff `m > 1`.
+                if m_gt_one {
+                    return true;
+                }
+                return m[1..i].iter().any(|&b| b > 0) || m[0] > 1;
+            }
+            // `m > n`, so `m < n - 1` is false.
+            Ordering::Less => return false,
+            Ordering::Equal => {}
+        }
+    }
+    // All bytes above the least-significant are equal: `m` and `n` differ
+    // only in the low byte, so `1 < m < n - 1` iff `m > 1` and
+    // `n[0] - m[0] > 1`.
+    (m_gt_one || m[0] > 1) && n[0] > m[0] && n[0] - m[0] > 1
+}
+
 #[cfg(test)]
 mod tests {
     use tokio::runtime::Handle;
@@ -325,6 +415,30 @@ mod tests {
         let mut msg = vec![0u8; key_size_bytes];
         msg[key_size_bytes - 1] = 0x02;
         msg
+    }
+
+    /// Edge cases for the `1 < m < n - 1` input-range check (all values
+    /// little-endian).
+    #[test]
+    fn mod_exp_input_range_check() {
+        // n = 0x0100FF (65791); valid m is 2..=65789 (1 < m < n-1).
+        let n = [0xFF, 0x00, 0x01];
+        assert!(!mod_exp_input_in_range(&n, &[0x00, 0x00, 0x00]), "m = 0");
+        assert!(!mod_exp_input_in_range(&n, &[0x01, 0x00, 0x00]), "m = 1");
+        assert!(mod_exp_input_in_range(&n, &[0x02, 0x00, 0x00]), "m = 2");
+        assert!(mod_exp_input_in_range(&n, &[0xFD, 0x00, 0x01]), "m = n-2");
+        assert!(!mod_exp_input_in_range(&n, &[0xFE, 0x00, 0x01]), "m = n-1");
+        assert!(!mod_exp_input_in_range(&n, &[0xFF, 0x00, 0x01]), "m = n");
+        assert!(!mod_exp_input_in_range(&n, &[0x00, 0x01, 0x01]), "m = n+1");
+
+        // Borrow pattern: n = 0x010000, so n-1 = 0x00FFFF.
+        let n2 = [0x00, 0x00, 0x01];
+        assert!(!mod_exp_input_in_range(&n2, &[0xFF, 0xFF, 0x00]), "m = n-1");
+        assert!(mod_exp_input_in_range(&n2, &[0xFE, 0xFF, 0x00]), "m = n-2");
+
+        // Length mismatch and empty inputs are rejected.
+        assert!(!mod_exp_input_in_range(&n, &[0x02, 0x00]));
+        assert!(!mod_exp_input_in_range(&[], &[]));
     }
 
     // ── Key generation ──────────────────────────────────────────
@@ -386,6 +500,38 @@ mod tests {
     #[tokio::test]
     async fn mod_exp_roundtrip_4096() {
         mod_exp_roundtrip(4096).await;
+    }
+
+    /// End-to-end driver check: `mod_exp_priv` recovers the modulus from
+    /// the OpenSSL key and rejects out-of-range wire inputs with
+    /// `InvalidArg`.  `m = 0` and `m = 1` (little-endian, byte 0 is the
+    /// LSB) are out of the `1 < m < n-1` range; a valid `m = 2` succeeds.
+    #[tokio::test]
+    async fn mod_exp_priv_rejects_out_of_range_inputs() {
+        let driver = make_driver();
+        let key_size_bytes = 256; // RSA-2048
+        let (priv_key, _pub_key) = driver.gen_keypair(2048).await.unwrap();
+        let mut out = vec![0u8; key_size_bytes];
+
+        let m_zero = vec![0u8; key_size_bytes];
+        assert!(matches!(
+            driver.mod_exp_priv(&priv_key, &m_zero, &mut out).await,
+            Err(HsmError::InvalidArg)
+        ));
+
+        let mut m_one = vec![0u8; key_size_bytes];
+        m_one[0] = 1;
+        assert!(matches!(
+            driver.mod_exp_priv(&priv_key, &m_one, &mut out).await,
+            Err(HsmError::InvalidArg)
+        ));
+
+        let mut m_two = vec![0u8; key_size_bytes];
+        m_two[0] = 2;
+        driver
+            .mod_exp_priv(&priv_key, &m_two, &mut out)
+            .await
+            .unwrap();
     }
 
     // ── Identity test: pub(priv(m)) == m ─────────────────────────


### PR DESCRIPTION
RSA sign / decrypt (private-key modular exponentiation) must reject an input value m outside the FIPS / NIST ACVP range 1 < m < n-1. The std PAL performed no such check, so on the emulator (which reports as a physical device and therefore runs the FIPS-only tests) a below-range input (m = 1) computed 1^d = 1 and succeeded, while an above-range input (m >= n) failed with the wrong error rather than InvalidArg.

Enforce the range in the std PAL RSA driver's mod_exp_priv, before the exponentiation: recover the modulus from the key and run a byte-wise 1 < m < n-1 comparison (most- to least-significant byte, no big-integer subtraction), returning InvalidArg when out of range. This mirrors the reference firmware's app-session validation and keeps the check at the driver level, where hardware backends perform it in the PKA. Only the private-key primitive is affected; valid padded inputs are unchanged.

Adds a driver unit test covering the boundary values (0, 1, 2, n-2, n-1, n, n+1) and the n-1 borrow pattern.

emu DDI suite (azihsm_ddi_mbor_types --features emu): the 18 RSA message-limit tests (2k/3k/4k x sign / decrypt-no-crt / decrypt-crt x above / below) now pass, moving the suite from 509/577 to 527/577 with no regressions (remaining failures are unrelated emu-unsupported areas). The tests short-circuit on the mock/sim backend. clippy -D warnings, fmt, and copyright are clean.