### PR TITLE
feat(fw): implement the DDI ChangePin handler

### DIFF
--- a/ddi/mbor/types/tests/azihsm_ddi_tests.rs
+++ b/ddi/mbor/types/tests/azihsm_ddi_tests.rs
@@ -14,6 +14,7 @@ mod integration {
     pub mod attest_key;
     pub mod attest_key_smoke;
     pub mod change_pin;
+    pub mod change_pin_smoke;
     pub mod close_session;
     pub mod close_session_smoke;
     pub mod common;

--- a/ddi/mbor/types/tests/integration/change_pin_smoke.rs
+++ b/ddi/mbor/types/tests/integration/change_pin_smoke.rs
@@ -1,0 +1,122 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! ChangePin smoke tests for the emu backend.
+//!
+//! Exercises the ChangePin firmware command end-to-end from the host
+//! side within an open session:
+//!
+//! - Happy path: ECDH + HKDF + HMAC verify + AES-CBC decrypt succeed
+//!   and the partition credential's PIN is replaced (`Success`); after
+//!   the change a fresh OpenSession with the *old* PIN is rejected
+//!   (`InvalidAppCredentials`) while the *new* PIN succeeds.
+//! - Tampered ciphertext: a flipped byte in the encrypted PIN fails the
+//!   `enc_pin ‖ iv ‖ nonce` HMAC check and is rejected with
+//!   `PinDecryptionFailed`, leaving the credential unchanged.
+
+#![cfg(test)]
+
+use azihsm_ddi::*;
+use azihsm_ddi_mbor_types::*;
+use test_with_tracing::test;
+
+use super::common::*;
+
+/// Attempts to open a fresh session with the given user id / PIN and
+/// returns the result, so a caller can assert the credential is (or is
+/// no longer) accepted.
+fn try_open_session_with_pin(
+    ddi: &DdiTest,
+    path: &str,
+    id: [u8; 16],
+    pin: [u8; 16],
+) -> Result<DdiOpenSessionCmdResp, DdiError> {
+    let login_dev = ddi.open_dev(path).unwrap();
+    let (encrypted_credential, pub_key) =
+        encrypt_userid_pin_for_open_session(&login_dev, id, pin, TEST_SESSION_SEED);
+    helper_open_session(
+        &login_dev,
+        None,
+        Some(DdiApiRev { major: 1, minor: 0 }),
+        encrypted_credential,
+        pub_key,
+    )
+}
+
+#[test]
+fn test_change_pin_smoke() {
+    ddi_dev_test(
+        common_setup,
+        common_cleanup,
+        |dev, ddi, path, session_id| {
+            let (new_pin, pub_key) = encrypt_pin_for_change_pin(dev, TEST_CRED_PIN_ALT);
+
+            let resp = helper_change_pin(
+                dev,
+                Some(session_id),
+                Some(DdiApiRev { major: 1, minor: 0 }),
+                new_pin,
+                pub_key,
+            )
+            .expect("ChangePin happy path must succeed");
+
+            assert_eq!(resp.hdr.op, DdiOp::ChangePin);
+            assert_eq!(resp.hdr.status, DdiStatus::Success);
+            assert_eq!(
+                resp.hdr.sess_id,
+                Some(session_id),
+                "ChangePin response must echo the session id"
+            );
+
+            // The old PIN must no longer authenticate a new session.
+            let old_pin_result = try_open_session_with_pin(ddi, path, TEST_CRED_ID, TEST_CRED_PIN);
+            assert!(
+                matches!(
+                    old_pin_result,
+                    Err(DdiError::DdiStatus(DdiStatus::InvalidAppCredentials))
+                ),
+                "OpenSession with the old PIN must be rejected after ChangePin, got {:?}",
+                old_pin_result
+            );
+
+            // The new PIN must authenticate a new session.
+            let new_pin_result =
+                try_open_session_with_pin(ddi, path, TEST_CRED_ID, TEST_CRED_PIN_ALT);
+            assert!(
+                new_pin_result.is_ok(),
+                "OpenSession with the new PIN must succeed after ChangePin, got {:?}",
+                new_pin_result
+            );
+        },
+    );
+}
+
+#[test]
+fn test_change_pin_tampered_pin_smoke() {
+    ddi_dev_test(
+        common_setup,
+        common_cleanup,
+        |dev, _ddi, _path, session_id| {
+            let (mut new_pin, pub_key) = encrypt_pin_for_change_pin(dev, TEST_CRED_PIN_ALT);
+
+            // Flip a ciphertext byte so the authenticated
+            // `enc_pin ‖ iv ‖ nonce` HMAC no longer matches the tag.
+            new_pin.encrypted_pin.data_mut()[10] = new_pin.encrypted_pin.data()[10].wrapping_add(1);
+
+            let err = helper_change_pin(
+                dev,
+                Some(session_id),
+                Some(DdiApiRev { major: 1, minor: 0 }),
+                new_pin,
+                pub_key,
+            )
+            .expect_err("tampered PIN must be rejected");
+
+            assert!(
+                matches!(err, DdiError::DdiStatus(DdiStatus::PinDecryptionFailed)),
+                "expected PinDecryptionFailed, got {:?}",
+                err
+            );
+        },
+    );
+}

--- a/fw/core/lib/src/ddi/mbor/aes_generate_key.rs
+++ b/fw/core/lib/src/ddi/mbor/aes_generate_key.rs
@@ -20,11 +20,14 @@ use super::*;
 
 /// Handle `DdiAesGenerateKeyCmd`.
 ///
-/// No `partition_lock` is needed.  Although `vault_key_create` is now
-/// awaited (it can yield on Uno during the GDMA key copy), DDI commands
-/// run on a single-threaded cooperative executor with one command in
-/// flight per partition, so no concurrent handler can interleave with
-/// this one — there is nothing for a lock to serialize.
+/// No `partition_lock` is needed.  DDI commands execute on a
+/// single-threaded cooperative executor; multiple IOs are in flight and
+/// interleave at await points — including inside the awaited
+/// `vault_key_create` (which can yield on Uno during the GDMA key copy) —
+/// but this handler's only partition-state mutation is that single,
+/// self-contained `vault_key_create`, with no multi-step
+/// read-modify-write across an await for an interleaved handler to
+/// corrupt.
 pub(crate) async fn aes_generate_key<'p, P: HsmPal>(
     pal: &'p P,
     io: &impl HsmIo,

--- a/fw/core/lib/src/ddi/mbor/change_pin.rs
+++ b/fw/core/lib/src/ddi/mbor/change_pin.rs
@@ -29,10 +29,10 @@ const CRED_FIELD_LEN: usize = 16;
 
 /// Handle `DdiChangePinCmd`.
 ///
-/// Runs entirely under the partition lock: DDI commands execute on a
-/// single-threaded cooperative executor with one command in flight per
-/// partition, so the fail-fast state checks stay consistent with the
-/// credential update at the end.
+/// Runs under the partition lock.  DDI commands execute on a
+/// single-threaded cooperative executor, but multiple IOs are in flight
+/// and interleave at await points, so the lock serializes this handler's
+/// multi-step fail-fast checks with the credential update at the end.
 pub(crate) async fn change_pin<'p, P: HsmPal>(
     pal: &'p P,
     io: &impl HsmIo,

--- a/fw/core/lib/src/ddi/mbor/change_pin.rs
+++ b/fw/core/lib/src/ddi/mbor/change_pin.rs
@@ -1,0 +1,177 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! DDI ChangePin command handler.
+//!
+//! Within an open session, authenticate a host-supplied encrypted new
+//! PIN and replace the partition credential's PIN in place, preserving
+//! the user id.
+//!
+//! The authentication mirrors [`open_session`](super::open_session):
+//! ECDH against the partition's session-encryption key + HKDF-SHA-384
+//! (`info = nonce`) yields an 80-byte OKM split into a 32-byte AES key
+//! and a 48-byte HMAC key.  The HMAC key authenticates
+//! `encrypted_pin ‖ iv ‖ nonce`; the AES key AES-CBC-decrypts the new
+//! PIN.  The partition nonce is refreshed before the credential is
+//! updated so the authenticated request cannot be replayed.
+
+use azihsm_fw_ddi_mbor_types::change_pin::DdiChangePinReq;
+use azihsm_fw_ddi_mbor_types::change_pin::DdiChangePinResp;
+use azihsm_fw_ddi_mbor_types::change_pin::DdiEncryptedPin;
+use azihsm_fw_ddi_mbor_types::DdiKeyType;
+use azihsm_fw_hsm_pal_traits::PartPropId;
+
+use super::*;
+
+/// Credential half-field length (id / pin) in bytes.  The stored
+/// credential is `id ‖ pin` (16 + 16 = 32 bytes).
+const CRED_FIELD_LEN: usize = 16;
+
+/// Handle `DdiChangePinCmd`.
+///
+/// Runs entirely under the partition lock: DDI commands execute on a
+/// single-threaded cooperative executor with one command in flight per
+/// partition, so the fail-fast state checks stay consistent with the
+/// credential update at the end.
+pub(crate) async fn change_pin<'p, P: HsmPal>(
+    pal: &'p P,
+    io: &impl HsmIo,
+    decoder: &mut DdiDecoder<'_>,
+    hdr: &DdiReqHdr,
+) -> HsmResult<&'p DmaBuf> {
+    let body: DdiChangePinReq = decoder.decode_data()?;
+    let sess_id = hdr.sess_id.ok_or(HsmError::SessionExpected)?;
+
+    let _lock = pal.partition_lock(io).await?;
+
+    // ── Fail-fast (under the lock, before any crypto) ────────────────
+    //
+    // The request is authenticated by the partition nonce; reject a
+    // stale nonce before doing ECDH work.
+    crate::part_state::part_verify_nonce(pal, io, body.new_pin.nonce)?;
+
+    // A PIN change only makes sense once a credential exists.
+    if !crate::part_state::part_is_credential_set(pal, io)? {
+        return Err(HsmError::InvalidAppCredentials);
+    }
+
+    if body.pub_key.key_kind != DdiKeyType::Ecc384Public {
+        return Err(HsmError::InvalidKeyType);
+    }
+    if body.pub_key.raw.len() != HsmEccCurve::P384.pub_key_len() {
+        return Err(HsmError::InvalidArg);
+    }
+
+    // ── ECDH + HKDF → 80-byte OKM (aes_key ‖ hmac_key) ───────────────
+    let okm = pal.dma_alloc(io, BK_LEN)?;
+    super::open_session::derive_session_credential_keys(
+        pal,
+        io,
+        body.pub_key.raw,
+        body.new_pin.nonce,
+        okm,
+    )
+    .await?;
+    // HMAC-SHA-384 key length matches the digest length; the AES key is
+    // the leading remainder of the 80-byte OKM.
+    let (aes_key, hmac_key) = okm.split_at(okm.len() - HsmHashAlgo::Sha384.digest_len());
+
+    // ── Authenticate the encrypted PIN ───────────────────────────────
+    verify_change_pin_hmac(pal, io, &body.new_pin, hmac_key).await?;
+
+    // ── Reset nonce before decrypt / commit ──────────────────────────
+    //
+    // The nonce that authenticated this request must not be replayable,
+    // so refresh it now even though a later step may still fail.
+    {
+        let nonce = pal.dma_alloc(io, crate::part_state::NONCE_LEN)?;
+        pal.rng_fill_bytes(io, nonce)?;
+        crate::part_state::part_set_nonce(pal, io, nonce)?;
+    }
+
+    // ── AES-CBC decrypt the new PIN in place ─────────────────────────
+    pal.aes_cbc_enc_dec_in_place(
+        io,
+        AesOp::Decrypt,
+        aes_key,
+        body.new_pin.encrypted_pin,
+        body.new_pin.iv,
+        None,
+    )
+    .await?;
+
+    // Reject an all-zero PIN *before* mutating the credential: the
+    // update clears the write-once credential then re-writes it, and
+    // there is no undo log yet, so a rejected change must leave the
+    // existing credential untouched.  (The CREDENTIAL prop setter also
+    // rejects an all-zero half.)
+    if body.new_pin.encrypted_pin.iter().all(|&b| b == 0) {
+        return Err(HsmError::InvalidAppCredentials);
+    }
+
+    // ── Update credential: preserve id, replace pin ──────────────────
+    //
+    // Snapshot the id half onto the stack (a public identifier, not a
+    // secret) so the `part_credential` borrow is released before the
+    // clear/re-write below.
+    let mut id = [0u8; CRED_FIELD_LEN];
+    {
+        let stored = crate::part_state::part_credential(pal, io)?;
+        if stored.len() != 2 * CRED_FIELD_LEN {
+            return Err(HsmError::InternalError);
+        }
+        id.copy_from_slice(&stored[..CRED_FIELD_LEN]);
+    }
+
+    let new_cred = pal.dma_alloc(io, 2 * CRED_FIELD_LEN)?;
+    new_cred[..CRED_FIELD_LEN].copy_from_slice(&id);
+    new_cred[CRED_FIELD_LEN..].copy_from_slice(&body.new_pin.encrypted_pin[..CRED_FIELD_LEN]);
+
+    // The credential is write-once: `part_set_credential` rejects a
+    // re-set without an intervening clear, so clear before re-writing
+    // `id ‖ new_pin`.
+    pal.part_prop_clear(io, PartPropId::CREDENTIAL)?;
+    crate::part_state::part_set_credential(pal, io, new_cred)?;
+
+    let resp = pal.dma_alloc_var(io, |buf| {
+        super::encode_resp(
+            &super::success_hdr_sess(hdr, DdiOp::ChangePin, sess_id),
+            &DdiChangePinResp {},
+            buf,
+        )
+    })?;
+    Ok(resp)
+}
+
+/// HMAC-SHA-384 verifies the encrypted PIN's tag over
+/// `encrypted_pin ‖ iv ‖ nonce`.
+///
+/// `hmac_key` must be at least 48 bytes (the HMAC-SHA-384 key).
+/// Returns [`HsmError::PinDecryptionFailed`] on a tag mismatch —
+/// covering a tampered PIN, IV, nonce, tag, or peer public key (which
+/// derives a different key).
+async fn verify_change_pin_hmac<P: HsmPal>(
+    pal: &P,
+    io: &impl HsmIo,
+    new_pin: &DdiEncryptedPin<'_>,
+    hmac_key: &DmaBuf,
+) -> HsmResult<()> {
+    let pin_len = new_pin.encrypted_pin.len();
+    let iv_len = new_pin.iv.len();
+    let nonce_len = new_pin.nonce.len();
+
+    let hmac_input = pal.dma_alloc(io, pin_len + iv_len + nonce_len)?;
+    let (pin_dst, rest) = hmac_input.split_at_mut(pin_len);
+    let (iv_dst, nonce_dst) = rest.split_at_mut(iv_len);
+    pin_dst.copy_from_slice(new_pin.encrypted_pin);
+    iv_dst.copy_from_slice(new_pin.iv);
+    nonce_dst.copy_from_slice(new_pin.nonce);
+
+    if !pal
+        .hmac_verify(io, HsmHashAlgo::Sha384, hmac_key, hmac_input, new_pin.tag)
+        .await?
+    {
+        return Err(HsmError::PinDecryptionFailed);
+    }
+    Ok(())
+}

