### PR TITLE
feat(fw): implement ReopenSession handler + live-migration session renego

### DIFF
--- a/ddi/emu/src/dev.rs
+++ b/ddi/emu/src/dev.rs
@@ -24,11 +24,15 @@ use azihsm_ddi_mbor_codec::MborDecode;
 use azihsm_ddi_mbor_codec::MborDecoder;
 use azihsm_ddi_mbor_codec::MborEncoder;
 use azihsm_ddi_mbor_types::DdiAesOp;
+use azihsm_ddi_mbor_types::DdiApiRev;
+use azihsm_ddi_mbor_types::DdiCloseSessionCmdReq;
+use azihsm_ddi_mbor_types::DdiCloseSessionReq;
 use azihsm_ddi_mbor_types::DdiDecoder;
 use azihsm_ddi_mbor_types::DdiDeviceKind;
 use azihsm_ddi_mbor_types::DdiOp;
 use azihsm_ddi_mbor_types::DdiOpReq;
 use azihsm_ddi_mbor_types::DdiOpenSessionCmdResp;
+use azihsm_ddi_mbor_types::DdiReqHdr;
 use azihsm_ddi_mbor_types::DdiRespHdr;
 use azihsm_ddi_mbor_types::DdiStatus;
 use azihsm_ddi_mbor_types::MborError;
@@ -133,6 +137,30 @@ impl DdiEmuDev {
             session: Arc::new(Mutex::new(SessionState::default())),
             device_kind: DdiDeviceKind::Physical,
         })
+    }
+
+    /// Best-effort close of the device's live session.
+    fn close_live_session(&self) {
+        let session_id = self.session.lock().session_id;
+        let Some(sess_id) = session_id else {
+            return;
+        };
+        let req = DdiCloseSessionCmdReq {
+            hdr: DdiReqHdr {
+                op: DdiOp::CloseSession,
+                sess_id: Some(sess_id),
+                rev: Some(DdiApiRev { major: 1, minor: 0 }),
+            },
+            data: DdiCloseSessionReq {},
+            ext: None,
+        };
+        let _ = self.exec_op_mbor(&req, &mut None);
+    }
+}
+
+impl Drop for DdiEmuDev {
+    fn drop(&mut self) {
+        self.close_live_session();
     }
 }
 
@@ -359,7 +387,41 @@ impl DdiDev for DdiEmuDev {
             resp_buf
         );
 
-        <T::OpResp>::decode_response(resp_buf).map_err(Into::into)
+        // `decode_response` returns `DecodeError::FwError` on a non-`Success`
+        // firmware status, so decoding first gates session tracking on
+        // success: a failed command must not change the tracked session id —
+        // a rejected `SessionClose` leaves the session live, so its id must
+        // stay tracked for the close-on-drop retry.
+        let resp = <T::OpResp>::decode_response(resp_buf).map_err(DdiError::from)?;
+
+        // Update session tracking on Open / Close success, mirroring
+        // `exec_op_mbor`.  The firmware allocates the session id and returns
+        // it in the `SessionOpenInit` response — the TBOR analog of MBOR's
+        // `hdr.sess_id`, carried here as a `SessionId` TOC entry — so record
+        // it from the Open response and clear it on Close.  In-session ops
+        // (including `SessionOpenFinish`) leave the tracked id unchanged.
+        match session_ctrl {
+            azihsm_ddi_tbor_types::SessionControlKind::Open => {
+                if let Some(id) = azihsm_ddi_tbor_codec::ResponseView::parse(resp_buf)
+                    .ok()
+                    .and_then(|view| {
+                        view.toc_iter().find_map(|entry| match entry {
+                            azihsm_ddi_tbor_codec::TocEntry::SessionId(id) => Some(id),
+                            _ => None,
+                        })
+                    })
+                {
+                    self.session.lock().session_id = Some(id);
+                }
+            }
+            azihsm_ddi_tbor_types::SessionControlKind::Close => {
+                self.session.lock().session_id = None
+            }
+            azihsm_ddi_tbor_types::SessionControlKind::InSession
+            | azihsm_ddi_tbor_types::SessionControlKind::NoSession => {}
+        }
+
+        Ok(resp)
     }
 
     fn exec_op_fp_gcm_slice(
@@ -404,12 +466,12 @@ impl DdiDev for DdiEmuDev {
         Err(DdiError::DdiStatus(DdiStatus::UnsupportedCmd))
     }
 
-    /// Erase the device.
+    /// Erase the device: disable and re-enable the emulator partition,
+    /// matching what real hardware does on NSSR.
     ///
-    /// For the emulator backend, this disables and re-enables the
-    /// emulator partition (matching what real hardware does on NSSR)
-    /// and clears the session state, returning the device to a clean
-    /// state.
+    /// The host-side session state is deliberately preserved so the host
+    /// can re-establish it with an in-session `ReopenSession`; clearing it
+    /// would fail that reopen with `FileHandleNoExistingSession`.
     fn erase(&self) -> Result<(), DdiError> {
         // Reset partition state: disable then re-enable. This
         // matches what real hardware does on NSSR.
@@ -420,11 +482,6 @@ impl DdiDev for DdiEmuDev {
                 Ok::<_, ()>(())
             })
             .map_err(|_| DdiError::DeviceNotReady)?;
-
-        // Clear session state for this device handle.
-        let mut session = self.session.lock();
-        session.session_id = None;
-        session.short_app_id = None;
 
         Ok(())
     }

