### PR TITLE
feat(uno): deterministic P-384 key generation (FIPS 186-5 A.2.2) + GSRAM seed table

### DIFF
--- a/fw/plat/uno/fw/drivers/upka/src/engine.rs
+++ b/fw/plat/uno/fw/drivers/upka/src/engine.rs
@@ -459,9 +459,13 @@ impl<const DEPTH: usize, const ENGINES: usize> UpkaEngine<'_, DEPTH, ENGINES> {
         .await
     }
 
-    /// Point-multiply `result = (scalar * point).x`, where `point` is the
-    /// affine `x ‖ y` (contiguous, PKA little-endian). Requires a prior
-    /// `ecc_mont_const_calc` over the curve prime on this engine.
+    /// Point-multiply `result = scalar * point`, where `point` is the affine
+    /// `x ‖ y` (contiguous, PKA little-endian). The hardware writes the full
+    /// affine result `X ‖ Y` in wire format — one `hsm_point_size`-wide
+    /// coordinate each — so `result` must be at least `2 * hsm_point_size(curve)`
+    /// bytes; callers needing only the x-coordinate read its low `point_size`
+    /// bytes. Requires a prior `ecc_mont_const_calc` over the curve prime on
+    /// this engine.
     pub async fn ecc_point_mul(
         &mut self,
         curve: UpkaEccCurve,
@@ -472,7 +476,7 @@ impl<const DEPTH: usize, const ENGINES: usize> UpkaEngine<'_, DEPTH, ENGINES> {
         Self::ensure_cmd_input(
             point_xy.len() >= hsm_point_size(curve) * 2
                 && scalar.len() >= hsm_point_size(curve)
-                && result.len() >= point_size(curve),
+                && result.len() >= hsm_point_size(curve) * 2,
         )?;
 
         self.execute_cmd(

--- a/fw/plat/uno/fw/pal/src/crypto/ecc_det.rs
+++ b/fw/plat/uno/fw/pal/src/crypto/ecc_det.rs
@@ -215,7 +215,7 @@ const PTA_OKM_LEN: usize = 48;
 
 /// Deterministic bounded-retry cap for the A.2.2 OKM derivation. The per-attempt
 /// reject probability is ~`2^-190` (the top 192 bits of `n` are 1s), so attempt
-/// 0 all but always wins; the bound only guarantees the loop terminates.
+/// 0 almost always wins; the bound only guarantees the loop terminates.
 const PTA_KEYGEN_MAX_TRIES: u8 = 4;
 
 // =============================================================================

--- a/fw/plat/uno/fw/pal/src/crypto/ecc_det.rs
+++ b/fw/plat/uno/fw/pal/src/crypto/ecc_det.rs
@@ -29,6 +29,7 @@ use azihsm_fw_hsm_pal_traits::HsmError;
 use azihsm_fw_hsm_pal_traits::HsmHashAlgo;
 use azihsm_fw_hsm_pal_traits::HsmHmac;
 use azihsm_fw_hsm_pal_traits::HsmIo;
+use azihsm_fw_hsm_pal_traits::HsmKdf;
 use azihsm_fw_hsm_pal_traits::HsmResult;
 use azihsm_fw_hsm_pal_traits::HsmScopedAlloc;
 use azihsm_fw_uno_drivers_upka::UpkaEccCurve;
@@ -183,6 +184,41 @@ impl Rfc6979Drbg<'_> {
 const RFC6979_MAX_TRIES: usize = 8;
 
 // =============================================================================
+// Deterministic P-384 key-pair generation (FIPS 186-5 A.2.2 + SP 800-133r3)
+// =============================================================================
+//
+// The Partition Trust Anchor (PTA) / alias key pair is regenerated on demand
+// from a device-rooted key-derivation key (KDK) rather than drawn from the RNG,
+// so it need not be stored and reproduces byte-identically across boots and
+// firmware updates. The scalar is derived by FIPS 186-5 Appendix A.2.2 "key
+// pair generation by rejection sampling": take N = 384 bits of pseudorandom
+// output, interpret big-endian, and accept iff the value already lies in
+// `[1, n-1]`. A.2.2 (not A.2.1's `d = (OKM mod (n-1)) + 1`) is used so no
+// modular reduction is needed — the even modulus `n-1` cannot be reduced by the
+// Montgomery-only PKA — and so the accept test reuses the exact constant-time
+// `[1, n-1]` primitive ([`ct_in_range`]) already used for the RFC 6979 `k`.
+//
+// The pseudorandom bits come from HKDF-Expand-SHA384 keyed by the KDK, with a
+// per-key unique label as context (SP 800-133r3 §4.2.1); the label + counter
+// scheme is fixed so a partition's key derivation is reproducible. Compliance
+// with SP 800-133r3 §4.2 is contingent on the KDK itself being an approved,
+// sufficiently strong, secret symmetric key.
+
+/// HKDF-Expand label binding the PTA key-derivation context (SP 800-133r3
+/// §4.2.1 "unique label / context"). This value is fixed by the protocol; the
+/// same label + counter must be used everywhere the key is derived so the
+/// derivation is reproducible.
+const KEYPAIR_LABEL_PTA: &[u8] = b"AZIHSM-PartInit-PTA-v1";
+
+/// FIPS 186-5 A.2.2 P-384 OKM length: `N/8` = 48 bytes (one field element).
+const PTA_OKM_LEN: usize = 48;
+
+/// Deterministic bounded-retry cap for the A.2.2 OKM derivation. The per-attempt
+/// reject probability is ~`2^-190` (the top 192 bits of `n` are 1s), so attempt
+/// 0 all but always wins; the bound only guarantees the loop terminates.
+const PTA_KEYGEN_MAX_TRIES: u8 = 4;
+
+// =============================================================================
 // Deterministic P-384 ECDSA sign (RFC 6979) — PAL orchestration
 // =============================================================================
 
@@ -261,7 +297,10 @@ impl UnoHsmPal {
             // essential, or the reduction sees `xR ‖ garbage` and yields a
             // wrong `r`.
             let mont_scratch = scope.dma_alloc(mont)?;
-            let xr = scope.dma_alloc(field)?;
+            // `ecc_point_mul` writes the full affine point X ‖ Y; the sign
+            // consumes only the x-coordinate (`xr[..field]`), but the buffer
+            // must hold both halves per the driver contract.
+            let xr = scope.dma_alloc(field * 2)?;
             let xr_wide = scope.dma_alloc_zeroed(field * 2)?;
             let k_mont = scope.dma_alloc(mont)?;
             let r_mont = scope.dma_alloc(mont)?;
@@ -609,5 +648,163 @@ impl UnoHsmPal {
         .await?;
         core::mem::swap(&mut drbg.v, &mut drbg.tag);
         Ok(())
+    }
+
+    /// Derive the deterministic PTA private scalar `d` (big-endian) from
+    /// `part_root`, the key-derivation key / PRK (FIPS 186-5 §A.2.2 rejection
+    /// sampling).
+    ///
+    /// For each attempt, `OKM = HKDF-Expand-SHA384(part_root, info)` with
+    /// `info = KEYPAIR_LABEL_PTA ‖ attempt(1 B) ‖ u16_be(48)`. The 48-byte OKM
+    /// is treated as a big-endian candidate and accepted iff it is a valid
+    /// scalar in `[1, n-1]` ([`ct_in_range`], the same primitive as the RFC 6979
+    /// `k` generator). A rejected candidate re-derives with a fresh counter, so
+    /// the loop is fully deterministic and reproduces the same scalar on replay
+    /// (SP 800-133r3 §4.2.3 "algorithm random values"). The accepted candidate
+    /// is written big-endian into `d_be`; the caller flips it to PKA
+    /// little-endian before the point multiply.
+    ///
+    /// # Parameters
+    /// * `part_root` — the key-derivation key / PRK, a caller-owned DMA buffer.
+    /// * `d_be` — caller-owned DMA output (≥ 48 B) for the big-endian scalar.
+    ///
+    /// # Errors
+    /// * [`HsmError::InvalidArg`] — `d_be` is shorter than the field size.
+    /// * [`HsmError::EccGenerateError`] — every attempt in
+    ///   [`PTA_KEYGEN_MAX_TRIES`] fell outside `[1, n-1]` (unreachable in
+    ///   practice at ~`2^-190` per attempt).
+    /// * Any [`HsmError`] surfaced by the HKDF / SHA driver.
+    #[allow(dead_code)] // consumed by ecc_gen_keypair_deterministic (keygen)
+    async fn derive_pta_scalar_be(
+        &self,
+        io: &impl HsmIo,
+        part_root: &DmaBuf,
+        d_be: &mut DmaBuf,
+    ) -> HsmResult<()> {
+        let field = PRIME384_LE.len(); // 48
+        if d_be.len() < field {
+            return Err(HsmError::InvalidArg);
+        }
+
+        self.alloc_scoped_async(io, async |scope| {
+            // info = label ‖ attempt(1 B) ‖ u16_be(OKM_LEN). The attempt byte is
+            // rewritten each iteration so the retry counter is folded into the
+            // KDF context — a fresh, unique derivation per SP 800-133r3 §4.2.1.
+            let info = scope.dma_alloc(KEYPAIR_LABEL_PTA.len() + 1 + 2)?;
+            info[..KEYPAIR_LABEL_PTA.len()].copy_from_slice(KEYPAIR_LABEL_PTA);
+            info[KEYPAIR_LABEL_PTA.len() + 1..]
+                .copy_from_slice(&(PTA_OKM_LEN as u16).to_be_bytes());
+
+            let okm = scope.dma_alloc(PTA_OKM_LEN)?;
+
+            // Run the loop in an inner block so the candidate OKM (private key
+            // material) is scrubbed on every exit path, including an early `?`.
+            let outcome = async {
+                for attempt in 0..PTA_KEYGEN_MAX_TRIES {
+                    info[KEYPAIR_LABEL_PTA.len()] = attempt;
+                    self.hkdf_expand(io, HsmHashAlgo::Sha384, part_root, Some(&*info), okm)
+                        .await?;
+                    // A.2.2: the big-endian OKM is the candidate; accept iff it
+                    // is a valid scalar in [1, n-1].
+                    if ct_in_range(&okm[..field], &ORDER384_BE[..field]) {
+                        // Accept the big-endian candidate as-is; the caller
+                        // flips it to PKA little-endian.
+                        d_be[..field].copy_from_slice(&okm[..field]);
+                        return Ok(());
+                    }
+                }
+                // Astronomically unreachable for P-384 (~2^-190 per attempt);
+                // signals ECC key generation failed.
+                Err(HsmError::EccGenerateError)
+            }
+            .await;
+
+            okm.zeroize();
+            outcome
+        })
+        .await
+    }
+
+    /// Deterministically generate a P-384 key pair from `part_root`, the
+    /// key-derivation key (KDK).
+    ///
+    /// Composes [`derive_pta_scalar_be`](Self::derive_pta_scalar_be)
+    /// (FIPS 186-5 §A.2.2 scalar) with the PKA point multiply `Q = d·G` (the
+    /// base point `G` supplied explicitly to the driver's `ecc_point_mul`,
+    /// after a field Montgomery-constant setup). The private scalar is written
+    /// little-endian into `d_le` and the public key `X ‖ Y` little-endian into
+    /// `pub_key` (both PKA wire format), so the pair regenerates byte-identically
+    /// on every call from the same `part_root`.
+    ///
+    /// A FIPS pairwise-consistency test is intentionally NOT run here yet — the
+    /// uno keygen PCT is a no-op across the PAL — so the boot KAT validates the
+    /// derived pair against known-answer vectors instead. Wiring a real PCT is
+    /// tracked with the FIPS self-test work.
+    ///
+    /// # Parameters
+    /// * `curve` — must be [`UpkaEccCurve::P384`]; other curves return
+    ///   [`HsmError::UnsupportedCmd`].
+    /// * `part_root` — the key-derivation key / PRK (caller-owned DMA).
+    /// * `d_le` — caller-owned DMA output (≥ 48 B) for the LE private scalar.
+    /// * `pub_key` — caller-owned DMA output (≥ 96 B) for the LE `X ‖ Y`.
+    ///
+    /// # Errors
+    /// * [`HsmError::UnsupportedCmd`] — `curve` is not P-384.
+    /// * [`HsmError::InvalidArg`] — an output buffer is undersized.
+    /// * [`HsmError::EccGenerateError`] — the A.2.2 derivation exhausted its
+    ///   retries (see [`derive_pta_scalar_be`](Self::derive_pta_scalar_be)).
+    /// * Any [`HsmError`] surfaced by the HKDF / SHA / PKA drivers.
+    #[allow(dead_code)] // consumed by PTA/alias keygen + boot KAT
+    pub(crate) async fn ecc_gen_keypair_deterministic(
+        &self,
+        io: &impl HsmIo,
+        curve: UpkaEccCurve,
+        part_root: &DmaBuf,
+        d_le: &mut DmaBuf,
+        pub_key: &mut DmaBuf,
+    ) -> HsmResult<()> {
+        if curve != UpkaEccCurve::P384 {
+            return Err(HsmError::UnsupportedCmd);
+        }
+        let field = PRIME384_LE.len(); // 48
+        let mont = mont_operand_size(curve);
+        if d_le.len() < field || pub_key.len() < field * 2 {
+            return Err(HsmError::InvalidArg);
+        }
+
+        // 1. Derive the scalar big-endian (A.2.2), then flip to PKA
+        //    little-endian in place for the point multiply.
+        self.derive_pta_scalar_be(io, part_root, d_le).await?;
+        d_le[..field].reverse();
+
+        // 2. Q = d·G on ONE held engine, using the proven point-multiply
+        //    primitive with the base point G supplied explicitly (exactly as
+        //    the sign path computes k·G). `ecc_mont_const_calc` over the field
+        //    prime must run first on the same engine (the constant stays
+        //    resident; `execute_cmd` does not wipe between commands). Every
+        //    operand — G, the scalar, and the output — is a GSRAM DMA buffer,
+        //    which the PKA requires. `ecc_point_mul` writes the full affine
+        //    point X ‖ Y (little-endian) into the 96-byte `pub_key`.
+        //
+        //    NOTE: the driver's `ecc_gen_pub_key` is NOT used — it issues the
+        //    point-mul opcode with a null (0) scalar operand, so the PKA reads
+        //    the scalar from address 0 (not GSRAM) and faults with an AXI
+        //    BUS_ERROR (0x08f0c003).
+        self.alloc_scoped_async(io, async |scope| {
+            let prime = scope.dma_alloc(field)?;
+            prime.copy_from_slice(&PRIME384_LE);
+            let base_xy = scope.dma_alloc(field * 2)?;
+            base_xy[..field].copy_from_slice(&BASE384_X_LE);
+            base_xy[field..].copy_from_slice(&BASE384_Y_LE);
+            let mont_scratch = scope.dma_alloc(mont)?;
+            self.pka
+                .with_engine(async |eng| {
+                    eng.ecc_mont_const_calc(curve, prime, mont_scratch).await?;
+                    eng.ecc_point_mul(curve, base_xy, &d_le[..field], &mut pub_key[..field * 2])
+                        .await
+                })
+                .await
+        })
+        .await
     }
 }

--- a/fw/plat/uno/fw/pal/src/crypto/ecc_det.rs
+++ b/fw/plat/uno/fw/pal/src/crypto/ecc_det.rs
@@ -695,21 +695,29 @@ impl UnoHsmPal {
             info[KEYPAIR_LABEL_PTA.len() + 1..]
                 .copy_from_slice(&(PTA_OKM_LEN as u16).to_be_bytes());
 
-            let okm = scope.dma_alloc(PTA_OKM_LEN)?;
-
-            // Run the loop in an inner block so the candidate OKM (private key
-            // material) is scrubbed on every exit path, including an early `?`.
+            // Expand each candidate directly into the caller's output buffer:
+            // the OKM length equals the field size (`PTA_OKM_LEN == field`), so
+            // an accepted candidate is already the scalar in place — no separate
+            // DMA buffer and no copy on the keygen hot path.
+            //
+            // Run the loop in an inner block so a rejected candidate (still
+            // sensitive HKDF output) is scrubbed on every error exit, including
+            // an early `?`.
             let outcome = async {
                 for attempt in 0..PTA_KEYGEN_MAX_TRIES {
                     info[KEYPAIR_LABEL_PTA.len()] = attempt;
-                    self.hkdf_expand(io, HsmHashAlgo::Sha384, part_root, Some(&*info), okm)
-                        .await?;
+                    self.hkdf_expand(
+                        io,
+                        HsmHashAlgo::Sha384,
+                        part_root,
+                        Some(&*info),
+                        &mut d_be[..PTA_OKM_LEN],
+                    )
+                    .await?;
                     // A.2.2: the big-endian OKM is the candidate; accept iff it
-                    // is a valid scalar in [1, n-1].
-                    if ct_in_range(&okm[..field], &ORDER384_BE[..field]) {
-                        // Accept the big-endian candidate as-is; the caller
-                        // flips it to PKA little-endian.
-                        d_be[..field].copy_from_slice(&okm[..field]);
+                    // is a valid scalar in [1, n-1]. On accept it already sits in
+                    // `d_be`; the caller flips it to PKA little-endian.
+                    if ct_in_range(&d_be[..field], &ORDER384_BE[..field]) {
                         return Ok(());
                     }
                 }
@@ -719,7 +727,11 @@ impl UnoHsmPal {
             }
             .await;
 
-            okm.zeroize();
+            if outcome.is_err() {
+                // Scrub the rejected candidate left in the output buffer; on
+                // success the accepted scalar is retained as the function output.
+                d_be.zeroize();
+            }
             outcome
         })
         .await

--- a/fw/plat/uno/fw/pal/src/crypto/ecc_det.rs
+++ b/fw/plat/uno/fw/pal/src/crypto/ecc_det.rs
@@ -659,17 +659,19 @@ impl UnoHsmPal {
     /// is treated as a big-endian candidate and accepted iff it is a valid
     /// scalar in `[1, n-1]` ([`ct_in_range`], the same primitive as the RFC 6979
     /// `k` generator). A rejected candidate re-derives with a fresh counter, so
-    /// the loop is fully deterministic and reproduces the same scalar on replay
-    /// (SP 800-133r3 §4.2.3 "algorithm random values"). The accepted candidate
+    /// the loop is fully deterministic and reproduces the same scalar on replay.
+    /// The accepted candidate
     /// is written big-endian into `d_be`; the caller flips it to PKA
     /// little-endian before the point multiply.
     ///
     /// # Parameters
-    /// * `part_root` — the key-derivation key / PRK, a caller-owned DMA buffer.
+    /// * `part_root` — the 48-byte P-384 key-derivation key / PRK, a
+    ///   caller-owned DMA buffer.
     /// * `d_be` — caller-owned DMA output (≥ 48 B) for the big-endian scalar.
     ///
     /// # Errors
-    /// * [`HsmError::InvalidArg`] — `d_be` is shorter than the field size.
+    /// * [`HsmError::InvalidArg`] — `part_root` is not 48 bytes, or `d_be` is
+    ///   shorter than the field size.
     /// * [`HsmError::EccGenerateError`] — every attempt in
     ///   [`PTA_KEYGEN_MAX_TRIES`] fell outside `[1, n-1]` (unreachable in
     ///   practice at ~`2^-190` per attempt).
@@ -682,7 +684,11 @@ impl UnoHsmPal {
         d_be: &mut DmaBuf,
     ) -> HsmResult<()> {
         let field = PRIME384_LE.len(); // 48
-        if d_be.len() < field {
+        // `d_be` must hold the field-width scalar (may be oversized), and
+        // `part_root` is the 48-byte P-384 KDK used as the HKDF-Expand PRK —
+        // reject any other `part_root` length so the derivation contract is
+        // exact.
+        if d_be.len() < field || part_root.len() != field {
             return Err(HsmError::InvalidArg);
         }
 
@@ -760,9 +766,10 @@ impl UnoHsmPal {
     /// on every call from the same `part_root`.
     ///
     /// A FIPS pairwise-consistency test is intentionally NOT run here yet — the
-    /// uno keygen PCT is a no-op across the PAL — so the boot KAT validates the
-    /// derived pair against known-answer vectors instead. Wiring a real PCT is
-    /// tracked with the FIPS self-test work.
+    /// uno keygen PCT is a no-op across the PAL. The derivation was validated
+    /// during bring-up against known-answer vectors via a boot KAT (not part of
+    /// this change); wiring a persistent KAT / PCT self-test is tracked with the
+    /// FIPS self-test work.
     ///
     /// # Parameters
     /// * `curve` — must be [`UpkaEccCurve::P384`]; other curves return
@@ -813,30 +820,42 @@ impl UnoHsmPal {
         //    point-mul opcode with a null (0) scalar operand, so the PKA reads
         //    the scalar from address 0 (not GSRAM) and faults with an AXI
         //    BUS_ERROR (0x08f0c003).
-        self.alloc_scoped_async(io, async |scope| {
-            let prime = scope.dma_alloc(field)?;
-            prime.copy_from_slice(&PRIME384_LE);
-            let base_xy = scope.dma_alloc(field * 2)?;
-            base_xy[..field].copy_from_slice(&BASE384_X_LE);
-            base_xy[field..].copy_from_slice(&BASE384_Y_LE);
-            let mont_scratch = scope.dma_alloc(mont)?;
-            self.pka
-                .with_engine(async |eng| {
-                    eng.ecc_mont_const_calc(curve, prime, mont_scratch).await?;
-                    eng.ecc_point_mul(curve, base_xy, &d_le[..field], &mut pub_key[..field * 2])
-                        .await
-                })
-                .await
-        })
-        .await?;
+        let mul_result = self
+            .alloc_scoped_async(io, async |scope| {
+                let prime = scope.dma_alloc(field)?;
+                prime.copy_from_slice(&PRIME384_LE);
+                let base_xy = scope.dma_alloc(field * 2)?;
+                base_xy[..field].copy_from_slice(&BASE384_X_LE);
+                base_xy[field..].copy_from_slice(&BASE384_Y_LE);
+                let mont_scratch = scope.dma_alloc(mont)?;
+                self.pka
+                    .with_engine(async |eng| {
+                        eng.ecc_mont_const_calc(curve, prime, mont_scratch).await?;
+                        eng.ecc_point_mul(curve, base_xy, &d_le[..field], &mut pub_key[..field * 2])
+                            .await
+                    })
+                    .await
+            })
+            .await;
 
-        // Zero any bytes past the 96-byte `X ‖ Y` point so an oversized output
-        // buffer is fully deterministic and leaves no stale material. No-op when
-        // `pub_key` is exact-sized. (`d_le`'s tail is already zeroed by
-        // `derive_pta_scalar_be`.)
-        if pub_key.len() > field * 2 {
-            pub_key[field * 2..].zeroize();
+        match mul_result {
+            Ok(()) => {
+                // Zero any bytes past the 96-byte `X ‖ Y` point so an oversized
+                // output buffer is fully deterministic and leaves no stale
+                // material. No-op when `pub_key` is exact-sized. (`d_le`'s tail
+                // is already zeroed by `derive_pta_scalar_be`.)
+                if pub_key.len() > field * 2 {
+                    pub_key[field * 2..].zeroize();
+                }
+                Ok(())
+            }
+            Err(e) => {
+                // The private scalar is already derived and flipped to LE in
+                // `d_le` before the point multiply; scrub it so it does not
+                // linger in the caller's output buffer after a PKA failure.
+                d_le.zeroize();
+                Err(e)
+            }
         }
-        Ok(())
     }
 }

--- a/fw/plat/uno/fw/pal/src/crypto/ecc_det.rs
+++ b/fw/plat/uno/fw/pal/src/crypto/ecc_det.rs
@@ -727,12 +727,23 @@ impl UnoHsmPal {
             }
             .await;
 
-            if outcome.is_err() {
-                // Scrub the rejected candidate left in the output buffer; on
-                // success the accepted scalar is retained as the function output.
-                d_be.zeroize();
+            match outcome {
+                Ok(()) => {
+                    // Zero any bytes past the 48-byte scalar so an oversized
+                    // output buffer is fully deterministic and leaves no stale
+                    // material next to the key. No-op when `d_be` is exact-sized.
+                    if d_be.len() > PTA_OKM_LEN {
+                        d_be[PTA_OKM_LEN..].zeroize();
+                    }
+                    Ok(())
+                }
+                Err(e) => {
+                    // Scrub the rejected candidate left in the output buffer; on
+                    // success the accepted scalar is retained as the output.
+                    d_be.zeroize();
+                    Err(e)
+                }
             }
-            outcome
         })
         .await
     }
@@ -817,6 +828,15 @@ impl UnoHsmPal {
                 })
                 .await
         })
-        .await
+        .await?;
+
+        // Zero any bytes past the 96-byte `X ‖ Y` point so an oversized output
+        // buffer is fully deterministic and leaves no stale material. No-op when
+        // `pub_key` is exact-sized. (`d_le`'s tail is already zeroed by
+        // `derive_pta_scalar_be`.)
+        if pub_key.len() > field * 2 {
+            pub_key[field * 2..].zeroize();
+        }
+        Ok(())
     }
 }

