### PR TITLE
feat(tbor): implement SdRestoreRemoteBackup (remote SD recovery)

### DIFF
--- a/ddi/tbor/types/src/sd_restore_remote_backup.rs
+++ b/ddi/tbor/types/src/sd_restore_remote_backup.rs
@@ -3,13 +3,12 @@
 
 //! Host-side wrapper for the TBOR `SdRestoreRemoteBackup` command.
 //!
-//! `SdRestoreRemoteBackup` is an **in-session** command that
-//! restores a security domain from a remote backup: it unmasks the
-//! caller-supplied remote partition-owner-key backup
-//! (`pok_remote_backup`, a masked BKS3) under the named sealing key,
-//! re-wraps it under the device-local key, and returns the local backup
-//! (`pok_local_backup`) together with the security-domain masking-key
-//! backup (`sd_mk_backup`).
+//! `SdRestoreRemoteBackup` is an **in-session** command that restores a
+//! security domain from a **remote** backup (manticore §3.3.8): it
+//! HPKE-Auth-opens the caller-supplied `src_remote_backup` (an HPKE seal of
+//! BKS3) with the masked receiver key — authenticated by the sender's
+//! attested key — recovers `SDMK` from `prev_sd_mk_backup`, and returns the
+//! device-local backups (`pok_local_backup`, `sd_mk_backup`).
 //!
 //! Both wire schemas are shared with the firmware handler via
 //! `azihsm_fw_ddi_tbor_types::sd_restore_remote_backup`; this module
@@ -22,6 +21,9 @@ use alloc::vec::Vec;
 
 use crate::evidence::ReportDescriptor;
 use crate::policy::PartPolicy;
+use crate::sd_create_remote_backup::POK_REMOTE_BACKUP_LEN;
+use crate::sd_create_remote_backup::SD_MK_BACKUP_LEN;
+use crate::sd_sealing_key_gen::MASKED_SEALING_KEY_LEN;
 use crate::tbor;
 use crate::CertDescriptor;
 
@@ -30,22 +32,25 @@ pub const TBOR_OP_SD_RESTORE_REMOTE_BACKUP: u8 = 0x0C;
 
 /// Host-facing TBOR `SdRestoreRemoteBackup` request.
 #[tbor(opcode = TBOR_OP_SD_RESTORE_REMOTE_BACKUP, session_ctrl = in_session)]
-#[derive(Debug, Default, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TborSdRestoreRemoteBackupReq {
     /// Session id this request is bound to.  Cross-checked against the
     /// SQE-carried session id by the dispatcher.
     #[tbor(session_id)]
     pub session_id: u16,
 
-    /// Vault id (`HsmKeyId`) of the sealing key the `pok_remote_backup` is
-    /// bound to.  Carried as a `KeyId` (inline 16-bit, TOC entry type 1);
-    /// represented here as the raw `u16` handle.
-    #[tbor(key_id)]
-    pub sealing_key_id: u16,
+    /// The receiver's masked SD-sealing key (from `SdSealingKeyGen`),
+    /// exactly [`MASKED_SEALING_KEY_LEN`] (180 B).  Unmasked on-device to
+    /// recover the receiver's private HPKE key (`RcvrPriv`).
+    pub masked_sealing_key: [u8; MASKED_SEALING_KEY_LEN],
+
+    /// Unified [`PartPolicy`] describing the security domain being
+    /// restored.  Encoded as its 484-byte little-endian image.
+    pub policy: PartPolicy,
 
     /// Sender manufacturer certificate-chain descriptors.  Flattened from
-    /// the firmware `sender_evidence` field group (its four TOC entries);
-    /// the DER bytes travel out of band.
+    /// the firmware `sender_evidence` field group (first of its four TOC
+    /// entries); the DER bytes travel out of band.
     #[tbor(max_len = 8)]
     pub sender_mfgr_cert_chain: Vec<CertDescriptor>,
 
@@ -60,21 +65,15 @@ pub struct TborSdRestoreRemoteBackupReq {
     /// Sender attestation-report (COSE_Sign1) descriptor.
     pub sender_report: ReportDescriptor,
 
-    /// Unified [`PartPolicy`] describing the security domain being
-    /// restored.  Encoded as its 484-byte little-endian image.
-    pub policy: PartPolicy,
-
-    /// Remote partition-owner-key backup to restore (a masked BKS3).
-    /// Exactly 180 B on the wire; the firmware schema is the length
+    /// Remote backup to restore: an HPKE-Auth seal of BKS3, exactly
+    /// [`POK_REMOTE_BACKUP_LEN`] (161 B).  The firmware schema is the length
     /// authority.
-    #[tbor(max_len = 180)]
-    pub pok_remote_backup: Vec<u8>,
+    pub src_remote_backup: [u8; POK_REMOTE_BACKUP_LEN],
 
-    /// Optional security-domain masking-key backup envelope.  Empty when
-    /// absent; when present it is exactly 164 B on the wire (the firmware
-    /// schema is the length authority).
-    #[tbor(max_len = 164)]
-    pub sd_mk_backup: Vec<u8>,
+    /// Previous security-domain masking-key backup (SDMK masked under the
+    /// derived SDBMK), exactly [`SD_MK_BACKUP_LEN`] (164 B), from which
+    /// `SDMK` is recovered.
+    pub prev_sd_mk_backup: [u8; SD_MK_BACKUP_LEN],
 }
 
 /// Host-facing TBOR `SdRestoreRemoteBackup` response.
@@ -98,44 +97,29 @@ mod tests {
     use azihsm_ddi_tbor_types::TborOpReq;
 
     use super::*;
-    use crate::sd_create_remote_backup::MASKED_SD_LEN;
-
-    const SD_MK_BACKUP_LEN: usize = 164;
 
     #[test]
     fn request_encodes_all_fields() {
         let req = TborSdRestoreRemoteBackupReq {
             session_id: 9,
-            sealing_key_id: 0x1234,
+            masked_sealing_key: [0u8; MASKED_SEALING_KEY_LEN],
             policy: PartPolicy::zeroed(),
-            pok_remote_backup: alloc::vec![0xABu8; MASKED_SD_LEN],
-            sd_mk_backup: alloc::vec![0xCDu8; SD_MK_BACKUP_LEN],
-            ..Default::default()
+            sender_mfgr_cert_chain: Vec::new(),
+            sender_owner_cert_chain: Vec::new(),
+            sender_part_owner_cert_chain: Vec::new(),
+            sender_report: ReportDescriptor::default(),
+            src_remote_backup: [0xABu8; POK_REMOTE_BACKUP_LEN],
+            prev_sd_mk_backup: [0xCDu8; SD_MK_BACKUP_LEN],
         };
 
-        let mut buf = [0u8; 1024];
+        let mut buf = [0u8; 2048];
         let frame = req.encode_request(&mut buf).expect("encode");
 
-        // The 484-byte policy plus the two backup blobs must be carried in
-        // the data section.
+        // The 484-byte policy plus the sealing key and the two backups must
+        // be carried in the data section.
         assert!(
-            frame.len() > 484 + MASKED_SD_LEN + SD_MK_BACKUP_LEN,
-            "encoded frame must carry the policy and backups"
+            frame.len() > 484 + MASKED_SEALING_KEY_LEN + POK_REMOTE_BACKUP_LEN + SD_MK_BACKUP_LEN,
+            "encoded frame must carry the policy, key, and backups"
         );
-    }
-
-    #[test]
-    fn request_encodes_absent_sd_mk_backup() {
-        let req = TborSdRestoreRemoteBackupReq {
-            session_id: 9,
-            sealing_key_id: 0x1234,
-            policy: PartPolicy::zeroed(),
-            pok_remote_backup: alloc::vec![0xABu8; MASKED_SD_LEN],
-            sd_mk_backup: Vec::new(),
-            ..Default::default()
-        };
-
-        let mut buf = [0u8; 1024];
-        req.encode_request(&mut buf).expect("encode");
     }
 }

--- a/ddi/tbor/types/tests/commands/mod.rs
+++ b/ddi/tbor/types/tests/commands/mod.rs
@@ -18,6 +18,7 @@ pub mod psk_change;
 pub mod sd_create_remote_backup;
 pub mod sd_reseal_remote_backup;
 pub mod sd_restore_local_backup;
+pub mod sd_restore_remote_backup;
 pub mod sd_sealing_key_gen;
 pub mod session_close;
 pub mod unexpected_toc_type;

