### PR TITLE
feat(tbor): grow SdCreateRemoteBackup into full CreateSD

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -27,6 +27,19 @@ jobs:
     steps:
     - uses: actions/checkout@v6
     - uses: ./.github/actions/ubuntu-setup
+    - name: Free disk space
+      run: |
+        # The two coverage steps below run with --skip-clean, so the
+        # instrumented mock-test artifacts stay on disk while the resiliency
+        # step builds a second, fully instrumented copy of the native
+        # api_tests harness (googletest + cbindgen + a duplicate dependency
+        # tree). Together they can exhaust the runner's disk ("No space left
+        # on device"). Reclaim ~25 GB by removing large preinstalled
+        # toolchains this project does not use.
+        echo "Disk space before cleanup:" && df -h /
+        sudo rm -rf /usr/share/dotnet /opt/ghc /usr/local/.ghcup /usr/local/lib/android /opt/hostedtoolcache/CodeQL
+        sudo docker image prune --all --force || true
+        echo "Disk space after cleanup:" && df -h /
     - name: Run all mock tests with code coverage
       id: test-mock-coverage
       run: cargo xtask precheck --coverage --skip-clean --exclude provider-integration-tests-cli --exclude provider-integration-tests-capi -F mock --profile ci-mock

--- a/ddi/tbor/types/src/sd_create_remote_backup.rs
+++ b/ddi/tbor/types/src/sd_create_remote_backup.rs
@@ -6,7 +6,9 @@
 //! `SdCreateRemoteBackup` is an **in-session Crypto Officer** command
 //! that creates a new security domain under the active session's
 //! partition from the caller-supplied unified `PartPolicy`, returning
-//! the remote partition-owner-key backup (`pok_remote_backup`).
+//! the remote partition-owner-key backup (`pok_remote_backup`) together
+//! with the local partition-owner-key backup (`pok_local_backup`) and the
+//! security-domain masking-key backup (`sd_mk_backup`).
 //!
 //! Both wire schemas are shared with the firmware handler via
 //! `azihsm_fw_ddi_tbor_types::sd_create_remote_backup`; this module adds
@@ -38,6 +40,11 @@ pub const MASKED_SD_LEN: usize = 180;
 /// `azihsm_fw_ddi_tbor_types::sd_create_remote_backup::
 /// POK_REMOTE_BACKUP_LEN`; the firmware schema is the length authority.
 pub const POK_REMOTE_BACKUP_LEN: usize = 161;
+
+/// Exact on-the-wire length of the security-domain masking-key backup
+/// envelope (`SDMK` masked under `SDBMK`).  Mirrors the firmware
+/// `LOCAL_MK_BACKUP_LEN`; the firmware schema is the length authority.
+pub const SD_MK_BACKUP_LEN: usize = 164;
 
 /// Host-facing TBOR `SdCreateRemoteBackup` request.
 #[tbor(opcode = TBOR_OP_SD_CREATE_REMOTE_BACKUP, session_ctrl = in_session)]
@@ -87,6 +94,17 @@ pub struct TborSdCreateRemoteBackupResp {
     /// field so host decode enforces the exact length — rejecting any
     /// malformed frame — instead of allocating from the encoded length.
     pub pok_remote_backup: [u8; POK_REMOTE_BACKUP_LEN],
+
+    /// Local partition-owner-key backup: the fresh BKS3 masked under the
+    /// partition-local masking key (exactly [`MASKED_SD_LEN`] = 180 B on
+    /// the wire).  Persisted by the host and replayed to recover the
+    /// security domain locally.
+    pub pok_local_backup: [u8; MASKED_SD_LEN],
+
+    /// Security-domain masking-key backup: the freshly minted `SDMK`
+    /// masked under the derived `SDBMK` (exactly [`SD_MK_BACKUP_LEN`] =
+    /// 164 B on the wire).  Persisted by the host and replayed on restore.
+    pub sd_mk_backup: [u8; SD_MK_BACKUP_LEN],
 }
 
 #[cfg(test)]

--- a/ddi/tbor/types/src/status.rs
+++ b/ddi/tbor/types/src/status.rs
@@ -306,6 +306,12 @@ pub enum TborStatus {
     /// POTA-anchored, but its leaf public key does not match the
     /// partition's PTA key (mirror of `HsmError::PartFinalPtaMismatch`).
     PartFinalPtaMismatch = 0x08700107,
+
+    /// `SdCreateRemoteBackup` was asked to create a security domain on a
+    /// partition whose security-domain masking key (`SDMK`) is already
+    /// provisioned in this incarnation (mirror of
+    /// `HsmError::SdAlreadyInitialized`).
+    SdAlreadyInitialized = 0x08700108,
 }
 
 impl core::fmt::Debug for TborStatus {

--- a/ddi/tbor/types/tests/commands/sd_create_remote_backup.rs
+++ b/ddi/tbor/types/tests/commands/sd_create_remote_backup.rs
@@ -3,20 +3,26 @@
 
 //! Integration tests for the TBOR `SdCreateRemoteBackup` command.
 //!
-//! `SdCreateRemoteBackup` seals a fresh BKS3 to a receiver's SD sealing
-//! public key (recovered from the receiver's `KeyReport`, carried out of
-//! band) authenticated by the sender's masked SD sealing key, returning a
-//! 161-byte HPKE-Auth remote backup.  Nothing is persisted.
+//! `SdCreateRemoteBackup` creates a security domain: it mints a fresh
+//! BKS3 and a random security-domain masking key (`SDMK`), provisions
+//! `SDMK` in the vault as the partition's SecurityDomain-scope masking
+//! key, and returns three backups — the 161-byte HPKE-Auth
+//! `pok_remote_backup`, the 180-byte `pok_local_backup` (BKS3 masked
+//! under `PartLocalMK`), and the 164-byte `sd_mk_backup` (`SDMK` masked
+//! under the derived `SDBMK`).
 //!
 //! These tests run a **self-backup** (sender == receiver): one partition
 //! mints an SD sealing key, attests it via `KeyReport`, then seals to its
 //! own attested public key.  This exercises the full path — the OOB SGL
 //! transport, the COSE_Key `RcvrPub` extraction, the sealing-key unmask,
-//! and the HPKE-Auth seal — without a second device.
+//! the HPKE-Auth seal, and the SDMK provisioning — without a second
+//! device.
 //!
 //! Coverage:
-//! * Happy path — a 161-byte, non-zero `pok_remote_backup`; each call
-//!   re-randomizes BKS3, so two backups differ.
+//! * Happy path — non-zero `pok_remote_backup` (161 B), `pok_local_backup`
+//!   (180 B), and `sd_mk_backup` (164 B).
+//! * One-shot: a second create on the now-initialized partition →
+//!   `SdAlreadyInitialized`.
 //! * Missing OOB evidence → `InvalidArg`.
 //! * Policy that does not name this partition as the backing partition
 //!   (`backup_part_id` / `backup_part_pub_key` absent) → `InvalidArg`.
@@ -34,9 +40,11 @@ use azihsm_ddi_tbor_types::TborSdCreateRemoteBackupReq;
 use azihsm_ddi_tbor_types::TborSdSealingKeyGenReq;
 use azihsm_ddi_tbor_types::TborStatus;
 use azihsm_ddi_tbor_types::KEY_REPORT_DATA_LEN;
+use azihsm_ddi_tbor_types::MASKED_SD_LEN;
 use azihsm_ddi_tbor_types::PART_POLICY_LEN;
 use azihsm_ddi_tbor_types::POK_REMOTE_BACKUP_LEN;
 use azihsm_ddi_tbor_types::POLICY_MAX_KEY_LEN;
+use azihsm_ddi_tbor_types::SD_MK_BACKUP_LEN;
 use zerocopy::TryFromBytes;
 
 use crate::commands::part_init::bootstrap_rotated_co;
@@ -298,10 +306,25 @@ fn sd_create_remote_backup_roundtrip_emu() {
         resp.pok_remote_backup.iter().any(|&b| b != 0),
         "pok_remote_backup must not be all-zero",
     );
+
+    // Local backup: BKS3 masked under PartLocalMK, 180 B, non-zero.
+    assert_eq!(resp.pok_local_backup.len(), MASKED_SD_LEN);
+    assert!(
+        resp.pok_local_backup.iter().any(|&b| b != 0),
+        "pok_local_backup must not be all-zero",
+    );
+
+    // Masking-key backup: SDMK masked under the derived SDBMK, 164 B,
+    // non-zero.
+    assert_eq!(resp.sd_mk_backup.len(), SD_MK_BACKUP_LEN);
+    assert!(
+        resp.sd_mk_backup.iter().any(|&b| b != 0),
+        "sd_mk_backup must not be all-zero",
+    );
 }
 
 #[test]