--- a/fw/core/lib/src/ddi/mbor/close_session.rs
+++ b/fw/core/lib/src/ddi/mbor/close_session.rs
@@ -19,10 +19,13 @@ use super::*;
 /// validates it before calling the handler.  We re-check defensively so
 /// the partition state never sees `session_destroy` with a `None` id.
 ///
-/// No `partition_lock` is needed.  Although `session_destroy` is now
-/// awaited (it can yield on Uno during vault GDMA cleanup), DDI commands
-/// run on a single-threaded cooperative executor with one command in
-/// flight per partition, so no concurrent handler can interleave.
+/// No `partition_lock` is needed.  DDI commands execute on a
+/// single-threaded cooperative executor; multiple IOs are in flight and
+/// interleave at await points — including inside the awaited
+/// `session_destroy` (which can yield on Uno during vault GDMA cleanup) —
+/// but this handler's only partition-state effect is that single,
+/// self-contained `session_destroy`, with no multi-step invariant across
+/// an await for an interleaved handler to corrupt.
 pub(crate) async fn close_session<'p, P: HsmPal>(
     pal: &'p P,
     io: &impl HsmIo,

--- a/fw/core/lib/src/ddi/mbor/ecc_generate_key_pair.rs
+++ b/fw/core/lib/src/ddi/mbor/ecc_generate_key_pair.rs
@@ -18,11 +18,14 @@ use super::*;
 
 /// Handle `DdiEccGenerateKeyPairCmd`.
 ///