--- a/ddi/tbor/types/tests/commands/sd_create_remote_backup.rs
+++ b/ddi/tbor/types/tests/commands/sd_create_remote_backup.rs
@@ -176,10 +176,10 @@ pub(crate) struct ReceiverEvidence {
     /// OOB SGL items in index order: `[mfgr root, mfgr leaf, owner root,
     /// owner leaf, part-owner root, part-owner leaf, report]`.
     oob_items: Vec<Vec<u8>>,
-    mfgr: Vec<CertDescriptor>,
-    owner: Vec<CertDescriptor>,
-    part_owner: Vec<CertDescriptor>,
-    report: ReportDescriptor,
+    pub(crate) mfgr: Vec<CertDescriptor>,
+    pub(crate) owner: Vec<CertDescriptor>,
+    pub(crate) part_owner: Vec<CertDescriptor>,
+    pub(crate) report: ReportDescriptor,
 }
 
 impl ReceiverEvidence {

--- a/ddi/tbor/types/tests/commands/sd_restore_remote_backup.rs
+++ b/ddi/tbor/types/tests/commands/sd_restore_remote_backup.rs
@@ -1,0 +1,243 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Integration tests for the TBOR `SdRestoreRemoteBackup` command.
+//!
+//! `SdRestoreRemoteBackup` restores a security domain from a **remote**
+//! backup: it HPKE-Auth-opens `src_remote_backup` (an HPKE seal of BKS3)
+//! with the receiver's masked SD-sealing key — authenticated by the
+//! sender's attested key — recovers `SDMK` from `prev_sd_mk_backup`, and
+//! returns the device-local backups.
+//!
+//! The **round-trip** test uses a self-backup (sender == receiver): a first
+//! device finalizes and `CreateSD`s (producing the `pok_remote_backup` /
+//! `sd_mk_backup` this command consumes, plus the `local_mk_backup`), then a
+//! second device (factory-reset, same machine seed) restores `PartLocalMK`
+//! via `PartFinal` — so it can unmask the captured sealing key — and
+//! restores the security domain from the remote backup.
+//!
+//! Coverage:
+//! * Round-trip — create → reboot → PartFinal(restore PartLocalMK) →
+//!   restore-remote returns non-zero refreshed local backups.
+//! * One-shot — restore onto an already-initialized SD → `SdAlreadyInitialized`.
+//! * Restore before finalize → `InvalidArg`.
+
+#![cfg(feature = "emu")]
+
+use azihsm_ddi_tbor_types::PartPolicy;
+use azihsm_ddi_tbor_types::TborPartInfoReq;
+use azihsm_ddi_tbor_types::TborSdRestoreRemoteBackupReq;
+use azihsm_ddi_tbor_types::TborStatus;
+use azihsm_ddi_tbor_types::MASKED_SD_LEN;
+use azihsm_ddi_tbor_types::PART_POLICY_LEN;
+use azihsm_ddi_tbor_types::POK_REMOTE_BACKUP_LEN;
+use azihsm_ddi_tbor_types::SD_MK_BACKUP_LEN;
+use zerocopy::TryFromBytes;
+
+use crate::commands::part_init::bootstrap_rotated_co;
+use crate::commands::part_init::mach_seed;
+use crate::commands::part_init::pota_thumbprint;
+use crate::commands::part_init::ROTATED_CO_PSK;
+use crate::commands::sd_create_remote_backup::backing_part_policy;
+use crate::commands::sd_create_remote_backup::backup_request;
+use crate::commands::sd_create_remote_backup::build_receiver_evidence;
+use crate::commands::sd_create_remote_backup::masked_key_and_report;
+use crate::commands::sd_create_remote_backup::ReceiverEvidence;
+use crate::harness::x509_fixture::make_pta_chain;
+use crate::harness::x509_fixture::pta_pub_from_csr;
+use crate::harness::x509_fixture::CaKey;
+use crate::harness::x509_fixture::RAW_PUB_LEN;
+use crate::harness::TestCtx;
+
+/// A remote backup produced by the first device's `CreateSD`, replayed on
+/// the second (rebooted) device to restore the security domain.
+struct RemoteBackup {
+    /// The receiver's masked SD-sealing key (used to open the backup).
+    masked_sealing_key: Vec<u8>,
+    /// Sender attestation evidence (OOB items + descriptors).  In a
+    /// self-backup this is the same evidence `CreateSD` used.
+    evidence: ReceiverEvidence,
+    /// The 484-byte `PartPolicy` image.
+    policy: [u8; PART_POLICY_LEN],
+    /// `pok_remote_backup` from `CreateSD` — the HPKE seal to restore.
+    src_remote_backup: [u8; POK_REMOTE_BACKUP_LEN],
+    /// `sd_mk_backup` from `CreateSD` — the previous SDMK backup.
+    prev_sd_mk_backup: [u8; SD_MK_BACKUP_LEN],
+    /// `PartFinal`'s `local_mk_backup`, replayed to restore `PartLocalMK`.
+    local_mk_backup: Vec<u8>,
+}
+
+/// Drive device 1: finalize a backing partition, `CreateSD`, and capture
+/// everything device 2 needs to restore the domain remotely.
+fn create_remote_backup(seed: &[u8], sata: &CaKey, pota: &CaKey) -> RemoteBackup {
+    let ctx = TestCtx::new();
+    let session = bootstrap_rotated_co(&ctx, &ROTATED_CO_PSK);
+
+    let info = ctx.tbor(&TborPartInfoReq::new()).expect("PartInfo");
+    let mut pid_pub = [0u8; RAW_PUB_LEN];
+    pid_pub.copy_from_slice(&info.pid_pub_key);
+    let policy = backing_part_policy(
+        &info.pid,
+        &info.pid_pub_key,
+        &sata.raw_pub(),
+        &pota.raw_pub(),
+    );
+
+    let init = ctx
+        .part_init(&session, seed, &policy, &pota_thumbprint())
+        .expect("PartInit");
+    let chain = make_pta_chain(pota, &pta_pub_from_csr(&init.pta_csr));
+    let local_mk_backup = ctx
+        .part_final(&session, &policy, &[], &chain.der_items())
+        .expect("PartFinal")
+        .local_mk_backup;
+
+    let (masked, report) = masked_key_and_report(&ctx, session.session_id);
+    let evidence = build_receiver_evidence(&pid_pub, sata, &report);
+    let req = backup_request(session.session_id, masked.clone(), &evidence, &policy);
+    let resp = ctx
+        .tbor_oob(&req, &evidence.oob())
+        .expect("SdCreateRemoteBackup");
+
+    RemoteBackup {
+        masked_sealing_key: masked,
+        evidence,
+        policy,
+        src_remote_backup: resp.pok_remote_backup,
+        prev_sd_mk_backup: resp.sd_mk_backup,
+        local_mk_backup,
+    }
+}
+
+/// Assemble a `SdRestoreRemoteBackup` request from a captured backup.
+fn restore_remote_req(session_id: u16, backup: &RemoteBackup) -> TborSdRestoreRemoteBackupReq {
+    TborSdRestoreRemoteBackupReq {
+        session_id,
+        masked_sealing_key: backup
+            .masked_sealing_key
+            .as_slice()
+            .try_into()
+            .expect("masked sealing key is exactly MASKED_SEALING_KEY_LEN bytes"),
+        policy: PartPolicy::try_read_from_bytes(&backup.policy).expect("policy image is canonical"),
+        sender_mfgr_cert_chain: backup.evidence.mfgr.clone(),
+        sender_owner_cert_chain: backup.evidence.owner.clone(),
+        sender_part_owner_cert_chain: backup.evidence.part_owner.clone(),
+        sender_report: backup.evidence.report,
+        src_remote_backup: backup.src_remote_backup,
+        prev_sd_mk_backup: backup.prev_sd_mk_backup,
+    }
+}
+
+#[test]
+fn sd_restore_remote_backup_roundtrip_emu() {
+    let seed = mach_seed();
+    let sata = CaKey::generate();
+    let pota = CaKey::generate();
+
+    // Device 1: finalize + CreateSD, capturing the remote backup.
+    let backup = create_remote_backup(&seed, &sata, &pota);
+
+    // Device 2 (reboot): restore PartLocalMK (so the captured sealing key
+    // unmasks), then restore the SD from the remote backup.
+    let ctx = TestCtx::new();
+    let session = bootstrap_rotated_co(&ctx, &ROTATED_CO_PSK);
+    let init = ctx
+        .part_init(&session, &seed, &backup.policy, &pota_thumbprint())
+        .expect("PartInit (device 2)");
+    let chain = make_pta_chain(&pota, &pta_pub_from_csr(&init.pta_csr));
+    ctx.part_final(
+        &session,
+        &backup.policy,
+        &backup.local_mk_backup,
+        &chain.der_items(),
+    )
+    .expect("PartFinal must restore PartLocalMK from the prior backup");
+
+    let req = restore_remote_req(session.session_id, &backup);
+    let resp = ctx
+        .tbor_oob(&req, &backup.evidence.oob())
+        .expect("SdRestoreRemoteBackup roundtrip");
+
+    // Local backup (BKS3 masked under PartLocalMK), 180 B, non-zero.
+    assert_eq!(resp.pok_local_backup.len(), MASKED_SD_LEN);
+    assert!(
+        resp.pok_local_backup.iter().any(|&b| b != 0),
+        "pok_local_backup must not be all-zero",
+    );
+    // Refreshed masking-key backup (SDMK re-masked under SDBMK), 164 B.
+    assert_eq!(resp.sd_mk_backup.len(), SD_MK_BACKUP_LEN);
+    assert!(
+        resp.sd_mk_backup.iter().any(|&b| b != 0),
+        "sd_mk_backup must not be all-zero",
+    );
+}
+
+#[test]
+fn sd_restore_remote_backup_is_one_shot_emu() {
+    let seed = mach_seed();
+    let sata = CaKey::generate();
+    let pota = CaKey::generate();
+
+    // A single device that has just created its SD is already
+    // SD-initialized, so a remote restore on the same incarnation is
+    // rejected by the one-shot gate.
+    let ctx = TestCtx::new();
+    let session = bootstrap_rotated_co(&ctx, &ROTATED_CO_PSK);
+    let info = ctx.tbor(&TborPartInfoReq::new()).expect("PartInfo");
+    let mut pid_pub = [0u8; RAW_PUB_LEN];
+    pid_pub.copy_from_slice(&info.pid_pub_key);
+    let policy = backing_part_policy(
+        &info.pid,
+        &info.pid_pub_key,
+        &sata.raw_pub(),
+        &pota.raw_pub(),
+    );
+    let init = ctx
+        .part_init(&session, &seed, &policy, &pota_thumbprint())
+        .expect("PartInit");
+    let chain = make_pta_chain(&pota, &pta_pub_from_csr(&init.pta_csr));
+    ctx.part_final(&session, &policy, &[], &chain.der_items())
+        .expect("PartFinal");
+
+    let (masked, report) = masked_key_and_report(&ctx, session.session_id);
+    let evidence = build_receiver_evidence(&pid_pub, &sata, &report);
+    let create_req = backup_request(session.session_id, masked.clone(), &evidence, &policy);
+    let created = ctx
+        .tbor_oob(&create_req, &evidence.oob())
+        .expect("SdCreateRemoteBackup");
+
+    let backup = RemoteBackup {
+        masked_sealing_key: masked,
+        evidence,
+        policy,
+        src_remote_backup: created.pok_remote_backup,
+        prev_sd_mk_backup: created.sd_mk_backup,
+        local_mk_backup: Vec::new(),
+    };
+    let req = restore_remote_req(session.session_id, &backup);
+    ctx.expect_fw_reject_oob(
+        &req,
+        &backup.evidence.oob(),
+        TborStatus::SdAlreadyInitialized,
+    );
+}
+
+#[test]
+fn sd_restore_remote_backup_rejects_before_finalize_emu() {
+    // A partition that has not been finalized is rejected at the lifecycle
+    // gate before any evidence or crypto work.
+    let ctx = TestCtx::new();
+    let session = bootstrap_rotated_co(&ctx, &ROTATED_CO_PSK);
+    let req = TborSdRestoreRemoteBackupReq {
+        session_id: session.session_id,
+        masked_sealing_key: [0u8; 180],
+        policy: PartPolicy::zeroed(),
+        sender_mfgr_cert_chain: Vec::new(),
+        sender_owner_cert_chain: Vec::new(),
+        sender_part_owner_cert_chain: Vec::new(),
+        sender_report: Default::default(),
+        src_remote_backup: [0u8; POK_REMOTE_BACKUP_LEN],
+        prev_sd_mk_backup: [0u8; SD_MK_BACKUP_LEN],
+    };
+    ctx.expect_fw_reject(&req, TborStatus::InvalidArg);
+}

--- a/docs/tbor-ddi/README.md
+++ b/docs/tbor-ddi/README.md
@@ -60,7 +60,7 @@ single `none` TOC placeholder and no typed body fields.
 | `0x09` | `SdSealingKeyGen` | InSession | [`commands/sd_sealing_key_gen.md`](./commands/sd_sealing_key_gen.md) |
 | `0x0A` | `SdCreateRemoteBackup` | InSession | [`commands/sd_create_remote_backup.md`](./commands/sd_create_remote_backup.md) |
 | `0x0B` | `SdResealRemoteBackup` | InSession | [`commands/sd_reseal_remote_backup.md`](./commands/sd_reseal_remote_backup.md) |
-| `0x0C` | `SdRestoreRemoteBackup` (schema-only) | InSession | [`commands/sd_restore_remote_backup.md`](./commands/sd_restore_remote_backup.md) |
+| `0x0C` | `SdRestoreRemoteBackup` | InSession | [`commands/sd_restore_remote_backup.md`](./commands/sd_restore_remote_backup.md) |
 | `0x0D` | `SdRestoreLocalBackup` | InSession | [`commands/sd_restore_local_backup.md`](./commands/sd_restore_local_backup.md) |
 | `0x0E` | `SdCreatePeerBackup` (schema-only) | InSession | [`commands/sd_create_peer_backup.md`](./commands/sd_create_peer_backup.md) |
 | `0x0F` | `SdRestorePeerBackup` (schema-only) | InSession | [`commands/sd_restore_peer_backup.md`](./commands/sd_restore_peer_backup.md) |

--- a/docs/tbor-ddi/commands/sd_restore_remote_backup.md
+++ b/docs/tbor-ddi/commands/sd_restore_remote_backup.md
@@ -5,16 +5,52 @@ Licensed under the MIT License.
 
 # SdRestoreRemoteBackup (Opcode 0x0C)
 
-**Handler:** _Not yet landed — wire schema only._
-**Session:** InSession
+**Handler:** `fw/core/lib/src/ddi/tbor/sd_restore_remote_backup.rs`
+**Session:** InSession (Crypto Officer)
 
 ## Description
 
-Restores a security domain from a remote backup: unmasks the
-caller-supplied remote partition-owner-key backup (`pok_remote_backup`, a
-masked BKS3) under the named sealing key, re-wraps it under the
-device-local key, and returns the local backup (`pok_local_backup`)
-together with the security-domain masking-key backup (`sd_mk_backup`).
+Restores a security domain from a **remote** backup (manticore §3.3.8) —
+the peer/migration recovery path.  It is **[`SdResealRemoteBackup`]'s
+HPKE-open front-end + [`SdRestoreLocalBackup`]'s provisioning back-end**:
+it HPKE-Auth-opens the caller-supplied `src_remote_backup` (an HPKE seal
+of BKS3) with the receiver's masked SD-sealing key — authenticated by the
+sender's attested key — recovers `SDMK` from `prev_sd_mk_backup`, and
+returns the device-local backups so the security domain can afterwards be
+restored locally without the sender.
+
+The provisioning half is shared with the local restore
+(`fw/core/lib/src/ddi/tbor/sd_backup.rs::reprovision_sd_from_bks3`).
+
+Algorithm:
+
+1. Gate to a Crypto-Officer, `Active` session on an `Initialized`
+   partition; fail-fast if the SD is already initialized
+   (`SdAlreadyInitialized`).
+2. Bind the caller-supplied `policy` to the partition's fixed
+   `policy_hash` (from `PartFinal`), then verify the **sender** evidence
+   against it: the manufacturer / owner / partition-owner certificate
+   chains are validated and anchored to the policy `SATA` key, the
+   report's v2 `policy_hash` must equal `SHA-384(policy)`, and its
+   attested COSE_Key is recovered as **`SndrPub`**.
+3. Unmask `masked_sealing_key` under its scope's masking key → the
+   receiver's private HPKE key **`RcvrPriv`** (must be an `SdSealing`
+   key), and derive `RcvrPub` on-device.
+4. HPKE-Auth-open `src_remote_backup` (`sk_r = RcvrPriv`, sender-auth
+   `SndrPub`) → **BKS3**.
+5. Recover `SDMK` from `prev_sd_mk_backup` (SDMK masked under the SDBMK
+   derived from BKS3 + the partition `policy_hash`), re-mask both backups
+   at the current `{svn, owner}`, vault `SDMK` (SecurityDomain scope),
+   record `SD_MK_KEY_ID`, and mark the partition SD-initialized —
+   undo-guarded.  `RcvrPriv`, BKS3, SDMK, and SDBMK are zeroized before
+   returning.
+
+The command is **stateful** (vaults `SDMK`, marks the partition
+SD-initialized) and **one-shot** per partition incarnation: a second
+create/restore returns `SdAlreadyInitialized`.  Because `masked_sealing_key`
+is bound to the device masking key, the realistic recovery sequence after
+a reboot is `PartInit` → `PartFinal(prev_local_mk_backup)` (which restores
+`PartLocalMK`) → `SdRestoreRemoteBackup`.
 
 ## Request
 
