### PR TITLE
refactor(fw): move hmac_hash to the shared ddi layer

### DIFF
--- a/fw/core/lib/src/ddi/mbor/from_pal.rs
+++ b/fw/core/lib/src/ddi/mbor/from_pal.rs
@@ -21,28 +21,11 @@
 use azihsm_fw_ddi_mbor_types::DdiKeyType;
 use azihsm_fw_hsm_pal_traits::HsmEccCurve;
 use azihsm_fw_hsm_pal_traits::HsmError;
-use azihsm_fw_hsm_pal_traits::HsmHashAlgo;
 use azihsm_fw_hsm_pal_traits::HsmResult;
 use azihsm_fw_hsm_pal_traits::HsmRsaKey;
 use azihsm_fw_hsm_pal_traits::HsmVaultKeyKind;
 
 // ── HsmVaultKeyKind → … ───────────────────────────────────────────
-
-/// Map an HMAC vault kind to the hash algorithm whose digest length
-/// is the MAC tag size.
-///
-/// Accepts both the fixed-length (`_HmacSha*`) and variable-length
-/// (`VarLenHmacSha*`) HMAC kinds — mirroring the reference firmware's
-/// `Hmac` handler.  Any non-HMAC kind returns
-/// [`HsmError::InvalidKeyType`].
-pub(crate) fn hmac_hash(kind: HsmVaultKeyKind) -> HsmResult<HsmHashAlgo> {
-    match kind {
-        HsmVaultKeyKind::_HmacSha256 | HsmVaultKeyKind::VarLenHmacSha256 => Ok(HsmHashAlgo::Sha256),
-        HsmVaultKeyKind::_HmacSha384 | HsmVaultKeyKind::VarLenHmacSha384 => Ok(HsmHashAlgo::Sha384),
-        HsmVaultKeyKind::_HmacSha512 | HsmVaultKeyKind::VarLenHmacSha512 => Ok(HsmHashAlgo::Sha512),
-        _ => Err(HsmError::InvalidKeyType),
-    }
-}
 
 /// Map an ECC private vault kind to its [`HsmEccCurve`].
 /// Non-ECC kinds return [`HsmError::InvalidKeyType`].

--- a/fw/core/lib/src/ddi/mbor/hmac.rs
+++ b/fw/core/lib/src/ddi/mbor/hmac.rs
@@ -36,7 +36,7 @@ pub(crate) async fn hmac<'p, P: HsmPal>(
 
     // Resolve the key's hash variant — an unknown id surfaces as
     // `KeyNotFound`, a non-HMAC kind as `InvalidKeyType`.
-    let algo = super::from_pal::hmac_hash(pal.vault_key_kind(io, key_id)?)?;
+    let algo = crate::ddi::hmac_hash(pal.vault_key_kind(io, key_id)?)?;
     let tag_len = algo.digest_len();
 
     // Generating a MAC is a PKCS#11 `C_Sign` operation, so the key

--- a/fw/core/lib/src/ddi/mod.rs
+++ b/fw/core/lib/src/ddi/mod.rs
@@ -52,3 +52,22 @@ pub(crate) async fn recover_bk_boot<P: HsmPal>(
     }
     azihsm_fw_core_crypto_key_derive::unmask_bk_boot(pal, io, masked_buf, out).await
 }
+
+/// Map an HMAC vault kind to the hash algorithm whose digest length is
+/// the MAC tag size.
+///
+/// Accepts both the fixed-length (`_HmacSha*`) and variable-length
+/// (`VarLenHmacSha*`) HMAC kinds.  Any non-HMAC kind returns
+/// [`HsmError::InvalidKeyType`].
+///
+/// Shared across both wire codecs (`Hmac` in [`mbor`], and the HMAC
+/// crypto commands in [`tbor`]), so it lives at the command level rather
+/// than in either codec — keeping `tbor` independent of `mbor`.
+pub(crate) fn hmac_hash(kind: HsmVaultKeyKind) -> HsmResult<HsmHashAlgo> {
+    match kind {
+        HsmVaultKeyKind::_HmacSha256 | HsmVaultKeyKind::VarLenHmacSha256 => Ok(HsmHashAlgo::Sha256),
+        HsmVaultKeyKind::_HmacSha384 | HsmVaultKeyKind::VarLenHmacSha384 => Ok(HsmHashAlgo::Sha384),
+        HsmVaultKeyKind::_HmacSha512 | HsmVaultKeyKind::VarLenHmacSha512 => Ok(HsmHashAlgo::Sha512),
+        _ => Err(HsmError::InvalidKeyType),
+    }
+}


### PR DESCRIPTION
## Summary

Groundwork for the TBOR HMAC command family (step 1 of the series; stacked on #578).

Relocates the `HsmVaultKeyKind → HsmHashAlgo` HMAC mapping (`hmac_hash`) out of the MBOR-only `mbor::from_pal` module up to the **codec-neutral `ddi` module** (alongside `recover_bk_boot`), so the upcoming TBOR HMAC handlers can reuse it via `crate::ddi::hmac_hash` **without depending on `mbor`** — matching the existing "shared helpers live at the command level, keeping `tbor` independent of `mbor`" convention.

Pure refactor — MBOR's `Hmac` handler now calls `crate::ddi::hmac_hash`; behavior is unchanged.

## Note on `resolve_masking_key`
The originally-planned scope resolver is deferred to the next PR (with the first HMAC handler that consumes it). The existing masking-key call sites are intentionally **key-id-based** (they carry the `Copy` `HsmKeyId` across awaits/closures and fetch material at the use site to avoid borrow-checker conflicts), so a material-returning resolver fits the *new* handlers rather than a refactor of existing code — and adding it now would be dead code.

## Validation
- **MBOR HMAC emu 36/36** — fixed + var-len HMAC keys, all SHA-256/384/512 variants, sign-permission, KBKDF-derived, masked-key HMAC.
- `cargo check` + `clippy` clean; nightly `fmt` clean.

Base: #578 (`tbor/session-mk-32`). Will auto-retarget to `main` when #578 merges.