### PR TITLE
feat(tbor): implement SdRestoreLocalBackup (CreateSD in reverse)

### DIFF
--- a/ddi/tbor/types/src/status.rs
+++ b/ddi/tbor/types/src/status.rs
@@ -312,6 +312,11 @@ pub enum TborStatus {
     /// provisioned in this incarnation (mirror of
     /// `HsmError::SdAlreadyInitialized`).
     SdAlreadyInitialized = 0x08700108,
+
+    /// A `SdRestore*` handler was asked to restore a security-domain
+    /// backup whose bound SVN is newer than the current firmware SVN
+    /// (mirror of `HsmError::SdBackupSvnRollback`).
+    SdBackupSvnRollback = 0x08700109,
 }
 
 impl core::fmt::Debug for TborStatus {

--- a/ddi/tbor/types/tests/commands/mod.rs
+++ b/ddi/tbor/types/tests/commands/mod.rs
@@ -17,6 +17,7 @@ pub mod part_init;
 pub mod psk_change;
 pub mod sd_create_remote_backup;
 pub mod sd_reseal_remote_backup;
+pub mod sd_restore_local_backup;
 pub mod sd_sealing_key_gen;
 pub mod session_close;
 pub mod unexpected_toc_type;

--- a/ddi/tbor/types/tests/commands/sd_create_remote_backup.rs
+++ b/ddi/tbor/types/tests/commands/sd_create_remote_backup.rs
@@ -85,7 +85,7 @@ const BACKUP_PART_ID_LEN: usize = 16;
 /// The caller learns the PID / PID public key from `PartInfo` (before
 /// `PartInit`); the SATA key is a synthetic trust anchor the test also
 /// uses to sign the partition-owner certificate chain.
-fn backing_part_policy(
+pub(crate) fn backing_part_policy(
     pid: &[u8],
     pid_pub: &[u8],
     sata_pub: &[u8; RAW_PUB_LEN],

--- a/ddi/tbor/types/tests/commands/sd_restore_local_backup.rs
+++ b/ddi/tbor/types/tests/commands/sd_restore_local_backup.rs
@@ -235,14 +235,15 @@ fn sd_restore_local_backup_rejects_tampered_pok_emu() {
     let n = tampered.len();
     tampered[n - 1] ^= 0xFF;
 
-    let err = ctx
-        .tbor(&TborSdRestoreLocalBackupReq {
+    // A byte-flipped local backup fails the AEAD tag check inside `unmask`;
+    // assert the exact status so the contract is locked in — the command must
+    // not succeed or provision the SD under any other failure mode.
+    ctx.expect_fw_reject(
+        &TborSdRestoreLocalBackupReq {
             session_id: session.session_id,
             pok_local_backup: tampered,
             sd_mk_backup: created.sd_mk_backup.clone(),
-        })
-        .expect_err("a tampered pok_local_backup must be rejected");
-    // The exact status is the AEAD tag-mismatch surfaced by `unmask`; the
-    // command must not succeed and must not provision the SD.
-    let _ = err;
+        },
+        TborStatus::AesGcmDecryptTagDoesNotMatch,
+    );
 }

--- a/ddi/tbor/types/tests/commands/sd_restore_local_backup.rs
+++ b/ddi/tbor/types/tests/commands/sd_restore_local_backup.rs
@@ -1,0 +1,248 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Integration tests for the TBOR `SdRestoreLocalBackup` command.
+//!
+//! `SdRestoreLocalBackup` restores a security domain from its device-local
+//! backups (`pok_local_backup` = BKS3 masked under `PartLocalMK`,
+//! `sd_mk_backup` = SDMK masked under the derived SDBMK), re-masks both at
+//! the current SVN, and re-provisions the SD — the local-reboot recovery
+//! path.  It needs no sender, HPKE, evidence, or out-of-band data.
+//!
+//! The **round-trip** test exercises the realistic recovery sequence: a
+//! first device finalizes and `CreateSD`s (capturing the local backups and
+//! the `local_mk_backup`), then a second device (factory-reset, same
+//! machine seed) restores `PartLocalMK` via `PartFinal` and finally
+//! restores the security domain from the captured local backups.
+//!
+//! Coverage:
+//! * Round-trip — create → reboot → PartFinal(restore PartLocalMK) →
+//!   restore-local returns non-zero refreshed backups.
+//! * One-shot — restore onto an already-initialized SD → `SdAlreadyInitialized`.
+//! * Restore before finalize → `InvalidArg`.
+//! * A tampered `pok_local_backup` is rejected (AEAD tag mismatch).
+
+#![cfg(feature = "emu")]
+
+use azihsm_ddi_tbor_types::TborPartInfoReq;
+use azihsm_ddi_tbor_types::TborSdRestoreLocalBackupReq;
+use azihsm_ddi_tbor_types::TborStatus;
+use azihsm_ddi_tbor_types::MASKED_SD_LEN;
+use azihsm_ddi_tbor_types::SD_MK_BACKUP_LEN;
+
+use crate::commands::part_init::bootstrap_rotated_co;
+use crate::commands::part_init::mach_seed;
+use crate::commands::part_init::pota_thumbprint;
+use crate::commands::part_init::ROTATED_CO_PSK;
+use crate::commands::sd_create_remote_backup::backing_part_policy;
+use crate::commands::sd_create_remote_backup::backup_request;
+use crate::commands::sd_create_remote_backup::build_receiver_evidence;
+use crate::commands::sd_create_remote_backup::masked_key_and_report;
+use crate::harness::x509_fixture::make_pta_chain;
+use crate::harness::x509_fixture::pta_pub_from_csr;
+use crate::harness::x509_fixture::CaKey;
+use crate::harness::x509_fixture::RAW_PUB_LEN;
+use crate::harness::TestCtx;
+
+/// Material captured from the first device's `CreateSD`, replayed on the
+/// second (rebooted) device to restore the security domain.
+struct CreatedSd {
+    /// The exact 484-byte `PartPolicy` image (needed verbatim to
+    /// re-finalize and to re-derive SDBMK on the second device).
+    policy: [u8; azihsm_ddi_tbor_types::PART_POLICY_LEN],
+    /// `PartFinal`'s `local_mk_backup`, replayed to restore `PartLocalMK`.
+    local_mk_backup: Vec<u8>,
+    /// The local SD backups from `CreateSD`.
+    pok_local_backup: Vec<u8>,
+    sd_mk_backup: Vec<u8>,
+}
+
+/// Drive device 1: finalize a backing partition, mint the SD via
+/// `CreateSD`, and capture everything device 2 needs to recover.  The
+/// `pota` / `sata` trust anchors and machine `seed` are supplied by the
+/// caller so the second device can re-finalize with an identical policy /
+/// certificate chain.
+fn create_sd_on_first_device(seed: &[u8], sata: &CaKey, pota: &CaKey) -> CreatedSd {
+    let ctx = TestCtx::new();
+    let session = bootstrap_rotated_co(&ctx, &ROTATED_CO_PSK);
+
+    let info = ctx.tbor(&TborPartInfoReq::new()).expect("PartInfo");
+    let mut pid_pub = [0u8; RAW_PUB_LEN];
+    pid_pub.copy_from_slice(&info.pid_pub_key);
+    let policy = backing_part_policy(
+        &info.pid,
+        &info.pid_pub_key,
+        &sata.raw_pub(),
+        &pota.raw_pub(),
+    );
+
+    let init = ctx
+        .part_init(&session, seed, &policy, &pota_thumbprint())
+        .expect("PartInit");
+    let chain = make_pta_chain(pota, &pta_pub_from_csr(&init.pta_csr));
+    let local_mk_backup = ctx
+        .part_final(&session, &policy, &[], &chain.der_items())
+        .expect("PartFinal")
+        .local_mk_backup;
+
+    let (masked, report) = masked_key_and_report(&ctx, session.session_id);
+    let evidence = build_receiver_evidence(&pid_pub, sata, &report);
+    let req = backup_request(session.session_id, masked, &evidence, &policy);
+    let resp = ctx
+        .tbor_oob(&req, &evidence.oob())
+        .expect("SdCreateRemoteBackup");
+
+    CreatedSd {
+        policy,
+        local_mk_backup,
+        pok_local_backup: resp.pok_local_backup.to_vec(),
+        sd_mk_backup: resp.sd_mk_backup.to_vec(),
+    }
+}
+
+/// Drive device 2 (reboot): re-init with the same seed/policy, restore
+/// `PartLocalMK` from `local_mk_backup`, and return the finalized session.
+fn reboot_and_restore_part_local_mk(
+    ctx: &TestCtx,
+    seed: &[u8],
+    pota: &CaKey,
+    created: &CreatedSd,
+) -> crate::harness::SessionHandshake {
+    let session = bootstrap_rotated_co(ctx, &ROTATED_CO_PSK);
+    let init = ctx
+        .part_init(&session, seed, &created.policy, &pota_thumbprint())
+        .expect("PartInit (device 2)");
+    let chain = make_pta_chain(pota, &pta_pub_from_csr(&init.pta_csr));
+    ctx.part_final(
+        &session,
+        &created.policy,
+        &created.local_mk_backup,
+        &chain.der_items(),
+    )
+    .expect("PartFinal must restore PartLocalMK from the prior backup");
+    session
+}
+
+#[test]
+fn sd_restore_local_backup_roundtrip_emu() {
+    let seed = mach_seed();
+    let sata = CaKey::generate();
+    let pota = CaKey::generate();
+
+    // Device 1: finalize + CreateSD, capturing the local backups.
+    let created = create_sd_on_first_device(&seed, &sata, &pota);
+
+    // Device 2 (reboot): restore PartLocalMK, then restore the SD locally.
+    let ctx = TestCtx::new();
+    let session = reboot_and_restore_part_local_mk(&ctx, &seed, &pota, &created);
+
+    let resp = ctx
+        .tbor(&TborSdRestoreLocalBackupReq {
+            session_id: session.session_id,
+            pok_local_backup: created.pok_local_backup.clone(),
+            sd_mk_backup: created.sd_mk_backup.clone(),
+        })
+        .expect("SdRestoreLocalBackup roundtrip");
+
+    // Refreshed local backup (BKS3 re-masked under PartLocalMK), 180 B.
+    assert_eq!(resp.pok_local_backup.len(), MASKED_SD_LEN);
+    assert!(
+        resp.pok_local_backup.iter().any(|&b| b != 0),
+        "refreshed pok_local_backup must not be all-zero",
+    );
+    // Refreshed masking-key backup (SDMK re-masked under SDBMK), 164 B.
+    assert_eq!(resp.sd_mk_backup.len(), SD_MK_BACKUP_LEN);
+    assert!(
+        resp.sd_mk_backup.iter().any(|&b| b != 0),
+        "refreshed sd_mk_backup must not be all-zero",
+    );
+}
+
+#[test]
+fn sd_restore_local_backup_is_one_shot_emu() {
+    let seed = mach_seed();
+    let sata = CaKey::generate();
+    let pota = CaKey::generate();
+
+    // A single device that has just created its SD is already
+    // SD-initialized, so a local restore on the same incarnation is
+    // rejected by the one-shot gate.
+    let ctx = TestCtx::new();
+    let session = bootstrap_rotated_co(&ctx, &ROTATED_CO_PSK);
+    let info = ctx.tbor(&TborPartInfoReq::new()).expect("PartInfo");
+    let mut pid_pub = [0u8; RAW_PUB_LEN];
+    pid_pub.copy_from_slice(&info.pid_pub_key);
+    let policy = backing_part_policy(
+        &info.pid,
+        &info.pid_pub_key,
+        &sata.raw_pub(),
+        &pota.raw_pub(),
+    );
+    let init = ctx
+        .part_init(&session, &seed, &policy, &pota_thumbprint())
+        .expect("PartInit");
+    let chain = make_pta_chain(&pota, &pta_pub_from_csr(&init.pta_csr));
+    ctx.part_final(&session, &policy, &[], &chain.der_items())
+        .expect("PartFinal");
+
+    let (masked, report) = masked_key_and_report(&ctx, session.session_id);
+    let evidence = build_receiver_evidence(&pid_pub, &sata, &report);
+    let req = backup_request(session.session_id, masked, &evidence, &policy);
+    let created = ctx
+        .tbor_oob(&req, &evidence.oob())
+        .expect("SdCreateRemoteBackup");
+
+    ctx.expect_fw_reject(
+        &TborSdRestoreLocalBackupReq {
+            session_id: session.session_id,
+            pok_local_backup: created.pok_local_backup.to_vec(),
+            sd_mk_backup: created.sd_mk_backup.to_vec(),
+        },
+        TborStatus::SdAlreadyInitialized,
+    );
+}
+
+#[test]
+fn sd_restore_local_backup_rejects_before_finalize_emu() {
+    // A partition that has not been finalized has no PartLocalMK, so the
+    // command is rejected at the lifecycle gate before any unmask.
+    let ctx = TestCtx::new();
+    let session = bootstrap_rotated_co(&ctx, &ROTATED_CO_PSK);
+    ctx.expect_fw_reject(
+        &TborSdRestoreLocalBackupReq {
+            session_id: session.session_id,
+            pok_local_backup: vec![0u8; MASKED_SD_LEN],
+            sd_mk_backup: vec![0u8; SD_MK_BACKUP_LEN],
+        },
+        TborStatus::InvalidArg,
+    );
+}
+
+#[test]
+fn sd_restore_local_backup_rejects_tampered_pok_emu() {
+    let seed = mach_seed();
+    let sata = CaKey::generate();
+    let pota = CaKey::generate();
+
+    let created = create_sd_on_first_device(&seed, &sata, &pota);
+
+    // Device 2 (reboot): restore PartLocalMK, then attempt a restore with a
+    // byte-flipped local backup — the AEAD tag no longer verifies.
+    let ctx = TestCtx::new();
+    let session = reboot_and_restore_part_local_mk(&ctx, &seed, &pota, &created);
+
+    let mut tampered = created.pok_local_backup.clone();
+    let n = tampered.len();
+    tampered[n - 1] ^= 0xFF;
+
+    let err = ctx
+        .tbor(&TborSdRestoreLocalBackupReq {
+            session_id: session.session_id,
+            pok_local_backup: tampered,
+            sd_mk_backup: created.sd_mk_backup.clone(),
+        })
+        .expect_err("a tampered pok_local_backup must be rejected");
+    // The exact status is the AEAD tag-mismatch surfaced by `unmask`; the
+    // command must not succeed and must not provision the SD.
+    let _ = err;
+}

--- a/docs/tbor-ddi/README.md
+++ b/docs/tbor-ddi/README.md
@@ -61,7 +61,7 @@ single `none` TOC placeholder and no typed body fields.
 | `0x0A` | `SdCreateRemoteBackup` | InSession | [`commands/sd_create_remote_backup.md`](./commands/sd_create_remote_backup.md) |
 | `0x0B` | `SdResealRemoteBackup` | InSession | [`commands/sd_reseal_remote_backup.md`](./commands/sd_reseal_remote_backup.md) |
 | `0x0C` | `SdRestoreRemoteBackup` (schema-only) | InSession | [`commands/sd_restore_remote_backup.md`](./commands/sd_restore_remote_backup.md) |
-| `0x0D` | `SdRestoreLocalBackup` (schema-only) | InSession | [`commands/sd_restore_local_backup.md`](./commands/sd_restore_local_backup.md) |
+| `0x0D` | `SdRestoreLocalBackup` | InSession | [`commands/sd_restore_local_backup.md`](./commands/sd_restore_local_backup.md) |
 | `0x0E` | `SdCreatePeerBackup` (schema-only) | InSession | [`commands/sd_create_peer_backup.md`](./commands/sd_create_peer_backup.md) |
 | `0x0F` | `SdRestorePeerBackup` (schema-only) | InSession | [`commands/sd_restore_peer_backup.md`](./commands/sd_restore_peer_backup.md) |
 | `0x10` | `KeyReport` | InSession | [`commands/key_report.md`](./commands/key_report.md) |

--- a/docs/tbor-ddi/commands/sd_restore_local_backup.md
+++ b/docs/tbor-ddi/commands/sd_restore_local_backup.md
@@ -5,15 +5,44 @@ Licensed under the MIT License.
 
 # SdRestoreLocalBackup (Opcode 0x0D)
 
-**Handler:** _Not yet landed — wire schema only._
-**Session:** InSession
+**Handler:** `fw/core/lib/src/ddi/tbor/sd_restore_local_backup.rs`
+**Session:** InSession (Crypto Officer)
 
 ## Description
 
-Restores a security domain from its device-local backups: takes the
-local partition-owner-key backup (`pok_local_backup`) and the
-security-domain masking-key backup (`sd_mk_backup`), and returns the
-refreshed local backups of the same.
+Restores a security domain from its **device-local** backups (manticore
+§3.3.9) — the local-reboot recovery path.  Unlike the remote/peer
+restores it needs no sender, HPKE, attestation evidence, or out-of-band
+data: it unmasks the two host-replayed backups with keys the device
+already holds, re-masks them at the current platform identity, and
+re-provisions the security domain.  It is **CreateSD in reverse** and
+shares that command's provisioning primitives
+(`fw/core/lib/src/ddi/tbor/sd_backup.rs`).
+
+Algorithm:
+
+1. Gate to a Crypto-Officer, `Active` session on an `Initialized`
+   partition; fail-fast if the SD is already initialized
+   (`SdAlreadyInitialized`).
+2. Unmask `pok_local_backup` under the partition-local masking key
+   (`PartLocalMK`, from `PartFinal`) → **BKS3**.  The blob must be an
+   `SdPartitionOwnerSeed` envelope, and its bound SVN must not be newer
+   than the current firmware SVN (`SdBackupSvnRollback`).
+3. Derive `SDBMK` from BKS3 + the partition `policy_hash`, then unmask
+   `sd_mk_backup` under `SDBMK` → **SDMK** (must be an `SdMasking`
+   envelope; same anti-rollback check).
+4. Re-mask both at the current `{svn, owner}`: `pok_local_backup =
+   mask(BKS3, PartLocalMK)` and `sd_mk_backup = mask(SDMK, SDBMK)`.
+5. Vault `SDMK` (SecurityDomain scope), record `SD_MK_KEY_ID`, and mark
+   the partition SD-initialized — undo-guarded.  BKS3, SDMK, and SDBMK are
+   zeroized before returning.
+
+The command is **stateful** (vaults `SDMK`, marks the partition
+SD-initialized) and **one-shot** per partition incarnation: a second
+create/restore returns `SdAlreadyInitialized`.  Because `pok_local_backup`
+is bound to `PartLocalMK`, the realistic recovery sequence after a reboot
+is `PartInit` → `PartFinal(prev_local_mk_backup)` (which restores
+`PartLocalMK`) → `SdRestoreLocalBackup`.
 
 ## Request
 
@@ -55,10 +84,17 @@ Carries the 180-byte `pok_local_backup` blob and the 164-byte
 | Error | Cause |
 |---|---|
 | `TborInvalidFixedLength` | `pok_local_backup` is not exactly 180 B, or `sd_mk_backup` is not exactly 164 B (rejected at decode before the handler runs) |
-| `SessionNotFound` | `session_id` does not refer to an allocated slot |
-| `DdiDecodeFailed` | Malformed request body |
+| `InvalidArg` | Partition is not `Initialized` (not finalized) |
+| `SdAlreadyInitialized` | A security domain is already initialized on this partition incarnation (one-shot gate) |
+| `SdBackupSvnRollback` | A backup's bound SVN is newer than the current firmware SVN (anti-rollback) |
+| `UnsupportedKeyType` | A backup envelope is not the expected kind (`SdPartitionOwnerSeed` / `SdMasking`) |
+| `AesGcmDecryptTagDoesNotMatch` | A backup blob is tampered or was masked under a different key (unmask tag mismatch) |
+| `InvalidPermissions` | Not a Crypto-Officer session |
+| `SessionNotFound` | `session_id` does not refer to an `Active` slot |
 
 ## See also
 
 - Wire encoding: [TBOR specification](../../../fw/core/ddi/tbor/docs/spec.md)
 - Wire schema: `fw/core/ddi/tbor/types/src/sd_restore_local_backup.rs`
+- Shared SD-backup mechanics: `fw/core/lib/src/ddi/tbor/sd_backup.rs`
+- Producer of the local backups: [`SdCreateRemoteBackup`](sd_create_remote_backup.md)

--- a/fw/core/ddi/tbor/types/src/sd_create_remote_backup.rs
+++ b/fw/core/ddi/tbor/types/src/sd_create_remote_backup.rs
@@ -85,10 +85,15 @@ const _: () = assert!(MASKED_SD_LEN == 180);
 pub const POK_REMOTE_BACKUP_LEN: usize = 97 + (48 + 16);
 const _: () = assert!(POK_REMOTE_BACKUP_LEN == 161);
 
-// `sd_mk_backup` is a `local_mk`-style masking-key backup envelope; the
-// derive needs an integer literal on the field, so the length is spelled
-// out as `164` and pinned against the canonical value here.
-const _: () = assert!(LOCAL_MK_BACKUP_LEN == 164);
+/// Exact on-the-wire length of the **SD masking-key backup** envelope
+/// (`sd_mk_backup`): the 32-byte SD masking key (`SDMK`) wrapped as a
+/// `local_mk`-style AEAD-GCM-256 masked-key envelope.  Equal to
+/// [`LOCAL_MK_BACKUP_LEN`] because both wrap a 32-byte key in the same
+/// envelope format, but named SD-specifically — and re-exported by the
+/// rest of the SD backup family — so the intent is explicit at each sizing
+/// site and the two can diverge without silent copy/paste breakage.
+pub const SD_MK_BACKUP_LEN: usize = LOCAL_MK_BACKUP_LEN;
+const _: () = assert!(SD_MK_BACKUP_LEN == 164);
 
 /// `SdCreateRemoteBackup` request schema.
 #[tbor(opcode = 0x0A)]

--- a/fw/core/ddi/tbor/types/src/sd_restore_local_backup.rs
+++ b/fw/core/ddi/tbor/types/src/sd_restore_local_backup.rs
@@ -18,19 +18,19 @@
 //!   (a masked BKS3 wrapped under the device-local key), exactly
 //!   [`MASKED_SD_LEN`] (180 B).
 //! * `sd_mk_backup` — the security-domain masking-key backup envelope,
-//!   exactly [`LOCAL_MK_BACKUP_LEN`] (164 B).
+//!   exactly [`SD_MK_BACKUP_LEN`] (164 B).
 //!
 //! Output:
 //!
 //! * `pok_local_backup` — the refreshed local partition-owner-key backup,
 //!   exactly [`MASKED_SD_LEN`] (180 B).
 //! * `sd_mk_backup` — the refreshed security-domain masking-key backup
-//!   envelope, exactly [`LOCAL_MK_BACKUP_LEN`] (164 B).
+//!   envelope, exactly [`SD_MK_BACKUP_LEN`] (164 B).
 
 use azihsm_fw_ddi_tbor_api::tbor;
 
-pub use crate::part_final::LOCAL_MK_BACKUP_LEN;
 pub use crate::sd_create_remote_backup::MASKED_SD_LEN;
+pub use crate::sd_create_remote_backup::SD_MK_BACKUP_LEN;
 
 /// TBOR opcode for `SdRestoreLocalBackup`.
 pub const TBOR_OP_SD_RESTORE_LOCAL_BACKUP: u8 = 0x0D;
@@ -43,7 +43,7 @@ const _: () = assert!(MASKED_SD_LEN == 180);
 // `sd_mk_backup` is a `local_mk`-style backup envelope; the derive needs
 // an integer literal on the field, so the length is spelled out as `164`
 // and pinned against the canonical value here.
-const _: () = assert!(LOCAL_MK_BACKUP_LEN == 164);
+const _: () = assert!(SD_MK_BACKUP_LEN == 164);
 
 /// `SdRestoreLocalBackup` request schema.
 #[tbor(opcode = 0x0D)]
@@ -61,7 +61,7 @@ pub struct TborSdRestoreLocalBackupReq<'a> {
     pub pok_local_backup: &'a [u8],
 
     /// Security-domain masking-key backup envelope.  Always exactly
-    /// [`LOCAL_MK_BACKUP_LEN`] (164 B).
+    /// [`SD_MK_BACKUP_LEN`] (164 B).
     #[tbor(buffer, len = 164)]
     pub sd_mk_backup: &'a [u8],
 }
@@ -75,7 +75,7 @@ pub struct TborSdRestoreLocalBackupResp<'a> {
     pub pok_local_backup: &'a [u8],
 
     /// Refreshed security-domain masking-key backup envelope.  Always
-    /// exactly [`LOCAL_MK_BACKUP_LEN`] (164 B).
+    /// exactly [`SD_MK_BACKUP_LEN`] (164 B).
     #[tbor(buffer, len = 164)]
     pub sd_mk_backup: &'a [u8],
 }
@@ -91,7 +91,7 @@ mod tests {
     #[test]
     fn request_round_trips_backups() {
         let pok_local = [0xABu8; MASKED_SD_LEN];
-        let sd_mk = [0xCDu8; LOCAL_MK_BACKUP_LEN];
+        let sd_mk = [0xCDu8; SD_MK_BACKUP_LEN];
         let mut buf = [0u8; 1024];
         let frame = TborSdRestoreLocalBackupReq::encode(&mut buf)
             .unwrap()
@@ -103,13 +103,13 @@ mod tests {
             .unwrap()
             .finish();
         assert_eq!(frame.pok_local_backup().len(), MASKED_SD_LEN);
-        assert_eq!(frame.sd_mk_backup().len(), LOCAL_MK_BACKUP_LEN);
+        assert_eq!(frame.sd_mk_backup().len(), SD_MK_BACKUP_LEN);
     }
 
     #[test]
     fn response_round_trips_backups() {
         let pok_local = [0xABu8; MASKED_SD_LEN];
-        let sd_mk = [0xCDu8; LOCAL_MK_BACKUP_LEN];
+        let sd_mk = [0xCDu8; SD_MK_BACKUP_LEN];
         let mut buf = [0u8; 512];
         let frame = TborSdRestoreLocalBackupResp::encode(&mut buf, 0, true)
             .unwrap()
@@ -119,6 +119,6 @@ mod tests {
             .unwrap()
             .finish();
         assert_eq!(frame.pok_local_backup().len(), MASKED_SD_LEN);
-        assert_eq!(frame.sd_mk_backup().len(), LOCAL_MK_BACKUP_LEN);
+        assert_eq!(frame.sd_mk_backup().len(), SD_MK_BACKUP_LEN);
     }
 }

--- a/fw/core/lib/src/ddi/tbor/mod.rs
+++ b/fw/core/lib/src/ddi/tbor/mod.rs
@@ -28,8 +28,10 @@ pub mod part_info;
 pub mod part_init;
 pub mod policy;
 pub(crate) mod psk_change;
+pub(crate) mod sd_backup;
 pub(crate) mod sd_create_remote_backup;
 pub(crate) mod sd_reseal_remote_backup;
+pub(crate) mod sd_restore_local_backup;
 pub(crate) mod sd_sealing_key_gen;
 pub(crate) mod session_close;
 pub(crate) mod session_open_finish;
@@ -125,6 +127,13 @@ pub(crate) mod opcode {
     /// recovered BKS3 to the destination receiver.  See
     /// [`super::sd_reseal_remote_backup`].
     pub(crate) const SD_RESEAL_REMOTE_BACKUP: u8 = 0x0B;
+
+    /// `SdRestoreLocalBackup` — restore a security domain from its
+    /// device-local backups: unmask `pok_local_backup` (BKS3 under
+    /// `PartLocalMK`) and `sd_mk_backup` (SDMK under the derived SDBMK),
+    /// re-mask both at the current SVN, and re-provision the SD.  See
+    /// [`super::sd_restore_local_backup`].
+    pub(crate) const SD_RESTORE_LOCAL_BACKUP: u8 = 0x0D;
 
     /// `KeyReport` — attest a masked key: unmask it, derive its public
     /// component on-device, and return a PID-signed COSE_Sign1
@@ -264,6 +273,9 @@ pub(crate) async fn dispatch<'p, P: HsmPal>(
         opcode::SD_RESEAL_REMOTE_BACKUP => {
             sd_reseal_remote_backup::handle(pal, io, req_buf, oob).await
         }
+        opcode::SD_RESTORE_LOCAL_BACKUP => {
+            sd_restore_local_backup::handle(pal, io, req_buf, undo).await
+        }
         opcode::KEY_REPORT => key_report::handle(pal, io, req_buf).await,
         _ => Err(HsmError::UnsupportedCmd),
     }
@@ -287,6 +299,7 @@ fn is_known_opcode(opcode: u8) -> bool {
             | opcode::SD_SEALING_KEY_GEN
             | opcode::SD_CREATE_REMOTE_BACKUP
             | opcode::SD_RESEAL_REMOTE_BACKUP
+            | opcode::SD_RESTORE_LOCAL_BACKUP
             | opcode::KEY_REPORT
     )
 }
@@ -317,6 +330,7 @@ fn is_in_session(opcode: u8) -> bool {
         | opcode::SD_SEALING_KEY_GEN
         | opcode::SD_CREATE_REMOTE_BACKUP
         | opcode::SD_RESEAL_REMOTE_BACKUP
+        | opcode::SD_RESTORE_LOCAL_BACKUP
         | opcode::KEY_REPORT => true,
         // Default-deny: any future opcode is treated as in-session
         // until classified, so the default-PSK gate applies to it.
@@ -355,6 +369,7 @@ fn needs_session_id_cross_check(opcode: u8) -> bool {
         | opcode::SD_SEALING_KEY_GEN
         | opcode::SD_CREATE_REMOTE_BACKUP
         | opcode::SD_RESEAL_REMOTE_BACKUP
+        | opcode::SD_RESTORE_LOCAL_BACKUP
         | opcode::KEY_REPORT => true,
         _ => true,
     }

--- a/fw/core/lib/src/ddi/tbor/sd_backup.rs
+++ b/fw/core/lib/src/ddi/tbor/sd_backup.rs
@@ -45,6 +45,9 @@ use crate::part_state;
 /// AES-256-GCM.
 pub(super) const SDMK_LEN: usize = 32;
 
+/// Length of the partition owner seed (`BKS3`) — 48 B.
+pub(super) const BKS3_LEN: usize = 48;
+
 /// Length of the derived security-domain backup masking key (`SDBMK`) —
 /// 32 B AES-256-GCM (the key that masks `SDMK` into `sd_mk_backup`).
 const SDBMK_LEN: usize = 32;

--- a/fw/core/lib/src/ddi/tbor/sd_backup.rs
+++ b/fw/core/lib/src/ddi/tbor/sd_backup.rs
@@ -25,8 +25,8 @@ use azihsm_fw_core_crypto_key_derive::derive_masking_key;
 use azihsm_fw_core_crypto_key_masking::aead::mask;
 use azihsm_fw_core_crypto_key_masking::aead::AeadAlg;
 use azihsm_fw_core_crypto_key_masking::aead::MaskParams;
-use azihsm_fw_ddi_tbor_types::LOCAL_MK_BACKUP_LEN;
 use azihsm_fw_ddi_tbor_types::MASKED_SD_LEN;
+use azihsm_fw_ddi_tbor_types::SD_MK_BACKUP_LEN;
 use azihsm_fw_hsm_pal_traits::DmaBuf;
 use azihsm_fw_hsm_pal_traits::HsmError;
 use azihsm_fw_hsm_pal_traits::HsmIo;
@@ -123,7 +123,7 @@ pub(super) async fn derive_sdbmk<'a, P: HsmPal>(
 }
 
 /// Mask `sdmk` under `sdbmk` into `out`, producing the `sd_mk_backup`
-/// envelope (exactly [`LOCAL_MK_BACKUP_LEN`], 164 B).
+/// envelope (exactly [`SD_MK_BACKUP_LEN`], 164 B).
 #[allow(clippy::too_many_arguments)]
 pub(super) async fn mask_sd_mk_backup<P: HsmPal>(
     pal: &P,
@@ -155,7 +155,7 @@ pub(super) async fn mask_sd_mk_backup<P: HsmPal>(
         Some(out),
     )
     .await?;
-    if n != LOCAL_MK_BACKUP_LEN {
+    if n != SD_MK_BACKUP_LEN {
         return Err(HsmError::InternalError);
     }
     Ok(())

--- a/fw/core/lib/src/ddi/tbor/sd_backup.rs
+++ b/fw/core/lib/src/ddi/tbor/sd_backup.rs
@@ -1,0 +1,242 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Shared security-domain backup mechanics.
+//!
+//! Both `SdCreateRemoteBackup` (which *mints* the SD key material) and
+//! `SdRestoreLocalBackup` (which *recovers* it) produce the same two
+//! on-device backup envelopes and provision the same vaulted `SDMK`, so
+//! the derivation / masking / commit primitives live here and are shared
+//! between the two handlers to keep their SD semantics identical.
+//!
+//! Key hierarchy:
+//!
+//! * `BKS3` (48 B) — the security-domain partition-owner seed.
+//! * `SDBMK` — the SD backup masking key, `KBKDF(BKS3, mfgr_seed[svn] ‖
+//!   owner_seed[owner] ‖ policy_hash)`; derived on demand, never vaulted.
+//! * `SDMK` (32 B) — the live SecurityDomain-scope masking key, vaulted.
+//!
+//! Envelopes:
+//!
+//! * `pok_local_backup` (180 B) = `mask(BKS3, PartLocalMK)`.
+//! * `sd_mk_backup` (164 B) = `mask(SDMK, SDBMK)`.
+
+use azihsm_fw_core_crypto_key_derive::derive_masking_key;
+use azihsm_fw_core_crypto_key_masking::aead::mask;
+use azihsm_fw_core_crypto_key_masking::aead::AeadAlg;
+use azihsm_fw_core_crypto_key_masking::aead::MaskParams;
+use azihsm_fw_ddi_tbor_types::LOCAL_MK_BACKUP_LEN;
+use azihsm_fw_ddi_tbor_types::MASKED_SD_LEN;
+use azihsm_fw_hsm_pal_traits::DmaBuf;
+use azihsm_fw_hsm_pal_traits::HsmError;
+use azihsm_fw_hsm_pal_traits::HsmIo;
+use azihsm_fw_hsm_pal_traits::HsmKeyScope;
+use azihsm_fw_hsm_pal_traits::HsmPal;
+use azihsm_fw_hsm_pal_traits::HsmResult;
+use azihsm_fw_hsm_pal_traits::HsmScopedAlloc;
+use azihsm_fw_hsm_pal_traits::HsmVaultKeyAttrs;
+use azihsm_fw_hsm_pal_traits::HsmVaultKeyKind;
+use azihsm_fw_hsm_pal_traits::PartPropId;
+use azihsm_fw_hsm_undo::UndoLog;
+
+use crate::part_state;
+
+/// Length of the random security-domain masking key (`SDMK`) — 32 B
+/// AES-256-GCM.
+pub(super) const SDMK_LEN: usize = 32;
+
+/// Length of the derived security-domain backup masking key (`SDBMK`) —
+/// 32 B AES-256-GCM (the key that masks `SDMK` into `sd_mk_backup`).
+const SDBMK_LEN: usize = 32;
+
+/// KBKDF label selecting the `SDBMK` derivation purpose (keyed on BKS3,
+/// with the partition `policy_hash` as extra context).
+const SDBMK_LABEL: &[u8] = b"AZIHSM-SdCreate-SDBMK-v1";
+
+/// Opaque envelope label stamped into the `sd_mk_backup`
+/// `MaskedKeyMetadata` (informational; bound by the AEAD tag).
+const SDMK_ENVELOPE_LABEL: &[u8] = b"SDMK";
+
+/// Opaque envelope label stamped into the `pok_local_backup`
+/// `MaskedKeyMetadata` (informational; bound by the AEAD tag).
+const POK_LOCAL_ENVELOPE_LABEL: &[u8] = b"BKS3";
+
+/// Vault attributes for the provisioned `SDMK`: SecurityDomain scope,
+/// on-device, internal, never extractable.
+const SDMK_ATTRS: HsmVaultKeyAttrs = HsmVaultKeyAttrs::new()
+    .with_local(true)
+    .with_internal(true)
+    .with_never_extractable(true)
+    .with_scope(HsmKeyScope::SecurityDomain);
+
+/// Vault attributes stamped into the `sd_mk_backup` / `pok_local_backup`
+/// metadata: on-device, internal, never extractable.
+const SD_BACKUP_ATTRS: HsmVaultKeyAttrs = HsmVaultKeyAttrs::new()
+    .with_local(true)
+    .with_internal(true)
+    .with_never_extractable(true);
+
+/// Read the platform identity `{svn, owner}` that binds the backup
+/// envelopes and the `SDBMK` derivation: SVN (BKS1 lineage) and owner-seed
+/// id (BKS2 lineage).
+pub(super) fn platform_svn_owner<P: HsmPal>(pal: &P) -> HsmResult<(u64, u16)> {
+    let svn = part_state::part_mfgr_svn(pal);
+    let owner = u16::try_from(part_state::part_owner_svn(pal)).map_err(|_| HsmError::InvalidArg)?;
+    Ok((svn, owner))
+}
+
+/// Derive `SDBMK` for `bks3` at `{svn, owner}` into a fresh scoped buffer.
+///
+/// `SDBMK = KBKDF(BKS3, mfgr_seed[svn] ‖ owner_seed[owner] ‖ policy_hash)`.
+/// Binding the partition `policy_hash` proves the backup was produced by a
+/// Manticore wielding the same policy.  Both the create and restore paths
+/// key on the same label so the derived key round-trips.
+pub(super) async fn derive_sdbmk<'a, P: HsmPal>(
+    pal: &P,
+    io: &impl HsmIo,
+    alloc: &'a impl HsmScopedAlloc,
+    bks3: &DmaBuf,
+    svn: u64,
+    owner: u16,
+) -> HsmResult<&'a mut DmaBuf> {
+    let sdbmk = alloc.dma_alloc(SDBMK_LEN)?;
+    // Stage the stored policy hash in scratch so the extra context does not
+    // hold a borrow of partition state across the derivation await.
+    let policy_hash = {
+        let stored = part_state::part_policy_hash(pal, io)?;
+        let ph = alloc.dma_alloc(stored.len())?;
+        ph.copy_from_slice(stored);
+        ph
+    };
+    derive_masking_key(
+        pal,
+        io,
+        bks3,
+        SDBMK_LABEL,
+        &policy_hash[..],
+        svn,
+        owner,
+        sdbmk,
+    )
+    .await?;
+    Ok(sdbmk)
+}
+
+/// Mask `sdmk` under `sdbmk` into `out`, producing the `sd_mk_backup`
+/// envelope (exactly [`LOCAL_MK_BACKUP_LEN`], 164 B).
+#[allow(clippy::too_many_arguments)]
+pub(super) async fn mask_sd_mk_backup<P: HsmPal>(
+    pal: &P,
+    io: &impl HsmIo,
+    alloc: &impl HsmScopedAlloc,
+    sdbmk: &DmaBuf,
+    sdmk: &DmaBuf,
+    svn: u64,
+    owner: u16,
+    out: &mut DmaBuf,
+) -> HsmResult<()> {
+    let label = alloc.dma_alloc(SDMK_ENVELOPE_LABEL.len())?;
+    label.copy_from_slice(SDMK_ENVELOPE_LABEL);
+    let params = MaskParams {
+        key_kind: HsmVaultKeyKind::SdMasking,
+        key_attrs: SDMK_ATTRS,
+        svn,
+        owner_seed_id: owner,
+        key_label: label,
+    };
+    let n = mask(
+        pal,
+        io,
+        alloc,
+        AeadAlg::AesGcm256,
+        sdbmk,
+        &params,
+        sdmk,
+        Some(out),
+    )
+    .await?;
+    if n != LOCAL_MK_BACKUP_LEN {
+        return Err(HsmError::InternalError);
+    }
+    Ok(())
+}
+
+/// Mask `bks3` under the partition-local masking key (`PartLocalMK`) into
+/// `out`, producing the `pok_local_backup` envelope (exactly
+/// [`MASKED_SD_LEN`], 180 B).
+pub(super) async fn mask_pok_local_backup<P: HsmPal>(
+    pal: &P,
+    io: &impl HsmIo,
+    alloc: &impl HsmScopedAlloc,
+    bks3: &DmaBuf,
+    svn: u64,
+    owner: u16,
+    out: &mut DmaBuf,
+) -> HsmResult<()> {
+    let local_mk_id = part_state::part_local_mk_key_id(pal, io)?;
+    let local_mk = pal.vault_key(io, local_mk_id)?;
+    let label = alloc.dma_alloc(POK_LOCAL_ENVELOPE_LABEL.len())?;
+    label.copy_from_slice(POK_LOCAL_ENVELOPE_LABEL);
+    let params = MaskParams {
+        key_kind: HsmVaultKeyKind::SdPartitionOwnerSeed,
+        key_attrs: SD_BACKUP_ATTRS,
+        svn,
+        owner_seed_id: owner,
+        key_label: label,
+    };
+    let m = mask(
+        pal,
+        io,
+        alloc,
+        AeadAlg::AesGcm256,
+        local_mk,
+        &params,
+        bks3,
+        Some(out),
+    )
+    .await?;
+    if m != MASKED_SD_LEN {
+        return Err(HsmError::InternalError);
+    }
+    Ok(())
+}
+
+/// Commit the security domain: mark it initialized, vault the `SDMK`, and
+/// record its key id.  Every mutation is pushed to `undo` so a failure
+/// rolls back all changes.
+pub(super) async fn commit_sd_to_vault<'p, P: HsmPal>(
+    pal: &P,
+    io: &impl HsmIo,
+    undo: &mut UndoLog<'p>,
+    sdmk: &DmaBuf,
+) -> HsmResult<()> {
+    // Atomic one-shot claim first (the race-winner gate); the recorded
+    // inverse clears the flag on rollback.
+    part_state::part_mark_sd_initialized(pal, io)?;
+    if let Err(e) = undo.push_prop_restore_scalar(PartPropId::SD_INITIALIZED, 0) {
+        // The claim succeeded but its rollback inverse could not be
+        // recorded (e.g. `UndoLogFull`); clear the flag now (best-effort)
+        // so a full undo log cannot permanently wedge the partition's
+        // one-shot SD gate.  Safe against a concurrent create/restore: this
+        // task owns the just-made claim and there is no await between the
+        // mark and here.
+        let _ = part_state::part_clear_sd_initialized(pal, io);
+        return Err(e);
+    }
+
+    // Vault SDMK as the partition's SecurityDomain-scope masking key, then
+    // record its id so `masking_key_id_for_scope` resolves it.
+    let sdmk_id = pal
+        .vault_key_create(io, sdmk, HsmVaultKeyKind::SdMasking, None, SDMK_ATTRS)
+        .await?;
+    if let Err(e) = undo.push_vault_create(sdmk_id) {
+        // The key exists but could not be tracked for rollback (e.g.
+        // `UndoLogFull`); best-effort delete it so a full undo log does not
+        // leak the vault slot for an untracked key.
+        let _ = pal.vault_key_delete(io, sdmk_id).await;
+        return Err(e);
+    }
+    undo.push_prop_restore_absent(part_state::part_sd_mk_key_id_prop_id())?;
+    part_state::part_set_sd_mk_key_id(pal, io, sdmk_id)?;
+    Ok(())
+}

--- a/fw/core/lib/src/ddi/tbor/sd_create_remote_backup.rs
+++ b/fw/core/lib/src/ddi/tbor/sd_create_remote_backup.rs
@@ -54,12 +54,8 @@ use azihsm_fw_core_crypto_hpke::seal;
 use azihsm_fw_core_crypto_hpke::AuthParams;
 use azihsm_fw_core_crypto_hpke::HpkeSealConfig;
 use azihsm_fw_core_crypto_hpke::HpkeSuite;
-use azihsm_fw_core_crypto_key_derive::derive_masking_key;
-use azihsm_fw_core_crypto_key_masking::aead::mask;
 use azihsm_fw_core_crypto_key_masking::aead::peek_metadata;
 use azihsm_fw_core_crypto_key_masking::aead::unmask;
-use azihsm_fw_core_crypto_key_masking::aead::AeadAlg;
-use azihsm_fw_core_crypto_key_masking::aead::MaskParams;
 use azihsm_fw_core_evidence::verify_evidence;
 use azihsm_fw_core_evidence::EvidenceRefs;
 use azihsm_fw_core_evidence::TrustAnchors;
@@ -77,19 +73,17 @@ use azihsm_fw_hsm_pal_traits::HsmEccCurve;
 use azihsm_fw_hsm_pal_traits::HsmError;
 use azihsm_fw_hsm_pal_traits::HsmIo;
 use azihsm_fw_hsm_pal_traits::HsmKeyId;
-use azihsm_fw_hsm_pal_traits::HsmKeyScope;
 use azihsm_fw_hsm_pal_traits::HsmPal;
 use azihsm_fw_hsm_pal_traits::HsmResult;
 use azihsm_fw_hsm_pal_traits::HsmScopedAlloc;
 use azihsm_fw_hsm_pal_traits::HsmSessId;
-use azihsm_fw_hsm_pal_traits::HsmVaultKeyAttrs;
 use azihsm_fw_hsm_pal_traits::HsmVaultKeyKind;
-use azihsm_fw_hsm_pal_traits::PartPropId;
 use azihsm_fw_hsm_pal_traits::PartState;
 use azihsm_fw_hsm_undo::UndoLog;
 
 use super::masking_key_id_for_scope;
 use super::part_final::verify_policy_hash;
+use super::sd_backup;
 use super::validate_crypto_officer_active_session;
 use crate::part_state;
 
@@ -104,41 +98,6 @@ const BKS3_LEN: usize = 48;
 
 /// SEC1 uncompressed point tag (`0x04 ‖ X ‖ Y`).
 const SEC1_UNCOMPRESSED: u8 = 0x04;
-
-/// Length of the random security-domain masking key (`SDMK`) — 32 B
-/// AES-256-GCM.
-const SDMK_LEN: usize = 32;
-
-/// Length of the derived security-domain backup masking key (`SDBMK`) —
-/// 32 B AES-256-GCM (the key that masks `SDMK` into `sd_mk_backup`).
-const SDBMK_LEN: usize = 32;
-
-/// KBKDF label selecting the `SDBMK` derivation purpose (keyed on BKS3,
-/// with the partition `policy_hash` as extra context).
-const SDBMK_LABEL: &[u8] = b"AZIHSM-SdCreate-SDBMK-v1";
-
-/// Opaque envelope label stamped into the `sd_mk_backup`
-/// `MaskedKeyMetadata` (informational; bound by the AEAD tag).
-const SDMK_ENVELOPE_LABEL: &[u8] = b"SDMK";
-
-/// Opaque envelope label stamped into the `pok_local_backup`
-/// `MaskedKeyMetadata` (informational; bound by the AEAD tag).
-const POK_LOCAL_ENVELOPE_LABEL: &[u8] = b"BKS3";
-
-/// Vault attributes for the provisioned `SDMK`: SecurityDomain scope,
-/// on-device, internal, never extractable.
-const SDMK_ATTRS: HsmVaultKeyAttrs = HsmVaultKeyAttrs::new()
-    .with_local(true)
-    .with_internal(true)
-    .with_never_extractable(true)
-    .with_scope(HsmKeyScope::SecurityDomain);
-
-/// Vault attributes stamped into the `sd_mk_backup` / `pok_local_backup`
-/// metadata: on-device, internal, never extractable.
-const SD_BACKUP_ATTRS: HsmVaultKeyAttrs = HsmVaultKeyAttrs::new()
-    .with_local(true)
-    .with_internal(true)
-    .with_never_extractable(true);
 
 /// Verify the policy names **this** partition as the backing partition.
 ///
@@ -379,58 +338,14 @@ pub(crate) async fn handle<'p, P: HsmPal>(
     encode_response(pal, io, pok, pok_local, sd_mk_backup)
 }
 