-/// No `partition_lock` is needed.  Although `vault_key_create` is now
-/// awaited (it can yield on Uno during the GDMA key copy), DDI commands
-/// run on a single-threaded cooperative executor with one command in
-/// flight per partition, so no concurrent handler can interleave with
-/// this one — there is nothing for a lock to serialize.
+/// No `partition_lock` is needed.  DDI commands execute on a
+/// single-threaded cooperative executor; multiple IOs are in flight and
+/// interleave at await points — including inside the awaited
+/// `vault_key_create` (which can yield on Uno during the GDMA key copy) —
+/// but this handler's only partition-state mutation is that single,
+/// self-contained `vault_key_create`, with no multi-step
+/// read-modify-write across an await for an interleaved handler to
+/// corrupt.
 pub(crate) async fn ecc_generate_key_pair<'p, P: HsmPal>(
     pal: &'p P,
     io: &impl HsmIo,

--- a/fw/core/lib/src/ddi/mbor/ecdh_key_exchange.rs
+++ b/fw/core/lib/src/ddi/mbor/ecdh_key_exchange.rs
@@ -18,11 +18,14 @@ use super::*;
 
 /// Handle `DdiEcdhKeyExchangeCmd`.
 ///
-/// No `partition_lock` is needed.  Although `vault_key_create` is now
-/// awaited (it can yield on Uno during the GDMA key copy), DDI commands
-/// run on a single-threaded cooperative executor with one command in
-/// flight per partition, so no concurrent handler can interleave with
-/// this one — there is nothing for a lock to serialize.
+/// No `partition_lock` is needed.  DDI commands execute on a
+/// single-threaded cooperative executor; multiple IOs are in flight and
+/// interleave at await points — including inside the awaited
+/// `vault_key_create` (which can yield on Uno during the GDMA key copy) —
+/// but this handler's only partition-state mutation is that single,
+/// self-contained `vault_key_create`, with no multi-step
+/// read-modify-write across an await for an interleaved handler to
+/// corrupt.
 pub(crate) async fn ecdh_key_exchange<'p, P: HsmPal>(
     pal: &'p P,
     io: &impl HsmIo,