-fn sd_create_remote_backup_rerandomizes_bks3_emu() {
+fn sd_create_remote_backup_is_one_shot_emu() {
     let ctx = TestCtx::new();
     let sata_key = CaKey::generate();
     let (session, policy, pid_pub) = finalized_backing_session(&ctx, &sata_key);
@@ -309,14 +332,15 @@ fn sd_create_remote_backup_rerandomizes_bks3_emu() {
     let evidence = build_receiver_evidence(&pid_pub, &sata_key, &report);
 
     let req = backup_request(session.session_id, masked, &evidence, &policy);
-    let first = ctx.tbor_oob(&req, &evidence.oob()).expect("first backup");
-    let second = ctx.tbor_oob(&req, &evidence.oob()).expect("second backup");
-
-    // Fresh BKS3 + fresh HPKE ephemeral each call → distinct backups.
-    assert_ne!(
-        first.pok_remote_backup, second.pok_remote_backup,
-        "each backup must re-randomize BKS3 and the HPKE encapsulation",
+    let first = ctx.tbor_oob(&req, &evidence.oob()).expect("first create");
+    assert!(
+        first.pok_remote_backup.iter().any(|&b| b != 0),
+        "first backup must be a real seal",
     );
+
+    // The security domain is now initialized (SDMK provisioned); a second
+    // create on the same partition is rejected by the one-shot gate.
+    ctx.expect_fw_reject_oob(&req, &evidence.oob(), TborStatus::SdAlreadyInitialized);
 }
 
 #[test]

--- a/docs/tbor-ddi/commands/sd_create_remote_backup.md
+++ b/docs/tbor-ddi/commands/sd_create_remote_backup.md
@@ -83,8 +83,8 @@ section.
 | Offset | Field | Type | Description |
 |---|---|---|---|
 | 8 | `pok_remote_backup` | `buffer` (fixed 161 B) | Remote partition-owner-key backup: an HPKE-Auth seal of BKS3 under `DHKemP384Sha384AesGcm256`, `enc(97) ‖ ct(64)` = `POK_REMOTE_BACKUP_LEN` (161 B). |
-| … | `pok_local_backup` | `buffer` (fixed 180 B) | Local partition-owner-key backup: BKS3 masked under `PartLocalMK`. `MASKED_SD_LEN` (180 B). |
-| … | `sd_mk_backup` | `buffer` (fixed 164 B) | Security-domain masking-key backup: `SDMK` masked under the derived `SDBMK`. `LOCAL_MK_BACKUP_LEN` (164 B). |
+| 12 | `pok_local_backup` | `buffer` (fixed 180 B) | Local partition-owner-key backup: BKS3 masked under `PartLocalMK`. `MASKED_SD_LEN` (180 B). |
+| 16 | `sd_mk_backup` | `buffer` (fixed 164 B) | Security-domain masking-key backup: `SDMK` masked under the derived `SDBMK`. `LOCAL_MK_BACKUP_LEN` (164 B). |
 
 ### Data section
 

--- a/docs/tbor-ddi/commands/sd_create_remote_backup.md
+++ b/docs/tbor-ddi/commands/sd_create_remote_backup.md
@@ -10,16 +10,30 @@ Licensed under the MIT License.
 
 ## Description
 
-Creates a security-domain **remote backup**: a fresh 48-byte BKS3
-HPKE-Auth-sealed to the *receiver's* SD sealing public key (`RcvrPub`,
-recovered from the receiver's `KeyReport` carried out of band) and
-authenticated by the *sender's* SD sealing private key (`SndrPriv`,
-recovered by unmasking `masked_sealing_key`).  Maps to manticore
-`CreateSD`, reduced to its remote-backup output.
+Creates a security domain on the partition (manticore `CreateSD`). It
+mints a fresh 48-byte BKS3 and a random 32-byte security-domain masking
+key (`SDMK`), provisions `SDMK` in the vault as the partition's
+`SecurityDomain`-scope masking key, and returns three backups:
 
-The command is **stateless** — nothing is persisted (no vault writes, no
-undo log). It requires an `Initialized` partition whose bound policy
-names this partition as the backing partition.
+- **`pok_remote_backup`** — the fresh BKS3 HPKE-Auth-sealed to the
+  *receiver's* SD sealing public key (`RcvrPub`, recovered from the
+  receiver's `KeyReport` carried out of band), authenticated by the
+  *sender's* SD sealing private key (`SndrPriv`, recovered by unmasking
+  `masked_sealing_key`).
+- **`pok_local_backup`** — the same BKS3 masked under the partition-local
+  masking key (`PartLocalMK`), for on-device (local) recovery of the
+  security domain.
+- **`sd_mk_backup`** — `SDMK` masked under `SDBMK` (a backup masking key
+  derived from BKS3, the platform seeds, and the policy hash), the
+  SVN-monotonic backup of the masking key.
+
+The command is **stateful**: it vaults `SDMK` and marks the partition
+security-domain-initialized. Every persistent mutation is recorded on the
+per-command undo log, so a handler failure — or a failed completion —
+rolls the whole command back. It is **one-shot** per partition
+incarnation: a second create returns `SdAlreadyInitialized` (the atomic
+claim is the race-winner gate). It requires an `Initialized` partition
+whose bound policy names this partition as the backing partition.
 
 The receiver attestation **evidence** is validated on-device
 ([`verify_evidence`](../../../fw/core/evidence/src/lib.rs)): the three
@@ -69,10 +83,13 @@ section.
 | Offset | Field | Type | Description |
 |---|---|---|---|
 | 8 | `pok_remote_backup` | `buffer` (fixed 161 B) | Remote partition-owner-key backup: an HPKE-Auth seal of BKS3 under `DHKemP384Sha384AesGcm256`, `enc(97) ‖ ct(64)` = `POK_REMOTE_BACKUP_LEN` (161 B). |
+| … | `pok_local_backup` | `buffer` (fixed 180 B) | Local partition-owner-key backup: BKS3 masked under `PartLocalMK`. `MASKED_SD_LEN` (180 B). |
+| … | `sd_mk_backup` | `buffer` (fixed 164 B) | Security-domain masking-key backup: `SDMK` masked under the derived `SDBMK`. `LOCAL_MK_BACKUP_LEN` (164 B). |
 
 ### Data section
 
-Carries the 161-byte `pok_remote_backup` seal.
+Carries the 161-byte `pok_remote_backup` seal, the 180-byte
+`pok_local_backup`, and the 164-byte `sd_mk_backup` envelope.
 
 ## Errors
 
@@ -80,6 +97,7 @@ Carries the 161-byte `pok_remote_backup` seal.
 |---|---|
 | `TborInvalidFixedLength` | `masked_sealing_key` (180 B) or `policy` (484 B) is the wrong length (rejected at decode before the handler runs) |
 | `InvalidArg` | Not `Initialized`; missing out-of-band evidence; policy hash mismatch; or the policy does not name this partition as the backing partition |
+| `SdAlreadyInitialized` | A security domain is already initialized on this partition incarnation (one-shot gate) |
 | `InvalidPermissions` | Not a Crypto-Officer session |
 | `UnsupportedKeyScope` | The masked sealing key's scope has no provisioned masking key |
 | `UnsupportedKeyType` | The unmasked key is not an `SdSealing` key |

--- a/fw/core/crypto/key-derive/src/lib.rs
+++ b/fw/core/crypto/key-derive/src/lib.rs
@@ -99,15 +99,22 @@ pub async fn derive_masking_key<P: HsmPal>(
         label_dma.copy_from_slice(label);
     }
 
-    pal.sp800_108_kdf(
-        io,
-        HsmHashAlgo::Sha384,
-        kdk,
-        Some(label_dma),
-        Some(ctx),
-        output,
-    )
-    .await
+    let res = pal
+        .sp800_108_kdf(
+            io,
+            HsmHashAlgo::Sha384,
+            kdk,
+            Some(label_dma),
+            Some(ctx),
+            output,
+        )
+        .await;
+
+    // Scrub the seed material (`mfgr_seed ‖ owner_seed`) staged in the
+    // reusable IO-scoped context buffer once the KDF has consumed it; scope
+    // rewind does not clear DMA memory, so wipe it explicitly on every path.
+    ctx.zeroize();
+    res
 }
 
 /// Derives the partition's `BKx` (the `BK_BOOT` masking key) into

--- a/fw/core/ddi/tbor/types/src/sd_create_remote_backup.rs
+++ b/fw/core/ddi/tbor/types/src/sd_create_remote_backup.rs
@@ -34,10 +34,19 @@
 //!   `SndrPriv` as the sender-authentication key, exactly
 //!   [`POK_REMOTE_BACKUP_LEN`] (161 B) = `enc(97) ‖ ct(64)` under the
 //!   `DHKemP384Sha384AesGcm256` suite.
+//! * `pok_local_backup` — the local partition-owner-key backup: the same
+//!   fresh BKS3 masked under the partition-local masking key
+//!   (`PartLocalMK`), exactly [`MASKED_SD_LEN`] (180 B).  Persisted by
+//!   the host and replayed to recover the security domain locally.
+//! * `sd_mk_backup` — the security-domain masking-key backup: the freshly
+//!   minted `SDMK` masked under the derived `SDBMK`, exactly
+//!   [`LOCAL_MK_BACKUP_LEN`] (164 B).  Persisted by the host and replayed
+//!   on restore.
 
 use azihsm_fw_ddi_tbor_api::tbor;
 
 use crate::evidence::*;
+pub use crate::part_final::LOCAL_MK_BACKUP_LEN;
 pub use crate::policy::PART_POLICY_LEN;
 pub use crate::sd_sealing_key_gen::MASKED_SEALING_KEY_LEN;
 
@@ -75,6 +84,11 @@ const _: () = assert!(MASKED_SD_LEN == 180);
 /// (`48 + 16 = 64`).
 pub const POK_REMOTE_BACKUP_LEN: usize = 97 + (48 + 16);
 const _: () = assert!(POK_REMOTE_BACKUP_LEN == 161);
+
+// `sd_mk_backup` is a `local_mk`-style masking-key backup envelope; the
+// derive needs an integer literal on the field, so the length is spelled
+// out as `164` and pinned against the canonical value here.
+const _: () = assert!(LOCAL_MK_BACKUP_LEN == 164);
 
 /// `SdCreateRemoteBackup` request schema.
 #[tbor(opcode = 0x0A)]
@@ -122,6 +136,20 @@ pub struct TborSdCreateRemoteBackupResp<'a> {
     /// Always exactly [`POK_REMOTE_BACKUP_LEN`] (161 B).
     #[tbor(buffer, len = 161)]
     pub pok_remote_backup: &'a [u8],
+
+    /// Local partition-owner-key backup: the fresh BKS3 masked under the
+    /// partition-local masking key (`PartLocalMK`), to be persisted by
+    /// the host and replayed to recover the security domain locally.
+    /// Always exactly [`MASKED_SD_LEN`] (180 B).
+    #[tbor(buffer, len = 180)]
+    pub pok_local_backup: &'a [u8],
+
+    /// Security-domain masking-key backup: the freshly minted `SDMK`
+    /// masked under the derived `SDBMK`, to be persisted by the host and
+    /// replayed on restore.  Always exactly [`LOCAL_MK_BACKUP_LEN`]
+    /// (164 B).
+    #[tbor(buffer, len = 164)]
+    pub sd_mk_backup: &'a [u8],
 }
 
 #[cfg(test)]
@@ -174,14 +202,22 @@ mod tests {
     }
 
     #[test]
-    fn response_round_trips_pok_remote_backup() {
-        let sealed = [0xABu8; POK_REMOTE_BACKUP_LEN];
-        let mut buf = [0u8; 512];
+    fn response_round_trips_backups() {
+        let remote = [0xABu8; POK_REMOTE_BACKUP_LEN];
+        let local = [0xCDu8; MASKED_SD_LEN];
+        let sd_mk = [0xEFu8; LOCAL_MK_BACKUP_LEN];
+        let mut buf = [0u8; 1024];
         let frame = TborSdCreateRemoteBackupResp::encode(&mut buf, 0, true)
             .unwrap()
-            .pok_remote_backup(&sealed)
+            .pok_remote_backup(&remote)
+            .unwrap()
+            .pok_local_backup(&local)
+            .unwrap()
+            .sd_mk_backup(&sd_mk)
             .unwrap()
             .finish();
         assert_eq!(frame.pok_remote_backup().len(), POK_REMOTE_BACKUP_LEN);
+        assert_eq!(frame.pok_local_backup().len(), MASKED_SD_LEN);
+        assert_eq!(frame.sd_mk_backup().len(), LOCAL_MK_BACKUP_LEN);
     }
 }

--- a/fw/core/lib/src/ddi/tbor/mod.rs
+++ b/fw/core/lib/src/ddi/tbor/mod.rs
@@ -161,17 +161,17 @@ fn masking_key_id_for_scope<P: HsmPal>(
     match scope {
         HsmKeyScope::Ephemeral => part_state::part_ephemeral_mk_key_id(pal, io),
         HsmKeyScope::Local => part_state::part_local_mk_key_id(pal, io),
-        // The SecurityDomain masking key (`SDMK`) exists only once a
-        // security domain has been created (`SdCreateRemoteBackup`); until
-        // then the scope has no backing key and is reported as
-        // unsupported (parity with the `Session` / other scopes).
-        HsmKeyScope::SecurityDomain => {
-            if part_state::part_is_sd_initialized(pal, io)? {
-                part_state::part_sd_mk_key_id(pal, io)
-            } else {
-                Err(HsmError::UnsupportedKeyScope)
-            }
-        }
+        // Resolve the SecurityDomain masking key (`SDMK`) by `SD_MK_KEY_ID`
+        // presence — the single source of truth.  A request that observes a
+        // partially-written commit (the `SD_INITIALIZED` claim is set but
+        // `SD_MK_KEY_ID` is not yet written, or a rollback is in flight)
+        // gets the documented `UnsupportedKeyScope` rather than a leaked
+        // `PartPropNotFound`; genuine read faults still propagate.
+        HsmKeyScope::SecurityDomain => match part_state::part_sd_mk_key_id(pal, io) {
+            Ok(id) => Ok(id),
+            Err(HsmError::PartPropNotFound) => Err(HsmError::UnsupportedKeyScope),
+            Err(e) => Err(e),
+        },
         _ => Err(HsmError::UnsupportedKeyScope),
     }
 }