-/// Commit the security domain: mark it initialized, vault the `SDMK`, and
-/// record its key id.  Every mutation is pushed to `undo` so a failure
-/// rolls back all changes.
-async fn commit_sd_to_vault<'p, P: HsmPal>(
-    pal: &P,
-    io: &impl HsmIo,
-    undo: &mut UndoLog<'p>,
-    sdmk: &DmaBuf,
-) -> HsmResult<()> {
-    // Atomic one-shot claim first (the race-winner gate); the recorded
-    // inverse clears the flag on rollback.
-    part_state::part_mark_sd_initialized(pal, io)?;
-    if let Err(e) = undo.push_prop_restore_scalar(PartPropId::SD_INITIALIZED, 0) {
-        // The claim succeeded but its rollback inverse could not be
-        // recorded (e.g. `UndoLogFull`); clear the flag now (best-effort)
-        // so a full undo log cannot permanently wedge the partition's
-        // one-shot SD gate.  Safe against a concurrent create: this task
-        // owns the just-made claim and there is no await between the mark
-        // and here.
-        let _ = part_state::part_clear_sd_initialized(pal, io);
-        return Err(e);
-    }
-
-    // Vault SDMK as the partition's SecurityDomain-scope masking key,
-    // then record its id so `masking_key_id_for_scope` resolves it.
-    let sdmk_id = pal
-        .vault_key_create(io, sdmk, HsmVaultKeyKind::SdMasking, None, SDMK_ATTRS)
-        .await?;
-    if let Err(e) = undo.push_vault_create(sdmk_id) {
-        // The key exists but could not be tracked for rollback (e.g.
-        // `UndoLogFull`); best-effort delete it so a full undo log does not
-        // leak the vault slot for an untracked key.
-        let _ = pal.vault_key_delete(io, sdmk_id).await;
-        return Err(e);
-    }
-    undo.push_prop_restore_absent(part_state::part_sd_mk_key_id_prop_id())?;
-    part_state::part_set_sd_mk_key_id(pal, io, sdmk_id)?;
-    Ok(())
-}
-
 /// Provision the security domain from a freshly minted `bks3`.
 ///