--- a/ddi/mbor/types/tests/azihsm_ddi_tests.rs
+++ b/ddi/mbor/types/tests/azihsm_ddi_tests.rs
@@ -53,6 +53,7 @@ mod integration {
     pub mod kbkdf_smoke;
     pub mod live_migration_expected_errors;
     pub mod live_migration_sim;
+    pub mod live_migration_smoke;
     pub mod lm_context;
     pub mod masked_key;
     pub mod masked_key_aes_gen;
@@ -68,6 +69,7 @@ mod integration {
     pub mod open_session_smoke;
     pub mod prov_part;
     pub mod reopen_session;
+    pub mod reopen_session_smoke;
     pub mod rsa_2k_decrypt_no_crt;
     pub mod rsa_2k_decrypt_with_crt;
     pub mod rsa_2k_sign;

--- a/ddi/mbor/types/tests/integration/live_migration_smoke.rs
+++ b/ddi/mbor/types/tests/integration/live_migration_smoke.rs
@@ -1,0 +1,233 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Live-migration smoke test for the emu backend.
+//!
+//! Exercises the full live-migration session lifecycle end-to-end,
+//! covering the firmware behaviour that is emu-specific (the sim echoes
+//! rather than re-keys):
+//!
+//! 1. An in-session op (AES key gen) succeeds on the open session.
+//! 2. A simulated NSSR (`erase`) migrates the partition; the session
+//!    slot is preserved as renegotiation-pending.
+//! 3. The same in-session op is now rejected with
+//!    `SessionNeedsRenegotiation` by the central session-liveness gate.
+//! 4. After re-establishing the credential and `ReopenSession`, the slot
+//!    is re-keyed under the same id and the in-session op works again.
+
+#![cfg(test)]
+
+use azihsm_ddi::*;
+use azihsm_ddi_mbor_codec::MborByteArray;
+use azihsm_ddi_mbor_types::*;
+use test_with_tracing::test;
+
+use super::common::*;
+
+#[test]
+fn test_live_migration_renegotiation_smoke() {
+    ddi_dev_test(
+        |_, _, _| 0,
+        common_cleanup,
+        |dev, ddi, path, _| {
+            let setup_res = common_setup_for_lm(dev, ddi, path);
+            let session_id = setup_res.session_id;
+            let key_props =
+                helper_key_properties(DdiKeyUsage::EncryptDecrypt, DdiKeyAvailability::App);
+
+            // 1. In-session op succeeds before migration.
+            let resp = helper_aes_generate(
+                dev,
+                Some(session_id),
+                Some(DdiApiRev { major: 1, minor: 0 }),
+                DdiAesKeySize::Aes256,
+                Some(0x1234),
+                key_props,
+            );
+            assert!(
+                resp.is_ok(),
+                "AES key gen before migration must succeed: {:?}",
+                resp
+            );
+
+            // 2. Simulate the live-migration NSSR.
+            let result = dev.erase();
+            assert!(
+                result.is_ok(),
+                "Migration simulation should succeed: {:?}",
+                result
+            );
+
+            // 3. In-session op on the migrated slot is rejected as
+            //    needing renegotiation.
+            let resp = helper_aes_generate(
+                dev,
+                Some(session_id),
+                Some(DdiApiRev { major: 1, minor: 0 }),
+                DdiAesKeySize::Aes128,
+                Some(0x5678),
+                key_props,
+            );
+            assert!(
+                matches!(
+                    resp,
+                    Err(DdiError::DdiStatus(DdiStatus::SessionNeedsRenegotiation))
+                ),
+                "In-session op after migration must return SessionNeedsRenegotiation, got {:?}",
+                resp
+            );
+
+            // 4a. Re-establish the credential and reopen the session.
+            let _ = helper_common_establish_credential_with_bmk(
+                dev,
+                TEST_CRED_ID,
+                TEST_CRED_PIN,
+                setup_res.masked_bk3,
+                setup_res.partition_bmk,
+                MborByteArray::from_slice(&[])
+                    .expect("Failed to create empty masked unwrapping key"),
+            );
+
+            let (encrypted_credential, pub_key) = encrypt_userid_pin_for_open_session(
+                dev,
+                TEST_CRED_ID,
+                TEST_CRED_PIN,
+                setup_res.random_seed,
+            );
+
+            let reopen_resp = helper_reopen_session(
+                dev,
+                session_id,
+                Some(DdiApiRev { major: 1, minor: 0 }),
+                encrypted_credential,
+                pub_key,
+                setup_res.session_bmk,
+            )
+            .expect("ReopenSession must succeed after migration");
+            assert_eq!(
+                reopen_resp.data.sess_id, session_id,
+                "Reopened session must keep the same id"
+            );
+
+            // 4b. In-session op works again after reopen.
+            let resp = helper_aes_generate(
+                dev,
+                Some(session_id),
+                Some(DdiApiRev { major: 1, minor: 0 }),
+                DdiAesKeySize::Aes192,
+                Some(0x9abc),
+                key_props,
+            );
+            assert!(
+                resp.is_ok(),
+                "AES key gen after reopen must succeed: {:?}",
+                resp
+            );
+        },
+    );
+}
+
+/// Fill the whole session table, migrate the partition (NSSR), then
+/// confirm the device is "out of sessions" for a fresh `OpenSession`
+/// while `ReopenSession` can still re-key a migrated slot.
+///
+/// After the NSSR every slot is renegotiation-pending, and those slots
+/// are reopen-only: a brand-new `OpenSession` must be rejected with
+/// `VaultSessionLimitReached` (the table is full of migrated slots that
+/// a fresh open may not reclaim), yet `ReopenSession` succeeds for the
+/// same migrated ids.
+///
+/// Each session is held on its own device handle so the partition holds
+/// `MAX_SESSIONS` sessions open at once (a handle rejects a second
+/// `OpenSession` while it already owns a session).
+#[test]
+fn test_live_migration_full_table_reopen_smoke() {
+    ddi_dev_test(
+        |_, _, _| 0,
+        common_cleanup,
+        |dev, ddi, path, _| {
+            let rev = Some(DdiApiRev { major: 1, minor: 0 });
+
+            // Session 0 (on `dev`), plus the partition credential / BK3 /
+            // BMK needed to re-establish after the migration.
+            let setup_res = common_setup_for_lm(dev, ddi, path);
+
+            // Fill the remaining slots, each on its own handle, so the
+            // whole table is occupied when the migration happens.
+            let mut extra_handles = Vec::new();
+            for _ in 0..(MAX_SESSIONS - 1) {
+                let handle = ddi.open_dev(path).unwrap();
+                let (cred, pub_key) = encrypt_userid_pin_for_open_session(
+                    &handle,
+                    TEST_CRED_ID,
+                    TEST_CRED_PIN,
+                    TEST_SESSION_SEED,
+                );
+                helper_open_session(&handle, None, rev, cred, pub_key)
+                    .expect("OpenSession must succeed until the table is full");
+                extra_handles.push(handle);
+            }
+
+            // Simulate the live-migration NSSR: every slot is preserved as
+            // renegotiation-pending.
+            dev.erase()
+                .expect("Migration simulation (erase) must succeed");
+
+            // Re-establish the partition credential (carrying the BMK
+            // forward) so post-migration session commands can authenticate.
+            let _ = helper_common_establish_credential_with_bmk(
+                dev,
+                TEST_CRED_ID,
+                TEST_CRED_PIN,
+                setup_res.masked_bk3,
+                setup_res.partition_bmk,
+                MborByteArray::from_slice(&[])
+                    .expect("Failed to create empty masked unwrapping key"),
+            );
+
+            // A fresh OpenSession must NOT reclaim a renegotiation-pending
+            // slot: with the whole table migrated, the device is out of
+            // sessions.
+            let spare = ddi.open_dev(path).unwrap();
+            let (cred, pub_key) = encrypt_userid_pin_for_open_session(
+                &spare,
+                TEST_CRED_ID,
+                TEST_CRED_PIN,
+                TEST_SESSION_SEED,
+            );
+            let resp = helper_open_session(&spare, None, rev, cred, pub_key);
+            assert!(
+                matches!(
+                    resp,
+                    Err(DdiError::DdiStatus(DdiStatus::VaultSessionLimitReached))
+                ),
+                "OpenSession on a fully-migrated table must return \
+                 VaultSessionLimitReached, got {:?}",
+                resp
+            );
+
+            // ReopenSession, however, re-keys a migrated slot under the same
+            // id and succeeds even though the table is otherwise full.
+            let (encrypted_credential, pub_key) = encrypt_userid_pin_for_open_session(
+                dev,
+                TEST_CRED_ID,
+                TEST_CRED_PIN,
+                setup_res.random_seed,
+            );
+            let reopen = helper_reopen_session(
+                dev,
+                setup_res.session_id,
+                rev,
+                encrypted_credential,
+                pub_key,
+                setup_res.session_bmk,
+            )
+            .expect("ReopenSession must succeed for a migrated slot");
+            assert_eq!(reopen.hdr.status, DdiStatus::Success);
+            assert_eq!(
+                reopen.data.sess_id, setup_res.session_id,
+                "ReopenSession must reuse the migrated session id"
+            );
+        },
+    );
+}

--- a/ddi/mbor/types/tests/integration/open_session_smoke.rs
+++ b/ddi/mbor/types/tests/integration/open_session_smoke.rs
@@ -148,6 +148,131 @@ fn test_open_session_without_establish_cred_smoke() {
     });
 }
 