--- a/fw/core/lib/src/ddi/tbor/mod.rs
+++ b/fw/core/lib/src/ddi/tbor/mod.rs
@@ -161,6 +161,17 @@ fn masking_key_id_for_scope<P: HsmPal>(
     match scope {
         HsmKeyScope::Ephemeral => part_state::part_ephemeral_mk_key_id(pal, io),
         HsmKeyScope::Local => part_state::part_local_mk_key_id(pal, io),
+        // The SecurityDomain masking key (`SDMK`) exists only once a
+        // security domain has been created (`SdCreateRemoteBackup`); until
+        // then the scope has no backing key and is reported as
+        // unsupported (parity with the `Session` / other scopes).
+        HsmKeyScope::SecurityDomain => {
+            if part_state::part_is_sd_initialized(pal, io)? {
+                part_state::part_sd_mk_key_id(pal, io)
+            } else {
+                Err(HsmError::UnsupportedKeyScope)
+            }
+        }
         _ => Err(HsmError::UnsupportedKeyScope),
     }
 }
@@ -248,7 +259,7 @@ pub(crate) async fn dispatch<'p, P: HsmPal>(
         opcode::PART_INFO => part_info::handle(pal, io, req_buf),
         opcode::SD_SEALING_KEY_GEN => sd_sealing_key_gen::handle(pal, io, req_buf).await,
         opcode::SD_CREATE_REMOTE_BACKUP => {
-            sd_create_remote_backup::handle(pal, io, req_buf, oob).await
+            sd_create_remote_backup::handle(pal, io, req_buf, oob, undo).await
         }
         opcode::SD_RESEAL_REMOTE_BACKUP => {
             sd_reseal_remote_backup::handle(pal, io, req_buf, oob).await

--- a/fw/core/lib/src/ddi/tbor/sd_create_remote_backup.rs
+++ b/fw/core/lib/src/ddi/tbor/sd_create_remote_backup.rs
@@ -407,7 +407,13 @@ async fn commit_sd_to_vault<'p, P: HsmPal>(
     let sdmk_id = pal
         .vault_key_create(io, sdmk, HsmVaultKeyKind::SdMasking, None, SDMK_ATTRS)
         .await?;
-    undo.push_vault_create(sdmk_id)?;
+    if let Err(e) = undo.push_vault_create(sdmk_id) {
+        // The key exists but could not be tracked for rollback (e.g.
+        // `UndoLogFull`); best-effort delete it so a full undo log does not
+        // leak the vault slot for an untracked key.
+        let _ = pal.vault_key_delete(io, sdmk_id).await;
+        return Err(e);
+    }
     undo.push_prop_restore_absent(part_state::part_sd_mk_key_id_prop_id())?;
     part_state::part_set_sd_mk_key_id(pal, io, sdmk_id)?;
     Ok(())

--- a/fw/core/lib/src/ddi/tbor/sd_create_remote_backup.rs
+++ b/fw/core/lib/src/ddi/tbor/sd_create_remote_backup.rs
@@ -281,7 +281,7 @@ pub(crate) async fn handle<'p, P: HsmPal>(
     // they survive the crypto scratch allocator's reset.
     let pok = pal.dma_alloc(io, POK_REMOTE_BACKUP_LEN)?;
     let pok_local = pal.dma_alloc(io, MASKED_SD_LEN)?;
-    let sd_mk = pal.dma_alloc(io, LOCAL_MK_BACKUP_LEN)?;
+    let sd_mk_backup = pal.dma_alloc(io, LOCAL_MK_BACKUP_LEN)?;
 
     pal.alloc_scoped_async(io, async |alloc| -> HsmResult<()> {
         // `pk_r` (the attested `RcvrPub`) is recovered by the evidence
@@ -353,7 +353,7 @@ pub(crate) async fn handle<'p, P: HsmPal>(
                 // Derive SDBMK, mint + vault SDMK, and write the local +
                 // masking-key backups.  Undo-guarded; the atomic
                 // `SD_INITIALIZED` claim inside is the race-winner gate.
-                provision_security_domain(pal, io, alloc, undo, bks3, sd_mk, pok_local).await
+                provision_security_domain(pal, io, alloc, undo, bks3, sd_mk_backup, pok_local).await
             }
             .await;
 
@@ -376,7 +376,7 @@ pub(crate) async fn handle<'p, P: HsmPal>(
     })
     .await?;
 
-    encode_response(pal, io, pok, pok_local, sd_mk)
+    encode_response(pal, io, pok, pok_local, sd_mk_backup)
 }
 
 /// Commit the security domain: mark it initialized, vault the `SDMK`, and
@@ -539,13 +539,13 @@ fn encode_response<'p, P: HsmPal>(
     io: &impl HsmIo,
     pok: &DmaBuf,
     pok_local: &DmaBuf,
-    sd_mk: &DmaBuf,
+    sd_mk_backup: &DmaBuf,
 ) -> HsmResult<&'p DmaBuf> {
     let resp = pal.dma_alloc_var(io, |buf| {
         let frame = TborSdCreateRemoteBackupResp::encode(buf, 0, false)?
             .pok_remote_backup(pok)?
             .pok_local_backup(pok_local)?
-            .sd_mk_backup(sd_mk)?
+            .sd_mk_backup(sd_mk_backup)?
             .finish();
         Ok(frame.as_bytes().len())
     })?;

--- a/fw/core/lib/src/ddi/tbor/sd_create_remote_backup.rs
+++ b/fw/core/lib/src/ddi/tbor/sd_create_remote_backup.rs
@@ -3,17 +3,19 @@
 
 //! TBOR `SdCreateRemoteBackup` handler.
 //!
-//! Creates a security-domain **remote backup**: a fresh 48-byte BKS3
-//! HPKE-Auth-sealed to the *receiver's* SD sealing public key
-//! (`RcvrPub`), authenticated by the *sender's* SD sealing private key
-//! (`SndrPriv`).  Maps to manticore `CreateSD`, reduced to its remote
-//! backup output.
+//! Creates a security domain on the partition (manticore `CreateSD`): it
+//! mints a fresh 48-byte BKS3 and a random 32-byte security-domain
+//! masking key (`SDMK`), provisions `SDMK` in the vault as the partition's
+//! [`SecurityDomain`](HsmKeyScope::SecurityDomain)-scope masking key, and
+//! returns three backups — the remote (`pok_remote_backup`), local
+//! (`pok_local_backup`), and masking-key (`sd_mk_backup`) envelopes.
 //!
 //! Flow:
 //!
 //! 1. Decode the request; gate to a Crypto-Officer, `Active` session on
 //!    an `Initialized` partition (parity with `SdSealingKeyGen` /
-//!    `KeyReport`).
+//!    `KeyReport`), and fail-fast if the security domain is already
+//!    initialized ([`SdAlreadyInitialized`](HsmError::SdAlreadyInitialized)).
 //! 2. Bind the caller-supplied [`PartPolicy`] to the one fixed at
 //!    `PartInit` (`SHA-384(policy) == policy_hash`), validate it, and
 //!    verify it names this partition as the backing partition
@@ -29,43 +31,62 @@
 //!    (must be an [`SdSealing`](HsmVaultKeyKind::SdSealing) key) and
 //!    derive `SndrPub` on-device.
 //! 5. Generate a fresh BKS3 and HPKE-Auth-seal it to `RcvrPub` under the
-//!    `DHKemP384Sha384AesGcm256` suite, returning
-//!    `pok_remote_backup = enc ‖ ct` (161 B).  BKS3 and `SndrPriv` are
-//!    zeroized before returning.
+//!    `DHKemP384Sha384AesGcm256` suite, producing
+//!    `pok_remote_backup = enc ‖ ct` (161 B).
+//! 6. Derive `SDBMK = KBKDF(BKS3, mfgr_seed[svn] ‖ owner_seed[owner] ‖
+//!    policy_hash)`, mint a random `SDMK`, and mask `SDMK` under `SDBMK`
+//!    into `sd_mk_backup` (164 B).  Mask BKS3 under the partition-local
+//!    masking key (`PartLocalMK`) into `pok_local_backup` (180 B).
+//! 7. **Commit** (undo-guarded): claim the one-shot `SD_INITIALIZED`
+//!    gate, `vault_key_create` the `SDMK` (SecurityDomain scope), and
+//!    record its id in `SD_MK_KEY_ID`.  BKS3, `SDMK`, `SDBMK`, and
+//!    `SndrPriv` are zeroized before returning.
 //!
-//! **Stateless:** nothing is persisted, no vault writes, no undo log —
-//! the same shape as `KeyReport` / `SdSealingKeyGen`.
+//! **Stateful:** provisions `SDMK` in the vault and marks the partition
+//! security-domain-initialized, guarded by the per-command undo log so a
+//! failure (or a failed completion) rolls the whole command back.
 //!
 //! This command is **Crypto-Officer-only**.
 //!
 //! [`PartPolicy`]: super::policy
 
-use azihsm_fw_core_crypto_hpke::seal;
 use azihsm_fw_core_crypto_hpke::AuthParams;
 use azihsm_fw_core_crypto_hpke::HpkeSealConfig;
 use azihsm_fw_core_crypto_hpke::HpkeSuite;
+use azihsm_fw_core_crypto_hpke::seal;
+use azihsm_fw_core_crypto_key_derive::derive_masking_key;
+use azihsm_fw_core_crypto_key_masking::aead::AeadAlg;
+use azihsm_fw_core_crypto_key_masking::aead::MaskParams;
+use azihsm_fw_core_crypto_key_masking::aead::mask;
 use azihsm_fw_core_crypto_key_masking::aead::peek_metadata;
 use azihsm_fw_core_crypto_key_masking::aead::unmask;
-use azihsm_fw_core_evidence::verify_evidence;
 use azihsm_fw_core_evidence::EvidenceRefs;
 use azihsm_fw_core_evidence::TrustAnchors;
-use azihsm_fw_ddi_tbor_types::policy::PartPolicy;
-use azihsm_fw_ddi_tbor_types::policy::PolicyKeyKind;
-use azihsm_fw_ddi_tbor_types::policy::POLICY_MAX_KEY_LEN;
+use azihsm_fw_core_evidence::verify_evidence;
+use azihsm_fw_ddi_tbor_types::LOCAL_MK_BACKUP_LEN;
+use azihsm_fw_ddi_tbor_types::MASKED_SD_LEN;
+use azihsm_fw_ddi_tbor_types::POK_REMOTE_BACKUP_LEN;
 use azihsm_fw_ddi_tbor_types::TborSdCreateRemoteBackupReq;
 use azihsm_fw_ddi_tbor_types::TborSdCreateRemoteBackupResp;
-use azihsm_fw_ddi_tbor_types::POK_REMOTE_BACKUP_LEN;
+use azihsm_fw_ddi_tbor_types::policy::POLICY_MAX_KEY_LEN;
+use azihsm_fw_ddi_tbor_types::policy::PartPolicy;
+use azihsm_fw_ddi_tbor_types::policy::PolicyKeyKind;
 use azihsm_fw_hsm_oob::OobPtr;
 use azihsm_fw_hsm_pal_traits::DmaBuf;
 use azihsm_fw_hsm_pal_traits::HsmEccCurve;
 use azihsm_fw_hsm_pal_traits::HsmError;
 use azihsm_fw_hsm_pal_traits::HsmIo;
+use azihsm_fw_hsm_pal_traits::HsmKeyId;
+use azihsm_fw_hsm_pal_traits::HsmKeyScope;
 use azihsm_fw_hsm_pal_traits::HsmPal;
 use azihsm_fw_hsm_pal_traits::HsmResult;
 use azihsm_fw_hsm_pal_traits::HsmScopedAlloc;
 use azihsm_fw_hsm_pal_traits::HsmSessId;
+use azihsm_fw_hsm_pal_traits::HsmVaultKeyAttrs;
 use azihsm_fw_hsm_pal_traits::HsmVaultKeyKind;
+use azihsm_fw_hsm_pal_traits::PartPropId;
 use azihsm_fw_hsm_pal_traits::PartState;
