### PR TITLE
refactor(fw): make TBOR CU/CO session masking key 32 B AES-256-GCM

### DIFF
--- a/fw/core/lib/src/ddi/tbor/session_open_finish.rs
+++ b/fw/core/lib/src/ddi/tbor/session_open_finish.rs
@@ -85,8 +85,8 @@ struct ParsedRequest<'a> {
 /// * `param_key` — 32 B AES-256 key used to AEAD-open `seed_envelope`
 ///   (this handler) and to authenticate per-parameter envelopes in
 ///   in-session commands like `PskChange`.  Always populated.
-/// * `masking_key` — 80 B `aes32 ‖ hmac48` used by the `cbc::mask`
-///   masked-key system.  Always populated.
+/// * `masking_key` — 32 B AES-256-GCM key for the `key_masking::aead`
+///   TBOR masked-key system.  Always populated.
 /// * `mac_tx_key` — 48 B HMAC-SHA-384 key for outbound (HSM → host)
 ///   message MACs.  `Some` iff `session_type` is `Authenticated`.
 /// * `mac_rx_key` — 48 B HMAC-SHA-384 key for inbound (host → HSM)

--- a/fw/pal/traits/src/lib.rs
+++ b/fw/pal/traits/src/lib.rs
@@ -429,13 +429,16 @@ pub const SESSION_BMK_KEY_LABEL: &[u8] = b"SMK";
 /// [`azihsm_fw_core_crypto_aead_envelope`].
 pub const SESSION_PARAM_KEY_LEN: usize = 32;
 
-/// Length in bytes of the per-session `masking_key`.
+/// Length in bytes of the per-session `masking_key` for TBOR
+/// **SessionEx (CU/CO)** sessions.
 ///
-/// 80 B = AES-CBC-256 key (32 B) ‖ HMAC-SHA-384 key (48 B). Consumed
-/// by the `key_masking::cbc`-based MBOR masked-key system; unrelated to
-/// [`SESSION_PARAM_KEY_LEN`] which now refers to the AEAD-GCM
-/// per-session wrap key.  Present for both CO and CU sessions.
-pub const SESSION_MASKING_KEY_LEN: usize = 80;
+/// 32 B AES-256-GCM key used by the `key_masking::aead`-based TBOR
+/// masked-key system (masked keys are scoped and wrapped under AES-GCM).
+/// Present for both CO and CU SessionEx blobs.  Distinct from the legacy
+/// MBOR `Session`-blob masking key (an 80 B `aes32 ‖ hmac48` cbc key,
+/// sized by the std-PAL-local `SESSION_MASKING_KEY_SIZE`), which the
+/// `key_masking::cbc`-based MBOR masked-key system continues to use.
+pub const SESSION_MASKING_KEY_LEN: usize = 32;
 
 /// Length in bytes of each directional message-MAC key (HMAC-SHA-384).
 ///

--- a/fw/plat/std/pal/src/session.rs
+++ b/fw/plat/std/pal/src/session.rs
@@ -34,12 +34,14 @@ const SESSION_MASKING_KEY_SIZE: usize = 80;
 const SESSION_BLOB_SIZE: usize = SESSION_API_REV_SIZE + SESSION_MASKING_KEY_SIZE;
 
 /// `SessionEx`-kind blob size for **PlainText (CU)** sessions:
-/// `api_rev(8) || param_key(32) || masking_key(80)` = 120 B.
+/// `api_rev(8) || param_key(32) || masking_key(32)` = 72 B.  The
+/// SessionEx masking key is the 32 B AES-256-GCM `key_masking::aead`
+/// key ([`SESSION_MASKING_KEY_LEN`]), not the legacy 80 B cbc key.
 const SESSION_CU_BLOB_SIZE: usize =
     SESSION_API_REV_SIZE + SESSION_PARAM_KEY_LEN + SESSION_MASKING_KEY_LEN;
 
 /// `SessionEx`-kind blob size for **Authenticated (CO)** sessions:
-/// PlainText blob ‖ `mac_tx(48) ‖ mac_rx(48)` = 216 B.
+/// PlainText blob ‖ `mac_tx(48) ‖ mac_rx(48)` = 168 B.
 const SESSION_CU_AUTH_BLOB_SIZE: usize = SESSION_CU_BLOB_SIZE + 2 * SESSION_MAC_DIR_KEY_LEN;
 
 impl HsmSessionManager for StdHsmPal {
@@ -228,8 +230,8 @@ impl HsmSessionManager for StdHsmPal {
         let attrs = HsmVaultKeyAttrs::new().with_internal(true);
 
         // Length-discriminated blob:
-        // - PlainText:     api_rev(8) + param_key(32) + masking_key(80)         = 120 B
-        // - Authenticated: above ‖ mac_tx(48) ‖ mac_rx(48)                       = 216 B
+        // - PlainText:     api_rev(8) + param_key(32) + masking_key(32)         = 72 B
+        // - Authenticated: above ‖ mac_tx(48) ‖ mac_rx(48)                       = 168 B
         let mut blob = [0u8; SESSION_CU_AUTH_BLOB_SIZE];
         blob[..SESSION_API_REV_SIZE].copy_from_slice(api_rev);
         blob[SESSION_API_REV_SIZE..SESSION_API_REV_SIZE + SESSION_PARAM_KEY_LEN]
@@ -280,16 +282,19 @@ impl HsmSessionManager for StdHsmPal {
         let kid = entry.session_table.physical_id(id)?;
         let blob = entry.vault.key(kid)?;
         // The masking key follows `api_rev` in a legacy MBOR `Session`
-        // blob, or `api_rev ‖ param_key` in a `SessionEx` (CU/CO) blob;
-        // pick the offset from the blob length so both schedules work.
-        let offset = match blob.len() {
-            SESSION_BLOB_SIZE => SESSION_API_REV_SIZE,
-            SESSION_CU_BLOB_SIZE | SESSION_CU_AUTH_BLOB_SIZE => {
-                SESSION_API_REV_SIZE + SESSION_PARAM_KEY_LEN
-            }
+        // blob (80 B `aes32 ‖ hmac48` cbc key), or `api_rev ‖ param_key`
+        // in a `SessionEx` (CU/CO) blob (32 B AES-256-GCM aead key); pick
+        // the offset *and length* from the blob length so both schedules
+        // work.
+        let (offset, size) = match blob.len() {
+            SESSION_BLOB_SIZE => (SESSION_API_REV_SIZE, SESSION_MASKING_KEY_SIZE),
+            SESSION_CU_BLOB_SIZE | SESSION_CU_AUTH_BLOB_SIZE => (
+                SESSION_API_REV_SIZE + SESSION_PARAM_KEY_LEN,
+                SESSION_MASKING_KEY_LEN,
+            ),
             _ => return Err(HsmError::InternalError),
         };
-        let key_bytes = &blob[offset..offset + SESSION_MASKING_KEY_SIZE];
+        let key_bytes = &blob[offset..offset + size];
         // SAFETY: same justification as `session_param_key` — on the
         // host, any heap byte is reachable; branding the sub-slice as
         // `DmaBuf` only satisfies the type system.

--- a/fw/plat/uno/fw/pal/src/session.rs
+++ b/fw/plat/uno/fw/pal/src/session.rs
@@ -32,6 +32,7 @@ use azihsm_fw_hsm_pal_traits::HsmVault;
 use azihsm_fw_hsm_pal_traits::HsmVaultKeyAttrs;
 use azihsm_fw_hsm_pal_traits::HsmVaultKeyKind;
 use azihsm_fw_hsm_pal_traits::SESSION_MAC_DIR_KEY_LEN;
+use azihsm_fw_hsm_pal_traits::SESSION_MASKING_KEY_LEN;
 use azihsm_fw_hsm_pal_traits::SESSION_PARAM_KEY_LEN;
 use azihsm_fw_hsm_pal_traits::SESSION_PENDING_BLOB_MAX;
 use azihsm_fw_hsm_pal_traits::SessionRole;
@@ -42,20 +43,22 @@ use crate::UnoHsmPal;
 /// API-revision portion of the session blob (bytes).
 const SESSION_API_REV_SIZE: usize = 8;
 
-/// Masking-key portion of the session blob: AES-CBC-256 (32) + HMAC-SHA-384
-/// (48) = 80 bytes.
+/// Masking-key portion of a **legacy MBOR `Session`** blob: AES-CBC-256
+/// (32) + HMAC-SHA-384 (48) = 80 bytes (the `key_masking::cbc` key).
 const SESSION_MASKING_KEY_SIZE: usize = 80;
 
 /// `Session`-kind blob: `[api_rev(8) || masking_key(80)]` = 88 bytes.
 const SESSION_BLOB_SIZE: usize = SESSION_API_REV_SIZE + SESSION_MASKING_KEY_SIZE;
 
 /// `SessionEx` plaintext (CU) blob:
-/// `[api_rev(8) || param_key(32) || masking_key(80)]` = 120 bytes.
+/// `[api_rev(8) || param_key(32) || masking_key(32)]` = 72 bytes.  The
+/// SessionEx masking key is the 32 B AES-256-GCM `key_masking::aead` key
+/// ([`SESSION_MASKING_KEY_LEN`]), not the legacy 80 B cbc key.
 const SESSION_CU_BLOB_SIZE: usize =
-    SESSION_API_REV_SIZE + SESSION_PARAM_KEY_LEN + SESSION_MASKING_KEY_SIZE;
+    SESSION_API_REV_SIZE + SESSION_PARAM_KEY_LEN + SESSION_MASKING_KEY_LEN;
 
 /// `SessionEx` authenticated (CO) blob: the plaintext blob followed by
-/// `mac_tx(48) || mac_rx(48)` = 216 bytes.
+/// `mac_tx(48) || mac_rx(48)` = 168 bytes.
 const SESSION_CU_AUTH_BLOB_SIZE: usize = SESSION_CU_BLOB_SIZE + 2 * SESSION_MAC_DIR_KEY_LEN;
 
 impl HsmSessionManager for UnoHsmPal {
@@ -237,7 +240,7 @@ impl HsmSessionManager for UnoHsmPal {
     ) -> HsmResult<()> {
         if api_rev.len() != SESSION_API_REV_SIZE
             || param_key.len() != SESSION_PARAM_KEY_LEN
-            || masking_key.len() != SESSION_MASKING_KEY_SIZE
+            || masking_key.len() != SESSION_MASKING_KEY_LEN
         {
             return Err(HsmError::InvalidArg);
         }
@@ -261,8 +264,8 @@ impl HsmSessionManager for UnoHsmPal {
         }
 
         // Build the length-discriminated SessionEx blob:
-        //   PlainText:     api_rev(8) ‖ param_key(32) ‖ masking_key(80)        = 120 B
-        //   Authenticated: above ‖ mac_tx(48) ‖ mac_rx(48)                     = 216 B
+        //   PlainText:     api_rev(8) ‖ param_key(32) ‖ masking_key(32)        = 72 B
+        //   Authenticated: above ‖ mac_tx(48) ‖ mac_rx(48)                     = 168 B
         let blob_len = match mac_pair {
             None => SESSION_CU_BLOB_SIZE,
             Some(_) => SESSION_CU_AUTH_BLOB_SIZE,


### PR DESCRIPTION
## Summary

Foundational fw-only change for the upcoming **TBOR HMAC / crypto masked-key** command family.

The TBOR SessionEx (CU/CO) per-session `masking_key` was an **80 B** `aes32 ‖ hmac48` key shaped for the legacy `key_masking::cbc` MBOR masked-key system. TBOR masked keys are wrapped with `key_masking::aead` (AES-256-GCM), which needs only a **32 B** key — so the extra 48 B were dead weight and blurred the key's purpose.

This reshapes the SessionEx masking key to a native **32 B AES-256-GCM** key.

## Changes
- `SESSION_MASKING_KEY_LEN` 80 → 32 (**CU/CO only**). The legacy MBOR `Session` blob keeps its 80 B cbc key via the std/uno-PAL-local `SESSION_MASKING_KEY_SIZE`, so **MBOR's cbc masked-key system is unaffected**.
- **std + uno PAL:** CU/CO blob shrinks (CU 120→72 B, CO 216→168 B). The std `session_masking_key` reader now sizes the returned key **by blob kind** — 32 B for SessionEx blobs, 80 B for the legacy Session blob — so MBOR still reads its full 80 B key. `session_promote` validation follows the const.
- **`session_open_finish`:** derives the 32 B key (auto via the const); `bmk_session` is variable-length (`BMK_SESSION_MAX_LEN`), so the shorter payload needs no schema change.

## Why safe
The CU/CO masking key is consumed by nothing today — `session_masking_key` is only read by MBOR's masked-key handlers, and only from legacy `Session` blobs. The host never derives this key (fw-only).

## Validation
- **TBOR emu 108/108** — CU + CO sessions, `session_close`, reopen, SD roundtrips.
- **MBOR emu 225/225** — `masked_key`, `unmask_key`, `aes_gen`, `rsa_unwrap`, `live_migration`/reopen (legacy 80 B path intact).
- std + uno `cargo check` + `clippy` clean; nightly `fmt` clean.