+/// Fill the partition's session table, then confirm a further
+/// `OpenSession` is rejected with `VaultSessionLimitReached`, and that
+/// closing a session frees its slot for a subsequent handshake.
+///
+/// Each `OpenSession` uses its own device handle: a handle rejects a
+/// second `OpenSession` while it already owns a session, so distinct
+/// handles are needed to hold `MAX_SESSIONS` sessions open at once.
+#[test]
+fn test_open_session_limit_reached_smoke() {
+    ddi_dev_test(setup, common_cleanup, |dev, ddi, path, _| {
+        helper_common_establish_credential(dev, TEST_CRED_ID, TEST_CRED_PIN);
+        let rev = Some(DdiApiRev { major: 1, minor: 0 });
+
+        let open_on_new_handle = |ddi: &DdiTest| {
+            let handle = ddi.open_dev(path).unwrap();
+            let (cred, pub_key) = encrypt_userid_pin_for_open_session(
+                &handle,
+                TEST_CRED_ID,
+                TEST_CRED_PIN,
+                TEST_SESSION_SEED,
+            );
+            let resp = helper_open_session(&handle, None, rev, cred, pub_key);
+            (handle, resp)
+        };
+
+        // Fill every session slot.
+        let mut sessions = Vec::new();
+        for _ in 0..MAX_SESSIONS {
+            let (handle, resp) = open_on_new_handle(ddi);
+            let resp = resp.expect("OpenSession must succeed until the table is full");
+            sessions.push((
+                handle,
+                resp.hdr.sess_id.expect("open must return a sess_id"),
+            ));
+        }
+
+        // The table is now full: a further OpenSession is rejected.
+        let (spare_handle, resp) = open_on_new_handle(ddi);
+        assert!(
+            matches!(
+                resp,
+                Err(DdiError::DdiStatus(DdiStatus::VaultSessionLimitReached))
+            ),
+            "OpenSession on a full table must return VaultSessionLimitReached, got {:?}",
+            resp
+        );
+
+        // Closing a session frees its slot; the next OpenSession succeeds.
+        let (freed_handle, freed_id) = sessions.pop().unwrap();
+        helper_close_session(&freed_handle, Some(freed_id), rev)
+            .expect("CloseSession must succeed");
+        let (cred, pub_key) = encrypt_userid_pin_for_open_session(
+            &spare_handle,
+            TEST_CRED_ID,
+            TEST_CRED_PIN,
+            TEST_SESSION_SEED,
+        );
+        let resp = helper_open_session(&spare_handle, None, rev, cred, pub_key)
+            .expect("OpenSession must succeed after a slot is freed");
+        assert_eq!(resp.hdr.status, DdiStatus::Success);
+    });
+}
+
+/// Fill the session table, confirm a further `OpenSession` is rejected,
+/// then *drop* one session handle and confirm the freed slot admits a
+/// new session.
+///
+/// This exercises the close-on-drop path: `DdiEmuDev::drop` issues a
+/// best-effort `CloseSession` for the handle's live session, so releasing
+/// a handle must free its slot just like an explicit `CloseSession`.
+#[test]
+fn test_open_session_freed_by_handle_drop_smoke() {
+    ddi_dev_test(setup, common_cleanup, |dev, ddi, path, _| {
+        helper_common_establish_credential(dev, TEST_CRED_ID, TEST_CRED_PIN);
+        let rev = Some(DdiApiRev { major: 1, minor: 0 });
+
+        let open_on_new_handle = |ddi: &DdiTest| {
+            let handle = ddi.open_dev(path).unwrap();
+            let (cred, pub_key) = encrypt_userid_pin_for_open_session(
+                &handle,
+                TEST_CRED_ID,
+                TEST_CRED_PIN,
+                TEST_SESSION_SEED,
+            );
+            let resp = helper_open_session(&handle, None, rev, cred, pub_key);
+            (handle, resp)
+        };
+
+        // Fill every session slot, each on its own handle.
+        let mut sessions = Vec::new();
+        for _ in 0..MAX_SESSIONS {
+            let (handle, resp) = open_on_new_handle(ddi);
+            resp.expect("OpenSession must succeed until the table is full");
+            sessions.push(handle);
+        }
+
+        // The table is now full: a further OpenSession is rejected.
+        let (spare_handle, resp) = open_on_new_handle(ddi);
+        assert!(
+            matches!(
+                resp,
+                Err(DdiError::DdiStatus(DdiStatus::VaultSessionLimitReached))
+            ),
+            "OpenSession on a full table must return VaultSessionLimitReached, got {:?}",
+            resp
+        );
+
+        // Dropping a session handle closes its session on Drop, which
+        // frees the slot -- no explicit CloseSession required.
+        let dropped_handle = sessions.pop().unwrap();
+        drop(dropped_handle);
+
+        // The freed slot now admits a new session.
+        let (cred, pub_key) = encrypt_userid_pin_for_open_session(
+            &spare_handle,
+            TEST_CRED_ID,
+            TEST_CRED_PIN,
+            TEST_SESSION_SEED,
+        );
+        let resp = helper_open_session(&spare_handle, None, rev, cred, pub_key)
+            .expect("OpenSession must succeed after a handle drop frees a slot");
+        assert_eq!(resp.hdr.status, DdiStatus::Success);
+    });
+}
+
 /// Build an OpenSession request body that the host MBOR codec will
 /// accept (correct field lengths and a wire-valid `DdiDerPublicKey`),
 /// for use by tests that exercise pre-crypto fail-fast paths.

--- a/ddi/mbor/types/tests/integration/reopen_session_smoke.rs
+++ b/ddi/mbor/types/tests/integration/reopen_session_smoke.rs
@@ -1,0 +1,133 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! ReopenSession smoke tests for the emu backend.
+//!
+//! Exercises the ReopenSession firmware command end-to-end after a
+//! simulated live-migration NSSR:
+//!
+//! - Happy path: after the NSSR the credential is re-established and the
+//!   migrated session is reopened under the same id by unmasking the
+//!   host-persisted `bmk_session` and re-keying the preserved
+//!   (renegotiation-pending) slot (`Success`).
+//! - Wrong PIN: reopening with a credential whose PIN does not match the
+//!   partition credential is rejected, leaving the slot unusable.
+
+#![cfg(test)]
+
+use azihsm_ddi::*;
+use azihsm_ddi_mbor_codec::MborByteArray;
+use azihsm_ddi_mbor_types::*;
+use test_with_tracing::test;
+
+use super::common::*;
+
+#[test]
+fn test_reopen_session_smoke() {
+    ddi_dev_test(
+        |_, _, _| 0,
+        common_cleanup,
+        |dev, ddi, path, _session_id| {
+            let setup_res = common_setup_for_lm(dev, ddi, path);
+
+            // Simulate the live-migration NSSR.
+            let result = dev.erase();
+            assert!(
+                result.is_ok(),
+                "Migration simulation should succeed: {:?}",
+                result
+            );
+
+            // Re-establish the partition credential (no unwrapping-key
+            // re-import) so the reopen can authenticate.
+            let _ = helper_common_establish_credential_with_bmk(
+                dev,
+                TEST_CRED_ID,
+                TEST_CRED_PIN,
+                setup_res.masked_bk3,
+                setup_res.partition_bmk,
+                MborByteArray::from_slice(&[])
+                    .expect("Failed to create empty masked unwrapping key"),
+            );
+
+            let (encrypted_credential, pub_key) = encrypt_userid_pin_for_open_session(
+                dev,
+                TEST_CRED_ID,
+                TEST_CRED_PIN,
+                setup_res.random_seed,
+            );
+
+            let resp = helper_reopen_session(
+                dev,
+                setup_res.session_id,
+                Some(DdiApiRev { major: 1, minor: 0 }),
+                encrypted_credential,
+                pub_key,
+                setup_res.session_bmk,
+            )
+            .expect("ReopenSession happy path must succeed");
+
+            assert_eq!(resp.hdr.op, DdiOp::ReopenSession);
+            assert_eq!(resp.hdr.status, DdiStatus::Success);
+            assert_eq!(
+                resp.data.sess_id, setup_res.session_id,
+                "ReopenSession must reuse the migrated session id"
+            );
+            assert!(
+                !resp.data.bmk_session.is_empty(),
+                "ReopenSession must return a re-enveloped session masking key"
+            );
+        },
+    );
+}
+
+#[test]
+fn test_reopen_session_incorrect_pin_smoke() {
+    ddi_dev_test(
+        |_, _, _| 0,
+        common_cleanup,
+        |dev, ddi, path, _session_id| {
+            let setup_res = common_setup_for_lm(dev, ddi, path);
+
+            let result = dev.erase();
+            assert!(
+                result.is_ok(),
+                "Migration simulation should succeed: {:?}",
+                result
+            );
+
+            let _ = helper_common_establish_credential_with_bmk(
+                dev,
+                TEST_CRED_ID,
+                TEST_CRED_PIN,
+                setup_res.masked_bk3,
+                setup_res.partition_bmk,
+                MborByteArray::from_slice(&[])
+                    .expect("Failed to create empty masked unwrapping key"),
+            );
+
+            // Reopen with a PIN that does not match the partition credential.
+            let (encrypted_credential, pub_key) = encrypt_userid_pin_for_open_session(
+                dev,
+                TEST_CRED_ID,
+                [1; 16],
+                setup_res.random_seed,
+            );
+
+            let resp = helper_reopen_session(
+                dev,
+                setup_res.session_id,
+                Some(DdiApiRev { major: 1, minor: 0 }),
+                encrypted_credential,
+                pub_key,
+                setup_res.session_bmk,
+            );
+
+            assert!(
+                resp.is_err(),
+                "ReopenSession with an incorrect PIN must be rejected, got {:?}",
+                resp
+            );
+        },
+    );
+}