@@ -26,14 +62,14 @@ variable-length data section.
 | Offset | Field | Type | Description |
 |---|---|---|---|
 | 4  | `session_id` | `session_id` (inline) | Session this request is bound to; cross-checked against the SQE-carried session id. |
-| 8  | `sealing_key_id` | `key_id` (inline) | Vault id (`HsmKeyId`) of the sealing key the `pok_remote_backup` is bound to (`KeyId`, TOC entry type 1). |
-| 12 | `mfgr_cert_chain` | `buffer` (typed `&[CertDescriptor]`) | Sender manufacturer certificate-chain descriptors (from the `sender_evidence` field group). |
-| 16 | `owner_cert_chain` | `buffer` (typed `&[CertDescriptor]`) | Sender owner certificate-chain descriptors. |
-| 20 | `part_owner_cert_chain` | `buffer` (typed `&[CertDescriptor]`) | Sender partition-owner certificate-chain descriptors. |
-| 24 | `evidence` | `buffer` (single `&ReportDescriptor`, 4 B) | Sender attestation-report (COSE_Sign1) descriptor. |
-| 28 | `policy` | `buffer` (fixed 484 B) | Caller-asserted unified `PartPolicy` describing the security domain being restored. Length pinned to `PART_POLICY_LEN` (484 B); a wrong length is rejected at decode. |
-| 32 | `pok_remote_backup` | `buffer` (fixed 180 B) | Remote partition-owner-key backup to restore (a masked BKS3) = `MASKED_SD_LEN` (180 B). |
-| 36 | `sd_mk_backup` | `buffer` (offset/len) | Optional security-domain masking-key backup envelope. An **empty** field means absent; when present it is exactly `LOCAL_MK_BACKUP_LEN` (164 B). |
+| 8  | `masked_sealing_key` | `buffer` (fixed 180 B) | The **receiver's** masked SD-sealing key (from [`SdSealingKeyGen`](sd_sealing_key_gen.md)); unmasked on-device to recover the receiver's private HPKE key (`RcvrPriv`). Length pinned to `MASKED_SEALING_KEY_LEN` (180 B). Never a vault handle. |
+| 12 | `policy` | `buffer` (fixed 484 B) | Caller-asserted unified `PartPolicy` describing the security domain being restored. Length pinned to `PART_POLICY_LEN` (484 B); its SHA-384 digest must equal the partition's bound `policy_hash` and each report's v2 `policy_hash`. |
+| 16 | `mfgr_cert_chain` | `buffer` (typed `&[CertDescriptor]`) | Sender manufacturer certificate-chain descriptors (from the `sender_evidence` field group). |
+| 20 | `owner_cert_chain` | `buffer` (typed `&[CertDescriptor]`) | Sender owner certificate-chain descriptors. |
+| 24 | `part_owner_cert_chain` | `buffer` (typed `&[CertDescriptor]`) | Sender partition-owner certificate-chain descriptors. |
+| 28 | `evidence` | `buffer` (single `&ReportDescriptor`, 4 B) | Sender attestation-report (COSE_Sign1) descriptor. |
+| 32 | `src_remote_backup` | `buffer` (fixed 161 B) | Remote backup to restore: an HPKE-Auth seal of BKS3 = `POK_REMOTE_BACKUP_LEN` (161 B). |
+| 36 | `prev_sd_mk_backup` | `buffer` (fixed 164 B) | Previous security-domain masking-key backup (SDMK masked under the derived SDBMK) = `SD_MK_BACKUP_LEN` (164 B); `SDMK` is recovered from it. |
 
 The four `mfgr_cert_chain` … `evidence` entries are spliced in by the
 shared [`Evidence`](../../../fw/core/ddi/tbor/types/src/evidence.rs)
@@ -43,9 +79,9 @@ COSE_Sign1 report travel **out of band**, referenced by these
 
 ### Data section
 
-Carries the packed sender cert-chain and report descriptors, the
-484-byte `policy` image, the 180-byte `pok_remote_backup` blob, and (when
-present) the 164-byte `sd_mk_backup` envelope.
+Carries the 180-byte `masked_sealing_key`, the packed sender cert-chain
+and report descriptors, the 484-byte `policy` image, the 161-byte
+`src_remote_backup` seal, and the 164-byte `prev_sd_mk_backup` envelope.
 
 ## Response
 
@@ -56,8 +92,8 @@ section.
 
 | Offset | Field | Type | Description |
 |---|---|---|---|
-| 8  | `pok_local_backup` | `buffer` (fixed 180 B) | Partition-owner-key backup re-wrapped under the device-local key, sized as a masked BKS3 = `MASKED_SD_LEN` (180 B). |
-| 12 | `sd_mk_backup` | `buffer` (fixed 164 B) | Security-domain masking-key backup envelope = `LOCAL_MK_BACKUP_LEN` (164 B). |
+| 8  | `pok_local_backup` | `buffer` (fixed 180 B) | Local partition-owner-key backup (BKS3 re-masked under `PartLocalMK`), sized as a masked BKS3 = `MASKED_SD_LEN` (180 B). |
+| 12 | `sd_mk_backup` | `buffer` (fixed 164 B) | Refreshed security-domain masking-key backup envelope (SDMK re-masked under SDBMK) = `SD_MK_BACKUP_LEN` (164 B). |
 
 ### Data section
 