+use azihsm_fw_hsm_undo::UndoLog;
 
 use super::masking_key_id_for_scope;
 use super::part_final::verify_policy_hash;
@@ -83,6 +104,41 @@ const BKS3_LEN: usize = 48;
 
 /// SEC1 uncompressed point tag (`0x04 ‖ X ‖ Y`).
 const SEC1_UNCOMPRESSED: u8 = 0x04;
+
+/// Length of the random security-domain masking key (`SDMK`) — 32 B
+/// AES-256-GCM.
+const SDMK_LEN: usize = 32;
+
+/// Length of the derived security-domain backup masking key (`SDBMK`) —
+/// 32 B AES-256-GCM (the key that masks `SDMK` into `sd_mk_backup`).
+const SDBMK_LEN: usize = 32;
+
+/// KBKDF label selecting the `SDBMK` derivation purpose (keyed on BKS3,
+/// with the partition `policy_hash` as extra context).
+const SDBMK_LABEL: &[u8] = b"AZIHSM-SdCreate-SDBMK-v1";
+
+/// Opaque envelope label stamped into the `sd_mk_backup`
+/// `MaskedKeyMetadata` (informational; bound by the AEAD tag).
+const SDMK_ENVELOPE_LABEL: &[u8] = b"SDMK";
+
+/// Opaque envelope label stamped into the `pok_local_backup`
+/// `MaskedKeyMetadata` (informational; bound by the AEAD tag).
+const POK_LOCAL_ENVELOPE_LABEL: &[u8] = b"BKS3";
+
+/// Vault attributes for the provisioned `SDMK`: SecurityDomain scope,
+/// on-device, internal, never extractable.
+const SDMK_ATTRS: HsmVaultKeyAttrs = HsmVaultKeyAttrs::new()
+    .with_local(true)
+    .with_internal(true)
+    .with_never_extractable(true)
+    .with_scope(HsmKeyScope::SecurityDomain);
+
+/// Vault attributes stamped into the `sd_mk_backup` / `pok_local_backup`
+/// metadata: on-device, internal, never extractable.
+const SD_BACKUP_ATTRS: HsmVaultKeyAttrs = HsmVaultKeyAttrs::new()
+    .with_local(true)
+    .with_internal(true)
+    .with_never_extractable(true);
 
 /// Verify the policy names **this** partition as the backing partition.
 ///
@@ -112,51 +168,120 @@ fn verify_backing_partition<P: HsmPal>(
     Ok(())
 }
 
+/// Gate the initial session/state checks and resolve the masking-key ID
+/// for the caller-supplied `masked_sealing_key`.
+///
+/// Validates that the session is an active Crypto-Officer session, that the
+/// partition is `Initialized`, that the security domain is not yet
+/// initialized, and routes the masked sealing key to its masking key.
+fn gate_request<P: HsmPal>(pal: &P, io: &impl HsmIo, req_buf: &DmaBuf) -> HsmResult<HsmKeyId> {
+    let req = TborSdCreateRemoteBackupReq::decode(req_buf)?;
+    let sess_id = HsmSessId::from(u16::from(req.session_id()));
+    validate_crypto_officer_active_session(pal, io, sess_id)?;
+
+    // The SD masking keys / policy hash are provisioned by `PartFinal`,
+    // so the partition must be finalized (`Initialized`).
+    if part_state::part_state(pal, io)? != PartState::Initialized {
+        return Err(HsmError::InvalidArg);
+    }
+
+    // Fail-fast: a second `CreateSD` on an already-initialized security
+    // domain is rejected.  The atomic `SD_INITIALIZED` claim in the
+    // commit phase is the authoritative race-winner gate; this check
+    // just avoids the crypto work in the common (non-racing) case.
+    if part_state::part_is_sd_initialized(pal, io)? {
+        return Err(HsmError::SdAlreadyInitialized);
+    }
+
+    // Route the masked sealing key to its masking key via the
+    // cleartext, tag-bound metadata (before unmasking).
+    let scope = peek_metadata(req.masked_sealing_key())?
+        .usage_flags()
+        .scope();
+    masking_key_id_for_scope(pal, io, scope)
+}
+
+/// Verify policy binding and receiver attestation evidence, writing the
+/// attested `RcvrPub` into `pk_r`.
+///
+/// Decodes the shared view of `req_buf`, verifies the re-supplied policy
+/// against the hash bound at `PartInit`, confirms this partition is named
+/// as the backing partition, validates the three certificate chains and the
+/// COSE_Sign1 attestation report, and recovers the attested public key.
+async fn verify_policy_and_receiver_evidence<P: HsmPal>(
+    pal: &P,
+    io: &impl HsmIo,
+    alloc: &impl HsmScopedAlloc,
+    req_buf: &DmaBuf,
+    oob: &OobPtr,
+    pk_r: &mut DmaBuf,
+) -> HsmResult<()> {
+    let req = TborSdCreateRemoteBackupReq::decode(req_buf)?;
+    let policy = req.policy();
+    verify_policy_hash(pal, io, alloc, policy).await?;
+    let part_policy = super::policy::from_bytes(policy)?;
+
+    // SD-policy identity binding (manticore `CreateSD` step a): the
+    // policy names this partition as the backing partition.  The
+    // caller populated `backup_part_id` / `backup_part_pub_key`
+    // from `PartInfo` (available in `Initializing`, before
+    // `PartInit`), so they must equal this partition's PID and PID
+    // public key.
+    verify_backing_partition(pal, io, part_policy)?;
+
+    // Validate all three certificate chains, bind the partition-owner
+    // chain to the policy SATA anchor, and recover the attested `RcvrPub`.
+    let sata = &part_policy.sata_pub_key;
+    if sata.kind() != PolicyKeyKind::Ecc384 || sata.len() != POLICY_MAX_KEY_LEN {
+        return Err(HsmError::InvalidArg);
+    }
+    let evidence = req.receiver_evidence();
+    verify_evidence(
+        pal,
+        io,
+        oob,
+        &EvidenceRefs {
+            mfgr_chain: evidence.mfgr_cert_chain(),
+            owner_chain: evidence.owner_cert_chain(),
+            part_owner_chain: evidence.part_owner_cert_chain(),
+            report: evidence.evidence(),
+        },
+        &TrustAnchors {
+            sata: &sata.data[..POLICY_MAX_KEY_LEN],
+        },
+        pk_r,
+        None,
+    )
+    .await
+}
+
 /// Handle a TBOR `SdCreateRemoteBackup` request.
 ///
-/// No partition lock or undo log is required: the command **persists
-/// nothing** — it validates evidence, unmasks the caller-supplied sealing
-/// key, and returns a freshly sealed backup.  It makes no observable state
-/// change, so a concurrently-dispatched command (IOs run in a task pool
-/// and interleave at await points) can neither observe it half-done nor
-/// require its rollback on failure.
+/// **Stateful**: provisions the security-domain masking key (`SDMK`) in
+/// the vault and marks the partition security-domain-initialized.  All
+/// persistent mutations are recorded on the per-command `undo` log, so a
+/// handler failure — or a failed completion — reverts them (the atomic
+/// one-shot `SD_INITIALIZED` claim is the race-winner gate against a
+/// concurrently-dispatched second create).
 pub(crate) async fn handle<'p, P: HsmPal>(
     pal: &'p P,
     io: &impl HsmIo,
     req_buf: &mut DmaBuf,
     oob: Option<OobPtr>,
+    undo: &mut UndoLog<'p>,
 ) -> HsmResult<&'p DmaBuf> {
-    // Session/state gating + masking-key routing use only the shared
-    // `decode` view.  Confine that borrow to this block so the request
-    // buffer can be borrowed mutably later to unmask the sealing key in
-    // place.  `mk_key_id` is `Copy`, so it outlives the view.
-    let mk_key_id = {
-        let req = TborSdCreateRemoteBackupReq::decode(&*req_buf)?;
-        let sess_id = HsmSessId::from(u16::from(req.session_id()));
-        validate_crypto_officer_active_session(pal, io, sess_id)?;
-
-        // The SD masking keys / policy hash are provisioned by `PartFinal`,
-        // so the partition must be finalized (`Initialized`).
-        if part_state::part_state(pal, io)? != PartState::Initialized {
-            return Err(HsmError::InvalidArg);
-        }
-
-        // Route the masked sealing key to its masking key via the
-        // cleartext, tag-bound metadata (before unmasking).
-        let scope = peek_metadata(req.masked_sealing_key())?
-            .usage_flags()
-            .scope();
-        masking_key_id_for_scope(pal, io, scope)?
-    };
+    let mk_key_id = gate_request(pal, io, req_buf)?;
 
     // The receiver attestation evidence — three certificate chains
     // (manufacturer / owner / partition-owner) plus a COSE_Sign1 report —
     // is mandatory side-band data carried in the out-of-band SGL page.
     let oob = oob.ok_or(HsmError::InvalidArg)?;
 
-    // Allocate the fixed-size response backup in the IO scope so it
-    // survives the crypto scratch allocator's reset.
+    // Allocate the three fixed-size response backups in the IO scope so
+    // they survive the crypto scratch allocator's reset.
     let pok = pal.dma_alloc(io, POK_REMOTE_BACKUP_LEN)?;
+    let pok_local = pal.dma_alloc(io, MASKED_SD_LEN)?;
+    let sd_mk = pal.dma_alloc(io, LOCAL_MK_BACKUP_LEN)?;
 
     pal.alloc_scoped_async(io, async |alloc| -> HsmResult<()> {
         // `pk_r` (the attested `RcvrPub`) is recovered by the evidence
@@ -166,55 +291,8 @@ pub(crate) async fn handle<'p, P: HsmPal>(
         let coord = SD_CURVE.priv_key_len();
         let pk_r = alloc.dma_alloc(1 + 2 * coord)?;
 
-        // ── Phase 1: policy binding + receiver evidence (shared view) ──
-        // Everything that reads the `receiver_evidence` field group goes
-        // through the shared `decode` view (the group is intentionally
-        // absent from `ViewMut`).  The borrow is confined to this block so
-        // the sealing key can be unmasked in place afterwards.
-        {
-            let req = TborSdCreateRemoteBackupReq::decode(&*req_buf)?;
-
-            // The re-supplied policy must match the one bound at `PartInit`.
-            let policy = req.policy();
-            verify_policy_hash(pal, io, alloc, policy).await?;
-            let part_policy = super::policy::from_bytes(policy)?;
-
-            // SD-policy identity binding (manticore `CreateSD` step a): the
-            // policy names this partition as the backing partition.  The
-            // caller populated `backup_part_id` / `backup_part_pub_key`
-            // from `PartInfo` (available in `Initializing`, before
-            // `PartInit`), so they must equal this partition's PID and PID
-            // public key.
-            verify_backing_partition(pal, io, part_policy)?;
-
-            // Validate all three certificate chains, bind the
-            // partition-owner chain to the policy SATA anchor, require one
-            // shared leaf key across the chains, and confirm that leaf key
-            // endorses the attestation report — then recover the attested
-            // `RcvrPub` into `pk_r`.
-            let sata = &part_policy.sata_pub_key;
-            if sata.kind() != PolicyKeyKind::Ecc384 || sata.len() != POLICY_MAX_KEY_LEN {
-                return Err(HsmError::InvalidArg);
-            }
-            let evidence = req.receiver_evidence();
-            verify_evidence(
-                pal,
-                io,
-                &oob,
-                &EvidenceRefs {
-                    mfgr_chain: evidence.mfgr_cert_chain(),
-                    owner_chain: evidence.owner_cert_chain(),
-                    part_owner_chain: evidence.part_owner_cert_chain(),
-                    report: evidence.evidence(),
-                },
-                &TrustAnchors {
-                    sata: &sata.data[..POLICY_MAX_KEY_LEN],
-                },
-                pk_r,
-                None,
-            )
-            .await?;
-        }
+        // Phase 1: verify policy binding and receiver attestation evidence.
+        verify_policy_and_receiver_evidence(pal, io, alloc, req_buf, &oob, pk_r).await?;
 
         // ── Phase 2: unmask SndrPriv in place, derive SndrPub, and
         // HPKE-Auth seal a fresh BKS3 to RcvrPub.  `unmask` decrypts the
@@ -261,23 +339,28 @@ pub(crate) async fn handle<'p, P: HsmPal>(
                 },
             );
 