--- a/ddi/tbor/types/tests/commands/open_session.rs
+++ b/ddi/tbor/types/tests/commands/open_session.rs
@@ -255,3 +255,29 @@ fn open_session_multiple_concurrent_emu() {
         "concurrent sessions must have distinct ids",
     );
 }
+
+#[test]
+fn open_session_cu_range_exhausted_rejected_emu() {
+    let ctx = TestCtx::new();
+    // The CU role occupies slots 1..=7 (7 slots); slot 0 is reserved for
+    // CO.  Fill every CU slot, holding the guards open, then a further CU
+    // handshake must be rejected because the range is exhausted.
+    let mut guards = Vec::new();
+    for _ in 0..7 {
+        guards.push(ctx.open_session(CU, SessionType::PlainText));
+    }
+    let err = ctx
+        .open_session_raw(CU, SessionType::PlainText)
+        .expect_err("a CU handshake with the range full must be rejected");
+
+    // Closing one session frees its slot, so a subsequent handshake
+    // succeeds again — the rejection was a capacity limit, not a
+    // permanent failure.
+    drop(guards.pop());
+    let _reopened = ctx.open_session(CU, SessionType::PlainText);
+
+    // Keep the remaining guards live until here so the table stayed full
+    // for the rejection above.
+    drop(guards);
+    let _ = err;
+}

--- a/fw/core/lib/src/ddi/mbor/mod.rs
+++ b/fw/core/lib/src/ddi/mbor/mod.rs
@@ -29,6 +29,7 @@ pub(crate) mod kdf;
 pub(crate) mod key_attrs;
 pub(crate) mod masking;
 pub(crate) mod open_session;
+pub(crate) mod reopen_session;
 pub(crate) mod rsa_mod_exp;
 pub(crate) mod rsa_unwrap;
 pub(crate) mod set_sealed_bk3;
@@ -63,6 +64,7 @@ pub(crate) use hmac::*;
 pub(crate) use init_bk3::*;
 pub(crate) use kbkdf_derive::*;
 pub(crate) use open_session::*;
+pub(crate) use reopen_session::*;
 pub(crate) use rsa_mod_exp::*;
 pub(crate) use rsa_unwrap::*;
 pub(crate) use set_sealed_bk3::*;
@@ -177,6 +179,7 @@ pub(crate) async fn dispatch<'p, P: HsmPal>(
         DdiOp::EstablishCredential => establish_credential(pal, io, decoder, hdr).await,
         DdiOp::ChangePin => change_pin(pal, io, decoder, hdr).await,
         DdiOp::CloseSession => close_session(pal, io, decoder, hdr).await,
+        DdiOp::ReopenSession => reopen_session(pal, io, decoder, hdr).await,
         DdiOp::DeleteKey => delete_key(pal, io, decoder, hdr).await,
         DdiOp::AesGenerateKey => aes_generate_key(pal, io, decoder, hdr).await,
         DdiOp::AesEncryptDecrypt => aes_encrypt_decrypt(pal, io, decoder, hdr).await,

--- a/fw/core/lib/src/ddi/mbor/open_session.rs
+++ b/fw/core/lib/src/ddi/mbor/open_session.rs
@@ -37,9 +37,11 @@
 
 use azihsm_fw_core_crypto_key_masking::cbc::mask;
 use azihsm_fw_ddi_mbor_types::masked_key::DdiMaskedKeyMetadata;
+use azihsm_fw_ddi_mbor_types::open_session::DdiEncryptedSessionCredential;
 use azihsm_fw_ddi_mbor_types::open_session::DdiOpenSessionReq;
 use azihsm_fw_ddi_mbor_types::open_session::DdiOpenSessionResp;
 use azihsm_fw_ddi_mbor_types::DdiKeyType;
+use azihsm_fw_ddi_mbor_types::DdiPublicKey;
 
 use super::*;
 
@@ -50,7 +52,7 @@ const SESSION_BK_LABEL: &[u8] = b"SESSION_BK";
 
 /// Cleartext label embedded in the BMK_SESSION metadata identifying
 /// the wrapped key as the session masking key.
-const SMK_KEY_LABEL: &[u8] = b"SMK";
+pub(super) const SMK_KEY_LABEL: &[u8] = b"SMK";
 
 /// Handle `DdiOpenSessionCmd`.
 ///
@@ -68,65 +70,28 @@ pub(crate) async fn open_session<'p, P: HsmPal>(
 
     let _lock = pal.partition_lock(io).await?;
 
-    check_fail_fast(pal, io, &body)?;
-    let api_rev = hdr.rev.ok_or(HsmError::UnsupportedRevision)?;
-
-    // ── Steps 2-3: ECDH + HKDF → 80-byte OKM (aes_key ‖ hmac_key) ────
-    let okm = pal.dma_alloc(io, BK_LEN)?;
-    derive_session_credential_keys(
+    check_fail_fast(
         pal,
         io,
-        body.pub_key.raw,
         body.encrypted_credential.nonce,
-        okm,
-    )
-    .await?;
-    let (aes_key, hmac_key) = okm.split_at(okm.len() - HsmHashAlgo::Sha384.digest_len());
+        &body.pub_key,
+        false,
+    )?;
+    let api_rev = hdr.rev.ok_or(HsmError::UnsupportedRevision)?;
 
-    // ── Step 4: HMAC verify the credential ───────────────────────────
-    verify_credential_hmac(pal, io, &body.encrypted_credential, hmac_key).await?;
+    // ── Steps 2-7: authenticate the credential and derive BK_SESSION ──
+    let pub_key_raw = body.pub_key.raw;
+    let bk_session =
+        authenticate_and_derive_bk_session(pal, io, &mut body.encrypted_credential, pub_key_raw)
+            .await?;
 
-    // ── Step 5: Reset nonce, then AES-CBC decrypt id, pin, seed ──────
+    // ── Step 8: fresh random MK_SESSION, then allocate a new slot ────
     //