@@ -68,12 +104,24 @@ Carries the 180-byte `pok_local_backup` blob and the 164-byte
 
 | Error | Cause |
 |---|---|
-| `TborInvalidFixedLength` | `policy` is not exactly 484 B, or `pok_remote_backup` is not exactly 180 B (rejected at decode before the handler runs) |
-| `InvalidArg` | `sd_mk_backup` is present but not exactly 164 B |
-| `SessionNotFound` | `session_id` does not refer to an allocated slot |
-| `DdiDecodeFailed` | Malformed request body |
+| `TborInvalidFixedLength` | `masked_sealing_key` ≠ 180 B, `policy` ≠ 484 B, `src_remote_backup` ≠ 161 B, or `prev_sd_mk_backup` ≠ 164 B (rejected at decode before the handler runs) |
+| `InvalidArg` | Partition is not `Initialized` (not finalized); or the policy `SATA` key is not P-384; or the sender report's `policy_hash` ≠ `SHA-384(policy)`; or the opened backup is not a 48-byte BKS3 |
+| `SdAlreadyInitialized` | A security domain is already initialized on this partition incarnation (one-shot gate) |
+| `SdBackupSvnRollback` | A backup's bound SVN is newer than the current firmware SVN (anti-rollback) |
+| `UnsupportedKeyType` | `masked_sealing_key` is not an `SdSealing` key, or `prev_sd_mk_backup` is not an `SdMasking` envelope |
+| `AesGcmDecryptTagDoesNotMatch` | A backup blob is tampered or was masked/sealed under a different key (unmask / HPKE-open tag mismatch) |
+| Evidence errors | The sender certificate chains fail validation or do not anchor to the policy `SATA` key, or the report signature is invalid |
+| `InvalidPermissions` | Not a Crypto-Officer session |
+| `SessionNotFound` | `session_id` does not refer to an `Active` slot |
 
 ## See also
 
 - Wire encoding: [TBOR specification](../../../fw/core/ddi/tbor/docs/spec.md)
 - Wire schema: `fw/core/ddi/tbor/types/src/sd_restore_remote_backup.rs`
+- Shared SD-backup mechanics: `fw/core/lib/src/ddi/tbor/sd_backup.rs`
+- HPKE-open front-end: [`SdResealRemoteBackup`](sd_reseal_remote_backup.md)
+- Local recovery path: [`SdRestoreLocalBackup`](sd_restore_local_backup.md)
+- Producer of the remote backup: [`SdCreateRemoteBackup`](sd_create_remote_backup.md)
+
+[`SdResealRemoteBackup`]: sd_reseal_remote_backup.md
+[`SdRestoreLocalBackup`]: sd_restore_local_backup.md

--- a/fw/core/ddi/tbor/types/src/sd_restore_remote_backup.rs
+++ b/fw/core/ddi/tbor/types/src/sd_restore_remote_backup.rs
@@ -4,43 +4,51 @@
 //! TBOR `SdRestoreRemoteBackup` wire schema.
 //!
 //! `SdRestoreRemoteBackup` is an in-session command that restores a
-//! security domain from a remote backup: it unmasks the caller-supplied
-//! remote partition-owner-key backup (`pok_remote_backup`, a masked BKS3)
-//! under the named sealing key, re-wraps it under the device-local key,
-//! and returns the local backup (`pok_local_backup`) together with the
-//! security-domain masking-key backup (`sd_mk_backup`).
+//! security domain from a **remote** backup (manticore §3.3.8): it
+//! HPKE-Auth-opens the caller-supplied `src_remote_backup` (an HPKE seal
+//! of BKS3) with the masked receiver key — authenticated by the sender's
+//! attested key — recovers `SDMK` from `prev_sd_mk_backup`, and returns
+//! the device-local backups (`pok_local_backup`, `sd_mk_backup`) so the
+//! security domain can later be restored locally without the sender.
 //!
 //! Inputs:
 //!
 //! * `session_id` — TOC-carried session id; cross-checked against the
 //!   SQE-carried session id by the dispatcher (parity with the other
 //!   in-session commands).
-//! * `sealing_key_id` — vault id
-//!   ([`KeyId`](azihsm_fw_ddi_tbor_api::KeyId), TOC entry type 1) of the
-//!   sealing key the `pok_remote_backup` is bound to.
-//! * `sender_evidence` — sender side-band attestation evidence
-//!   ([`Evidence`](crate::evidence::Evidence) field group).
+//! * `masked_sealing_key` — the **receiver's** masked SD-sealing key (from
+//!   [`SdSealingKeyGen`](crate::sd_sealing_key_gen)), exactly
+//!   [`MASKED_SEALING_KEY_LEN`] (180 B).  Unmasked on-device to recover the
+//!   receiver's private HPKE key (`RcvrPriv`) that opens the backup; never
+//!   a vault handle.
 //! * `policy` — the unified [`PartPolicy`] describing the security domain
-//!   being restored.  Length pinned to [`PART_POLICY_LEN`] (484 B).
-//! * `pok_remote_backup` — the remote partition-owner-key backup to
-//!   restore (a masked BKS3), exactly [`MASKED_SD_LEN`] (180 B).
-//! * `sd_mk_backup` — **optional** security-domain masking-key backup
-//!   envelope.  An empty field means absent; when present it is exactly
-//!   [`LOCAL_MK_BACKUP_LEN`] (164 B).
+//!   being restored.  Length pinned to [`PART_POLICY_LEN`] (484 B); its
+//!   SHA-384 digest must equal the partition's bound `policy_hash` and each
+//!   report's v2 `policy_hash`.
+//! * `sender_evidence` — **sender** side-band attestation evidence
+//!   ([`Evidence`](crate::evidence::Evidence) field group); its attested
+//!   key is the sender public key that sealed `src_remote_backup`.
+//! * `src_remote_backup` — the remote backup to restore: an HPKE-Auth seal
+//!   of BKS3, exactly [`POK_REMOTE_BACKUP_LEN`] (161 B).
+//! * `prev_sd_mk_backup` — the previous security-domain masking-key backup
+//!   (SDMK masked under the derived SDBMK), exactly
+//!   [`SD_MK_BACKUP_LEN`] (164 B), from which `SDMK` is recovered.
 //!
 //! Output:
 //!
-//! * `pok_local_backup` — the partition-owner-key backup re-wrapped under
-//!   the device-local key, exactly [`MASKED_SD_LEN`] (180 B).
-//! * `sd_mk_backup` — the security-domain masking-key backup envelope,
-//!   exactly [`LOCAL_MK_BACKUP_LEN`] (164 B).
+//! * `pok_local_backup` — the local partition-owner-key backup (BKS3 masked
+//!   under `PartLocalMK`), exactly [`MASKED_SD_LEN`] (180 B).
+//! * `sd_mk_backup` — the refreshed security-domain masking-key backup
+//!   envelope, exactly [`SD_MK_BACKUP_LEN`] (164 B).
 
 use azihsm_fw_ddi_tbor_api::tbor;
 
 use crate::evidence::*;
-pub use crate::part_final::LOCAL_MK_BACKUP_LEN;
 pub use crate::policy::PART_POLICY_LEN;
 pub use crate::sd_create_remote_backup::MASKED_SD_LEN;
+pub use crate::sd_create_remote_backup::POK_REMOTE_BACKUP_LEN;
+pub use crate::sd_create_remote_backup::SD_MK_BACKUP_LEN;
+pub use crate::sd_sealing_key_gen::MASKED_SEALING_KEY_LEN;
 
 /// TBOR opcode for `SdRestoreRemoteBackup`.
 pub const TBOR_OP_SD_RESTORE_REMOTE_BACKUP: u8 = 0x0C;
@@ -50,15 +58,26 @@ pub const TBOR_OP_SD_RESTORE_REMOTE_BACKUP: u8 = 0x0C;
 // against the canonical value here.
 const _: () = assert!(PART_POLICY_LEN == 484);
 
-// `pok_remote_backup` / `pok_local_backup` are masked BKS3 envelopes; the
-// derive needs an integer literal on the field, so the length is spelled
-// out as `180` and pinned against the canonical value here.
+// `masked_sealing_key` is a masked SD-sealing key; the derive needs an
+// integer literal on the field, so the length is spelled out as `180` and
+// pinned against the canonical `MASKED_SEALING_KEY_LEN` here.
+const _: () = assert!(MASKED_SEALING_KEY_LEN == 180);
+
+// `src_remote_backup` is an HPKE-Auth seal; the derive needs an integer
+// literal on the field, so the length is spelled out as `161` and pinned
+// against `POK_REMOTE_BACKUP_LEN` here.
+const _: () = assert!(POK_REMOTE_BACKUP_LEN == 161);
+
+// `pok_local_backup` is a masked BKS3 envelope; the derive needs an integer
+// literal on the field, so the length is spelled out as `180` and pinned
+// against the canonical value here.
 const _: () = assert!(MASKED_SD_LEN == 180);
 
-// `sd_mk_backup` is a `local_mk`-style backup envelope; the derive needs
-// an integer literal on the field, so the length is spelled out as `164`
-// and pinned against the canonical value here.
-const _: () = assert!(LOCAL_MK_BACKUP_LEN == 164);
+// `prev_sd_mk_backup` / `sd_mk_backup` are `local_mk`-style backup
+// envelopes; the derive needs an integer literal on the field, so the
+// length is spelled out as `164` and pinned against the canonical value
+// here.
+const _: () = assert!(SD_MK_BACKUP_LEN == 164);
 
 /// `SdRestoreRemoteBackup` request schema.
 #[tbor(opcode = 0x0C)]
@@ -69,18 +88,11 @@ pub struct TborSdRestoreRemoteBackupReq<'a> {
     #[tbor(session_id)]
     pub session_id: SessionId,
 
-    /// Vault id ([`HsmKeyId`](azihsm_fw_hsm_pal_traits::HsmKeyId)) of the
-    /// sealing key the `pok_remote_backup` is bound to.  Carried as a
-    /// [`KeyId`](azihsm_fw_ddi_tbor_api::KeyId) (TOC entry type 1).
-    #[tbor(key_id)]
-    pub sealing_key_id: KeyId,
-
-    /// Sender side-band attestation evidence (manufacturer / owner /
-    /// partition-owner certificate chains plus the attestation report).
-    /// Spliced in as the [`Evidence`](crate::evidence::Evidence) field
-    /// group's four TOC entries.
-    #[tbor(include)]
-    pub sender_evidence: Evidence<'a>,
+    /// The receiver's masked SD-sealing key (from `SdSealingKeyGen`),
+    /// exactly [`MASKED_SEALING_KEY_LEN`] (180 B).  Unmasked on-device to
+    /// recover the receiver's private HPKE key (`RcvrPriv`).
+    #[tbor(buffer, len = 180)]
+    pub masked_sealing_key: &'a [u8],
 
     /// Caller-asserted unified [`PartPolicy`] describing the security
     /// domain being restored.  Length pinned to [`PART_POLICY_LEN`]