-/// Derives `SDBMK` (KBKDF keyed on `bks3`, folding in the platform seeds
-/// and the partition `policy_hash`), mints a random `SDMK`, and writes the
-/// two backups: `sd_mk_out` (`SDMK` masked under `SDBMK`, 164 B) and
-/// `pok_local_out` (`bks3` masked under `PartLocalMK`, 180 B).  Then it
-/// claims the one-shot `SD_INITIALIZED` gate, vaults `SDMK`
-/// ([`SecurityDomain`](HsmKeyScope::SecurityDomain) scope), and records its
-/// id in `SD_MK_KEY_ID`.  Every persistent mutation is pushed to `undo`;
-/// the minted `SDMK` / derived `SDBMK` scratch is zeroized on all paths
-/// (the caller wipes `bks3`).
-#[allow(clippy::too_many_arguments)]
+/// Mints a random `SDMK`, derives `SDBMK`, and writes the two backups —
+/// `sd_mk_out` (`SDMK` masked under `SDBMK`, 164 B) and `pok_local_out`
+/// (`bks3` masked under `PartLocalMK`, 180 B) — then commits the SD to the
+/// vault (see [`sd_backup::commit_sd_to_vault`]).  The minted `SDMK` /
+/// derived `SDBMK` scratch is zeroized on all paths (the caller wipes
+/// `bks3`).
 async fn provision_security_domain<'p, P: HsmPal>(
     pal: &P,
     io: &impl HsmIo,