-    // Reset the partition nonce *before* decrypting / verifying the
-    // credential so the nonce that authenticated this request cannot
-    // be replayed if a later step fails partway through.
-    {
-        let nonce = pal.dma_alloc(io, crate::part_state::NONCE_LEN)?;
-        pal.rng_fill_bytes(io, nonce)?;
-        crate::part_state::part_set_nonce(pal, io, nonce)?;
-    }
-    decrypt_session_credential(pal, io, &mut body.encrypted_credential, aes_key).await?;
-
-    // ── Step 6: Verify decrypted credential matches persisted ────────
-    let id: &[u8] = body.encrypted_credential.encrypted_id;
-    let pin: &[u8] = body.encrypted_credential.encrypted_pin;
-    if id == [0u8; CRED_FIELD_LEN] || pin == [0u8; CRED_FIELD_LEN] {
-        return Err(HsmError::InvalidAppCredentials);
-    }
-    crate::part_state::part_verify_credential(pal, io, id, pin)?;
-
-    // ── Step 7: Fresh MK_SESSION + derived BK_SESSION ────────────────
+    // The host stores the wrapped MK_SESSION (`bmk_session`, below) and
+    // re-presents it on `ReopenSession` after a migration / NSSR.
     let mk_session = pal.dma_alloc(io, BK_LEN)?;
     pal.rng_fill_bytes(io, mk_session)?;
 
-    let bk_boot = pal.dma_alloc(io, BK_BOOT_LEN)?;
-    crate::ddi::recover_bk_boot(pal, io, bk_boot).await?;
-
-    let bk_session = pal.dma_alloc(io, BK_LEN)?;
-    let session_bk_label = pal.dma_alloc(io, SESSION_BK_LABEL.len())?;
-    session_bk_label.copy_from_slice(SESSION_BK_LABEL);
-    pal.sp800_108_kdf(
-        io,
-        HsmHashAlgo::Sha384,
-        bk_boot,
-        Some(session_bk_label),
-        Some(body.encrypted_credential.encrypted_seed),
-        bk_session,
-    )
-    .await?;
-
-    // ── Step 8: Allocate the session table entry ─────────────────────
     let api_rev_bytes = pack_api_rev(api_rev);
     let sess_id = pal
         .session_create(io, &api_rev_bytes, mk_session, None)
@@ -155,19 +120,24 @@ pub(crate) async fn open_session<'p, P: HsmPal>(
     })
 }
 
-/// Performs all fail-fast checks before any cryptographic work.
+/// Performs all fail-fast checks before any cryptographic work, shared
+/// by `OpenSession` and `ReopenSession`.
 ///
 /// Must be called under the partition lock so the partition-state
 /// checks (nonce, credential-set, provisioned, session-table) stay
-/// consistent with the subsequent state mutations.
+/// consistent with the subsequent state mutations.  `is_reopen` skips
+/// the free-slot check, since `ReopenSession` recreates the migrated
+/// session's own slot rather than allocating a new one.
 ///
 /// Session-id and api-rev presence are validated centrally — see
 /// `validate_session` (io.rs) and `check_api_rev` (mod.rs) — so they
 /// are not re-checked here.
