### PR TITLE
Fix for AES CBC and ECC Multi process flaky tests

### DIFF
--- a/api/tests/cpp/multi_process_tests.cpp
+++ b/api/tests/cpp/multi_process_tests.cpp
@@ -329,12 +329,17 @@ TEST_F(azihsm_multi_process, ecc_sign_verify_cross_process_child)
 
     PartInitConfig init_config{};
     make_part_init_config(part_handle, init_config);
+    // Function-scoped so its address stays valid for azihsm_part_init() below.
+    azihsm_buffer obk_buf{};
     if (!obk.empty())
     {
-        // Override OBK with the deserialized key from parent process
-        azihsm_buffer obk_buf = { obk.data(), static_cast<uint32_t>(obk.size()) };
+        // Override with the parent's raw OBK. Clear masked_owner_backup_key
+        // (possibly set by make_part_init_config from a cached MOBK): the
+        // Caller source requires exactly one of the two to be non-NULL.
+        obk_buf = { obk.data(), static_cast<uint32_t>(obk.size()) };
         init_config.backup_config.source = AZIHSM_OWNER_BACKUP_KEY_SOURCE_CALLER;
         init_config.backup_config.owner_backup_key = &obk_buf;
+        init_config.backup_config.masked_owner_backup_key = nullptr;
     }
 
     // Child process re-init: the device may have BK3 already initialized

--- a/api/tests/src/algo/aes/key_tests.rs
+++ b/api/tests/src/algo/aes/key_tests.rs
@@ -951,7 +951,19 @@ fn test_aes_cbc_wrong_key_fails(session: HsmSession) {
 
     let result = HsmDecrypter::decrypt(&mut dec, &key2, &ciphertext, Some(&mut out));
 
-    assert!(result.is_err());
+    // Wrong-key decrypt yields random plaintext, so PKCS#7 unpadding passes
+    // ~1/256 of the time (valid final byte). Asserting it always errors is
+    // flaky; the real invariant is that it must never recover the plaintext.
+    match result {
+        Err(_) => {}
+        Ok(written) => {
+            out.truncate(written);
+            assert_ne!(
+                out, plaintext,
+                "decryption with the wrong key must not recover the original plaintext"
+            );
+        }
+    }
 
     HsmKeyManager::delete_key(key1).unwrap();
     HsmKeyManager::delete_key(key2).unwrap();


### PR DESCRIPTION
This pull request makes important improvements to test reliability and correctness in both the C++ and Rust test suites. The main changes address a flaky test assertion in the AES CBC decryption test and clarify ownership key handling in a multi-process test.

**Test reliability and correctness improvements:**

* [`api/tests/src/algo/aes/key_tests.rs`](diffhunk://#diff-61e2a310897305e1fd68c9c80a18644aa7b920b7db1ed18fe607ea6c8f95502aL954-R966): Updated the AES CBC "wrong key" test to avoid a flaky assertion. Instead of always expecting an error (which was unreliable due to PKCS#7 padding occasionally passing by chance), the test now asserts that decryption with the wrong key never recovers the original plaintext.

**Ownership key handling in multi-process tests:**

* [`api/tests/cpp/multi_process_tests.cpp`](diffhunk://#diff-900c52bf588d0b97aec4c87b72c3f57780d74e0a5176a8ec24108fb2fcf86cf3R332-R342): In the ECC sign/verify cross-process child test, clarified and fixed the logic for overriding the owner backup key (OBK) with the parent's key. Ensured that only one of `owner_backup_key` or `masked_owner_backup_key` is set, as required, and that the buffer's lifetime is correct.