@@ -440,95 +355,17 @@ async fn provision_security_domain<'p, P: HsmPal>(
     sd_mk_out: &mut DmaBuf,
     pok_local_out: &mut DmaBuf,
 ) -> HsmResult<()> {
-    // Platform identity that binds both backup envelopes and the SDBMK
-    // derivation: SVN (BKS1 lineage) and owner-seed id (BKS2 lineage).
-    let svn = part_state::part_mfgr_svn(pal);
-    let owner = u16::try_from(part_state::part_owner_svn(pal)).map_err(|_| HsmError::InvalidArg)?;
-
-    // SDBMK = KBKDF(BKS3, mfgr_seed[svn] ‖ owner_seed[owner] ‖ policy_hash).
-    // Stage the stored policy hash in scratch so the extra context does not
-    // hold a borrow of partition state across the derivation await.
-    let sdbmk = alloc.dma_alloc(SDBMK_LEN)?;
-    {
-        let policy_hash = {
-            let stored = part_state::part_policy_hash(pal, io)?;
-            let ph = alloc.dma_alloc(stored.len())?;
-            ph.copy_from_slice(stored);
-            ph
-        };
-        derive_masking_key(
-            pal,
-            io,
-            bks3,
-            SDBMK_LABEL,
-            &policy_hash[..],
-            svn,
-            owner,
-            sdbmk,
-        )
-        .await?;
-    }
+    let (svn, owner) = sd_backup::platform_svn_owner(pal)?;
+    let sdbmk = sd_backup::derive_sdbmk(pal, io, alloc, bks3, svn, owner).await?;
 
     // Mint the random SDMK.
-    let sdmk = alloc.dma_alloc(SDMK_LEN)?;
+    let sdmk = alloc.dma_alloc(sd_backup::SDMK_LEN)?;
     pal.rng_fill_bytes(io, sdmk)?;
 
     let res = async {
-        // sd_mk_backup = mask(SDMK under SDBMK) — the caller-persisted,
-        // SVN-monotonic backup of the masking key.
-        let mk_label = alloc.dma_alloc(SDMK_ENVELOPE_LABEL.len())?;
-        mk_label.copy_from_slice(SDMK_ENVELOPE_LABEL);
-        let mk_params = MaskParams {
-            key_kind: HsmVaultKeyKind::SdMasking,
-            key_attrs: SDMK_ATTRS,
-            svn,
-            owner_seed_id: owner,
-            key_label: mk_label,
-        };
-        let n = mask(
-            pal,
-            io,
-            alloc,
-            AeadAlg::AesGcm256,
-            sdbmk,
-            &mk_params,
-            sdmk,
-            Some(sd_mk_out),
-        )
-        .await?;
-        if n != LOCAL_MK_BACKUP_LEN {
-            return Err(HsmError::InternalError);
-        }
-
-        // pok_local_backup = mask(BKS3 under PartLocalMK) — the on-device
-        // local backup of the SD seed, replayed to recover it later.
-        let local_mk_id = part_state::part_local_mk_key_id(pal, io)?;
-        let local_mk = pal.vault_key(io, local_mk_id)?;
-        let pok_label = alloc.dma_alloc(POK_LOCAL_ENVELOPE_LABEL.len())?;
-        pok_label.copy_from_slice(POK_LOCAL_ENVELOPE_LABEL);
-        let pok_params = MaskParams {
-            key_kind: HsmVaultKeyKind::SdPartitionOwnerSeed,
-            key_attrs: SD_BACKUP_ATTRS,
-            svn,
-            owner_seed_id: owner,
-            key_label: pok_label,
-        };
-        let m = mask(
-            pal,
-            io,
-            alloc,
-            AeadAlg::AesGcm256,
-            local_mk,
-            &pok_params,
-            bks3,
-            Some(pok_local_out),
-        )
-        .await?;
-        if m != MASKED_SD_LEN {
-            return Err(HsmError::InternalError);
-        }
-
-        commit_sd_to_vault(pal, io, undo, sdmk).await
+        sd_backup::mask_sd_mk_backup(pal, io, alloc, sdbmk, sdmk, svn, owner, sd_mk_out).await?;
+        sd_backup::mask_pok_local_backup(pal, io, alloc, bks3, svn, owner, pok_local_out).await?;
+        sd_backup::commit_sd_to_vault(pal, io, undo, sdmk).await
     }
     .await;
 

--- a/fw/core/lib/src/ddi/tbor/sd_restore_local_backup.rs
+++ b/fw/core/lib/src/ddi/tbor/sd_restore_local_backup.rs
@@ -24,8 +24,10 @@
 //!    [`SdPartitionOwnerSeed`](HsmVaultKeyKind::SdPartitionOwnerSeed)
 //!    envelope, and its bound SVN must not be newer than the current
 //!    firmware SVN ([`SdBackupSvnRollback`](HsmError::SdBackupSvnRollback)).
-//! 3. Derive `SDBMK` from BKS3 + the partition `policy_hash`, then unmask
-//!    `sd_mk_backup` under `SDBMK` → **SDMK** (must be an
+//! 3. Derive `SDBMK` from BKS3 + the partition `policy_hash` at the
+//!    `sd_mk_backup`'s *own* `{svn, owner}` (peeked from its metadata, so an
+//!    older-SVN backup unmasks on newer firmware), then unmask `sd_mk_backup`
+//!    under `SDBMK` → **SDMK** (must be an
 //!    [`SdMasking`](HsmVaultKeyKind::SdMasking) envelope; same anti-rollback).
 //! 4. Re-mask both at the current `{svn, owner}`: `CurrSDLocalBackup =
 //!    mask(BKS3, PartLocalMK)` and `CurrSDKMKBackup = mask(SDMK, SDBMK)`.
@@ -39,6 +41,7 @@
 //!
 //! This command is **Crypto-Officer-only**.
 
+use azihsm_fw_core_crypto_key_masking::aead::peek_metadata;
 use azihsm_fw_core_crypto_key_masking::aead::unmask;
 use azihsm_fw_ddi_tbor_types::TborSdRestoreLocalBackupReq;
 use azihsm_fw_ddi_tbor_types::TborSdRestoreLocalBackupResp;
@@ -133,17 +136,32 @@ pub(crate) async fn handle<'p, P: HsmPal>(
                 view.target_key
             };
 