--- a/fw/core/lib/src/ddi/mbor/hkdf_derive.rs
+++ b/fw/core/lib/src/ddi/mbor/hkdf_derive.rs
@@ -25,11 +25,14 @@ use super::*;
 
 /// Handle `DdiHkdfDeriveCmd`.
 ///
-/// No `partition_lock` is needed.  Although `vault_key_create` is now
-/// awaited (it can yield on Uno during the GDMA key copy), DDI commands
-/// run on a single-threaded cooperative executor with one command in
-/// flight per partition, so no concurrent handler can interleave with
-/// this one — there is nothing for a lock to serialize.
+/// No `partition_lock` is needed.  DDI commands execute on a
+/// single-threaded cooperative executor; multiple IOs are in flight and
+/// interleave at await points — including inside the awaited
+/// `vault_key_create` (which can yield on Uno during the GDMA key copy) —
+/// but this handler's only partition-state mutation is that single,
+/// self-contained `vault_key_create`, with no multi-step
+/// read-modify-write across an await for an interleaved handler to
+/// corrupt.
 pub(crate) async fn hkdf_derive<'p, P: HsmPal>(
     pal: &'p P,
     io: &impl HsmIo,

--- a/fw/core/lib/src/ddi/mbor/kbkdf_derive.rs
+++ b/fw/core/lib/src/ddi/mbor/kbkdf_derive.rs
@@ -29,11 +29,14 @@ use super::*;
 
 /// Handle `DdiKbkdfCounterHmacDeriveCmd`.
 ///
