### PR TITLE
feat(fw): re-import unwrapping key on EstablishCredential after live …

### DIFF
--- a/ddi/mbor/types/tests/integration/masked_key_get_unwrapping.rs
+++ b/ddi/mbor/types/tests/integration/masked_key_get_unwrapping.rs
@@ -128,3 +128,46 @@ fn test_masked_key_get_unwrapping_with_lm() {
         },
     )
 }
+
+#[test]
+fn test_masked_key_get_unwrapping_lm_tampered_key_rejected() {
+    ddi_dev_test(
+        |_, _, _| 0,
+        common_cleanup,
+        |dev, ddi, path, _session_id| {
+            let setup_res = common_setup_for_lm(dev, ddi, path);
+            let (_, _, masked_key) = get_unwrapping_key(dev, setup_res.session_id);
+
+            let result = dev.erase();
+            assert!(
+                result.is_ok(),
+                "Migration simulation should succeed: {:?}",
+                result
+            );
+
+            // Corrupt the masked unwrapping key so its HMAC no longer
+            // verifies; the step-12 re-import must reject it rather than
+            // importing forged key material.
+            let mut tampered = masked_key.as_slice().to_vec();
+            let last = tampered.len() - 1;
+            tampered[last] ^= 0xFF;
+            let tampered_key =
+                MborByteArray::from_slice(&tampered).expect("failed to create tampered byte array");
+
+            let resp = helper_common_establish_credential_with_bmk_no_unwrap(
+                dev,
+                TEST_CRED_ID,
+                TEST_CRED_PIN,
+                setup_res.masked_bk3,
+                setup_res.partition_bmk,
+                tampered_key,
+            );
+
+            assert!(
+                resp.is_err(),
+                "EstablishCredential with a tampered masked unwrapping key must be rejected, got {:?}",
+                resp
+            );
+        },
+    )
+}

--- a/fw/core/lib/src/ddi/mbor/establish_credential.rs
+++ b/fw/core/lib/src/ddi/mbor/establish_credential.rs
@@ -12,7 +12,10 @@ use core::ops::Deref;
 
 use azihsm_fw_core_crypto_key_derive::derive_masking_key;
 use azihsm_fw_core_crypto_key_masking::cbc::mask;
+use azihsm_fw_core_crypto_key_masking::cbc::peek_metadata;
 use azihsm_fw_core_crypto_key_masking::cbc::unmask;
+use azihsm_fw_ddi_mbor::MborDecode;
+use azihsm_fw_ddi_mbor::MborDecoder;
 use azihsm_fw_ddi_mbor_types::establish_credential::DdiEstablishCredentialReq;
 use azihsm_fw_ddi_mbor_types::establish_credential::DdiEstablishCredentialResp;
 use azihsm_fw_ddi_mbor_types::masked_key::DdiMaskedKeyMetadata;
@@ -57,9 +60,7 @@ const MK_VAULT_ATTRS: HsmVaultKeyAttrs = HsmVaultKeyAttrs::new()
 
 /// Handle `DdiEstablishCredentialCmd`.
 ///
-/// Implements protocol steps 1-13 (step 12 — optional unwrapping key
-/// import — is rejected up-front with `UnsupportedCmd` until the
-/// underlying vault primitives land).
+/// Implements protocol steps 1-13.
 ///
 /// All partition state mutations are batched into the final
 /// atomic-commit block; any failure in steps 8-13 leaves partition
@@ -169,6 +170,16 @@ pub(crate) async fn establish_credential<'p, P: HsmPal>(
     // single lineage so this is a no-op today.
     let mk_key_id = provision_mk(pal, io, body.bmk, bk).await?;
 
+    // ── Step 12: Optional unwrapping-key re-import ───────────────────
+    //
+    // After a live migration the host replays the masked unwrapping key
+    // it persisted from GetUnwrappingKey; re-import it under the MK just
+    // provisioned above so GetUnwrappingKey returns the same key rather
+    // than lazily generating a fresh one.  `None` on the fresh-
+    // provisioning path (no unwrapping key supplied).
+    let unwrapping_key_id =
+        reimport_unwrapping_key(pal, io, mk_key_id, body.masked_unwrapping_key).await?;
+
     // ── Step 13: Envelope MK into BMK and emit the response ──────────
     let resp = encode_bmk_response(pal, io, hdr, bk, mk_key_id, svn, bks2_id).await?;
 