-fn check_fail_fast<P: HsmPal>(
+pub(super) fn check_fail_fast<P: HsmPal>(
     pal: &P,
     io: &impl HsmIo,
-    body: &DdiOpenSessionReq<'_>,
+    nonce: &DmaBuf,
+    pub_key: &DdiPublicKey<'_>,
+    is_reopen: bool,
 ) -> HsmResult<()> {
     // Credential / provisioning state is checked BEFORE the nonce.
     // Matches the mcr-hsm reference (which gates on `verify_cred_is_set`
@@ -176,26 +146,105 @@ fn check_fail_fast<P: HsmPal>(
     // partition: NonceMismatch could be hit by any random replay,
     // whereas CredentialsNotEstablished tells the host it must
     // EstablishCredential first.
-    if !crate::part_state::part_is_credential_set(pal, io)? {
-        return Err(HsmError::CredentialsNotEstablished);
-    }
-    if !crate::part_state::part_is_provisioned(pal, io)? {
+    //
+    // The report order differs for ReopenSession: it re-keys a session
+    // that migrated away and carries its own credential in the request,
+    // so a missing provisioning root (BK/MK) is the more actionable
+    // failure and is surfaced first as PartitionNotProvisioned. That
+    // matches the simulator's reopen contract and the live-migration
+    // recovery flow, which re-provisions the partition (`restore_partition`)
+    // before reopening the session.
+    let cred_set = crate::part_state::part_is_credential_set(pal, io)?;
+    let provisioned = crate::part_state::part_is_provisioned(pal, io)?;
+    if is_reopen && !provisioned {
         return Err(HsmError::PartitionNotProvisioned);
     }
-    if pal.session_limit_reached(io) {
+    if !cred_set {
+        return Err(HsmError::CredentialsNotEstablished);
+    }
+    if !provisioned {
+        return Err(HsmError::PartitionNotProvisioned);
+    }
+    // ReopenSession reuses the migrated-away session's slot, so it is not
+    // gated on free-slot availability (mirrors the reference firmware).
+    if !is_reopen && pal.session_limit_reached(io) {
         return Err(HsmError::VaultSessionLimitReached);
     }
 
-    crate::part_state::part_verify_nonce(pal, io, body.encrypted_credential.nonce)?;
+    crate::part_state::part_verify_nonce(pal, io, nonce)?;
 
-    if body.pub_key.key_kind != DdiKeyType::Ecc384Public {
+    if pub_key.key_kind != DdiKeyType::Ecc384Public {
         return Err(HsmError::InvalidKeyType);
     }
-    if body.pub_key.raw.len() != HsmEccCurve::P384.pub_key_len() {
+    if pub_key.raw.len() != HsmEccCurve::P384.pub_key_len() {
         return Err(HsmError::InvalidArg);
     }
 
     Ok(())
+}
+
+/// Shared `OpenSession` / `ReopenSession` credential authentication and
+/// `BK_SESSION` derivation (steps 2-7).
+///
+/// Runs ECDH-P384 + HKDF, HMAC-verifies the credential, resets the
+/// partition nonce, AES-CBC decrypts and constant-time verifies the
+/// credential, then derives the 80-byte `BK_SESSION` by SP 800-108
+/// KBKDF rooted in `BK_BOOT` (label `SESSION_BK`, context = decrypted
+/// seed).  `enc_cred` is decrypted in place; the returned buffer is
+/// `BK_SESSION`.
+///
+/// Both handlers derive `BK_SESSION` here, so the blob `OpenSession`
+/// masks under it is exactly what `ReopenSession` unmasks with it.
+pub(super) async fn authenticate_and_derive_bk_session<'p, P: HsmPal>(
+    pal: &'p P,
+    io: &impl HsmIo,
+    enc_cred: &mut DdiEncryptedSessionCredential<'_>,
+    pub_key_raw: &DmaBuf,
+) -> HsmResult<&'p mut DmaBuf> {
+    // Steps 2-3: ECDH + HKDF → 80-byte OKM (aes_key ‖ hmac_key).
+    let okm = pal.dma_alloc(io, BK_LEN)?;
+    derive_session_credential_keys(pal, io, pub_key_raw, enc_cred.nonce, okm).await?;
+    let (aes_key, hmac_key) = okm.split_at(okm.len() - HsmHashAlgo::Sha384.digest_len());
+
+    // Step 4: HMAC verify the credential.
+    verify_credential_hmac(pal, io, enc_cred, hmac_key).await?;
+
+    // Step 5: reset the nonce *before* decrypting / verifying so it
+    // cannot be replayed if a later step fails, then AES-CBC decrypt id,
+    // pin, and seed in place.
+    {
+        let nonce = pal.dma_alloc(io, crate::part_state::NONCE_LEN)?;
+        pal.rng_fill_bytes(io, nonce)?;
+        crate::part_state::part_set_nonce(pal, io, nonce)?;
+    }
+    decrypt_session_credential(pal, io, enc_cred, aes_key).await?;
+
+    // Step 6: verify the decrypted credential matches the persisted one.
+    let id: &[u8] = enc_cred.encrypted_id;
+    let pin: &[u8] = enc_cred.encrypted_pin;
+    if id == [0u8; CRED_FIELD_LEN] || pin == [0u8; CRED_FIELD_LEN] {
+        return Err(HsmError::InvalidAppCredentials);
+    }
+    crate::part_state::part_verify_credential(pal, io, id, pin)?;
+
+    // Step 7: BK_SESSION = SP800-108(BK_BOOT, "SESSION_BK", seed).
+    let bk_boot = pal.dma_alloc(io, BK_BOOT_LEN)?;
+    crate::ddi::recover_bk_boot(pal, io, bk_boot).await?;
+
+    let bk_session = pal.dma_alloc(io, BK_LEN)?;
+    let session_bk_label = pal.dma_alloc(io, SESSION_BK_LABEL.len())?;
+    session_bk_label.copy_from_slice(SESSION_BK_LABEL);
+    pal.sp800_108_kdf(
+        io,
+        HsmHashAlgo::Sha384,
+        bk_boot,
+        Some(session_bk_label),
+        Some(enc_cred.encrypted_seed),
+        bk_session,
+    )
+    .await?;
+
+    Ok(bk_session)
 }
 
 /// Derives the AES-256 ‖ HMAC-SHA-384 OKM used to authenticate and
@@ -416,7 +465,7 @@ async fn encode_response<'p, P: HsmPal>(
 
 /// Pack a [`DdiApiRev`] into the 8-byte little-endian form expected by
 /// [`HsmSessionManager::session_create`].
-fn pack_api_rev(rev: azihsm_fw_ddi_mbor_types::DdiApiRev) -> [u8; 8] {
+pub(super) fn pack_api_rev(rev: azihsm_fw_ddi_mbor_types::DdiApiRev) -> [u8; 8] {
     let mut out = [0u8; 8];
     out[..4].copy_from_slice(&rev.major.to_le_bytes());
     out[4..].copy_from_slice(&rev.minor.to_le_bytes());

--- a/fw/core/lib/src/ddi/mbor/reopen_session.rs
+++ b/fw/core/lib/src/ddi/mbor/reopen_session.rs
@@ -1,0 +1,180 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! DDI ReopenSession command handler.
+//!
+//! Re-establishes a session that a live-migration / NSSR reset left in
+//! the [`NeedsRenegotiation`](azihsm_fw_hsm_pal_traits::HsmSessionState::NeedsRenegotiation)
+//! state.  It shares the credential-authentication and `BK_SESSION`
+//! derivation with [`OpenSession`](super::open_session) — the two must
+//! stay in lock-step so the `BK_SESSION` that masked `bmk_session` on
+//! open is exactly the one that unmasks it on reopen — then, instead of
+//! generating a fresh `MK_SESSION`, recovers it by unmasking the
+//! host-persisted `bmk_session` and re-keys the **same** session slot.
+//!
+//! Flow at a glance (mirrors the reference firmware's `is_reopen` path
+//! in the OpenSession FSM):
+//!
+//! 1. Decode + fail-fast (shared [`check_fail_fast`] with
+//!    `is_reopen = true`, which skips the free-slot check since the slot
+//!    already exists).
+//! 2. Authenticate the credential and derive `BK_SESSION` via the shared
+//!    [`authenticate_and_derive_bk_session`].
+//! 3. Unmask the host-persisted `bmk_session` under `BK_SESSION` to
+//!    recover `MK_SESSION` (the HMAC is verified before decryption, so a
+//!    tampered blob or wrong credential lineage is rejected).
+//! 4. `session_create(Some(old_sess_id))` — re-key the migrated slot with
+//!    the recovered `MK_SESSION`.
+//! 5. Re-envelope `MK_SESSION` under `BK_SESSION` into the response's
+//!    `bmk_session` for the host to persist, and echo the reused
+//!    `sess_id` in the response header.
+
+use azihsm_fw_core_crypto_key_masking::cbc::mask;
+use azihsm_fw_core_crypto_key_masking::cbc::unmask;
+use azihsm_fw_ddi_mbor_types::masked_key::DdiMaskedKeyMetadata;
+use azihsm_fw_ddi_mbor_types::reopen_session::DdiReopenSessionReq;
+use azihsm_fw_ddi_mbor_types::reopen_session::DdiReopenSessionResp;
+use azihsm_fw_ddi_mbor_types::DdiKeyType;
+
+use super::open_session::authenticate_and_derive_bk_session;
+use super::open_session::check_fail_fast;
+use super::open_session::pack_api_rev;
+use super::open_session::SMK_KEY_LABEL;
+use super::*;
+
+/// Handle `DdiReopenSessionCmd`.
+///
+/// Re-establishes a session that a live-migration / NSSR wiped from the
+/// partition.  Authenticates the host credential and derives `BK_SESSION`
+/// exactly as [`open_session`](super::open_session::open_session); then,
+/// instead of generating a fresh `MK_SESSION`, recovers it by unmasking
+/// the host-persisted `bmk_session` under `BK_SESSION`, and recreates the
+/// **same** session slot via `session_create(Some(old_sess_id))`.  The
+/// session id to reopen is carried in the request header.  Mirrors the
+/// reference firmware's `is_reopen` path in the OpenSession FSM.
+pub(crate) async fn reopen_session<'p, P: HsmPal>(
+    pal: &'p P,
+    io: &impl HsmIo,
+    decoder: &mut DdiDecoder<'_>,
+    hdr: &DdiReqHdr,
+) -> HsmResult<&'p DmaBuf> {
+    let mut body: DdiReopenSessionReq = decoder.decode_data()?;
+    let reopen_id = HsmSessId::from(hdr.sess_id.ok_or(HsmError::SessionExpected)?);
+
+    let _lock = pal.partition_lock(io).await?;
+
+    check_fail_fast(
+        pal,
+        io,
+        body.encrypted_credential.nonce,
+        &body.pub_key,
+        true,
+    )?;
+    let api_rev = hdr.rev.ok_or(HsmError::UnsupportedRevision)?;
+
+    // Authenticate the credential and derive BK_SESSION — identical to
+    // OpenSession, so the same BK_SESSION that masked `bmk_session`
+    // unmasks it below.
+    let pub_key_raw = body.pub_key.raw;
+    let bk_session =
+        authenticate_and_derive_bk_session(pal, io, &mut body.encrypted_credential, pub_key_raw)
+            .await?;
+
+    // Recover MK_SESSION by unmasking the host-persisted `bmk_session`
+    // under BK_SESSION.  `unmask` verifies the HMAC before decrypting, so
+    // a tampered blob or one from a different credential lineage (wrong
+    // BK_SESSION) is rejected without leaking plaintext.
+    let layout = unmask(pal, io, bk_session, body.bmk_session).await?;
+    // The authenticated blob must carry at least a full MK_SESSION; a
+    // shorter plaintext is a malformed masked key, reported like the rest
+    // of the unmask path.
+    if layout.plaintext_max_len < BK_LEN {
+        return Err(HsmError::MaskedKeyDecodeFailed);
+    }
+    let mk_session = pal.dma_alloc(io, BK_LEN)?;
+    mk_session.copy_from_slice(
+        &body.bmk_session[layout.plaintext_offset..layout.plaintext_offset + BK_LEN],
+    );
+
+    // Recreate the migrated session's own slot with the recovered key.
+    let api_rev_bytes = pack_api_rev(api_rev);
+    let sess_id = pal
+        .session_create(io, &api_rev_bytes, mk_session, Some(reopen_id))
+        .await?;
+
+    // Re-envelope MK_SESSION under BK_SESSION for the host to persist
+    // (the SVN etc. recorded in the metadata may have advanced), mirroring
+    // OpenSession's response.
+    let resp = encode_reopen_response(
+        pal,
+        io,
+        hdr,
+        sess_id,
+        bk_session,
+        mk_session,
+        crate::part_state::part_mfgr_svn(pal),
+        u16::try_from(crate::part_state::part_owner_svn(pal)).map_err(|_| HsmError::InvalidArg)?,
+    )
+    .await?;
+
+    // `ReopenSession` is an in-session command: it reuses the caller's
+    // existing session id (echoed in the response header), so unlike
+    // `OpenSession` there is no *new* id to surface to the CQE — return the
+    // plain response slice.
+    Ok(resp)
+}
+
+/// Envelopes `mk_session` under `bk_session` and encodes the
+/// `ReopenSession` response.  Structurally identical to
+/// [`encode_response`](super::open_session) but frames a
+/// [`DdiReopenSessionResp`] under the [`DdiOp::ReopenSession`] opcode.
+#[allow(clippy::too_many_arguments)]
+async fn encode_reopen_response<'p, P: HsmPal>(
+    pal: &'p P,
+    io: &impl HsmIo,
+    hdr: &DdiReqHdr,
+    sess_id: HsmSessId,
+    bk_session: &DmaBuf,
+    mk_session: &DmaBuf,
+    svn: u64,
+    bks2_id: u16,
+) -> HsmResult<&'p DmaBuf> {
+    let bmk_metadata = DdiMaskedKeyMetadata {
+        svn,
+        key_type: DdiKeyType::AesCbc256Hmac384,
+        key_attributes: HsmVaultKeyAttrs::new().into(),
+        bks2_index: Some(bks2_id),
+        rsvd: None,
+        key_label: SMK_KEY_LABEL,
+        key_length: BK_LEN as u16,
+    };
+
+    let bmk_len = mask(pal, io, bk_session, mk_session, &bmk_metadata, None).await?;
+
+    let short_app_id: u8 = 0;
+
+    let (resp, layout) = pal.dma_alloc_var_with(io, |buf| {
+        let mut encoder = super::encode_resp_hdr(
+            &super::success_hdr_sess(hdr, DdiOp::ReopenSession, u16::from(sess_id)),
+            buf,
+        )?;
+        let layout =
+            DdiReopenSessionResp::reserve(&mut encoder, u16::from(sess_id), short_app_id, bmk_len)?;
+        Ok((encoder.position(), layout))
+    })?;
+    let frame = DdiReopenSessionResp::from_layout(resp, &layout);
+
+    // `key_masking::cbc::mask` requires `out[..total_len]` to be zero
+    // on entry.
+    frame.bmk_session.fill(0);
+    mask(
+        pal,
+        io,
+        bk_session,
+        mk_session,
+        &bmk_metadata,
+        Some(frame.bmk_session),
+    )
+    .await?;
+    Ok(resp)
+}

--- a/fw/plat/std/pal/src/drivers/session.rs
+++ b/fw/plat/std/pal/src/drivers/session.rs
@@ -144,6 +144,41 @@ impl SessionTable {
         }
     }
 
+    /// Snapshot the set of Active session slots for a live-migration
+    /// disable.
+    ///
+    /// Returns a bitmask of the currently-Active slots so it can be
+    /// handed to [`restore`](Self::restore) after the partition's crypto
+    /// state has been cleared.  In-flight Pending handshakes are excluded
+    /// because they carry no reopenable credential state.  Mirrors the
+    /// reference firmware's `backup`/`restore` pair.
+    pub fn backup(&self) -> u8 {
+        self.alloc_mask & !self.pending_mask
+    }
+
+    /// Re-establish session slots preserved across a partition disable,
+    /// marking every survivor as [`NeedsRenegotiation`](HsmSessionState::NeedsRenegotiation).
+    ///
+    /// `mask` is a snapshot taken by [`backup`](Self::backup) *before*
+    /// the partition's vault and keys were cleared.  Every bit set in
+    /// `mask` becomes an allocated slot needing renegotiation: its
+    /// physical vault mapping is dropped (the key material did not
+    /// survive the disable) and a subsequent `ReopenSession` re-keys it
+    /// via [`recreate`](Self::recreate).  Any leftover Pending state is
+    /// discarded.  Mirrors the reference firmware's `restore`.
+    pub fn restore(&mut self, mask: u8) {
+        self.alloc_mask = mask;
+        self.renego_mask = mask;
+        self.pending_mask = 0;
+        self.psk_change_mask = 0;
+        self.phys_ids = [0; MAX_SESSIONS];
+        for blob in &mut self.pending_blobs {
+            blob.clear();
+        }
+        self.pending_seqs = [0u64; MAX_SESSIONS];
+        self.next_init_seq = 0;
+    }
+
     /// Validate that a logical session ID refers to an allocated slot.
     /// Returns the slot index on success.
     fn active_slot(&self, id: HsmSessId) -> HsmResult<usize> {
@@ -307,7 +342,9 @@ impl SessionTable {
             return Ok(HsmSessId::from(slot as u16));
         }
 
-        // 3. All slots in range are Active or NeedsRenegotiation.
+        // 3. All slots in range are Active or NeedsRenegotiation.  A
+        //    NeedsRenegotiation slot is reserved for its own
+        //    `ReopenSession`; it is never reclaimed by a fresh handshake.
         Err(HsmError::VaultSessionLimitReached)
     }
 
@@ -598,6 +635,133 @@ mod tests {
             .create_pending(SessionRole::CryptoOfficer, b"x")
             .unwrap_err();
         assert_eq!(err, HsmError::VaultSessionLimitReached);
+    }
+
+    #[test]
+    fn co_init_with_slot_zero_renego_returns_limit_reached() {
+        let mut table = SessionTable::new();
+        // A CO session left NeedsRenegotiation by a live-migration disable
+        // is reserved for its own ReopenSession — a fresh CO handshake must
+        // NOT reclaim it, and reports the table full instead.
+        let id = table
+            .create_pending(SessionRole::CryptoOfficer, b"hs")
+            .unwrap();
+        table.promote(id, HsmKeyId::from(0xCAFE)).unwrap();
+        table.set_needs_renego(id);
+        assert!(matches!(
+            table.state(id),
+            HsmSessionState::NeedsRenegotiation
+        ));
+        let err = table
+            .create_pending(SessionRole::CryptoOfficer, b"fresh")
+            .unwrap_err();
+        assert_eq!(err, HsmError::VaultSessionLimitReached);
+    }
+
+    #[test]
+    fn cu_init_with_all_renego_returns_limit_reached() {
+        let mut table = SessionTable::new();
+        // Fill the CU range (slots 1..=7) with sessions and mark them all
+        // NeedsRenegotiation (as a live-migration disable would). A fresh
+        // CU handshake must NOT reclaim any of them — they are reserved for
+        // their own ReopenSession — and reports the table full instead.
+        for _ in 1u16..=7 {
+            let id = table
+                .create_pending(SessionRole::CryptoUser, b"cu")
+                .unwrap();
+            table.promote(id, HsmKeyId::from(0x100)).unwrap();
+            table.set_needs_renego(id);
+        }
+        let err = table
+            .create_pending(SessionRole::CryptoUser, b"fresh")
+            .unwrap_err();
+        assert_eq!(err, HsmError::VaultSessionLimitReached);
+    }
+
+    #[test]
+    fn legacy_create_skips_renego_slot_and_uses_next_free() {
+        let mut table = SessionTable::new();
+        // An Active session in slot 0 marked NeedsRenegotiation must be
+        // skipped by the legacy `create` path: a fresh session lands in the
+        // next free slot rather than reclaiming the renego slot.
+        let id0 = table.create(HsmKeyId::from(0x10)).unwrap();
+        table.set_needs_renego(id0);
+        assert!(matches!(
+            table.state(id0),
+            HsmSessionState::NeedsRenegotiation
+        ));
+
+        let id1 = table.create(HsmKeyId::from(0x11)).unwrap();
+        assert_eq!(u16::from(id1), 1);
+        // The renego slot is untouched and still reopenable.
+        assert!(matches!(
+            table.state(id0),
+            HsmSessionState::NeedsRenegotiation
+        ));
+    }
+
+    #[test]
+    fn legacy_create_with_all_renego_returns_limit_reached() {
+        let mut table = SessionTable::new();
+        for i in 0u16..MAX_SESSIONS as u16 {
+            let id = table.create(HsmKeyId::from(0x100 + i)).unwrap();
+            table.set_needs_renego(id);
+        }
+        let err = table.create(HsmKeyId::from(0x999)).unwrap_err();
+        assert_eq!(err, HsmError::VaultSessionLimitReached);
+    }
+
+    #[test]
+    fn backup_snapshots_active_and_renego_but_not_pending() {
+        let mut table = SessionTable::new();
+        // slot 0: Active (CO); slot 1: NeedsRenegotiation (CU); slot 2:
+        // Pending (CU, in-flight handshake).
+        table.create(HsmKeyId::from(0xA0)).unwrap(); // slot 0 Active
+        let renego = table.create_pending(SessionRole::CryptoUser, b"r").unwrap();
+        table.promote(renego, HsmKeyId::from(0xA1)).unwrap();
+        table.set_needs_renego(renego); // slot 1 renego
+        table.create_pending(SessionRole::CryptoUser, b"p").unwrap(); // slot 2 Pending
+
+        // Active + renego preserved; the in-flight Pending is excluded.
+        assert_eq!(table.backup(), 0b0000_0011);
+    }
+
+    #[test]
+    fn restore_marks_all_survivors_renego_and_drops_pending() {
+        let mut table = SessionTable::new();
+        // A Pending in-flight handshake must not survive the disable.
+        table.create_pending(SessionRole::CryptoUser, b"p").unwrap();
+        // Re-apply a snapshot of slots 0 and 3.
+        table.restore(0b0000_1001);
+
+        assert!(matches!(
+            table.state(HsmSessId::from(0)),
+            HsmSessionState::NeedsRenegotiation
+        ));
+        assert!(matches!(
+            table.state(HsmSessId::from(3)),
+            HsmSessionState::NeedsRenegotiation
+        ));
+        // The pre-restore Pending slot (2) is gone.
+        assert!(matches!(
+            table.state(HsmSessId::from(2)),
+            HsmSessionState::Invalid
+        ));
+    }
+
+    #[test]
+    fn delete_frees_a_renego_slot() {
+        let mut table = SessionTable::new();
+        // A NeedsRenegotiation session can still be torn down (CloseSession),
+        // which frees its slot for a subsequent fresh handshake.
+        let id = table.create(HsmKeyId::from(0x42)).unwrap();
+        table.set_needs_renego(id);
+        table.delete(id).unwrap();
+        assert!(matches!(table.state(id), HsmSessionState::Invalid));
+
+        // The freed slot is now reusable.
+        let reused = table.create(HsmKeyId::from(0x43)).unwrap();
+        assert_eq!(u16::from(reused), u16::from(id));
     }
 
     #[test]

--- a/fw/plat/std/pal/src/part.rs
+++ b/fw/plat/std/pal/src/part.rs
@@ -888,8 +888,16 @@ impl StdHsmPal {
             return Err(HsmError::InvalidArg);
         }
 
-        Self::clear_enabled_state(&mut table.entries[idx]);
-        table.entries[idx].state = PartState::Disabled;
+        // Preserve any live sessions across the NSSR as
+        // NeedsRenegotiation so a subsequent ReopenSession can re-key
+        // them (mirrors the reference firmware's `disable`, which does
+        // `restore(backup())`).  The snapshot must be taken *before*
+        // `clear_enabled_state` wipes the session table and vault.
+        let entry = &mut table.entries[idx];
+        let session_backup = entry.session_table.backup();
+        Self::clear_enabled_state(entry);
+        entry.session_table.restore(session_backup);
+        entry.state = PartState::Disabled;
         Ok(())
     }
 