-/// No `partition_lock` is needed.  Although `vault_key_create` is now
-/// awaited (it can yield on Uno during the GDMA key copy), DDI commands
-/// run on a single-threaded cooperative executor with one command in
-/// flight per partition, so no concurrent handler can interleave with
-/// this one — there is nothing for a lock to serialize.
+/// No `partition_lock` is needed.  DDI commands execute on a
+/// single-threaded cooperative executor; multiple IOs are in flight and
+/// interleave at await points — including inside the awaited
+/// `vault_key_create` (which can yield on Uno during the GDMA key copy) —
+/// but this handler's only partition-state mutation is that single,
+/// self-contained `vault_key_create`, with no multi-step
+/// read-modify-write across an await for an interleaved handler to
+/// corrupt.
 pub(crate) async fn kbkdf_counter_hmac_derive<'p, P: HsmPal>(
     pal: &'p P,
     io: &impl HsmIo,

--- a/fw/core/lib/src/ddi/mbor/mod.rs
+++ b/fw/core/lib/src/ddi/mbor/mod.rs
@@ -4,6 +4,7 @@
 pub(crate) mod aes_encrypt_decrypt;
 pub(crate) mod aes_generate_key;
 pub(crate) mod attest_key;
+pub(crate) mod change_pin;
 pub(crate) mod close_session;
 pub(crate) mod delete_key;
 pub(crate) mod ecc_generate_key_pair;