-            // ── Derive SDBMK, recover SDMK, re-mask, and commit ──
-            // SDBMK is its own scratch allocation (not a view into the
-            // scrubbed staging buffers), so it is zeroized on EVERY path
-            // below: scope rewind does not clear DMA memory.
-            let sdbmk = sd_backup::derive_sdbmk(pal, io, alloc, bks3, svn, owner).await?;
+            // ── Recover SDMK, re-mask, and commit ──
+            // Re-derive the SDBMK that masked `sd_mk_backup` at the backup's
+            // OWN {svn, owner} (peeked from its cleartext metadata) so an
+            // older-SVN backup unmasks on newer firmware — the versioned device
+            // seeds are forward-derivable, and deriving at the current SVN would
+            // fail the AEAD tag.  The peeked values are authenticated by the
+            // `unmask` tag below; the anti-rollback check is deferred until
+            // after it.  A second SDBMK at the current {svn, owner} re-masks the
+            // refreshed backup.  Both are their own scratch allocations (not
+            // views into the scrubbed staging buffers) and scope rewind does not
+            // clear DMA memory, so both are zeroized on EVERY path below.
+            // Mirrors `restore_part_local_mk` in `part_final`.
+            let (prev_svn, prev_owner) = {
+                let meta = peek_metadata(mk_scratch)?;
+                (meta.svn.get(), meta.owner_seed_id.get())
+            };
+            let sdbmk_prev =
+                sd_backup::derive_sdbmk(pal, io, alloc, bks3, prev_svn, prev_owner).await?;
+            let sdbmk_curr = sd_backup::derive_sdbmk(pal, io, alloc, bks3, svn, owner).await?;
             let inner = async {
                 let sdmk = {
-                    let view = unmask(pal, io, sdbmk, mk_scratch).await?;
+                    let view = unmask(pal, io, sdbmk_prev, mk_scratch).await?;
                     if !matches!(view.key_kind, HsmVaultKeyKind::SdMasking) {
                         return Err(HsmError::UnsupportedKeyType);
                     }
+                    // Anti-rollback on the now-authenticated `view.svn`.
                     if view.svn > svn {
                         return Err(HsmError::SdBackupSvnRollback);
                     }
@@ -153,14 +171,17 @@ pub(crate) async fn handle<'p, P: HsmPal>(
                 // ── Re-mask both at the current {svn, owner} ──
                 sd_backup::mask_pok_local_backup(pal, io, alloc, bks3, svn, owner, pok_local_out)
                     .await?;
-                sd_backup::mask_sd_mk_backup(pal, io, alloc, sdbmk, sdmk, svn, owner, sd_mk_out)
-                    .await?;
+                sd_backup::mask_sd_mk_backup(
+                    pal, io, alloc, sdbmk_curr, sdmk, svn, owner, sd_mk_out,
+                )
+                .await?;
 
                 // ── Commit: vault SDMK, mark SD-initialized (undo-guarded) ──
                 sd_backup::commit_sd_to_vault(pal, io, undo, sdmk).await
             }
             .await;
-            sdbmk.zeroize();
+            sdbmk_curr.zeroize();
+            sdbmk_prev.zeroize();
             inner
         }
         .await;