--- a/fw/plat/std/pal/src/session.rs
+++ b/fw/plat/std/pal/src/session.rs
@@ -72,12 +72,21 @@ impl HsmSessionManager for StdHsmPal {
         let pid = io.pid();
         let entry = self.active_part_mut(pid)?;
 
-        // On re-key: clean up old session-scoped keys and old session key
-        // before creating the replacement.
+        // On re-key: clean up the old session-scoped keys and the old
+        // session key before creating the replacement.  A slot awaiting
+        // renegotiation after a live-migration disable has already had
+        // its vault key material cleared, so there is nothing to tear
+        // down — `recreate` below simply installs the fresh mapping
+        // (mirroring the reference firmware's `recreate_session`).
         if let Some(reopen_id) = id {
-            let old_phys = entry.session_table.physical_id(reopen_id)?;
-            entry.vault.delete_by_session_key(old_phys)?;
-            entry.vault.delete(old_phys)?;
+            if !matches!(
+                entry.session_table.state(reopen_id),
+                HsmSessionState::NeedsRenegotiation
+            ) {
+                let old_phys = entry.session_table.physical_id(reopen_id)?;
+                entry.vault.delete_by_session_key(old_phys)?;
+                entry.vault.delete(old_phys)?;
+            }
         }
 
         // Build 88-byte session blob: [api_rev(8) || masking_key(80)].


### PR DESCRIPTION
Wire the ReopenSession DDI command and the live-migration session lifecycle for the emulator (std PAL). The firmware core is shared with real hardware; only the PAL differs.

- Add the reopen_session MBOR handler (new reopen_session.rs): it authenticates the credential and derives BK_SESSION via the same helpers as OpenSession, then unmasks the host-persisted bmk_session to recover MK_SESSION and re-keys the migrated session slot.
- Route ReopenSession as an in-session command: it reuses the caller's existing session id, so it surfaces no new CQE session id. The central session-liveness gate added in #561 (io.rs validate_session_live) already returns SessionNeedsRenegotiation for in-session ops on a migrated slot and exempts ReopenSession, so no per-op renego check is needed in dispatch.
- std PAL: preserve live sessions across the NSSR as NeedsRenegotiation (SessionTable::backup/restore in part_disable_internal) and skip the old-key cleanup in session_create for renego slots -- mirrors the reference firmware's migrate() = restore(backup()) + recreate_session.
- ReopenSession reports PartitionNotProvisioned before the credential check, since it re-supplies its own credential in the request.
- emu dev: erase() preserves the file-handle session so the in-session reopen clears the host-side session check; and DdiEmuDev now closes its session on Drop (mirroring the mock backend and the host driver) so the process-global emulator partition does not leak the now-preserved sessions across tests and exhaust the table.

emu DDI suite (azihsm_ddi_mbor_types --features emu): 556 -> 575 passing, no regressions. The reopen_session, live_migration_sim, and live_migration_expected_errors suites now fully pass. Mock stays green; uno builds clean (uno PAL functional fix deferred to a follow-up). The 4 remaining failures (get_cert_chain x2, masked_key_get_unwrapping_with_lm, rsa_unwrap_generated_key::test_rsa_unwrap_aes_key) are pre-existing on main and unrelated to sessions.