@@ -205,8 +216,95 @@ pub(crate) async fn establish_credential<'p, P: HsmPal>(
     crate::part_state::part_set_bk3_session(pal, io, bk3_session)?;
     crate::part_state::part_clear_establish_cred_key(pal, io)?;
     crate::part_state::part_set_mk_key_id(pal, io, mk_key_id)?;
+    if let Some(uk_id) = unwrapping_key_id {
+        crate::part_state::part_set_unwrapping_key_id(pal, io, uk_id)?;
+    }
 
     Ok(resp)
+}
+
+/// Re-import the partition unwrapping key from a host-persisted masked
+/// blob (protocol step 12 of `EstablishCredential`).
+///
+/// After a live migration the host replays the `masked_unwrapping_key`
+/// it received from [`get_unwrapping_key`](super::get_unwrapping_key):
+/// an AES-CBC-256 + HMAC-SHA-384 envelope of the RSA-2048 private key,
+/// tagged [`DdiKeyType::RsaUnwrap`] and enveloped under the partition
+/// masking key (`MK`).  It is unmasked with the freshly re-provisioned
+/// `MK` (`mk_key_id`) and re-imported into the vault so a subsequent
+/// `GetUnwrappingKey` returns the same key — and thus the same public
+/// key — as before the migration, instead of lazily generating a fresh
+/// one.  The returned id is committed to `RSA_UNWRAPPING_KEY_ID` by the
+/// caller's atomic-commit block.
+///
+/// Returns `Ok(None)` when no unwrapping key is supplied (the fresh-
+/// provisioning path, where the PAL generates one on first read).
+///
+/// # Errors
+/// - [`HsmError::MaskedKeyDecodeFailed`] — the blob's metadata could not
+///   be decoded.
+/// - [`HsmError::InvalidKeyType`] — the blob is not tagged `RsaUnwrap`
+///   (only the partition unwrapping key may be imported here).
+/// - the HMAC failure surfaced by [`unmask`] on a tampered blob or an
+///   `MK` mismatch.
+async fn reimport_unwrapping_key<P: HsmPal>(
+    pal: &P,
+    io: &impl HsmIo,
+    mk_key_id: HsmKeyId,
+    masked: &mut DmaBuf,
+) -> HsmResult<Option<HsmKeyId>> {
+    if masked.is_empty() {
+        return Ok(None);
+    }
+
+    // Peek the cleartext (MAC-covered) metadata to validate the key tag
+    // and recover the length + attributes for re-import.  These are only
+    // *acted on* after `unmask` (below) verifies the HMAC.
+    let (attrs, key_len) = {
+        let meta = peek_metadata(masked)?;
+        let meta_buf = pal.dma_alloc(io, meta.len())?;
+        meta_buf.copy_from_slice(meta);
+        let mut dec = MborDecoder::new(meta_buf);
+        let metadata = DdiMaskedKeyMetadata::mbor_decode(&mut dec)
+            .map_err(|_| HsmError::MaskedKeyDecodeFailed)?;
+
+        // Only the partition unwrapping key (tagged RsaUnwrap) may be
+        // re-imported here — never a general key masquerading as one.
+        if metadata.key_type != DdiKeyType::RsaUnwrap {
+            return Err(HsmError::InvalidKeyType);
+        }
+
+        let attrs: HsmVaultKeyAttrs = metadata.key_attributes.into();
+        (attrs, metadata.key_length as usize)
+    };
+
+    // Authenticate-then-decrypt in place under MK, copy out the RSA
+    // private key material, and import it into the vault — inside an
+    // allocation scope so the multi-KB import scratch is freed before we
+    // return.  A tampered blob or wrong MK fails the HMAC in `unmask`
+    // without leaking plaintext; only the owned vault key id escapes.
+    let key_id = pal
+        .alloc_scoped_async(io, async |_scope| -> HsmResult<HsmKeyId> {
+            let mk = pal.vault_key(io, mk_key_id)?;
+            let layout = unmask(pal, io, mk, masked).await?;
+
+            // Guard the metadata length so an inconsistent `key_length`
+            // errors instead of panicking on the slice below.
+            if key_len > layout.plaintext_max_len {
+                return Err(HsmError::MaskedKeyDecodeFailed);
+            }
+
+            let key_buf = pal.dma_alloc(io, key_len)?;
+            key_buf.copy_from_slice(
+                &masked[layout.plaintext_offset..layout.plaintext_offset + key_len],
+            );
+
+            pal.vault_key_create(io, key_buf, HsmVaultKeyKind::Rsa2kPrivate, None, attrs)
+                .await
+        })
+        .await?;
+
+    Ok(Some(key_id))
 }
 
 /// Performs all fail-fast checks before any cryptographic work.