-            // Size query, then split the fixed response buffer into the
-            // `enc` and `ct` regions the seal writes.
-            let seal_res = async {
+            // Size query, then split the remote-backup response buffer into
+            // the `enc` and `ct` regions the seal writes; then provision the
+            // security domain from the same fresh BKS3.
+            let provision_res = async {
                 let sizes = seal(pal, io, &cfg, bks3, None, None, alloc).await?;
                 if sizes.enc_len + sizes.ct_len != POK_REMOTE_BACKUP_LEN {
                     return Err(HsmError::InternalError);
                 }
                 let (enc, ct) = pok.split_at_mut(sizes.enc_len);
                 seal(pal, io, &cfg, bks3, Some(enc), Some(ct), alloc).await?;
-                Ok::<(), HsmError>(())
+
+                // Derive SDBMK, mint + vault SDMK, and write the local +
+                // masking-key backups.  Undo-guarded; the atomic
+                // `SD_INITIALIZED` claim inside is the race-winner gate.
+                provision_security_domain(pal, io, alloc, undo, bks3, sd_mk, pok_local).await
             }
             .await;
 
             // Wipe the fresh BKS3 on both success and failure before the
             // borrow of the request buffer (via `SndrPriv`) is released.
             bks3.zeroize();
-            seal_res
+            provision_res
         }
         .await;
 
@@ -293,18 +376,167 @@ pub(crate) async fn handle<'p, P: HsmPal>(
     })
     .await?;
 
-    encode_response(pal, io, pok)
+    encode_response(pal, io, pok, pok_local, sd_mk)
 }
 
-/// Encode the `SdCreateRemoteBackup` response around the sealed backup.
+/// Commit the security domain: mark it initialized, vault the `SDMK`, and
+/// record its key id.  Every mutation is pushed to `undo` so a failure
+/// rolls back all changes.
+async fn commit_sd_to_vault<'p, P: HsmPal>(
+    pal: &P,
+    io: &impl HsmIo,
+    undo: &mut UndoLog<'p>,
+    sdmk: &DmaBuf,
+) -> HsmResult<()> {
+    // Atomic one-shot claim first (the race-winner gate); the recorded
+    // inverse clears the flag on rollback.
+    part_state::part_mark_sd_initialized(pal, io)?;
+    undo.push_prop_restore_scalar(PartPropId::SD_INITIALIZED, 0)?;
+
+    // Vault SDMK as the partition's SecurityDomain-scope masking key,
+    // then record its id so `masking_key_id_for_scope` resolves it.
+    let sdmk_id = pal
+        .vault_key_create(io, sdmk, HsmVaultKeyKind::SdMasking, None, SDMK_ATTRS)
+        .await?;
+    undo.push_vault_create(sdmk_id)?;
+    undo.push_prop_restore_absent(part_state::part_sd_mk_key_id_prop_id())?;
+    part_state::part_set_sd_mk_key_id(pal, io, sdmk_id)?;
+    Ok(())
+}
+
+/// Provision the security domain from a freshly minted `bks3`.
+///
+/// Derives `SDBMK` (KBKDF keyed on `bks3`, folding in the platform seeds
+/// and the partition `policy_hash`), mints a random `SDMK`, and writes the
+/// two backups: `sd_mk_out` (`SDMK` masked under `SDBMK`, 164 B) and
+/// `pok_local_out` (`bks3` masked under `PartLocalMK`, 180 B).  Then it
+/// claims the one-shot `SD_INITIALIZED` gate, vaults `SDMK`
+/// ([`SecurityDomain`](HsmKeyScope::SecurityDomain) scope), and records its
+/// id in `SD_MK_KEY_ID`.  Every persistent mutation is pushed to `undo`;
+/// the minted `SDMK` / derived `SDBMK` scratch is zeroized on all paths
+/// (the caller wipes `bks3`).
+#[allow(clippy::too_many_arguments)]
+async fn provision_security_domain<'p, P: HsmPal>(
+    pal: &P,
+    io: &impl HsmIo,
+    alloc: &impl HsmScopedAlloc,
+    undo: &mut UndoLog<'p>,
+    bks3: &DmaBuf,
+    sd_mk_out: &mut DmaBuf,
+    pok_local_out: &mut DmaBuf,
+) -> HsmResult<()> {
+    // Platform identity that binds both backup envelopes and the SDBMK
+    // derivation: SVN (BKS1 lineage) and owner-seed id (BKS2 lineage).
+    let svn = part_state::part_mfgr_svn(pal);
+    let owner = u16::try_from(part_state::part_owner_svn(pal)).map_err(|_| HsmError::InvalidArg)?;
+
+    // SDBMK = KBKDF(BKS3, mfgr_seed[svn] ‖ owner_seed[owner] ‖ policy_hash).
+    // Stage the stored policy hash in scratch so the extra context does not
+    // hold a borrow of partition state across the derivation await.
+    let sdbmk = alloc.dma_alloc(SDBMK_LEN)?;
+    {
+        let policy_hash = {
+            let stored = part_state::part_policy_hash(pal, io)?;
+            let ph = alloc.dma_alloc(stored.len())?;
+            ph.copy_from_slice(stored);
+            ph
+        };
+        derive_masking_key(
+            pal,
+            io,
+            bks3,
+            SDBMK_LABEL,
+            &policy_hash[..],
+            svn,
+            owner,
+            sdbmk,
+        )
+        .await?;
+    }
+
+    // Mint the random SDMK.
+    let sdmk = alloc.dma_alloc(SDMK_LEN)?;
+    pal.rng_fill_bytes(io, sdmk)?;
+
+    let res = async {
+        // sd_mk_backup = mask(SDMK under SDBMK) — the caller-persisted,
+        // SVN-monotonic backup of the masking key.
+        let mk_label = alloc.dma_alloc(SDMK_ENVELOPE_LABEL.len())?;
+        mk_label.copy_from_slice(SDMK_ENVELOPE_LABEL);
+        let mk_params = MaskParams {
+            key_kind: HsmVaultKeyKind::SdMasking,
+            key_attrs: SDMK_ATTRS,
+            svn,
+            owner_seed_id: owner,
+            key_label: mk_label,
+        };
+        let n = mask(
+            pal,
+            io,
+            alloc,
+            AeadAlg::AesGcm256,
+            sdbmk,
+            &mk_params,
+            sdmk,
+            Some(sd_mk_out),
+        )
+        .await?;
+        if n != LOCAL_MK_BACKUP_LEN {
+            return Err(HsmError::InternalError);
+        }
+
+        // pok_local_backup = mask(BKS3 under PartLocalMK) — the on-device
+        // local backup of the SD seed, replayed to recover it later.
+        let local_mk_id = part_state::part_local_mk_key_id(pal, io)?;
+        let local_mk = pal.vault_key(io, local_mk_id)?;
+        let pok_label = alloc.dma_alloc(POK_LOCAL_ENVELOPE_LABEL.len())?;
+        pok_label.copy_from_slice(POK_LOCAL_ENVELOPE_LABEL);
+        let pok_params = MaskParams {
+            key_kind: HsmVaultKeyKind::SdPartitionOwnerSeed,
+            key_attrs: SD_BACKUP_ATTRS,
+            svn,
+            owner_seed_id: owner,
+            key_label: pok_label,
+        };
+        let m = mask(
+            pal,
+            io,
+            alloc,
+            AeadAlg::AesGcm256,
+            local_mk,
+            &pok_params,
+            bks3,
+            Some(pok_local_out),
+        )
+        .await?;
+        if m != MASKED_SD_LEN {
+            return Err(HsmError::InternalError);
+        }
+
+        commit_sd_to_vault(pal, io, undo, sdmk).await
+    }
+    .await;
+
+    // Scrub the minted SDMK and derived SDBMK on every path — scope rewind
+    // does not clear DMA memory.
+    sdmk.zeroize();
+    sdbmk.zeroize();
+    res
+}
+
+/// Encode the `SdCreateRemoteBackup` response around the three backups.
 fn encode_response<'p, P: HsmPal>(
     pal: &'p P,
     io: &impl HsmIo,
     pok: &DmaBuf,
+    pok_local: &DmaBuf,
+    sd_mk: &DmaBuf,
 ) -> HsmResult<&'p DmaBuf> {
     let resp = pal.dma_alloc_var(io, |buf| {
         let frame = TborSdCreateRemoteBackupResp::encode(buf, 0, false)?
             .pok_remote_backup(pok)?
+            .pok_local_backup(pok_local)?
+            .sd_mk_backup(sd_mk)?
             .finish();
         Ok(frame.as_bytes().len())
     })?;

--- a/fw/core/lib/src/ddi/tbor/sd_create_remote_backup.rs
+++ b/fw/core/lib/src/ddi/tbor/sd_create_remote_backup.rs
@@ -50,27 +50,27 @@
 //!
 //! [`PartPolicy`]: super::policy
 
+use azihsm_fw_core_crypto_hpke::seal;
 use azihsm_fw_core_crypto_hpke::AuthParams;
 use azihsm_fw_core_crypto_hpke::HpkeSealConfig;
 use azihsm_fw_core_crypto_hpke::HpkeSuite;
-use azihsm_fw_core_crypto_hpke::seal;
 use azihsm_fw_core_crypto_key_derive::derive_masking_key;
-use azihsm_fw_core_crypto_key_masking::aead::AeadAlg;
-use azihsm_fw_core_crypto_key_masking::aead::MaskParams;
 use azihsm_fw_core_crypto_key_masking::aead::mask;
 use azihsm_fw_core_crypto_key_masking::aead::peek_metadata;
 use azihsm_fw_core_crypto_key_masking::aead::unmask;
+use azihsm_fw_core_crypto_key_masking::aead::AeadAlg;
+use azihsm_fw_core_crypto_key_masking::aead::MaskParams;
+use azihsm_fw_core_evidence::verify_evidence;
 use azihsm_fw_core_evidence::EvidenceRefs;
 use azihsm_fw_core_evidence::TrustAnchors;
-use azihsm_fw_core_evidence::verify_evidence;
+use azihsm_fw_ddi_tbor_types::policy::PartPolicy;
+use azihsm_fw_ddi_tbor_types::policy::PolicyKeyKind;
+use azihsm_fw_ddi_tbor_types::policy::POLICY_MAX_KEY_LEN;
+use azihsm_fw_ddi_tbor_types::TborSdCreateRemoteBackupReq;
+use azihsm_fw_ddi_tbor_types::TborSdCreateRemoteBackupResp;
 use azihsm_fw_ddi_tbor_types::LOCAL_MK_BACKUP_LEN;
 use azihsm_fw_ddi_tbor_types::MASKED_SD_LEN;
 use azihsm_fw_ddi_tbor_types::POK_REMOTE_BACKUP_LEN;
-use azihsm_fw_ddi_tbor_types::TborSdCreateRemoteBackupReq;
-use azihsm_fw_ddi_tbor_types::TborSdCreateRemoteBackupResp;
-use azihsm_fw_ddi_tbor_types::policy::POLICY_MAX_KEY_LEN;
-use azihsm_fw_ddi_tbor_types::policy::PartPolicy;
-use azihsm_fw_ddi_tbor_types::policy::PolicyKeyKind;
 use azihsm_fw_hsm_oob::OobPtr;
 use azihsm_fw_hsm_pal_traits::DmaBuf;
 use azihsm_fw_hsm_pal_traits::HsmEccCurve;