@@ -90,16 +102,23 @@ pub struct TborSdRestoreRemoteBackupReq<'a> {
     #[tbor(buffer, len = 484)]
     pub policy: &'a [u8],
 
-    /// Remote partition-owner-key backup to restore (a masked BKS3).
-    /// Always exactly [`MASKED_SD_LEN`] (180 B).
-    #[tbor(buffer, len = 180)]
-    pub pok_remote_backup: &'a [u8],
+    /// Sender side-band attestation evidence (manufacturer / owner /
+    /// partition-owner certificate chains plus the attestation report).
+    /// Spliced in as the [`Evidence`](crate::evidence::Evidence) field
+    /// group's four TOC entries; its attested key is the sender public key
+    /// that sealed `src_remote_backup`.
+    #[tbor(include)]
+    pub sender_evidence: Evidence<'a>,
 
-    /// Optional security-domain masking-key backup envelope.  An **empty**
-    /// field means absent; when present it is exactly
-    /// [`LOCAL_MK_BACKUP_LEN`] (164 B).
-    #[tbor(buffer, max_len = 164)]
-    pub sd_mk_backup: &'a [u8],
+    /// Remote backup to restore: an HPKE-Auth seal of BKS3.  Always exactly
+    /// [`POK_REMOTE_BACKUP_LEN`] (161 B).
+    #[tbor(buffer, len = 161)]
+    pub src_remote_backup: &'a [u8],
+
+    /// Previous security-domain masking-key backup (SDMK masked under the
+    /// derived SDBMK).  Always exactly [`SD_MK_BACKUP_LEN`] (164 B).
+    #[tbor(buffer, len = 164)]
+    pub prev_sd_mk_backup: &'a [u8],
 }
 
 /// `SdRestoreRemoteBackup` response schema.
@@ -111,7 +130,7 @@ pub struct TborSdRestoreRemoteBackupResp<'a> {
     pub pok_local_backup: &'a [u8],
 
     /// Security-domain masking-key backup envelope.  Always exactly
-    /// [`LOCAL_MK_BACKUP_LEN`] (164 B).
+    /// [`SD_MK_BACKUP_LEN`] (164 B).
     #[tbor(buffer, len = 164)]
     pub sd_mk_backup: &'a [u8],
 }