--- a/fw/core/lib/src/ddi/tbor/sd_restore_local_backup.rs
+++ b/fw/core/lib/src/ddi/tbor/sd_restore_local_backup.rs
@@ -133,27 +133,35 @@ pub(crate) async fn handle<'p, P: HsmPal>(
                 view.target_key
             };
 
-            // ── Derive SDBMK, recover SDMK from sd_mk_backup ──
+            // ── Derive SDBMK, recover SDMK, re-mask, and commit ──
+            // SDBMK is its own scratch allocation (not a view into the
+            // scrubbed staging buffers), so it is zeroized on EVERY path
+            // below: scope rewind does not clear DMA memory.
             let sdbmk = sd_backup::derive_sdbmk(pal, io, alloc, bks3, svn, owner).await?;
-            let sdmk = {
-                let view = unmask(pal, io, sdbmk, mk_scratch).await?;
-                if !matches!(view.key_kind, HsmVaultKeyKind::SdMasking) {
-                    return Err(HsmError::UnsupportedKeyType);
-                }
-                if view.svn > svn {
-                    return Err(HsmError::SdBackupSvnRollback);
-                }
-                view.target_key
-            };
+            let inner = async {
+                let sdmk = {
+                    let view = unmask(pal, io, sdbmk, mk_scratch).await?;
+                    if !matches!(view.key_kind, HsmVaultKeyKind::SdMasking) {
+                        return Err(HsmError::UnsupportedKeyType);
+                    }
+                    if view.svn > svn {
+                        return Err(HsmError::SdBackupSvnRollback);
+                    }
+                    view.target_key
+                };
 
-            // ── Re-mask both at the current {svn, owner} ──
-            sd_backup::mask_pok_local_backup(pal, io, alloc, bks3, svn, owner, pok_local_out)
-                .await?;
-            sd_backup::mask_sd_mk_backup(pal, io, alloc, sdbmk, sdmk, svn, owner, sd_mk_out)
-                .await?;
+                // ── Re-mask both at the current {svn, owner} ──
+                sd_backup::mask_pok_local_backup(pal, io, alloc, bks3, svn, owner, pok_local_out)
+                    .await?;
+                sd_backup::mask_sd_mk_backup(pal, io, alloc, sdbmk, sdmk, svn, owner, sd_mk_out)
+                    .await?;
 
-            // ── Commit: vault SDMK, mark SD-initialized (undo-guarded) ──
-            sd_backup::commit_sd_to_vault(pal, io, undo, sdmk).await
+                // ── Commit: vault SDMK, mark SD-initialized (undo-guarded) ──
+                sd_backup::commit_sd_to_vault(pal, io, undo, sdmk).await
+            }
+            .await;
+            sdbmk.zeroize();
+            inner
         }
         .await;
 