--- a/fw/core/lib/src/ddi/tbor/sd_create_remote_backup.rs
+++ b/fw/core/lib/src/ddi/tbor/sd_create_remote_backup.rs
@@ -391,7 +391,16 @@ async fn commit_sd_to_vault<'p, P: HsmPal>(
     // Atomic one-shot claim first (the race-winner gate); the recorded
     // inverse clears the flag on rollback.
     part_state::part_mark_sd_initialized(pal, io)?;
-    undo.push_prop_restore_scalar(PartPropId::SD_INITIALIZED, 0)?;
+    if let Err(e) = undo.push_prop_restore_scalar(PartPropId::SD_INITIALIZED, 0) {
+        // The claim succeeded but its rollback inverse could not be
+        // recorded (e.g. `UndoLogFull`); clear the flag now (best-effort)
+        // so a full undo log cannot permanently wedge the partition's
+        // one-shot SD gate.  Safe against a concurrent create: this task
+        // owns the just-made claim and there is no await between the mark
+        // and here.
+        let _ = part_state::part_clear_sd_initialized(pal, io);
+        return Err(e);
+    }
 
     // Vault SDMK as the partition's SecurityDomain-scope masking key,
     // then record its id so `masking_key_id_for_scope` resolves it.

--- a/fw/core/lib/src/part_state.rs
+++ b/fw/core/lib/src/part_state.rs
@@ -502,6 +502,32 @@ pub const fn part_ephemeral_mk_key_id_prop_id() -> PartPropId {
     PartPropId::EPHEMERAL_MK_KEY_ID
 }
 
+/// Vault id of the security-domain key masking key (`SDMK`).
+///
+/// Wraps [`PartPropId::SD_MK_KEY_ID`] (`U16 → HsmKeyId`,
+/// `AbsentUntilSet`).  Bound by the TBOR `SdCreateRemoteBackup` handler;
+/// resolves the [`SecurityDomain`](azihsm_fw_hsm_pal_traits::HsmKeyScope::SecurityDomain)
+/// scope to its live masking key.
+pub fn part_sd_mk_key_id(pal: &impl HsmPartitionManager, io: &impl HsmIo) -> HsmResult<HsmKeyId> {
+    key_id_get(pal, io, PartPropId::SD_MK_KEY_ID)
+}
+
+/// Set the security-domain masking-key id.
+pub fn part_set_sd_mk_key_id(
+    pal: &impl HsmPartitionManager,
+    io: &impl HsmIo,
+    key_id: HsmKeyId,
+) -> HsmResult<()> {
+    key_id_set(pal, io, PartPropId::SD_MK_KEY_ID, key_id)
+}
+
+/// [`PartPropId`] backing [`part_sd_mk_key_id`] /
+/// [`part_set_sd_mk_key_id`].
+#[inline]
+pub const fn part_sd_mk_key_id_prop_id() -> PartPropId {
+    PartPropId::SD_MK_KEY_ID
+}
+
 /// Vault id of the partition's unwrapping key.
 ///
 /// Wraps [`PartPropId::RSA_UNWRAPPING_KEY_ID`] (`U16 → HsmKeyId`,
@@ -1149,6 +1175,20 @@ pub fn part_is_bk3_initialized(pal: &impl HsmPartitionManager, io: &impl HsmIo) 
 /// authoritative race-winner gate for `DdiInitBk3`.
 pub fn part_mark_bk3_initialized(pal: &impl HsmPartitionManager, io: &impl HsmIo) -> HsmResult<()> {
     pal.part_prop_set_bool(io, PartPropId::BK3_INITIALIZED, true)
+}
+
+/// Whether the partition has completed one-shot security-domain
+/// initialization (its `SDMK` is provisioned).
+pub fn part_is_sd_initialized(pal: &impl HsmPartitionManager, io: &impl HsmIo) -> HsmResult<bool> {
+    pal.part_prop_get_bool(io, PartPropId::SD_INITIALIZED)
+}
+
+/// Atomically commit the partition's one-shot security-domain init
+/// state to `true`.  Returns [`HsmError::SdAlreadyInitialized`] if the
+/// flag was already set in the current partition incarnation.  This is
+/// the authoritative race-winner gate for `SdCreateRemoteBackup`.
+pub fn part_mark_sd_initialized(pal: &impl HsmPartitionManager, io: &impl HsmIo) -> HsmResult<()> {
+    pal.part_prop_set_bool(io, PartPropId::SD_INITIALIZED, true)
 }
 
 /// Current owner-seed (BKS2) selector (BKS2 lineage; always 0 today).

--- a/fw/core/lib/src/part_state.rs
+++ b/fw/core/lib/src/part_state.rs
@@ -1191,6 +1191,16 @@ pub fn part_mark_sd_initialized(pal: &impl HsmPartitionManager, io: &impl HsmIo)
     pal.part_prop_set_bool(io, PartPropId::SD_INITIALIZED, true)
 }
 
+/// Clear the partition's one-shot security-domain init flag.
+///
+/// Used only to best-effort roll back a just-made claim when its undo
+/// inverse could not be recorded, so a full undo log cannot permanently
+/// wedge the partition's SD gate.  (The one-shot setter permits
+/// `→ false`; the normal rollback path is the undo log.)
+pub fn part_clear_sd_initialized(pal: &impl HsmPartitionManager, io: &impl HsmIo) -> HsmResult<()> {
+    pal.part_prop_set_bool(io, PartPropId::SD_INITIALIZED, false)
+}
+
 /// Current owner-seed (BKS2) selector (BKS2 lineage; always 0 today).
 ///
 /// Device-global (not per-partition); served by