@@ -120,16 +139,16 @@ pub struct TborSdRestoreRemoteBackupResp<'a> {
 mod tests {
     #![allow(clippy::unwrap_used)]
 
-    use azihsm_fw_ddi_tbor_api::KeyId;
     use azihsm_fw_ddi_tbor_api::SessionId;
 
     use super::*;
 
     #[test]
     fn request_round_trips_fields() {
+        let masked = [0u8; MASKED_SEALING_KEY_LEN];
         let policy = [0u8; PART_POLICY_LEN];
-        let pok_remote = [0xABu8; MASKED_SD_LEN];
-        let sd_mk = [0xCDu8; LOCAL_MK_BACKUP_LEN];
+        let src_remote = [0xABu8; POK_REMOTE_BACKUP_LEN];
+        let prev_sd_mk = [0xCDu8; SD_MK_BACKUP_LEN];
         let cert = CertDescriptor {
             index: 0,
             length: crate::tbor_int::U16::new(8),
@@ -139,12 +158,14 @@ mod tests {
             length: crate::tbor_int::U16::new(16),
         };
         let chain = [cert];
-        let mut buf = [0u8; 1024];
+        let mut buf = [0u8; 2048];
         let frame = TborSdRestoreRemoteBackupReq::encode(&mut buf)
             .unwrap()
             .session_id(SessionId(7))
             .unwrap()
-            .sealing_key_id(KeyId(0x5678))
+            .masked_sealing_key(&masked)
+            .unwrap()
+            .policy(&policy)
             .unwrap()
             .sender_evidence(|e| {
                 e.mfgr_cert_chain(&chain)?
@@ -153,59 +174,21 @@ mod tests {
                     .evidence(&report)
             })
             .unwrap()
-            .policy(&policy)
+            .src_remote_backup(&src_remote)
             .unwrap()
-            .pok_remote_backup(&pok_remote)
-            .unwrap()
-            .sd_mk_backup(&sd_mk)
+            .prev_sd_mk_backup(&prev_sd_mk)
             .unwrap()
             .finish();
+        assert_eq!(frame.masked_sealing_key().len(), MASKED_SEALING_KEY_LEN);
         assert_eq!(frame.policy().len(), PART_POLICY_LEN);
-        assert_eq!(frame.pok_remote_backup().len(), MASKED_SD_LEN);
-        assert_eq!(frame.sd_mk_backup().len(), LOCAL_MK_BACKUP_LEN);
-    }
-
-    #[test]
-    fn request_accepts_absent_sd_mk_backup() {
-        let policy = [0u8; PART_POLICY_LEN];
-        let pok_remote = [0xABu8; MASKED_SD_LEN];
-        let cert = CertDescriptor {
-            index: 0,
-            length: crate::tbor_int::U16::new(8),
-        };
-        let report = ReportDescriptor {
-            index: 1,
-            length: crate::tbor_int::U16::new(16),
-        };
-        let chain = [cert];
-        let mut buf = [0u8; 1024];
-        let frame = TborSdRestoreRemoteBackupReq::encode(&mut buf)
-            .unwrap()
-            .session_id(SessionId(7))
-            .unwrap()
-            .sealing_key_id(KeyId(0x5678))
-            .unwrap()
-            .sender_evidence(|e| {
-                e.mfgr_cert_chain(&chain)?
-                    .owner_cert_chain(&chain)?
-                    .part_owner_cert_chain(&chain)?
-                    .evidence(&report)
-            })
-            .unwrap()
-            .policy(&policy)
-            .unwrap()
-            .pok_remote_backup(&pok_remote)
-            .unwrap()
-            .sd_mk_backup(&[])
-            .unwrap()
-            .finish();
-        assert!(frame.sd_mk_backup().is_empty());
+        assert_eq!(frame.src_remote_backup().len(), POK_REMOTE_BACKUP_LEN);
+        assert_eq!(frame.prev_sd_mk_backup().len(), SD_MK_BACKUP_LEN);
     }
 
     #[test]
     fn response_round_trips_backups() {
         let pok_local = [0xABu8; MASKED_SD_LEN];
-        let sd_mk = [0xCDu8; LOCAL_MK_BACKUP_LEN];
+        let sd_mk = [0xCDu8; SD_MK_BACKUP_LEN];
         let mut buf = [0u8; 512];
         let frame = TborSdRestoreRemoteBackupResp::encode(&mut buf, 0, true)
             .unwrap()
@@ -215,6 +198,6 @@ mod tests {
             .unwrap()
             .finish();
         assert_eq!(frame.pok_local_backup().len(), MASKED_SD_LEN);
-        assert_eq!(frame.sd_mk_backup().len(), LOCAL_MK_BACKUP_LEN);
+        assert_eq!(frame.sd_mk_backup().len(), SD_MK_BACKUP_LEN);
     }
 }

--- a/fw/core/lib/src/ddi/tbor/mod.rs
+++ b/fw/core/lib/src/ddi/tbor/mod.rs
@@ -32,6 +32,7 @@ pub(crate) mod sd_backup;
 pub(crate) mod sd_create_remote_backup;
 pub(crate) mod sd_reseal_remote_backup;
 pub(crate) mod sd_restore_local_backup;
+pub(crate) mod sd_restore_remote_backup;
 pub(crate) mod sd_sealing_key_gen;
 pub(crate) mod session_close;
 pub(crate) mod session_open_finish;
@@ -127,6 +128,13 @@ pub(crate) mod opcode {
     /// recovered BKS3 to the destination receiver.  See
     /// [`super::sd_reseal_remote_backup`].
     pub(crate) const SD_RESEAL_REMOTE_BACKUP: u8 = 0x0B;
+
+    /// `SdRestoreRemoteBackup` — restore a security domain from a remote
+    /// backup: HPKE-Auth-open `src_remote_backup` with the masked receiver
+    /// key (authenticated by the sender's attested key), recover SDMK from
+    /// `prev_sd_mk_backup`, and re-provision the SD.  See
+    /// [`super::sd_restore_remote_backup`].
+    pub(crate) const SD_RESTORE_REMOTE_BACKUP: u8 = 0x0C;
 
     /// `SdRestoreLocalBackup` — restore a security domain from its
     /// device-local backups: unmask `pok_local_backup` (BKS3 under
@@ -273,6 +281,9 @@ pub(crate) async fn dispatch<'p, P: HsmPal>(
         opcode::SD_RESEAL_REMOTE_BACKUP => {
             sd_reseal_remote_backup::handle(pal, io, req_buf, oob).await
         }
+        opcode::SD_RESTORE_REMOTE_BACKUP => {
+            sd_restore_remote_backup::handle(pal, io, req_buf, oob, undo).await
+        }
         opcode::SD_RESTORE_LOCAL_BACKUP => {
             sd_restore_local_backup::handle(pal, io, req_buf, undo).await
         }
@@ -299,6 +310,7 @@ fn is_known_opcode(opcode: u8) -> bool {
             | opcode::SD_SEALING_KEY_GEN
             | opcode::SD_CREATE_REMOTE_BACKUP
             | opcode::SD_RESEAL_REMOTE_BACKUP
+            | opcode::SD_RESTORE_REMOTE_BACKUP
             | opcode::SD_RESTORE_LOCAL_BACKUP
             | opcode::KEY_REPORT
     )
@@ -330,6 +342,7 @@ fn is_in_session(opcode: u8) -> bool {
         | opcode::SD_SEALING_KEY_GEN
         | opcode::SD_CREATE_REMOTE_BACKUP
         | opcode::SD_RESEAL_REMOTE_BACKUP
+        | opcode::SD_RESTORE_REMOTE_BACKUP
         | opcode::SD_RESTORE_LOCAL_BACKUP
         | opcode::KEY_REPORT => true,
         // Default-deny: any future opcode is treated as in-session
@@ -369,6 +382,7 @@ fn needs_session_id_cross_check(opcode: u8) -> bool {
         | opcode::SD_SEALING_KEY_GEN
         | opcode::SD_CREATE_REMOTE_BACKUP
         | opcode::SD_RESEAL_REMOTE_BACKUP
+        | opcode::SD_RESTORE_REMOTE_BACKUP
         | opcode::SD_RESTORE_LOCAL_BACKUP
         | opcode::KEY_REPORT => true,
         _ => true,

--- a/fw/core/lib/src/ddi/tbor/sd_backup.rs
+++ b/fw/core/lib/src/ddi/tbor/sd_backup.rs
@@ -23,6 +23,8 @@
 
 use azihsm_fw_core_crypto_key_derive::derive_masking_key;
 use azihsm_fw_core_crypto_key_masking::aead::mask;
+use azihsm_fw_core_crypto_key_masking::aead::peek_metadata;
+use azihsm_fw_core_crypto_key_masking::aead::unmask;
 use azihsm_fw_core_crypto_key_masking::aead::AeadAlg;
 use azihsm_fw_core_crypto_key_masking::aead::MaskParams;
 use azihsm_fw_ddi_tbor_types::MASKED_SD_LEN;
@@ -202,6 +204,93 @@ pub(super) async fn mask_pok_local_backup<P: HsmPal>(
         return Err(HsmError::InternalError);
     }
     Ok(())
+}
+
+/// Re-provision the security domain from a recovered `bks3` and the
+/// previous SD masking-key backup.
+///
+/// Shared by the restore commands (local unmasks `bks3` from
+/// `pok_local_backup`; remote HPKE-opens it from `src_remote_backup`).
+/// Given the recovered `bks3` and the caller-staged `prev_sd_mk_scratch`
+/// (SDMK masked under SDBMK, unmasked here in place), it: re-derives the
+/// `SDBMK` that masked `prev_sd_mk_scratch` at the *backup's own*
+/// `{svn, owner}` (peeked from its cleartext metadata) so an older-SVN
+/// backup unmasks on newer firmware, recovers `SDMK` (checking the
+/// `SdMasking` kind and anti-rollback SVN), re-masks both backups at the
+/// *current* `{svn, owner}` into `pok_local_out` / `sd_mk_out`, and commits
+/// the SD to the vault (undo-guarded).
+///
+/// The caller wipes `bks3` and `prev_sd_mk_scratch`; both derived `SDBMK`s
+/// are scrubbed here on every exit path.
+#[allow(clippy::too_many_arguments)]
+pub(super) async fn reprovision_sd_from_bks3<'p, P: HsmPal>(
+    pal: &P,
+    io: &impl HsmIo,
+    alloc: &impl HsmScopedAlloc,
+    undo: &mut UndoLog<'p>,
+    svn: u64,
+    owner: u16,
+    bks3: &DmaBuf,
+    prev_sd_mk_scratch: &mut DmaBuf,
+    pok_local_out: &mut DmaBuf,
+    sd_mk_out: &mut DmaBuf,
+) -> HsmResult<()> {
+    // Peek the previous sd_mk_backup's own cleartext `{svn, owner}`.  SDBMK is
+    // bound to `{svn, owner}` (KBKDF over `mfgr_seed[svn] ‖ owner_seed[owner]`),
+    // so the backup must be unmasked with SDBMK re-derived at the SVN/owner it
+    // was *minted* under — not the current platform's.  The versioned device
+    // seeds are forward-derivable, so this is what lets an older-SVN backup be
+    // restored on newer firmware; deriving at the current SVN would fail the
+    // AEAD tag and break that (spec-mandated) forward-restore.  The peeked
+    // values are NOT yet authenticated (`peek_metadata` does not verify the
+    // tag); `unmask` below authenticates them and the anti-rollback check is
+    // deferred until after it succeeds.  Mirrors `restore_part_local_mk` in
+    // `part_final`.
+    let (prev_svn, prev_owner) = {
+        let meta = peek_metadata(prev_sd_mk_scratch)?;
+        (meta.svn.get(), meta.owner_seed_id.get())
+    };
+
+    // SDBMK for the UNMASK, derived at the backup's own `{svn, owner}`; and
+    // SDBMK for the RE-MASK, derived at the current `{svn, owner}` so the
+    // refreshed envelope is bound to this firmware's identity.  Both are their
+    // own scratch allocations (scope rewind does not clear DMA memory), so both
+    // are zeroized on EVERY exit path below.
+    let sdbmk_prev = derive_sdbmk(pal, io, alloc, bks3, prev_svn, prev_owner).await?;
+    let sdbmk_curr = derive_sdbmk(pal, io, alloc, bks3, svn, owner).await?;
+    let res = async {
+        let sdmk = {
+            let view = unmask(pal, io, sdbmk_prev, prev_sd_mk_scratch).await?;
+            if !matches!(view.key_kind, HsmVaultKeyKind::SdMasking) {
+                return Err(HsmError::UnsupportedKeyType);
+            }
+            // Anti-rollback: a backup minted under a newer SVN cannot be
+            // restored on this (older) firmware.  Enforced on the now-
+            // authenticated `view.svn` (== `prev_svn`) after the AEAD tag
+            // authenticates the envelope.
+            if view.svn > svn {
+                return Err(HsmError::SdBackupSvnRollback);
+            }
+            // Firmware invariant (tag-authenticated): a genuine backup always
+            // carries an `SDMK_LEN` key; a mismatch signals corruption / a
+            // sizing bug, not a client error.
+            if view.target_key.len() != SDMK_LEN {
+                return Err(HsmError::InternalError);
+            }
+            view.target_key
+        };
+
+        // Re-mask both backups at the current `{svn, owner}`.
+        mask_pok_local_backup(pal, io, alloc, bks3, svn, owner, pok_local_out).await?;
+        mask_sd_mk_backup(pal, io, alloc, sdbmk_curr, sdmk, svn, owner, sd_mk_out).await?;
+
+        // Commit: vault SDMK, mark SD-initialized (undo-guarded).
+        commit_sd_to_vault(pal, io, undo, sdmk).await
+    }
+    .await;
+    sdbmk_curr.zeroize();
+    sdbmk_prev.zeroize();
+    res
 }
 
 /// Commit the security domain: mark it initialized, vault the `SDMK`, and

--- a/fw/core/lib/src/ddi/tbor/sd_restore_local_backup.rs
+++ b/fw/core/lib/src/ddi/tbor/sd_restore_local_backup.rs
@@ -24,10 +24,8 @@
 //!    [`SdPartitionOwnerSeed`](HsmVaultKeyKind::SdPartitionOwnerSeed)
 //!    envelope, and its bound SVN must not be newer than the current
 //!    firmware SVN ([`SdBackupSvnRollback`](HsmError::SdBackupSvnRollback)).
-//! 3. Derive `SDBMK` from BKS3 + the partition `policy_hash` at the
-//!    `sd_mk_backup`'s *own* `{svn, owner}` (peeked from its metadata, so an
-//!    older-SVN backup unmasks on newer firmware), then unmask `sd_mk_backup`
-//!    under `SDBMK` → **SDMK** (must be an
+//! 3. Derive `SDBMK` from BKS3 + the partition `policy_hash`, then unmask
+//!    `sd_mk_backup` under `SDBMK` → **SDMK** (must be an
 //!    [`SdMasking`](HsmVaultKeyKind::SdMasking) envelope; same anti-rollback).
 //! 4. Re-mask both at the current `{svn, owner}`: `CurrSDLocalBackup =
 //!    mask(BKS3, PartLocalMK)` and `CurrSDKMKBackup = mask(SDMK, SDBMK)`.
@@ -41,7 +39,6 @@
 //!
 //! This command is **Crypto-Officer-only**.
 
-use azihsm_fw_core_crypto_key_masking::aead::peek_metadata;
 use azihsm_fw_core_crypto_key_masking::aead::unmask;
 use azihsm_fw_ddi_tbor_types::TborSdRestoreLocalBackupReq;
 use azihsm_fw_ddi_tbor_types::TborSdRestoreLocalBackupResp;
@@ -143,59 +140,21 @@ pub(crate) async fn handle<'p, P: HsmPal>(
                 view.target_key
             };
 
-            // ── Recover SDMK, re-mask, and commit ──
-            // Re-derive the SDBMK that masked `sd_mk_backup` at the backup's
-            // OWN {svn, owner} (peeked from its cleartext metadata) so an
-            // older-SVN backup unmasks on newer firmware — the versioned device
-            // seeds are forward-derivable, and deriving at the current SVN would
-            // fail the AEAD tag.  The peeked values are authenticated by the
-            // `unmask` tag below; the anti-rollback check is deferred until
-            // after it.  A second SDBMK at the current {svn, owner} re-masks the
-            // refreshed backup.  Both are their own scratch allocations (not
-            // views into the scrubbed staging buffers) and scope rewind does not
-            // clear DMA memory, so both are zeroized on EVERY path below.
-            // Mirrors `restore_part_local_mk` in `part_final`.
-            let (prev_svn, prev_owner) = {
-                let meta = peek_metadata(mk_scratch)?;
-                (meta.svn.get(), meta.owner_seed_id.get())
-            };
-            let sdbmk_prev =
-                sd_backup::derive_sdbmk(pal, io, alloc, bks3, prev_svn, prev_owner).await?;
-            let sdbmk_curr = sd_backup::derive_sdbmk(pal, io, alloc, bks3, svn, owner).await?;
-            let inner = async {
-                let sdmk = {
-                    let view = unmask(pal, io, sdbmk_prev, mk_scratch).await?;
-                    if !matches!(view.key_kind, HsmVaultKeyKind::SdMasking) {
-                        return Err(HsmError::UnsupportedKeyType);
-                    }
-                    // Anti-rollback on the now-authenticated `view.svn`.
-                    if view.svn > svn {
-                        return Err(HsmError::SdBackupSvnRollback);
-                    }
-                    // Firmware invariant (tag-authenticated): a genuine backup
-                    // always carries an `SDMK_LEN` key; a mismatch signals
-                    // corruption / a sizing bug, not a client error.
-                    if view.target_key.len() != sd_backup::SDMK_LEN {
-                        return Err(HsmError::InternalError);
-                    }
-                    view.target_key
-                };
-
-                // ── Re-mask both at the current {svn, owner} ──
-                sd_backup::mask_pok_local_backup(pal, io, alloc, bks3, svn, owner, pok_local_out)
-                    .await?;
-                sd_backup::mask_sd_mk_backup(
-                    pal, io, alloc, sdbmk_curr, sdmk, svn, owner, sd_mk_out,
-                )
-                .await?;
-
-                // ── Commit: vault SDMK, mark SD-initialized (undo-guarded) ──
-                sd_backup::commit_sd_to_vault(pal, io, undo, sdmk).await
-            }
-            .await;
-            sdbmk_curr.zeroize();
-            sdbmk_prev.zeroize();
-            inner
+            // Recover SDMK from `mk_scratch`, re-mask both backups, and
+            // commit the SD to the vault (shared with the remote restore).
+            sd_backup::reprovision_sd_from_bks3(
+                pal,
+                io,
+                alloc,
+                undo,
+                svn,
+                owner,
+                bks3,
+                mk_scratch,
+                pok_local_out,
+                sd_mk_out,
+            )
+            .await
         }
         .await;
 

--- a/fw/core/lib/src/ddi/tbor/sd_restore_remote_backup.rs
+++ b/fw/core/lib/src/ddi/tbor/sd_restore_remote_backup.rs
@@ -1,0 +1,313 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! TBOR `SdRestoreRemoteBackup` handler.
+//!
+//! Restores a security domain from a **remote** backup (manticore §3.3.8):
+//! it HPKE-Auth-opens the caller-supplied `src_remote_backup` (an HPKE seal
+//! of BKS3) with the receiver's masked SD-sealing key — authenticated by
+//! the sender's attested key — recovers `SDMK` from `prev_sd_mk_backup`,
+//! and returns the device-local backups so the security domain can later be
+//! restored locally without the sender.
+//!
+//! It is **reseal's open front-end + the shared SD provisioning back-end**:
+//! the open half mirrors [`SdResealRemoteBackup`](super::sd_reseal_remote_backup),
+//! and the provisioning half is shared with
+//! [`SdRestoreLocalBackup`](super::sd_restore_local_backup) via
+//! [`sd_backup::reprovision_sd_from_bks3`](super::sd_backup::reprovision_sd_from_bks3).
+//!
+//! Flow:
+//!
+//! 1. Decode; gate to a Crypto-Officer, `Active` session on an
+//!    `Initialized` partition, and fail-fast if the SD is already
+//!    initialized ([`SdAlreadyInitialized`](HsmError::SdAlreadyInitialized)).
+//! 2. Bind the caller-supplied [`PartPolicy`] to the partition's fixed
+//!    `policy_hash`, then verify the **sender** evidence against it: its
+//!    cert chains are validated and anchored to the policy SATA key, its
+//!    report's v2 `policy_hash` must equal `SHA-384(policy)`, and its
+//!    attested COSE_Key is recovered as `SndrPub`.
+//! 3. Unmask `masked_sealing_key` → `RcvrPriv` (must be an
+//!    [`SdSealing`](HsmVaultKeyKind::SdSealing) key) and derive `RcvrPub`.
+//! 4. HPKE-Auth-open `src_remote_backup` (`sk_r = RcvrPriv`, sender-auth
+//!    `SndrPub`) → **BKS3**.
+//! 5. Recover `SDMK` from `prev_sd_mk_backup`, re-mask both backups, vault
+//!    `SDMK`, and mark the partition SD-initialized — undo-guarded (shared
+//!    [`reprovision_sd_from_bks3`](super::sd_backup::reprovision_sd_from_bks3)).
+//!    `RcvrPriv`, BKS3, SDMK, and SDBMK are zeroized before returning.
+//!
+//! **Stateful & one-shot** (parity with the other SD-provisioning
+//! commands).  This command is **Crypto-Officer-only**.
+//!
+//! [`PartPolicy`]: super::policy
+
+use azihsm_fw_core_crypto_hpke::open;
+use azihsm_fw_core_crypto_hpke::HpkeOpenConfig;
+use azihsm_fw_core_crypto_hpke::HpkeSuite;
+use azihsm_fw_core_crypto_key_masking::aead::peek_metadata;
+use azihsm_fw_core_crypto_key_masking::aead::unmask;
+use azihsm_fw_core_crypto_key_report::POLICY_HASH_LEN;
+use azihsm_fw_core_evidence::verify_evidence;
+use azihsm_fw_core_evidence::EvidenceRefs;
+use azihsm_fw_core_evidence::TrustAnchors;
+use azihsm_fw_core_evidence::ATTESTED_KEY_LEN;
+use azihsm_fw_ddi_tbor_types::policy::PolicyKeyKind;
+use azihsm_fw_ddi_tbor_types::policy::POLICY_MAX_KEY_LEN;
+use azihsm_fw_ddi_tbor_types::TborSdRestoreRemoteBackupReq;
+use azihsm_fw_ddi_tbor_types::TborSdRestoreRemoteBackupResp;
+use azihsm_fw_ddi_tbor_types::MASKED_SD_LEN;
+use azihsm_fw_ddi_tbor_types::MASKED_SEALING_KEY_LEN;
+use azihsm_fw_ddi_tbor_types::POK_REMOTE_BACKUP_LEN;
+use azihsm_fw_ddi_tbor_types::SD_MK_BACKUP_LEN;
+use azihsm_fw_hsm_oob::OobPtr;
+use azihsm_fw_hsm_pal_traits::DmaBuf;
+use azihsm_fw_hsm_pal_traits::HsmEccCurve;
+use azihsm_fw_hsm_pal_traits::HsmError;
+use azihsm_fw_hsm_pal_traits::HsmHashAlgo;
+use azihsm_fw_hsm_pal_traits::HsmIo;
+use azihsm_fw_hsm_pal_traits::HsmPal;
+use azihsm_fw_hsm_pal_traits::HsmResult;
+use azihsm_fw_hsm_pal_traits::HsmScopedAlloc;
+use azihsm_fw_hsm_pal_traits::HsmSessId;
+use azihsm_fw_hsm_pal_traits::HsmVaultKeyKind;
+use azihsm_fw_hsm_pal_traits::PartState;
+use azihsm_fw_hsm_undo::UndoLog;
+
+use super::masking_key_id_for_scope;
+use super::part_final::verify_policy_hash;
+use super::sd_backup;
+use super::validate_crypto_officer_active_session;
+use crate::part_state;
+
+/// NIST curve for the SD sealing keys and the remote-backup HPKE seal.
+const SD_CURVE: HsmEccCurve = HsmEccCurve::P384;
+
+/// HPKE ciphersuite for the remote-backup seal.
+const HPKE_SUITE: HpkeSuite = HpkeSuite::DHKemP384Sha384AesGcm256;
+
+/// Length of the BKS3 carried inside the remote backup.
+const BKS3_LEN: usize = 48;
+
+/// SEC1 uncompressed point tag (`0x04 ‖ X ‖ Y`).
+const SEC1_UNCOMPRESSED: u8 = 0x04;
+
+/// Length of the HPKE encapsulated key `enc` (P-384 SEC1 uncompressed).
+const SD_ENC_LEN: usize = 1 + 2 * 48;
+
+// A remote backup is `enc(97) ‖ ct(BKS3 48 + GCM tag 16 = 64)` = 161 B.
+const _: () = assert!(SD_ENC_LEN + (BKS3_LEN + 16) == POK_REMOTE_BACKUP_LEN);
+
+/// Handle a TBOR `SdRestoreRemoteBackup` request.
+///
+/// **Stateful**: re-provisions the security-domain masking key (`SDMK`) in
+/// the vault and marks the partition security-domain-initialized, guarded
+/// by the per-command `undo` log.  The one-shot `SD_INITIALIZED` claim is
+/// the race-winner gate against a concurrently-dispatched create/restore.
+pub(crate) async fn handle<'p, P: HsmPal>(
+    pal: &'p P,
+    io: &impl HsmIo,
+    req_buf: &mut DmaBuf,
+    oob: Option<OobPtr>,
+    undo: &mut UndoLog<'p>,
+) -> HsmResult<&'p DmaBuf> {
+    // Session/state gating + masking-key routing use only the shared
+    // `decode` view.  `mk_key_id` is `Copy`, so it outlives the view.
+    let mk_key_id = {
+        let req = TborSdRestoreRemoteBackupReq::decode(&*req_buf)?;
+        let sess_id = HsmSessId::from(u16::from(req.session_id()));
+        validate_crypto_officer_active_session(pal, io, sess_id)?;
+
+        // The SD masking keys / policy hash are provisioned by `PartFinal`,
+        // so the partition must be finalized (`Initialized`).
+        if part_state::part_state(pal, io)? != PartState::Initialized {
+            return Err(HsmError::InvalidArg);
+        }
+
+        // Fail-fast: a restore onto an already-initialized security domain
+        // is rejected.  The atomic `SD_INITIALIZED` claim in the commit
+        // phase is the authoritative race-winner gate.
+        if part_state::part_is_sd_initialized(pal, io)? {
+            return Err(HsmError::SdAlreadyInitialized);
+        }
+
+        // Route the masked receiver key to its masking key via the
+        // cleartext, tag-bound metadata (before unmasking).
+        let scope = peek_metadata(req.masked_sealing_key())?
+            .usage_flags()
+            .scope();
+        masking_key_id_for_scope(pal, io, scope)?
+    };
+
+    // The sender attestation evidence is mandatory side-band data carried
+    // in the out-of-band SGL page.
+    let oob = oob.ok_or(HsmError::InvalidArg)?;
+
+    // Allocate the two fixed-size response backups in the IO scope so they
+    // survive the crypto scratch allocator's reset.
+    let pok_local_out = pal.dma_alloc(io, MASKED_SD_LEN)?;
+    let sd_mk_out = pal.dma_alloc(io, SD_MK_BACKUP_LEN)?;
+
+    pal.alloc_scoped_async(io, async |alloc| -> HsmResult<()> {
+        let coord = SD_CURVE.priv_key_len();
+        let (svn, owner) = sd_backup::platform_svn_owner(pal)?;
+
+        // `pk_sndr` (the attested `SndrPub`) is recovered by the evidence
+        // check in phase 1 and consumed by the HPKE open in phase 2.
+        let pk_sndr = alloc.dma_alloc(ATTESTED_KEY_LEN)?;
+
+        // ── Phase 1: policy binding + sender evidence (shared view) ──
+        {
+            let req = TborSdRestoreRemoteBackupReq::decode(&*req_buf)?;
+            let policy = req.policy();
+
+            // The re-supplied policy must match the one bound at `PartInit`.
+            verify_policy_hash(pal, io, alloc, policy).await?;
+            let part_policy = super::policy::from_bytes(policy)?;
+            let sata = &part_policy.sata_pub_key;
+            if sata.kind() != PolicyKeyKind::Ecc384 || sata.len() != POLICY_MAX_KEY_LEN {
+                return Err(HsmError::InvalidArg);
+            }
+
+            // The sender's report must attest to the same policy.
+            let expected = alloc.dma_alloc(POLICY_HASH_LEN)?;
+            pal.hash(io, HsmHashAlgo::Sha384, policy, expected, true)
+                .await?;
+
+            let src_hash = alloc.dma_alloc(POLICY_HASH_LEN)?;
+            {
+                let ev = req.sender_evidence();
+                verify_evidence(
+                    pal,
+                    io,
+                    &oob,
+                    &EvidenceRefs {
+                        mfgr_chain: ev.mfgr_cert_chain(),
+                        owner_chain: ev.owner_cert_chain(),
+                        part_owner_chain: ev.part_owner_cert_chain(),
+                        report: ev.evidence(),
+                    },
+                    &TrustAnchors {
+                        sata: &sata.data[..POLICY_MAX_KEY_LEN],
+                    },
+                    pk_sndr,
+                    Some(src_hash),
+                )
+                .await?;
+            }
+            if src_hash[..POLICY_HASH_LEN] != expected[..POLICY_HASH_LEN] {
+                return Err(HsmError::InvalidArg);
+            }
+        }
+
+        // ── Phase 2: recover RcvrPriv, HPKE-open the source backup, and
+        // re-provision the SD.  The masked key, source backup, and previous
+        // masking-key backup are copied into crypto scratch so the
+        // request-buffer borrow is confined; every recovered secret is
+        // scrubbed on EVERY exit path (scope rewind does not clear DMA).
+        let masking_key = pal.vault_key(io, mk_key_id)?;
+
+        let blob = alloc.dma_alloc(MASKED_SEALING_KEY_LEN)?;
+        let src_backup = alloc.dma_alloc(POK_REMOTE_BACKUP_LEN)?;
+        let prev_sd_mk = alloc.dma_alloc(SD_MK_BACKUP_LEN)?;
+        {
+            let req = TborSdRestoreRemoteBackupReq::decode(&*req_buf)?;
+            blob.copy_from_slice(req.masked_sealing_key());
+            src_backup.copy_from_slice(req.src_remote_backup());
+            prev_sd_mk.copy_from_slice(req.prev_sd_mk_backup());
+        }
+
+        // Unmask into `blob`, copy the recovered private key out into its
+        // own scratch, then scrub `blob` immediately.
+        let unmask_res = async {
+            let view = unmask(pal, io, masking_key, blob).await?;
+            let rcvr_priv = alloc.dma_alloc(view.target_key.len())?;
+            rcvr_priv.copy_from_slice(view.target_key);
+            Ok::<_, HsmError>((view.key_kind, rcvr_priv))
+        }
+        .await;
+        blob.zeroize();
+        let (key_kind, rcvr_priv) = unmask_res?;
+
+        let crypto_res = async {
+            if !matches!(key_kind, HsmVaultKeyKind::SdSealing) {
+                return Err(HsmError::UnsupportedKeyType);
+            }
+
+            // Receiver public key (`RcvrPub`) in SEC1 BE, derived on-device
+            // from the recovered private key.
+            let pk_r = alloc.dma_alloc(1 + 2 * coord)?;
+            pal.ecc_pub_from_priv(io, SD_CURVE, rcvr_priv, &mut pk_r[1..1 + 2 * coord])
+                .await?;
+            pk_r[0] = SEC1_UNCOMPRESSED;
+            pk_r[1..1 + coord].reverse();
+            pk_r[1 + coord..1 + 2 * coord].reverse();
+
+            // HPKE `open` needs a plaintext buffer at least the ciphertext
+            // length (`ct` = BKS3 + GCM tag = 64 B); the recovered BKS3
+            // occupies its first `BKS3_LEN` bytes.  Both hold secret
+            // material and are scrubbed on all paths.
+            let pt_buf = alloc.dma_alloc(POK_REMOTE_BACKUP_LEN - SD_ENC_LEN)?;
+            let bks3 = alloc.dma_alloc(BKS3_LEN)?;
+            let inner = async {
+                // ── Open the source backup with RcvrPriv, authenticated by
+                // the sender key (`SndrPub`).
+                let (enc, ct) = src_backup.split_at(SD_ENC_LEN);
+                let open_cfg = HpkeOpenConfig::auth(HPKE_SUITE, rcvr_priv, pk_r, &[], &[], pk_sndr);
+                let pt_len =
+                    open(pal, io, &open_cfg, enc, ct, Some(&mut pt_buf[..]), alloc).await?;
+                if pt_len != BKS3_LEN {
+                    return Err(HsmError::InvalidArg);
+                }
+                bks3.copy_from_slice(&pt_buf[..BKS3_LEN]);
+
+                // ── Recover SDMK, re-mask both backups, and commit the SD
+                // to the vault (shared with the local restore).
+                sd_backup::reprovision_sd_from_bks3(
+                    pal,
+                    io,
+                    alloc,
+                    undo,
+                    svn,
+                    owner,
+                    bks3,
+                    prev_sd_mk,
+                    pok_local_out,
+                    sd_mk_out,
+                )
+                .await
+            }
+            .await;
+
+            bks3.zeroize();
+            pt_buf.zeroize();
+            prev_sd_mk.zeroize();
+            inner
+        }
+        .await;
+
+        // Scrub the recovered receiver private key on every path.
+        rcvr_priv.zeroize();
+        crypto_res?;
+
+        Ok(())
+    })
+    .await?;
+
+    encode_response(pal, io, pok_local_out, sd_mk_out)
+}
+
+/// Encode the `SdRestoreRemoteBackup` response around the local backups.
+fn encode_response<'p, P: HsmPal>(
+    pal: &'p P,
+    io: &impl HsmIo,
+    pok_local: &DmaBuf,
+    sd_mk: &DmaBuf,
+) -> HsmResult<&'p DmaBuf> {
+    let resp = pal.dma_alloc_var(io, |buf| {
+        let frame = TborSdRestoreRemoteBackupResp::encode(buf, 0, false)?
+            .pok_local_backup(pok_local)?
+            .sd_mk_backup(sd_mk)?
+            .finish();
+        Ok(frame.as_bytes().len())
+    })?;
+    Ok(resp)
+}