--- a/fw/plat/uno/fw/reg/soc/src/io_gsram.rs
+++ b/fw/plat/uno/fw/reg/soc/src/io_gsram.rs
@@ -61,6 +61,10 @@ pub const BKS_TABLE_OFFSET: u32 = 0x1110;
 pub const BKS_TABLE_COUNT: u32 = 12;
 pub const BKS_TABLE_STRIDE: u32 = 0x29;
 pub const BKS_TABLE_SIZE: u32 = 0x29;
+pub const HSM_SEED_TABLE_OFFSET: u32 = 0x12FC;
+pub const HSM_SEED_TABLE_COUNT: u32 = 2;
+pub const HSM_SEED_TABLE_STRIDE: u32 = 0x30;
+pub const HSM_SEED_TABLE_SIZE: u32 = 0x30;
 pub const SRAM_IO_BUF_OFFSET: u32 = 0x20D60;
 pub const SRAM_IO_BUF_COUNT: u32 = 33;
 pub const SRAM_IO_BUF_STRIDE: u32 = 0x4800;
@@ -314,7 +318,8 @@ pub mod regs {
         pub IoGsramRegs {
             (0x0 => _reserved0),
             (0x1110 => pub bks_table: [u8; 492]),
-            (0x12fc => _reserved1),
+            (0x12fc => pub hsm_seed_table: [u8; 96]),
+            (0x135c => _reserved1),
             (0x7000 => pub boot_status: crate::RW<u32, super::BOOT_STATUS::Register>),
             (0x7004 => pub ipc_admin_hsm_rx_pi: crate::RW<u32, super::IPC_ADMIN_HSM_RX_PI::Register>),
             (0x7008 => pub ipc_admin_hsm_rx_ci: crate::RW<u32, super::IPC_ADMIN_HSM_RX_CI::Register>),

--- a/fw/plat/uno/rdl/soc/gsram_map.rdl
+++ b/fw/plat/uno/rdl/soc/gsram_map.rdl
@@ -9,6 +9,7 @@
 //
 // Region layout:
 //   0x01110 - 0x012FC  BKS table (device-global, 12 × 41-byte entries)
+//   0x012FC - 0x0135C  HSM seed table (UDS + FMC-CDI, 2 × 48-byte seeds)
 //   0x07000            BOOT_STATUS (4 B)
 //   0x07004 - 0x07114  Admin↔HSM IPC queues (indices + 2×2 ring slots)
 //   0x0E440 - 0x0F580  IIC / OIC queues
@@ -39,6 +40,28 @@
 mem bks_table_entry_t {
     desc = "Packed 41-byte BKS entry: valid(1) + svn(8) + bks(32).";
     mementries = 41;
+    memwidth   = 8;
+};
+
+
+// ══════════════════════════════════════════════════════════════
+// HSM Seed Table (device-rooted, SP-populated, read-only)
+// ══════════════════════════════════════════════════════════════
+//
+// Mirrors the reference firmware's GsRamMemMap::hsm_seed_table at the
+// identical GSRAM offset 0x12FC (abs 0x6100_12FC), immediately after
+// the BKS table. 2 packed 48-byte entries = 96 B (0x60):
+//   entry[0] = UDS seed      (firmware-state-independent device root)
+//   entry[1] = FMC-CDI seed  (DICE-CDI / firmware-measurement-bound)
+// Each entry is a bare 48-byte HMAC-SHA384 output written by the HSP
+// during boot; there is no per-entry header. Modeled as a byte-granular
+// (memwidth = 8) mem — the seed bytes are opaque key-derivation-key
+// material consumed by the deterministic-keygen path, so no typed field
+// split is imposed here.
+
+mem hsm_seed_entry_t {
+    desc = "48-byte device-rooted HSM seed (HMAC-SHA384 output).";
+    mementries = 48;
     memwidth   = 8;
 };
 
@@ -505,6 +528,11 @@ addrmap io_gsram {
 
     // ─── BKS table (device-global, SP-populated): 12 × 41-byte entries ───
     bks_table_entry_t BKS_TABLE[12]    @ 0x01110 += 0x29;  // 0x1110 - 0x12FC
+
+    // ─── HSM seed table (device-rooted, SP-populated): 2 × 48-byte seeds ───
+    //   [0] = UDS seed (firmware-state-independent)
+    //   [1] = FMC-CDI seed (firmware-measurement-bound)
+    hsm_seed_entry_t HSM_SEED_TABLE[2] @ 0x012FC += 0x30;  // 0x12FC - 0x135C
 
     // ─── Boot ───
     boot_status_t    BOOT_STATUS        @ 0x07000;


### PR DESCRIPTION
## Summary

Adds deterministic NIST P-384 key-pair generation for the uno CP HSM, plus the GSRAM memory-map entry the key-derivation input is sourced from.

The PTA/alias P-384 key pair is regenerated on demand from a device-rooted key-derivation key (KDK) instead of drawing it from the RNG, so it need not be stored and reproduces byte-identically across boots and firmware updates.

## Details

### `feat(uno/rdl): add hsm_seed_table (UDS + FMC-CDI) to GSRAM map`
- Adds `hsm_seed_table` (2 × 48-byte HMAC-SHA384 seeds — UDS + FMC-CDI) to `gsram_map.rdl` at `0x6100_12FC`, matching the HSP-populated GSRAM layout; regenerated `io_gsram.rs` via `cargo xtask reggen`.

### `feat(uno/keygen): deterministic FIPS 186-5 A.2.2 P-384 key generation`
- **Private scalar** (`derive_pta_scalar_be`): `OKM = HKDF-Expand-SHA384(part_root, label ‖ attempt ‖ len)`, accepted iff in `[1, n-1]` (FIPS 186-5 Appendix A.2.2 rejection sampling), reusing the existing `ct_in_range` primitive and `ORDER384_BE`. A rejected candidate re-derives with a fresh counter folded into the HKDF context, so the loop is fully deterministic (SP 800-133r3 §4.2 / §4.2.3). A.2.2 is used over A.2.1 to avoid the even-modulus `n-1` reduction the Montgomery-only PKA cannot perform.
- **Public key** (`ecc_gen_keypair_deterministic`): `Q = d·G` via `ecc_mont_const_calc` + `ecc_point_mul` with the base point G supplied explicitly on one held engine, all operands in GSRAM. The point-mul opcode writes the full point `X ‖ Y` little-endian.
- Exhaustion returns `EccGenerateError`.

## FIPS 140-3

The compliance basis is SP 800-133r3 §4.2 (deriving asymmetric key-pair input from a key-derivation key via an approved KDM), contingent on the KDK provenance (approved, ≥192-bit, secret) — tracked separately.

## Testing

- **Hardware**: validated on the Manticore EVB with a known-answer boot self-test — the derived `d`, `Qx`, `Qy` matched vectors computed off-device (HKDF-Expand-SHA384 + A.2.2 + P-384 `d·G`): `det keygen P384 KAT: PASS`. The self-test scaffolding is intentionally **not** part of this PR.
- `cargo xtask precheck` — fmt, clippy (`-D warnings`), copyright, and taplo all pass.

## Notes

- The keygen entry points are `#[allow(dead_code)]` until the DDI / PartInit wiring lands in a follow-up.
- The driver `ecc_gen_pub_key` is intentionally avoided: it issues the point-mul opcode with a null scalar operand, so the PKA reads the scalar from address 0 (not GSRAM) and faults with an AXI bus error. `Q = d·G` uses the explicit-base-point point-multiply instead.