--- a/fw/core/lib/src/ddi/tbor/sd_restore_local_backup.rs
+++ b/fw/core/lib/src/ddi/tbor/sd_restore_local_backup.rs
@@ -42,8 +42,8 @@
 use azihsm_fw_core_crypto_key_masking::aead::unmask;
 use azihsm_fw_ddi_tbor_types::TborSdRestoreLocalBackupReq;
 use azihsm_fw_ddi_tbor_types::TborSdRestoreLocalBackupResp;
-use azihsm_fw_ddi_tbor_types::LOCAL_MK_BACKUP_LEN;
 use azihsm_fw_ddi_tbor_types::MASKED_SD_LEN;
+use azihsm_fw_ddi_tbor_types::SD_MK_BACKUP_LEN;
 use azihsm_fw_hsm_pal_traits::DmaBuf;
 use azihsm_fw_hsm_pal_traits::HsmError;
 use azihsm_fw_hsm_pal_traits::HsmIo;
@@ -95,7 +95,7 @@ pub(crate) async fn handle<'p, P: HsmPal>(
     // Allocate the two fixed-size response backups in the IO scope so they
     // survive the crypto scratch allocator's reset.
     let pok_local_out = pal.dma_alloc(io, MASKED_SD_LEN)?;
-    let sd_mk_out = pal.dma_alloc(io, LOCAL_MK_BACKUP_LEN)?;
+    let sd_mk_out = pal.dma_alloc(io, SD_MK_BACKUP_LEN)?;
 
     pal.alloc_scoped_async(io, async |alloc| -> HsmResult<()> {
         let (svn, owner) = sd_backup::platform_svn_owner(pal)?;
@@ -104,7 +104,7 @@ pub(crate) async fn handle<'p, P: HsmPal>(
         // (decrypted) in place without borrowing the request buffer across
         // the re-mask / vault steps.
         let pok_scratch = alloc.dma_alloc(MASKED_SD_LEN)?;
-        let mk_scratch = alloc.dma_alloc(LOCAL_MK_BACKUP_LEN)?;
+        let mk_scratch = alloc.dma_alloc(SD_MK_BACKUP_LEN)?;
         {
             let req = TborSdRestoreLocalBackupReq::decode(&*req_buf)?;
             pok_scratch.copy_from_slice(req.pok_local_backup());

--- a/fw/core/lib/src/ddi/tbor/sd_restore_local_backup.rs
+++ b/fw/core/lib/src/ddi/tbor/sd_restore_local_backup.rs
@@ -1,0 +1,186 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! TBOR `SdRestoreLocalBackup` handler.
+//!
+//! Restores a security domain from its **device-local** backups
+//! (manticore §3.3.9 RestoreSDLocalBackup) — the local-reboot recovery
+//! path.  Unlike the remote/peer restores it needs no sender, no HPKE, no
+//! attestation evidence, and no out-of-band data: it simply unmasks the
+//! two host-replayed backups with keys the device already holds, re-masks
+//! them at the current platform identity, and re-provisions the SD.
+//!
+//! It is **CreateSD in reverse** — it *recovers* the SD key material a
+//! prior `SdCreateRemoteBackup` *minted*, and shares that command's
+//! provisioning primitives via [`sd_backup`](super::sd_backup).
+//!
+//! Flow:
+//!
+//! 1. Decode; gate to a Crypto-Officer, `Active` session on an
+//!    `Initialized` partition, and fail-fast if the security domain is
+//!    already initialized ([`SdAlreadyInitialized`](HsmError::SdAlreadyInitialized)).
+//! 2. Unmask `pok_local_backup` under the partition-local masking key
+//!    (`PartLocalMK`, from `PartFinal`) → **BKS3**.  The blob must be an
+//!    [`SdPartitionOwnerSeed`](HsmVaultKeyKind::SdPartitionOwnerSeed)
+//!    envelope, and its bound SVN must not be newer than the current
+//!    firmware SVN ([`SdBackupSvnRollback`](HsmError::SdBackupSvnRollback)).
+//! 3. Derive `SDBMK` from BKS3 + the partition `policy_hash`, then unmask
+//!    `sd_mk_backup` under `SDBMK` → **SDMK** (must be an
+//!    [`SdMasking`](HsmVaultKeyKind::SdMasking) envelope; same anti-rollback).
+//! 4. Re-mask both at the current `{svn, owner}`: `CurrSDLocalBackup =
+//!    mask(BKS3, PartLocalMK)` and `CurrSDKMKBackup = mask(SDMK, SDBMK)`.
+//! 5. **Commit** ([`commit_sd_to_vault`](super::sd_backup::commit_sd_to_vault)):
+//!    vault `SDMK` (SecurityDomain scope), record `SD_MK_KEY_ID`, and mark
+//!    the partition SD-initialized — undo-guarded.  BKS3, SDMK, and SDBMK
+//!    are zeroized before returning.
+//!
+//! **Stateful & one-shot** (parity with `SdCreateRemoteBackup`): a second
+//! restore/create on the same partition incarnation is rejected.
+//!
+//! This command is **Crypto-Officer-only**.
+
+use azihsm_fw_core_crypto_key_masking::aead::unmask;
+use azihsm_fw_ddi_tbor_types::TborSdRestoreLocalBackupReq;
+use azihsm_fw_ddi_tbor_types::TborSdRestoreLocalBackupResp;
+use azihsm_fw_ddi_tbor_types::LOCAL_MK_BACKUP_LEN;
+use azihsm_fw_ddi_tbor_types::MASKED_SD_LEN;
+use azihsm_fw_hsm_pal_traits::DmaBuf;
+use azihsm_fw_hsm_pal_traits::HsmError;
+use azihsm_fw_hsm_pal_traits::HsmIo;
+use azihsm_fw_hsm_pal_traits::HsmPal;
+use azihsm_fw_hsm_pal_traits::HsmResult;
+use azihsm_fw_hsm_pal_traits::HsmScopedAlloc;
+use azihsm_fw_hsm_pal_traits::HsmSessId;
+use azihsm_fw_hsm_pal_traits::HsmVaultKeyKind;
+use azihsm_fw_hsm_pal_traits::PartState;
+use azihsm_fw_hsm_undo::UndoLog;
+
+use super::sd_backup;
+use super::validate_crypto_officer_active_session;
+use crate::part_state;
+
+/// Handle a TBOR `SdRestoreLocalBackup` request.
+///
+/// **Stateful**: re-provisions the security-domain masking key (`SDMK`) in
+/// the vault and marks the partition security-domain-initialized, guarded
+/// by the per-command `undo` log.  The one-shot `SD_INITIALIZED` claim is
+/// the race-winner gate against a concurrently-dispatched create/restore.
+pub(crate) async fn handle<'p, P: HsmPal>(
+    pal: &'p P,
+    io: &impl HsmIo,
+    req_buf: &mut DmaBuf,
+    undo: &mut UndoLog<'p>,
+) -> HsmResult<&'p DmaBuf> {
+    // Session/state gating uses only the shared `decode` view; confine the
+    // borrow so the request buffer is free afterwards.
+    {
+        let req = TborSdRestoreLocalBackupReq::decode(&*req_buf)?;
+        let sess_id = HsmSessId::from(u16::from(req.session_id()));
+        validate_crypto_officer_active_session(pal, io, sess_id)?;
+
+        // The SD masking keys / policy hash are provisioned by `PartFinal`,
+        // so the partition must be finalized (`Initialized`).
+        if part_state::part_state(pal, io)? != PartState::Initialized {
+            return Err(HsmError::InvalidArg);
+        }
+
+        // Fail-fast: a restore onto an already-initialized security domain
+        // is rejected.  The atomic `SD_INITIALIZED` claim in the commit
+        // phase is the authoritative race-winner gate.
+        if part_state::part_is_sd_initialized(pal, io)? {
+            return Err(HsmError::SdAlreadyInitialized);
+        }
+    }
+
+    // Allocate the two fixed-size response backups in the IO scope so they
+    // survive the crypto scratch allocator's reset.
+    let pok_local_out = pal.dma_alloc(io, MASKED_SD_LEN)?;
+    let sd_mk_out = pal.dma_alloc(io, LOCAL_MK_BACKUP_LEN)?;
+
+    pal.alloc_scoped_async(io, async |alloc| -> HsmResult<()> {
+        let (svn, owner) = sd_backup::platform_svn_owner(pal)?;
+
+        // Stage the two masked backups in scratch so they can be unmasked
+        // (decrypted) in place without borrowing the request buffer across
+        // the re-mask / vault steps.
+        let pok_scratch = alloc.dma_alloc(MASKED_SD_LEN)?;
+        let mk_scratch = alloc.dma_alloc(LOCAL_MK_BACKUP_LEN)?;
+        {
+            let req = TborSdRestoreLocalBackupReq::decode(&*req_buf)?;
+            pok_scratch.copy_from_slice(req.pok_local_backup());
+            mk_scratch.copy_from_slice(req.sd_mk_backup());
+        }
+
+        // BKS3 and SDMK are recovered into `pok_scratch` / `mk_scratch`;
+        // scope rewind does not clear DMA memory, so both are scrubbed on
+        // EVERY exit path below.
+        let res = async {
+            // ── Recover BKS3 from pok_local_backup under PartLocalMK ──
+            let bks3 = {
+                let local_mk_id = part_state::part_local_mk_key_id(pal, io)?;
+                let local_mk = pal.vault_key(io, local_mk_id)?;
+                let view = unmask(pal, io, local_mk, pok_scratch).await?;
+                if !matches!(view.key_kind, HsmVaultKeyKind::SdPartitionOwnerSeed) {
+                    return Err(HsmError::UnsupportedKeyType);
+                }
+                // Anti-rollback: a backup minted under a newer SVN cannot be
+                // restored on this (older) firmware.  Enforced after the
+                // AEAD tag authenticates the envelope, so a tampered
+                // cleartext SVN fails the tag rather than spoofing this.
+                if view.svn > svn {
+                    return Err(HsmError::SdBackupSvnRollback);
+                }
+                view.target_key
+            };
+
+            // ── Derive SDBMK, recover SDMK from sd_mk_backup ──
+            let sdbmk = sd_backup::derive_sdbmk(pal, io, alloc, bks3, svn, owner).await?;
+            let sdmk = {
+                let view = unmask(pal, io, sdbmk, mk_scratch).await?;
+                if !matches!(view.key_kind, HsmVaultKeyKind::SdMasking) {
+                    return Err(HsmError::UnsupportedKeyType);
+                }
+                if view.svn > svn {
+                    return Err(HsmError::SdBackupSvnRollback);
+                }
+                view.target_key
+            };
+
+            // ── Re-mask both at the current {svn, owner} ──
+            sd_backup::mask_pok_local_backup(pal, io, alloc, bks3, svn, owner, pok_local_out)
+                .await?;
+            sd_backup::mask_sd_mk_backup(pal, io, alloc, sdbmk, sdmk, svn, owner, sd_mk_out)
+                .await?;
+
+            // ── Commit: vault SDMK, mark SD-initialized (undo-guarded) ──
+            sd_backup::commit_sd_to_vault(pal, io, undo, sdmk).await
+        }
+        .await;
+
+        // Scrub the recovered BKS3 / SDMK plaintext from scratch on every
+        // path before the buffers return to the per-IO pool.
+        pok_scratch.zeroize();
+        mk_scratch.zeroize();
+        res
+    })
+    .await?;
+
+    encode_response(pal, io, pok_local_out, sd_mk_out)
+}
+
+/// Encode the `SdRestoreLocalBackup` response around the refreshed backups.
+fn encode_response<'p, P: HsmPal>(
+    pal: &'p P,
+    io: &impl HsmIo,
+    pok_local: &DmaBuf,
+    sd_mk: &DmaBuf,
+) -> HsmResult<&'p DmaBuf> {
+    let resp = pal.dma_alloc_var(io, |buf| {
+        let frame = TborSdRestoreLocalBackupResp::encode(buf, 0, false)?
+            .pok_local_backup(pok_local)?
+            .sd_mk_backup(sd_mk)?
+            .finish();
+        Ok(frame.as_bytes().len())
+    })?;
+    Ok(resp)
+}