--- a/fw/pal/traits/src/error.rs
+++ b/fw/pal/traits/src/error.rs
@@ -403,6 +403,15 @@ pub enum HsmError {
     /// cryptographically valid, its identity is simply wrong.
     PartFinalPtaMismatch = 0x08700107,
 
+    /// The TBOR `SdCreateRemoteBackup` handler was asked to create a
+    /// security domain on a partition whose one-shot
+    /// [`SD_INITIALIZED`](crate::PartPropId::SD_INITIALIZED) flag is
+    /// already set (the security-domain masking key `SDMK` is already
+    /// provisioned in this partition incarnation).  The one-shot gate
+    /// permits only `false → true`; reset happens PAL-internally on
+    /// partition free / NSSR.
+    SdAlreadyInitialized = 0x08700108,
+
     // Firmware-internal diagnostic codes logged by the CPU fault and panic
     // exception handlers (`azihsm_fw_uno_fault`). These are not DDI protocol
     // statuses: they use the PAL diagnostic facility (`0x08F`) to stay clear of

--- a/fw/pal/traits/src/part.rs
+++ b/fw/pal/traits/src/part.rs
@@ -771,6 +771,15 @@ impl PartPropId {
     /// PAL-internally on partition free / NSSR.
     pub const BK3_INITIALIZED: PartPropId = PartPropId(0x0008);
 
+    /// One-shot security-domain initialization flag.  Bool,
+    /// `RequiredPresent`, `Rw`.  A redundant `true` write (the flag is
+    /// already set in this incarnation) is rejected with
+    /// [`HsmError::SdAlreadyInitialized`] — the atomic race-winner gate
+    /// for `SdCreateRemoteBackup`.  A `false` write is permitted so the
+    /// TBOR undo log can roll the claim back on a failed command; the
+    /// flag is also reset PAL-internally on partition free / NSSR.
+    pub const SD_INITIALIZED: PartPropId = PartPropId(0x0009);
+
     // ── Vault references (0x0010..) ───────────────────────────────
 
     /// Vault [`HsmKeyId`](crate::HsmKeyId) for the partition identity
@@ -813,6 +822,12 @@ impl PartPropId {
     /// key masking key (`EphemeralMK`).  Bound by the TBOR `PartFinal`
     /// handler; freshly generated each launch (never backed up).
     pub const EPHEMERAL_MK_KEY_ID: PartPropId = PartPropId(0x001C);
+
+    /// Vault [`HsmKeyId`](crate::HsmKeyId) for the security-domain key
+    /// masking key (`SDMK`).  Bound by the TBOR `SdCreateRemoteBackup`
+    /// handler; resolves the [`SecurityDomain`](crate::HsmKeyScope::SecurityDomain)
+    /// scope to its live masking key.
+    pub const SD_MK_KEY_ID: PartPropId = PartPropId(0x001D);
 
     /// Raw ECC-P384 public-key coordinates (x ∥ y, 96 B) of the
     /// partition identity key.  Read-only from caller perspective;
@@ -961,6 +976,7 @@ impl PartPropId {
             Self::GEN => PartPropMeta::scalar(U32, Ro, Req, false),
             Self::RES_COUNT => PartPropMeta::scalar(U8, Ro, Req, false),
             Self::BK3_INITIALIZED => PartPropMeta::scalar(Bool, Rw, Req, false),
+            Self::SD_INITIALIZED => PartPropMeta::scalar(Bool, Rw, Req, false),
 
             // ── Vault refs (HsmKeyId as u16) ──
             Self::ID_KEY_ID | Self::RSA_UNWRAPPING_KEY_ID => VAULT_REF_RO,
@@ -970,7 +986,8 @@ impl PartPropId {
             | Self::SESSION_ENC_KEY_ID
             | Self::ESTABLISH_CRED_KEY_ID
             | Self::LOCAL_MK_KEY_ID
-            | Self::EPHEMERAL_MK_KEY_ID => VAULT_REF_RW,
+            | Self::EPHEMERAL_MK_KEY_ID
+            | Self::SD_MK_KEY_ID => VAULT_REF_RW,
 
             // ── Public-key views (fixed P-384 sizes) ──
             Self::ID_PUB_KEY | Self::SESSION_ENC_PUB_KEY | Self::ESTABLISH_CRED_PUB_KEY => {

--- a/fw/pal/traits/src/vault.rs
+++ b/fw/pal/traits/src/vault.rs
@@ -70,6 +70,8 @@ use super::*;
 /// | 37–38 | Partition incarnation keys | `PartitionTrustAnchor`, `UniquePartitionSecret` |
 /// | 39–40 | PartFinal masking keys | `PartitionLocalMaskingKey`, `PartitionEphemeralMaskingKey` |
 /// | 41 | Security-domain sealing key | `SdSealing` |
+/// | 42 | Security-domain masking key | `SdMasking` |
+/// | 43 | Security-domain partition-owner seed | `SdPartitionOwnerSeed` |
 #[repr(u8)]
 #[open_enum]
 #[derive(Clone, Copy, Debug)]
@@ -217,6 +219,32 @@ pub enum HsmVaultKeyKind {
     /// field.  Represented as the 48-byte raw private scalar, mirroring
     /// [`PartitionTrustAnchor`](Self::PartitionTrustAnchor).
     SdSealing = 41,
+
+    /// Security-domain key masking key (`SDMK`) — 32 B AES-256-GCM
+    /// masking key.
+    ///
+    /// Minted (random) on device by the TBOR `SdCreateRemoteBackup`
+    /// handler when a security domain is created, vaulted with
+    /// [`HsmKeyScope::SecurityDomain`] scope, and backed up to the caller
+    /// as `sd_mk_backup` (masked under the derived `SDBMK`).  It is the
+    /// live masking key that
+    /// [`SecurityDomain`](HsmKeyScope::SecurityDomain)-scoped keys are
+    /// masked under; recovered across launches from the caller-replayed
+    /// `sd_mk_backup` (parity with
+    /// [`PartitionLocalMaskingKey`](Self::PartitionLocalMaskingKey)).
+    SdMasking = 42,
+
+    /// Security-domain partition-owner seed (`BKS3`) — the 48 B root
+    /// secret of a security domain (firmware `BK3`).
+    ///
+    /// Never stored live on-device: minted (random) by
+    /// `SdCreateRemoteBackup`, HPKE-Auth-sealed to a recipient as
+    /// `pok_remote_backup` and masked under the partition-local masking
+    /// key (`PartLocalMK`) as `pok_local_backup`.  This kind is recorded
+    /// only as the masked blob's `key_kind` metadata (parity with
+    /// [`SdSealing`](Self::SdSealing)); the on-device security domain is
+    /// re-derived from it on restore.
+    SdPartitionOwnerSeed = 43,
 }
 
 /// Key scope: the lifecycle / visibility domain a vault key belongs

--- a/fw/plat/std/pal/src/drivers/vault.rs
+++ b/fw/plat/std/pal/src/drivers/vault.rs
@@ -103,6 +103,8 @@ pub fn fw_key_size(kind: HsmVaultKeyKind) -> Option<usize> {
         HsmVaultKeyKind::PartitionLocalMaskingKey
         | HsmVaultKeyKind::PartitionEphemeralMaskingKey => 32,
         HsmVaultKeyKind::SdSealing => 48,
+        HsmVaultKeyKind::SdMasking => 32,
+        HsmVaultKeyKind::SdPartitionOwnerSeed => 48,
         // SessionEx is length-discriminated by session type
         // (PlainText=120, Authenticated=216); reported as variable
         // length, same handling as VarLenHmac*.
@@ -692,6 +694,8 @@ mod tests {
             (HsmVaultKeyKind::PartitionLocalMaskingKey, 32),
             (HsmVaultKeyKind::PartitionEphemeralMaskingKey, 32),
             (HsmVaultKeyKind::SdSealing, 48),
+            (HsmVaultKeyKind::SdMasking, 32),
+            (HsmVaultKeyKind::SdPartitionOwnerSeed, 48),
         ];
         for &(kind, expected) in cases {
             assert_eq!(

--- a/fw/plat/std/pal/src/part.rs
+++ b/fw/plat/std/pal/src/part.rs
@@ -232,6 +232,14 @@ pub(crate) struct PartitionEntry {
     /// one-shot gate for `InitBk3`.
     bk3_initialized: bool,
 
+    /// Security-domain initialization state for the current partition
+    /// incarnation.
+    ///
+    /// `false` on every enable; set to `true` by a successful
+    /// `part_mark_sd_initialized`.  Acts as the authoritative one-shot
+    /// gate for `SdCreateRemoteBackup`.
+    sd_initialized: bool,
+
     /// User credential blob (`id ‖ pin`, 16 + 16 = 32 bytes).  Zeroed
     /// until set via the `CREDENTIAL` property.
     credential: [u8; 32],
@@ -277,6 +285,10 @@ pub(crate) struct PartitionEntry {
     /// (`EphemeralMK`), bound by `PartFinal`.
     ephemeral_mk_key_id: Option<HsmKeyId>,
 
+    /// Vault key ID of the security-domain key masking key (`SDMK`),
+    /// bound by `SdCreateRemoteBackup`.
+    sd_mk_key_id: Option<HsmKeyId>,
+
     /// SEC1 uncompressed P-384 public key for the Partition Trust Anchor.
     pta_pub_key: Option<[u8; P384_PUB_KEY_LEN]>,
 
@@ -319,6 +331,7 @@ impl Default for PartitionEntry {
             masked_bk_boot_len: 0,
             vm_launch_guid: [0u8; VM_LAUNCH_GUID_LEN],
             bk3_initialized: false,
+            sd_initialized: false,
             credential: [0u8; 32],
             credential_set: false,
             bk3_session: [0u8; 48],
@@ -331,6 +344,7 @@ impl Default for PartitionEntry {
             ups_key_id: None,
             local_mk_key_id: None,
             ephemeral_mk_key_id: None,
+            sd_mk_key_id: None,
             pta_pub_key: None,
             policy_hash: None,
             pota_thumbprint: None,
@@ -867,6 +881,7 @@ impl StdHsmPal {
 
         entry.vm_launch_guid = STD_VM_LAUNCH_GUID;
         entry.bk3_initialized = false;
+        entry.sd_initialized = false;
 
         entry.state = PartState::Enabled;
         Ok(())
@@ -1058,6 +1073,7 @@ impl StdHsmPal {
         drop_key(&mut entry.vault, &mut entry.ups_key_id);
         drop_key(&mut entry.vault, &mut entry.local_mk_key_id);
         drop_key(&mut entry.vault, &mut entry.ephemeral_mk_key_id);
+        drop_key(&mut entry.vault, &mut entry.sd_mk_key_id);
         entry.id_key_id = None;
 
         // Public-key mirrors and other non-secret fixed buffers.
@@ -1082,6 +1098,7 @@ impl StdHsmPal {
         // grouping.
         entry.vm_launch_guid.fill(0);
         entry.bk3_initialized = false;
+        entry.sd_initialized = false;
 
         // Caller-presented secrets and per-session derived material.
         entry.credential.fill(0);
@@ -1199,6 +1216,7 @@ impl PartitionEntry {
             PartPropId::GEN => Ok(self.gen),
             PartPropId::RES_COUNT => Ok(self.res_mask.count_ones()),
             PartPropId::BK3_INITIALIZED => Ok(u32::from(self.bk3_initialized)),
+            PartPropId::SD_INITIALIZED => Ok(u32::from(self.sd_initialized)),
             PartPropId::ID_KEY_ID => key_id_to_u32(self.id_key_id),
             PartPropId::MK_KEY_ID => key_id_to_u32(self.mk_key_id),
             PartPropId::UPS_KEY_ID => key_id_to_u32(self.ups_key_id),
@@ -1208,6 +1226,7 @@ impl PartitionEntry {
             PartPropId::ESTABLISH_CRED_KEY_ID => key_id_to_u32(self.establish_cred_key_id),
             PartPropId::LOCAL_MK_KEY_ID => key_id_to_u32(self.local_mk_key_id),
             PartPropId::EPHEMERAL_MK_KEY_ID => key_id_to_u32(self.ephemeral_mk_key_id),
+            PartPropId::SD_MK_KEY_ID => key_id_to_u32(self.sd_mk_key_id),
             _ => Err(HsmError::InvalidArg),
         }
     }
@@ -1252,6 +1271,10 @@ impl PartitionEntry {
                 self.ephemeral_mk_key_id = Some(HsmKeyId::from(value as u16));
                 Ok(())
             }
+            PartPropId::SD_MK_KEY_ID => {
+                self.sd_mk_key_id = Some(HsmKeyId::from(value as u16));
+                Ok(())
+            }
             PartPropId::ESTABLISH_CRED_KEY_ID => {
                 self.establish_cred_key_id = Some(HsmKeyId::from(value as u16));
                 Ok(())
@@ -1270,6 +1293,19 @@ impl PartitionEntry {
                     return Err(HsmError::Bk3AlreadyInitialized);
                 }
                 self.bk3_initialized = true;
+                Ok(())
+            }
+            PartPropId::SD_INITIALIZED => {
+                // One-shot claim: a redundant `true` fails the race and
+                // returns SdAlreadyInitialized.  `false` is permitted so
+                // the TBOR undo log can roll the claim back on a failed
+                // command; PAL-internal reset also clears it on free /
+                // NSSR.
+                let want = value != 0;
+                if want && self.sd_initialized {
+                    return Err(HsmError::SdAlreadyInitialized);
+                }
+                self.sd_initialized = want;
                 Ok(())
             }
             // GEN/SVN/RES_COUNT/ID_KEY_ID/RSA_UNWRAPPING_KEY_ID are Ro
@@ -1507,6 +1543,10 @@ impl PartitionEntry {
             }
             PartPropId::EPHEMERAL_MK_KEY_ID => {
                 self.ephemeral_mk_key_id = None;
+                Ok(())
+            }
+            PartPropId::SD_MK_KEY_ID => {
+                self.sd_mk_key_id = None;
                 Ok(())
             }
             PartPropId::ESTABLISH_CRED_KEY_ID => {
@@ -1998,6 +2038,27 @@ mod tests {
             e.prop_set_scalar(PartPropId::BK3_INITIALIZED, 0),
             Err(HsmError::InvalidArg)
         ));
+    }
+
+    #[test]
+    fn sd_initialized_one_shot_claim_and_undo_clear() {
+        let mut e = fresh_entry();
+        assert_eq!(e.prop_get_scalar(PartPropId::SD_INITIALIZED).unwrap(), 0);
+        // First true write (the atomic claim) succeeds.
+        e.prop_set_scalar(PartPropId::SD_INITIALIZED, 1).unwrap();
+        assert!(e.sd_initialized);
+        // Re-asserting true fails the one-shot race.
+        assert!(matches!(
+            e.prop_set_scalar(PartPropId::SD_INITIALIZED, 1),
+            Err(HsmError::SdAlreadyInitialized)
+        ));
+        // Unlike BK3, clearing to false IS permitted so the TBOR undo log
+        // can roll the claim back on a failed command.
+        e.prop_set_scalar(PartPropId::SD_INITIALIZED, 0).unwrap();
+        assert!(!e.sd_initialized);
+        // After a rollback the claim can be re-made.
+        e.prop_set_scalar(PartPropId::SD_INITIALIZED, 1).unwrap();
+        assert!(e.sd_initialized);
     }
 
     #[test]

--- a/fw/plat/uno/fw/crates/key_vault/src/kind.rs
+++ b/fw/plat/uno/fw/crates/key_vault/src/kind.rs
@@ -82,7 +82,7 @@ impl KeyLen {
 /// and var-HMAC min/max. `SessionEx` is length-discriminated by session
 /// type (PlainText=120, Authenticated=216) and modelled as variable;
 /// `SessionExPending` holds the in-flight TBOR Pending blob (up to 256).
-static KIND_LEN: [KeyLen; 42] = [
+static KIND_LEN: [KeyLen; 44] = [
     /* 0  Free                         */ KeyLen::Invalid,
     /* 1  Rsa2kPublic                  */ KeyLen::Fixed(260),
     /* 2  Rsa3kPublic                  */ KeyLen::Fixed(388),
@@ -125,6 +125,8 @@ static KIND_LEN: [KeyLen; 42] = [
     /* 39 PartitionLocalMaskingKey     */ KeyLen::Fixed(32),
     /* 40 PartitionEphemeralMaskingKey */ KeyLen::Fixed(32),
     /* 41 SdSealing                    */ KeyLen::Fixed(48),
+    /* 42 SdMasking                    */ KeyLen::Fixed(32),
+    /* 43 SdPartitionOwnerSeed         */ KeyLen::Fixed(48),
 ];
 
 /// Resolves the length contract for `kind` in O(1).
@@ -190,6 +192,8 @@ mod tests {
             (HsmVaultKeyKind::PartitionLocalMaskingKey, 32),
             (HsmVaultKeyKind::PartitionEphemeralMaskingKey, 32),
             (HsmVaultKeyKind::SdSealing, 48),
+            (HsmVaultKeyKind::SdMasking, 32),
+            (HsmVaultKeyKind::SdPartitionOwnerSeed, 48),
         ];
         for (kind, len) in table {
             assert_eq!(key_len(kind), Ok(KeyLen::Fixed(len)), "{kind:?}");

--- a/fw/plat/uno/fw/drivers/part_store/src/part_store.rs
+++ b/fw/plat/uno/fw/drivers/part_store/src/part_store.rs
@@ -52,13 +52,13 @@ const RESERVED3_LEN: usize = 626
     - 4  // state
     - 4  // generation
     - RES_MASK_LEN
-    - 9 * 2  // key handles (u16 + sentinel)
+    - 10 * 2  // key handles (u16 + sentinel)
     - PUB_KEY_LEN  // ec_pub_key
     - PUB_KEY_LEN  // se_pub_key
     - PSK_LEN  // psk_co
     - PSK_LEN  // psk_cu
     - CREDENTIAL_LEN
-    - 1  // valid_flags (7 packed presence/init bits)
+    - 1  // valid_flags (8 packed presence/init bits)
     - PUB_KEY_LEN  // pta_pub_key
     - 2; // session_meta (pending_mask + psk_change_mask)
 
@@ -70,6 +70,7 @@ const FLAG_SAPOTA_THUMBPRINT_VALID: u8 = 1 << 3;
 const FLAG_PTA_PUB_KEY_VALID: u8 = 1 << 4;
 const FLAG_POLICY_HASH_VALID: u8 = 1 << 5;
 const FLAG_BK3_INITIALIZED: u8 = 1 << 6;
+const FLAG_SD_INITIALIZED: u8 = 1 << 7;
 
 /// Total per-partition slot size (matches the reference layout).
 const STORE_SIZE: usize = 3072;
@@ -267,6 +268,7 @@ struct Storage {
     unwrapping_key_id: [u8; 2],
     local_mk_key_id: [u8; 2],
     ephemeral_mk_key_id: [u8; 2],
+    sd_mk_key_id: [u8; 2],
     // Presence flags for `AbsentUntilSet` byte fields plus the one-shot
     // InitBk3 gate, bit-packed into a single byte (see the `FLAG_*`
     // constants).  Placed after the key handles, before `reserved3`,
@@ -404,6 +406,7 @@ impl Partition {
         slot.pta_key_id = absent;
         slot.local_mk_key_id = absent;
         slot.ephemeral_mk_key_id = absent;
+        slot.sd_mk_key_id = absent;
         slot.unwrapping_key_id = absent;
     }
 
@@ -458,6 +461,7 @@ impl Partition {
         self.set_pta_key_id(None);
         self.set_local_mk_key_id(None);
         self.set_ephemeral_mk_key_id(None);
+        self.set_sd_mk_key_id(None);
         self.set_unwrapping_key_id(None);
         // Caller-presented secret + derived BK3 session key.
         self.clear_credential();
@@ -484,6 +488,7 @@ impl Partition {
             self.clear_sapota_thumbprint();
             self.clear_sealed_bk3();
             self.set_bk3_initialized(false);
+            self.set_sd_initialized(false);
             let slot = self.slot_mut();
             slot.psk_co = [0u8; PSK_LEN];
             slot.psk_cu = [0u8; PSK_LEN];
@@ -764,6 +769,24 @@ impl Partition {
             slot.valid_flags |= FLAG_BK3_INITIALIZED;
         } else {
             slot.valid_flags &= !FLAG_BK3_INITIALIZED;
+        }
+    }
+
+    /// Whether a security domain has already been created for this
+    /// partition (one-shot gate).
+    #[inline(never)]
+    pub fn sd_initialized(self) -> bool {
+        self.slot().valid_flags & FLAG_SD_INITIALIZED != 0
+    }
+
+    /// Sets the one-shot security-domain init gate.
+    #[inline(never)]
+    pub fn set_sd_initialized(mut self, valid: bool) {
+        let slot = self.slot_mut();
+        if valid {
+            slot.valid_flags |= FLAG_SD_INITIALIZED;
+        } else {
+            slot.valid_flags &= !FLAG_SD_INITIALIZED;
         }
     }
 
@@ -1116,6 +1139,18 @@ impl Partition {
     #[inline(never)]
     pub fn set_ephemeral_mk_key_id(mut self, key: Option<HsmKeyId>) {
         self.slot_mut().ephemeral_mk_key_id = write_handle(key);
+    }
+
+    /// Reads the security-domain masking key (`SDMK`) handle.
+    #[inline(never)]
+    pub fn sd_mk_key_id(self) -> Option<HsmKeyId> {
+        read_handle(self.slot().sd_mk_key_id)
+    }
+
+    /// Sets (or clears) the security-domain masking key handle.
+    #[inline(never)]
+    pub fn set_sd_mk_key_id(mut self, key: Option<HsmKeyId>) {
+        self.slot_mut().sd_mk_key_id = write_handle(key);
     }
 
     // ── cached public keys (establish-cred / session-enc) ────────────────

--- a/fw/plat/uno/fw/drivers/part_store/src/part_store.rs
+++ b/fw/plat/uno/fw/drivers/part_store/src/part_store.rs
@@ -270,10 +270,10 @@ struct Storage {
     ephemeral_mk_key_id: [u8; 2],
     sd_mk_key_id: [u8; 2],
     // Presence flags for `AbsentUntilSet` byte fields plus the one-shot
-    // InitBk3 gate, bit-packed into a single byte (see the `FLAG_*`
-    // constants).  Placed after the key handles, before `reserved3`,
-    // where 1-byte alignment is harmless and the DMA-target public keys
-    // above stay 4-aligned.
+    // InitBk3 and security-domain (`SD_INITIALIZED`) gates, bit-packed into
+    // a single byte (see the `FLAG_*` constants).  Placed after the key
+    // handles, before `reserved3`, where 1-byte alignment is harmless and
+    // the DMA-target public keys above stay 4-aligned.
     valid_flags: u8,
     // Volatile TBOR session slot metadata: byte 0 = pending_mask
     // (bit N set while slot N's handshake is in flight), byte 1 =

--- a/fw/plat/uno/fw/pal/src/part.rs
+++ b/fw/plat/uno/fw/pal/src/part.rs
@@ -554,6 +554,7 @@ impl HsmPartitionManager for UnoHsmPal {
             PartPropId::SESSION_ENC_KEY_ID => part.se_key_id(),
             PartPropId::LOCAL_MK_KEY_ID => part.local_mk_key_id(),
             PartPropId::EPHEMERAL_MK_KEY_ID => part.ephemeral_mk_key_id(),
+            PartPropId::SD_MK_KEY_ID => part.sd_mk_key_id(),
             _ => return Err(HsmError::UnsupportedCmd),
         };
         key.map(u16::from).ok_or(HsmError::PartPropNotFound)
@@ -568,6 +569,7 @@ impl HsmPartitionManager for UnoHsmPal {
             PartPropId::ESTABLISH_CRED_KEY_ID => part.set_ec_key_id(Some(key)),
             PartPropId::LOCAL_MK_KEY_ID => part.set_local_mk_key_id(Some(key)),
             PartPropId::EPHEMERAL_MK_KEY_ID => part.set_ephemeral_mk_key_id(Some(key)),
+            PartPropId::SD_MK_KEY_ID => part.set_sd_mk_key_id(Some(key)),
             // Raw mechanism: UPS / PTA write-once is upper-layer policy
             // (`part_state::part_set_ups_key_id` / `part_set_pta_key_id`); the
             // undo log restores a prior id through this raw path.
@@ -595,6 +597,7 @@ impl HsmPartitionManager for UnoHsmPal {
         let part = PartStore::partition(io.pid())?;
         match id {
             PartPropId::BK3_INITIALIZED => Ok(part.bk3_initialized()),
+            PartPropId::SD_INITIALIZED => Ok(part.sd_initialized()),
             _ => Err(HsmError::UnsupportedCmd),
         }
     }
@@ -614,6 +617,14 @@ impl HsmPartitionManager for UnoHsmPal {
                     return Err(HsmError::Bk3AlreadyInitialized);
                 }
                 part.set_bk3_initialized(true);
+                Ok(())
+            }
+            PartPropId::SD_INITIALIZED => {
+                // One-shot claim; `false` permitted for undo rollback.
+                if value && part.sd_initialized() {
+                    return Err(HsmError::SdAlreadyInitialized);
+                }
+                part.set_sd_initialized(value);
                 Ok(())
             }
             _ => Err(HsmError::UnsupportedCmd),
@@ -709,6 +720,7 @@ impl HsmPartitionManager for UnoHsmPal {
             PartPropId::ESTABLISH_CRED_KEY_ID => p.set_ec_key_id(None),
             PartPropId::LOCAL_MK_KEY_ID => p.set_local_mk_key_id(None),
             PartPropId::EPHEMERAL_MK_KEY_ID => p.set_ephemeral_mk_key_id(None),
+            PartPropId::SD_MK_KEY_ID => p.set_sd_mk_key_id(None),
             // AbsentUntilSet byte fields zeroize and reset to absent.
             PartPropId::CREDENTIAL => p.clear_credential(),
             PartPropId::POTA_THUMBPRINT => p.clear_pota_thumbprint(),


### PR DESCRIPTION
## Summary

Grows `SdCreateRemoteBackup` from a stateless remote-backup seal into the full **CreateSD** provisioning command (manticore `CreateSD`). It now provisions the security-domain masking key (**SDMK**) so security-domain-scoped keys can be masked, and returns the local + masking-key backups alongside the existing remote backup.

## What changed

**Handler (`fw/core/lib/src/ddi/tbor/sd_create_remote_backup.rs`)**
- Mints a random **SDMK** and derives **SDBMK** (`KBKDF(BKS3, mfgr_seed[svn] ‖ owner_seed[owner] ‖ policy_hash)`).
- Returns **three** backups: `pok_remote_backup` (161 B), `pok_local_backup` (180 B — BKS3 masked under `PartLocalMK`), and `sd_mk_backup` (164 B — SDMK masked under SDBMK).
- **Vaults SDMK** (new `SdMasking` kind, `SecurityDomain` scope) and records `SD_MK_KEY_ID`, so `masking_key_id_for_scope(SecurityDomain)` now resolves it — enabling SD-scoped key masking.
- Marks the partition SD-initialized via a new **one-shot `SD_INITIALIZED`** gate; a second create returns `SdAlreadyInitialized`.
- **Undo-guarded** commit: a handler failure (or failed completion) rolls back the vault write, the `SD_MK_KEY_ID` prop, and the `SD_INITIALIZED` claim. The one-shot flag permits `→false` so the undo log can clear it cleanly.

**Design decisions**
- **SDMK is vaulted** (not recomputed on demand) because SD-scoped masking needs a stable key id resolved by `masking_key_id_for_scope`. On non-initialized partitions that scope still returns `UnsupportedKeyScope`, preserving `SdSealingKeyGen` behavior.
- **BKS3 is installed** as `pok_local_backup` (masked under `PartLocalMK`), not vaulted — tagged with a new `SdPartitionOwnerSeed` metadata kind.

**Supporting infra (traits + std + uno PALs)**
- New `PartPropId::SD_INITIALIZED` (one-shot) and `SD_MK_KEY_ID` (vault ref).
- New `HsmVaultKeyKind::SdMasking` (32 B) and `SdPartitionOwnerSeed` (48 B); `HsmError::SdAlreadyInitialized` + `TborStatus` mirror.
- `part_state` helpers; uno persistent slot + flag bit (layout assert balanced).

## Testing
- `cargo xtask build` — fw core, std PAL, host + fw TBOR types, and uno `part_store` / `key_vault` / `pal` all build clean.
- **107 emu tests** pass, including the updated 3-backup roundtrip and new one-shot rejection; reseal + sealing-key-gen paths intact.
- Added a std-PAL unit test for the `SD_INITIALIZED` one-shot claim + rollback-clear semantics.
- `cargo xtask clippy` (main + uno workspaces), `cargo +nightly xtask fmt`, and `cargo xtask copyright` all clean.
- Updated `docs/tbor-ddi/commands/sd_create_remote_backup.md`.

## Follow-up
This is the create-side groundwork; **RestoreSD** (which consumes these envelopes) is the next PR.