--- a/fw/core/lib/src/op.rs
+++ b/fw/core/lib/src/op.rs
@@ -264,6 +264,7 @@ impl SessionCtrl {
             | opcode::SD_SEALING_KEY_GEN
             | opcode::SD_CREATE_REMOTE_BACKUP
             | opcode::SD_RESEAL_REMOTE_BACKUP
+            | opcode::SD_RESTORE_REMOTE_BACKUP
             | opcode::SD_RESTORE_LOCAL_BACKUP
             | opcode::KEY_REPORT => Self::InSession,
             opcode::SESSION_CLOSE => Self::Close,


### PR DESCRIPTION
## What

Implements **`SdRestoreRemoteBackup`** (opcode `0x0C`, manticore §3.3.8) — the peer/migration recovery path for a security domain. It is **`SdResealRemoteBackup`'s HPKE-open front-end + `SdRestoreLocalBackup`'s provisioning back-end**.

> **Stacked on #566** (`sd/restore-local-backup`). Review/merge that first; this PR's diff is only the remote-restore delta.

## Flow

1. Gate to a Crypto-Officer `Active` session on an `Initialized` partition; fail-fast one-shot (`SdAlreadyInitialized`).
2. Bind the caller `policy` to the partition `policy_hash`, then verify the **sender** evidence: cert chains validated + anchored to the policy `SATA` key, report v2 `policy_hash == SHA-384(policy)` → recover **`SndrPub`**.
3. Unmask `masked_sealing_key` → **`RcvrPriv`** (must be `SdSealing`); derive `RcvrPub` on-device.
4. HPKE-Auth-open `src_remote_backup` (sender-auth `SndrPub`) → **BKS3**.
5. `reprovision_sd_from_bks3`: recover `SDMK` from `prev_sd_mk_backup`, re-mask both backups at the current `{svn, owner}`, vault `SDMK`, mark the partition SD-initialized — undo-guarded. `RcvrPriv`, BKS3, SDMK, SDBMK are zeroized on every exit path.

## Changes

- **Handler** `fw/core/lib/src/ddi/tbor/sd_restore_remote_backup.rs` (new).
- **Wire schema** reworked (was a stale placeholder): `masked_sealing_key`(180) · `policy`(484) · `sender_evidence` · `src_remote_backup`(161) · `prev_sd_mk_backup`(164, required). Host + fw schemas + round-trip unit tests.
- **Shared back-end**: extracted `reprovision_sd_from_bks3` into `sd_backup.rs` (recover SDMK + anti-rollback + re-mask + vault-commit); **refactored `SdRestoreLocalBackup` to reuse it** — both restores now share one provisioning path.
- **Dispatch wiring** for `0x0C`: `mod.rs` (dispatch arm + `is_known_opcode`/`is_in_session`/`needs_session_id_cross_check`) and `op.rs` `from_tbor_opcode` (required, else the SQE session-flag check rejects it as `InvalidArg`).
- **Docs**: full `docs/tbor-ddi/commands/sd_restore_remote_backup.md` + README table row (drops "schema-only").

## Tests

New emu integration tests (`ddi/tbor/types/tests/commands/sd_restore_remote_backup.rs`):
- **Round-trip** — device 1 finalize + CreateSD → reboot → device 2 `PartFinal(prev_local_mk_backup)` restores `PartLocalMK` (so the captured sealing key unmasks) → **HPKE-open restore** returns non-zero refreshed local backups.
- **One-shot** — restore onto an already-initialized SD → `SdAlreadyInitialized`.
- **Reject before finalize** → `InvalidArg`.

## Validation

- `cargo xtask nextest --features emu -p azihsm_ddi_tbor_types` → **113/113** pass (109 prior + 4 new, no regression).
- `cargo xtask build -p azihsm_fw_hsm_std` ✓ · uno `cargo xtask clippy` (core lib + uno PAL) ✓ · main `cargo xtask clippy` (full workspace) ✓.
- `cargo +nightly fmt` + `cargo xtask copyright` clean.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
Copilot-Session: 0b09e50a-a9be-4bae-b347-d42dc775a258