@@ -42,6 +43,7 @@ use azihsm_fw_ddi_mbor_api::DdiDecoder;
 use azihsm_fw_ddi_mbor_api::DdiEncoder;
 use azihsm_fw_ddi_mbor_types::error::DdiErrResp;
 use azihsm_fw_ddi_mbor_types::*;
+pub(crate) use change_pin::*;
 pub(crate) use close_session::*;
 pub(crate) use delete_key::*;
 pub(crate) use ecc_generate_key_pair::*;
@@ -173,6 +175,7 @@ pub(crate) async fn dispatch<'p, P: HsmPal>(
         DdiOp::SetSealedBk3 => set_sealed_bk3(pal, io, decoder, hdr),
         DdiOp::InitBk3 => init_bk3(pal, io, decoder, hdr).await,
         DdiOp::EstablishCredential => establish_credential(pal, io, decoder, hdr).await,
+        DdiOp::ChangePin => change_pin(pal, io, decoder, hdr).await,
         DdiOp::CloseSession => close_session(pal, io, decoder, hdr).await,
         DdiOp::DeleteKey => delete_key(pal, io, decoder, hdr).await,
         DdiOp::AesGenerateKey => aes_generate_key(pal, io, decoder, hdr).await,

--- a/fw/core/lib/src/ddi/mbor/open_session.rs
+++ b/fw/core/lib/src/ddi/mbor/open_session.rs
@@ -206,7 +206,11 @@ fn check_fail_fast<P: HsmPal>(
 /// the `EstablishCred` private key.
 ///
 /// `okm_out` must be exactly [`BK_LEN`] (80) bytes.
-async fn derive_session_credential_keys<P: HsmPal>(
+///
+/// Exposed to sibling handlers (e.g. [`change_pin`](super::change_pin))
+/// that also authenticate an in-session payload keyed by the
+/// session-encryption key.
+pub(super) async fn derive_session_credential_keys<P: HsmPal>(
     pal: &P,
     io: &impl HsmIo,
     host_eph_pub_key_raw: &DmaBuf,


### PR DESCRIPTION
ChangePin had no handler in fw/core/lib (only the sim implemented it), so it was absent from the emu MBOR dispatch and every change_pin test failed on emu.

Implement the handler mirroring open_session/establish_credential and the sim + mcr-hsm reference:
- open_session: expose derive_session_credential_keys (pub(super)) for reuse of the session-key ECDH + HKDF.
- change_pin: session-scoped handler — fail-fast (nonce match, cred set, P-384 pubkey); ECDH(session key)+HKDF-SHA384(info=nonce,80B) → aes32‖hmac48; HMAC-verify enc_pin‖iv‖nonce (PinDecryptionFailed); reset nonce; AES-CBC decrypt; reject null pin; update credential preserving the id; empty response.
- mod: register the handler in the dispatch.

Add a dedicated change_pin_smoke.rs: the happy path also confirms a fresh OpenSession with the old PIN is rejected (InvalidAppCredentials) and the new PIN succeeds; plus a tampered-ciphertext rejection.

emu azihsm_ddi_mbor_types (ci-emu-smoke): 548/577 -> 557/579 passing (29 -> 22 failing). All 15 change_pin tests pass (13 existing + 2 new smoke); the 22 remaining failures are pre-existing emu limitations (live-migration / reopen_session / get_cert_chain / rsa_unwrap), unchanged. clippy/fmt/copyright clean.


Copilot-Session: da3d9f1c-2153-486c-b15a-2ef3b2cfd90d