@@ -227,8 +325,6 @@ pub(crate) async fn establish_credential<'p, P: HsmPal>(
 ///   decoder already bounds `masked_bk3` / `bmk` to `max_len = 1024`
 ///   per the type definition, so no separate upper-bound check is
 ///   needed for those.
-/// - `UnsupportedCmd` — optional unwrapping-key import was requested
-///   (not yet implemented; TODO: step 12).
 fn check_fail_fast<P: HsmPal>(
     pal: &P,
     io: &impl HsmIo,
@@ -255,10 +351,6 @@ fn check_fail_fast<P: HsmPal>(
         || body.pota_sig.len() != HsmEccCurve::P384.sig_len()
     {
         return Err(HsmError::InvalidArg);
-    }
-
-    if !body.masked_unwrapping_key.is_empty() {
-        return Err(HsmError::UnsupportedCmd);
     }
 
     Ok(())

--- a/fw/core/lib/src/ddi/mbor/unmask_key.rs
+++ b/fw/core/lib/src/ddi/mbor/unmask_key.rs
@@ -106,6 +106,12 @@ pub(crate) async fn unmask_key<'p, P: HsmPal>(
                 unmask(pal, io, part_mk, body.masked_key).await?
             };
 
+            // Guard the metadata length so an inconsistent `key_length`
+            // errors instead of panicking on the slice below.
+            if key_len > layout.plaintext_max_len {
+                return Err(HsmError::MaskedKeyDecodeFailed);
+            }
+
             // Copy the primary key material (plaintext prefix) into a fresh
             // vault-import scratch buffer.  For ECC the trailing public
             // point is ignored here; the private scalar re-derives it.

--- a/fw/core/lib/src/part_state.rs
+++ b/fw/core/lib/src/part_state.rs
@@ -531,12 +531,24 @@ pub const fn part_sd_mk_key_id_prop_id() -> PartPropId {
 /// Vault id of the partition's unwrapping key.
 ///
 /// Wraps [`PartPropId::RSA_UNWRAPPING_KEY_ID`] (`U16 → HsmKeyId`,
-/// `AbsentUntilSet`, **read-only**).
+/// `AbsentUntilSet`).
 pub fn part_unwrapping_key_id(
     pal: &impl HsmPartitionManager,
     io: &impl HsmIo,
 ) -> HsmResult<HsmKeyId> {
     key_id_get(pal, io, PartPropId::RSA_UNWRAPPING_KEY_ID)
+}
+
+/// Set the partition's unwrapping key id.
+///
+/// Used by `EstablishCredential` to re-import the host-persisted key
+/// after a live migration.
+pub fn part_set_unwrapping_key_id(
+    pal: &impl HsmPartitionManager,
+    io: &impl HsmIo,
+    key_id: HsmKeyId,
+) -> HsmResult<()> {
+    key_id_set(pal, io, PartPropId::RSA_UNWRAPPING_KEY_ID, key_id)
 }
 
 /// [`PartPropId`] backing [`part_unwrapping_key_id`].

--- a/fw/pal/traits/src/part.rs
+++ b/fw/pal/traits/src/part.rs
@@ -800,8 +800,8 @@ impl PartPropId {
     pub const PTA_KEY_ID: PartPropId = PartPropId(0x0013);
 
     /// Vault [`HsmKeyId`](crate::HsmKeyId) for the partition's
-    /// unwrapping key.  Read-only from caller perspective; assigned
-    /// by the PAL when the key is materialised.
+    /// unwrapping key.  Writable so `EstablishCredential` can re-import
+    /// the host-persisted key after a live migration.
     pub const RSA_UNWRAPPING_KEY_ID: PartPropId = PartPropId(0x0014);
 
     /// Vault [`HsmKeyId`](crate::HsmKeyId) for the partition's
@@ -979,7 +979,7 @@ impl PartPropId {
             Self::SD_INITIALIZED => PartPropMeta::scalar(Bool, Rw, Req, false),
 
             // ── Vault refs (HsmKeyId as u16) ──
-            Self::ID_KEY_ID | Self::RSA_UNWRAPPING_KEY_ID => VAULT_REF_RO,
+            Self::ID_KEY_ID => VAULT_REF_RO,
             Self::MK_KEY_ID
             | Self::UPS_KEY_ID
             | Self::PTA_KEY_ID
@@ -987,7 +987,8 @@ impl PartPropId {
             | Self::ESTABLISH_CRED_KEY_ID
             | Self::LOCAL_MK_KEY_ID
             | Self::EPHEMERAL_MK_KEY_ID
-            | Self::SD_MK_KEY_ID => VAULT_REF_RW,
+            | Self::SD_MK_KEY_ID
+            | Self::RSA_UNWRAPPING_KEY_ID => VAULT_REF_RW,
 
             // ── Public-key views (fixed P-384 sizes) ──
             Self::ID_PUB_KEY | Self::SESSION_ENC_PUB_KEY | Self::ESTABLISH_CRED_PUB_KEY => {

--- a/fw/plat/std/pal/src/part.rs
+++ b/fw/plat/std/pal/src/part.rs
@@ -1287,6 +1287,11 @@ impl PartitionEntry {
                 self.establish_cred_key_id = Some(HsmKeyId::from(value as u16));
                 Ok(())
             }
+            PartPropId::RSA_UNWRAPPING_KEY_ID => {
+                // Settable for EstablishCredential's post-migration re-import.
+                self.unwrapping_key_id = Some(HsmKeyId::from(value as u16));
+                Ok(())
+            }
             PartPropId::BK3_INITIALIZED => {
                 // One-shot gate: false→true is the only legal
                 // transition.  Re-asserting true returns
@@ -1316,7 +1321,7 @@ impl PartitionEntry {
                 self.sd_initialized = want;
                 Ok(())
             }
-            // GEN/SVN/RES_COUNT/ID_KEY_ID/RSA_UNWRAPPING_KEY_ID are Ro
+            // GEN/SVN/RES_COUNT/ID_KEY_ID are Ro
             // — rejected by validate_set.  Non-scalar ids — rejected
             // by the kind check.
             _ => Err(HsmError::InvalidArg),

--- a/fw/plat/uno/fw/pal/src/part.rs
+++ b/fw/plat/uno/fw/pal/src/part.rs
@@ -575,7 +575,8 @@ impl HsmPartitionManager for UnoHsmPal {
             // undo log restores a prior id through this raw path.
             PartPropId::UPS_KEY_ID => part.set_ups_key_id(Some(key)),
             PartPropId::PTA_KEY_ID => part.set_pta_key_id(Some(key)),
-            // ID_KEY_ID / RSA_UNWRAPPING_KEY_ID are read-only.
+            PartPropId::RSA_UNWRAPPING_KEY_ID => part.set_unwrapping_key_id(Some(key)),
+            // ID_KEY_ID is read-only.
             _ => return Err(HsmError::UnsupportedCmd),
         }
         Ok(())


### PR DESCRIPTION
…migration

Implement protocol step 12 of EstablishCredential: after a live migration the host replays the masked unwrapping key it persisted from GetUnwrappingKey, and the firmware re-imports it so GetUnwrappingKey returns the same key (same public key) as before the migration instead of lazily generating a fresh one. Previously a non-empty masked_unwrapping_key was rejected up-front with UnsupportedCmd.

- fw/core establish_credential: add the reimport_unwrapping_key step-12 helper — peek the masked-key metadata (require the RsaUnwrap role tag), unmask it under the MK just re-provisioned in step 11, and vault-import the RSA-2048 private key. HMAC-before-decrypt (via unmask) rejects a tampered blob or MK mismatch; the import scratch is freed inside an alloc scope. The new id is committed to RSA_UNWRAPPING_KEY_ID in the atomic-commit block. The fail-fast UnsupportedCmd rejection is removed.
- Make RSA_UNWRAPPING_KEY_ID a writable vault-ref property: flip its shared metadata from VAULT_REF_RO to VAULT_REF_RW (pal traits), add the core part_set_unwrapping_key_id setter, and wire the property write in both the std and uno PALs (uno reuses the existing set_unwrapping_key_id). The id is still materialised lazily on first read when not re-imported.

Tests: test_masked_key_get_unwrapping_with_lm now passes on emu (was UnsupportedCmd); add a negative test that a tampered masked unwrapping key is rejected. Both pass on emu and mock.

emu DDI suite (azihsm_ddi_mbor_types --features emu): 582 -> 584 passing of 586 (585 -> 586 total with the new negative test). The 2 remaining failures (get_cert_chain x2) are fixed by a separate open PR and are unrelated. Mock stays green; uno builds clean; clippy (-D warnings) / fmt / copyright clean.


Copilot-Session: 82c8bd53-6639-46fc-8a79-a7539921e4c1