--- a/fw/core/lib/src/ddi/tbor/sd_restore_local_backup.rs
+++ b/fw/core/lib/src/ddi/tbor/sd_restore_local_backup.rs
@@ -133,6 +133,13 @@ pub(crate) async fn handle<'p, P: HsmPal>(
                 if view.svn > svn {
                     return Err(HsmError::SdBackupSvnRollback);
                 }
+                // Firmware invariant: the AEAD tag has authenticated the
+                // envelope, so a genuine backup always carries a `BKS3_LEN`
+                // seed; a mismatch signals corruption / a sizing bug, not a
+                // client error.  Mirrors `restore_part_local_mk` in `part_final`.
+                if view.target_key.len() != sd_backup::BKS3_LEN {
+                    return Err(HsmError::InternalError);
+                }
                 view.target_key
             };
 
@@ -164,6 +171,12 @@ pub(crate) async fn handle<'p, P: HsmPal>(
                     // Anti-rollback on the now-authenticated `view.svn`.
                     if view.svn > svn {
                         return Err(HsmError::SdBackupSvnRollback);
+                    }
+                    // Firmware invariant (tag-authenticated): a genuine backup
+                    // always carries an `SDMK_LEN` key; a mismatch signals
+                    // corruption / a sizing bug, not a client error.
+                    if view.target_key.len() != sd_backup::SDMK_LEN {
+                        return Err(HsmError::InternalError);
                     }
                     view.target_key
                 };

--- a/fw/core/lib/src/op.rs
+++ b/fw/core/lib/src/op.rs
@@ -264,6 +264,7 @@ impl SessionCtrl {
             | opcode::SD_SEALING_KEY_GEN
             | opcode::SD_CREATE_REMOTE_BACKUP
             | opcode::SD_RESEAL_REMOTE_BACKUP
+            | opcode::SD_RESTORE_LOCAL_BACKUP
             | opcode::KEY_REPORT => Self::InSession,
             opcode::SESSION_CLOSE => Self::Close,
             _ => Self::NoSession,

--- a/fw/pal/traits/src/error.rs
+++ b/fw/pal/traits/src/error.rs
@@ -412,6 +412,16 @@ pub enum HsmError {
     /// partition free / NSSR.
     SdAlreadyInitialized = 0x08700108,
 
+    /// A `SdRestore*` handler was asked to restore a security-domain
+    /// backup whose bound SVN is **newer** than the current firmware SVN.
+    /// A backup minted under a newer SVN cannot be restored on this
+    /// (older) firmware (anti-rollback); older-or-equal SVNs are accepted
+    /// since the masking keys are re-derivable from the versioned device
+    /// seeds.  Enforced only after the AEAD tag authenticates the
+    /// envelope, so a tampered cleartext SVN fails the tag rather than
+    /// spoofing this error.
+    SdBackupSvnRollback = 0x08700109,
+
     // Firmware-internal diagnostic codes logged by the CPU fault and panic
     // exception handlers (`azihsm_fw_uno_fault`). These are not DDI protocol
     // statuses: they use the PAL diagnostic facility (`0x08F`) to stay clear of


### PR DESCRIPTION
## Summary

Implements **`SdRestoreLocalBackup`** (manticore §3.3.9) — restoring a security domain from its **device-local** backups after a reboot. It is **CreateSD in reverse**: it *recovers* the SD key material that `SdCreateRemoteBackup` *mints*, reusing that command's provisioning primitives. No sender, HPKE, attestation evidence, or out-of-band data.

> **Stacked on #563** (`sd/create-sd-full`) — this PR depends on that command's infrastructure (`commit_sd_to_vault`, `SdMasking`, `SD_INITIALIZED`, …). Base will be retargeted to `main` once #563 merges.

## What changed

**Shared module** (`fw/core/lib/src/ddi/tbor/sd_backup.rs`, new)
- Extracts the SD-backup mechanics both commands share: SDBMK derivation, `mask_sd_mk_backup` / `mask_pok_local_backup`, `commit_sd_to_vault`, and the SDMK/SDBMK consts + attrs. `SdCreateRemoteBackup` is refactored to call it (no behavior change; 107 create/reseal emu tests still pass).

**Handler** (`fw/core/lib/src/ddi/tbor/sd_restore_local_backup.rs`, new)
- Recover `PartLocalMK` → unmask `pok_local_backup` → **BKS3** (checks `SdPartitionOwnerSeed` kind + anti-rollback SVN).
- Derive `SDBMK` from BKS3 + `policy_hash` → unmask `sd_mk_backup` → **SDMK** (checks `SdMasking` kind + anti-rollback).
- Re-mask both at the current `{svn, owner}`, then `commit_sd_to_vault` (vault SDMK, mark `SD_INITIALIZED`, undo-guarded). One-shot (`SdAlreadyInitialized`).

**Error**: new `HsmError::SdBackupSvnRollback` (+ `TborStatus` mirror) for a backup minted under a newer SVN.

**Dispatch**: opcode `0x0D` wired — dispatch arm, the `mod.rs` classifiers, and (the easy-to-miss one) `SessionCtrl::from_tbor_opcode` in-session mapping.

## Design decisions (per review)
- **Vault SDMK only** (SDBMK derived on-demand) — parity with create.
- **Always re-mask** at the current SVN (advances the backup).
- **New `SdBackupSvnRollback`** error (not reusing `PartFinalBackupSvnRollback`).

## Testing
- **Emu round-trip**: device 1 finalizes + `CreateSD` (captures `pok_local_backup`, `sd_mk_backup`, `local_mk_backup`); device 2 (factory-reset, same seed) restores `PartLocalMK` via `PartFinal`, then `SdRestoreLocalBackup` returns non-zero refreshed backups. Plus one-shot, reject-before-finalize, and tamper tests.
- **111 emu tests pass** (was 107); create/reseal/sealing/part_final suites intact.
- `cargo +nightly fmt`, `cargo xtask clippy` (main + uno), and `cargo xtask copyright` all clean; fw core / std / uno all build.

## Follow-up
`SdRestoreRemoteBackup` (§3.3.8) and `SdRestorePeerBackup` (§3.3.11) can reuse the same `sd_backup` module.