### PR TITLE
fix(ecc-sign): zero-extend short ECDSA digests to the curve field width

### DIFF
--- a/fw/core/lib/src/ddi/mbor/ecc_sign.rs
+++ b/fw/core/lib/src/ddi/mbor/ecc_sign.rs
@@ -24,15 +24,15 @@ pub(crate) async fn ecc_sign<'p, P: HsmPal>(
 
     let sess_id = hdr.sess_id.ok_or(HsmError::SessionExpected)?;
 
-    // Validate the digest_algo enum is supported and pin the slice
-    // length to the algo's native digest size — the host's
-    // `digest_pre_encode` LE-reverses `input_array.len()` bytes and
-    // zero-pads the rest to 68 wire bytes, so the leading
-    // `real_digest_len` bytes are the actual digest in wire-LE form.
-    // We hand that sub-slice straight to the PAL, which is
-    // responsible for any endianness flip its underlying primitive
-    // requires (e.g. std PAL reverses to BE for OpenSSL; real-HW
-    // PALs pass through to the PKA engine).
+    // Validate the digest_algo enum is supported and read the algo's native
+    // digest size — the host's `digest_pre_encode` LE-reverses
+    // `input_array.len()` bytes and zero-pads the rest to 68 wire bytes, so
+    // the leading `real_digest_len` bytes are the actual digest in wire-LE
+    // form and the remainder is zero. The slice handed to the PAL is widened
+    // to the curve field width below (see `sign_len`); each PAL is
+    // responsible for any endianness flip its underlying primitive requires
+    // (e.g. std PAL reverses to BE for OpenSSL; real-HW PALs pass through to
+    // the PKA engine).
     let pal_algo = super::from_ddi::hash(body.digest_algo)?;
     let real_digest_len = pal_algo.digest_len();
     if body.digest.len() < real_digest_len {
@@ -59,11 +59,33 @@ pub(crate) async fn ecc_sign<'p, P: HsmPal>(
         Ok((encoder.position(), layout))
     })?;
     let frame = DdiEccSignResp::from_layout(resp, &layout);
+
+    // The PKA engine DMA-reads a word-aligned, field-width operand for the
+    // digest (e.g. 68 bytes for P-521), while the driver only validates
+    // `hash.len() >= hash_size` (64 for P-521). The slice handed below is
+    // widened to the field width but its backing must cover the full wire
+    // coordinate width, or the engine would read past the request buffer into
+    // adjacent memory. The host always zero-pads `digest` to this width; reject
+    // anything shorter defensively so a malformed frame cannot trigger an
+    // out-of-bounds operand read.
+    if body.digest.len() < curve.wire_coord_len() {
+        return Err(HsmError::InvalidArg);
+    }
+
+    // Widen the digest slice to at least the curve's ECDSA field width. The
+    // leading `real_digest_len` bytes are the digest (wire-LE) and the padding
+    // beyond is zero, so a short digest (e.g. a SHA-256 digest signed with a
+    // P-384 key) is zero-extended up to the field width without any copy, and
+    // the operand stays backed by the padded wire buffer. A digest longer than
+    // the field is passed through so the std PAL's OpenSSL applies ECDSA
+    // leftmost-bits truncation; the uno PKA consumes only its field-width
+    // operand (full truncation for over-long digests is future FIPS ACVP work).
+    let sign_len = real_digest_len.max(curve.ecdsa_digest_len());
     pal.ecc_sign(
         io,
         curve,
         priv_key,
-        &body.digest[..real_digest_len],
+        &body.digest[..sign_len],
         frame.signature,
     )
     .await?;

--- a/fw/core/lib/src/ddi/mbor/ecc_sign.rs
+++ b/fw/core/lib/src/ddi/mbor/ecc_sign.rs
@@ -61,14 +61,32 @@ pub(crate) async fn ecc_sign<'p, P: HsmPal>(
     let frame = DdiEccSignResp::from_layout(resp, &layout);
 
     // The PKA engine DMA-reads a word-aligned, field-width operand for the
-    // digest (e.g. 68 bytes for P-521), while the driver only validates
-    // `hash.len() >= hash_size` (64 for P-521). The slice handed below is
-    // widened to the field width but its backing must cover the full wire
-    // coordinate width, or the engine would read past the request buffer into
-    // adjacent memory. The host always zero-pads `digest` to this width; reject
-    // anything shorter defensively so a malformed frame cannot trigger an
-    // out-of-bounds operand read.
-    if body.digest.len() < curve.wire_coord_len() {
+    // digest (`wire_coord_len`, e.g. 68 bytes for P-521), while the driver only
+    // validates `hash.len() >= hash_size` (64 for P-521). Two invariants must
+    // hold for the widened slice below to be well-defined:
+    //   1. the digest buffer must cover the full operand width, or the engine
+    //      would read past the request buffer into adjacent memory; and
+    //   2. every byte between the declared digest and the operand width is
+    //      folded into the signed value by that read, so it must be zero.
+    // The host zero-pads `digest` to the operand width (`digest_pre_encode`);
+    // reject a malformed frame that is too short or carries non-zero padding
+    // (including the P-521 trailing wire pad) so the signature is always
+    // well-defined over exactly the declared digest.
+    //
+    // Cost: the scan below touches only the padding region
+    // (`operand_len - real_digest_len`), once per sign — not the whole buffer.
+    // For a digest matched to its curve (P-256+SHA-256, P-384+SHA-384,
+    // P-521+SHA-512) that region is 0-4 bytes (only the P-521 `[64..68]` wire
+    // pad), so the common path is effectively free; the worst case is a short
+    // digest on P-521 (~36 bytes), trivial next to the PKA sign.
+    let operand_len = curve.wire_coord_len();
+    if body.digest.len() < operand_len {
+        return Err(HsmError::InvalidArg);
+    }
+    if body.digest[real_digest_len.min(operand_len)..operand_len]
+        .iter()
+        .any(|&b| b != 0)
+    {
         return Err(HsmError::InvalidArg);
     }
 

--- a/fw/core/lib/src/ddi/mbor/ecc_sign.rs
+++ b/fw/core/lib/src/ddi/mbor/ecc_sign.rs
@@ -60,18 +60,29 @@ pub(crate) async fn ecc_sign<'p, P: HsmPal>(
     })?;
     let frame = DdiEccSignResp::from_layout(resp, &layout);
 
-    // The PKA engine DMA-reads a word-aligned, field-width operand for the
-    // digest (`wire_coord_len`, e.g. 68 bytes for P-521), while the driver only
-    // validates `hash.len() >= hash_size` (64 for P-521). Two invariants must
-    // hold for the widened slice below to be well-defined:
-    //   1. the digest buffer must cover the full operand width, or the engine
-    //      would read past the request buffer into adjacent memory; and
-    //   2. every byte between the declared digest and the operand width is
-    //      folded into the signed value by that read, so it must be zero.
-    // The host zero-pads `digest` to the operand width (`digest_pre_encode`);
-    // reject a malformed frame that is too short or carries non-zero padding
-    // (including the P-521 trailing wire pad) so the signature is always
-    // well-defined over exactly the declared digest.
+    // Two curve-specific widths matter here, each with a single source of truth:
+    //   * the digest VALUE width, `curve.ecdsa_digest_len()` (32 / 48 / 64) —
+    //     the meaningful digest bytes that are signed (also what the std PAL's
+    //     OpenSSL and the UPKA driver's `hash.len() >= hash_size` check bound);
+    //     and
+    //   * the PKA DMA OPERAND width, `curve.wire_coord_len()` (32 / 48 / 68) —
+    //     the word-aligned field the engine actually DMA-reads for the digest.
+    // They coincide for P-256/P-384 but differ for P-521 (64 vs 68): the 66-byte
+    // P-521 field is zero-padded to a 32-bit word boundary. The engine reads the
+    // full operand width regardless of the slice length handed to the driver, so
+    // the driver's `hash_size` check alone is NOT sufficient to keep the read in
+    // bounds (verified on HW: a 64-byte-backed P-521 digest over-reads and
+    // yields a wrong signature). Enforce the operand-width invariants here, where
+    // the whole `digest` buffer is visible, rather than at the driver, which only
+    // sees the sliced view's length.
+    //
+    // The host zero-pads `digest` to the operand width (`digest_pre_encode`
+    // always emits 68 wire bytes, so a conforming frame never trips these). We
+    // require that (1) the buffer covers the operand width, so the DMA read stays
+    // in bounds, and (2) every byte between the declared digest and the operand
+    // width is zero, since the read folds them into the signed value — so the
+    // signature is well-defined over exactly the declared digest even for a
+    // malformed frame.
     //
     // Cost: the scan below touches only the padding region
     // (`operand_len - real_digest_len`), once per sign — not the whole buffer.

--- a/fw/pal/traits/src/crypto/ecc.rs
+++ b/fw/pal/traits/src/crypto/ecc.rs
@@ -279,11 +279,17 @@ pub trait HsmEcc {
     ///   (32 / 48 / 68 bytes for P-256 / P-384 / P-521).
     /// - `hash` — message digest to sign, in **little-endian** byte
     ///   order to match the wire-native format produced by real PKA
-    ///   hardware.  Must contain exactly the digest's native length
-    ///   (e.g. 32 bytes for SHA-256, 64 bytes for SHA-512); ECDSA
-    ///   truncates internally if longer than the curve's order.
-    ///   Implementations that delegate to a big-endian-native
-    ///   primitive (e.g. OpenSSL) must reverse the bytes internally.
+    ///   hardware.  This is the field-width sign *operand*, not
+    ///   necessarily the raw digest: the caller (the DDI `EccSign`
+    ///   handler) widens a short digest to at least
+    ///   `HsmEccCurve::ecdsa_digest_len(curve)` (32 / 48 / 64 for
+    ///   P-256 / P-384 / P-521) by zero-extending the trailing bytes,
+    ///   so e.g. a SHA-256 digest signed with a P-384 key arrives as
+    ///   48 bytes with the high 16 zero.  Any bytes past the digest
+    ///   must be zero.  A digest longer than the curve's order is
+    ///   ECDSA-truncated internally.  Implementations that delegate to
+    ///   a big-endian-native primitive (e.g. OpenSSL) must reverse the
+    ///   bytes internally.
     /// - `signature` — output buffer.  On return, holds `r || s`
     ///   with **each component in little-endian** byte order — the
     ///   wire-native format produced by real PKA hardware.  P-521

--- a/fw/pal/traits/src/crypto/ecc.rs
+++ b/fw/pal/traits/src/crypto/ecc.rs
@@ -70,6 +70,25 @@ impl HsmEccCurve {
         }
     }
 
+    /// Return the ECDSA digest field width in bytes that the sign path
+    /// zero-extends the host digest to before handing it to the signing
+    /// primitive: the raw curve field size ([`HsmEccCurve::priv_key_len`])
+    /// capped at the largest FIPS digest (SHA-512, 64 bytes).
+    ///
+    /// | Curve  | Width |
+    /// |--------|-------|
+    /// | P-256  | 32    |
+    /// | P-384  | 48    |
+    /// | P-521  | 64    |
+    ///
+    /// A host digest shorter than this (e.g. a SHA-256 digest signed with a
+    /// P-384 key) is zero-extended up to this width so the on-chip PKA engine
+    /// receives a full field-width little-endian operand; the width stays
+    /// `<= 64` so the OpenSSL-backed std PAL signs it without truncation.
+    pub fn ecdsa_digest_len(&self) -> usize {
+        self.priv_key_len().min(64)
+    }
+
     /// Return the **raw cryptographic** public-key length in bytes
     /// (`X || Y`, each [`HsmEccCurve::priv_key_len`] bytes).
     ///

--- a/fw/plat/uno/fw/drivers/upka/src/engine.rs
+++ b/fw/plat/uno/fw/drivers/upka/src/engine.rs
@@ -64,7 +64,15 @@ impl<const DEPTH: usize, const ENGINES: usize> UpkaEngine<'_, DEPTH, ENGINES> {
     ///
     /// - `curve`: ECC curve selector.
     /// - `priv_key`: DMA-capable private key buffer.
-    /// - `hash`: DMA-capable digest buffer.
+    /// - `hash`: DMA-capable digest buffer. The engine DMA-reads a
+    ///   **word-aligned, field-width operand** — one `hsm_point_size(curve)`
+    ///   (32 / 48 / 68) — regardless of `hash.len()`. The length check below
+    ///   only enforces the digest **value** width (`hash_size`, 32 / 48 / 64),
+    ///   which is a lower bound; for P-521 the read extends past it (66-byte
+    ///   field padded to 68), so **the caller must ensure `hash` is backed to
+    ///   the operand width and zero-padded there** (the DDI `EccSign` handler
+    ///   enforces this against the full request buffer). A shorter backing
+    ///   over-reads adjacent memory and produces a wrong signature.
     /// - `signature`: DMA-capable output buffer for `r || s`.
     ///
     /// # Returns


### PR DESCRIPTION
## Summary

The DDI `EccSign` handler forwarded a digest sized to the **hash algorithm** (e.g. 32 bytes for SHA-256), which can be shorter than the **curve field** (48 bytes for P-384, 64 for P-521). The uno PKA engine consumes a word-aligned, field-width operand, so signing any digest shorter than the curve field (e.g. a SHA-256 digest with a P-384 key) failed with `CMD_ERROR`.

This widens the digest slice to `HsmEccCurve::ecdsa_digest_len()` by reusing the zero-padding the host already applies (`digest_pre_encode` pads to 68 wire bytes), so short digests are zero-extended to the field width with **no allocation or copy on the sign hot path**. A defensive bounds check ensures the digest buffer covers the full wire coordinate width so a malformed frame cannot trigger an out-of-bounds PKA operand read.

### Changes
- `fw/core/lib/src/ddi/mbor/ecc_sign.rs` — widen the digest slice to the curve field width (zero-copy) + out-of-bounds bounds check.
- `fw/pal/traits/src/crypto/ecc.rs` — add `HsmEccCurve::ecdsa_digest_len()` (curve field size capped at SHA-512 = 64 bytes).

## Test report

`ecc_sign` DDI integration suite (`ddi/mbor/types/tests/integration`):

| Backend | Result |
|---|---|
| emu | **18 / 18 pass** |
| uno HW (Manticore EVB) | **16 / 18 pass** |

All 9 `ecc_sign_compat` cases pass on both backends (including P-521 + SHA-384, which previously produced a non-verifying signature). The 2 remaining uno HW failures are pre-existing `UnsupportedCmd` feature stubs unrelated to this change — `attest_key` (attestation not yet implemented on uno) and `ecc_sign_verify::incorrect_key_type` (blocked by AES-128 generate) — both pass on emu.

## Performance (uno HW, `mcr_perf`, 128 threads, 5 s stabilize, 60 s)

| Curve | Throughput |
|---|---|
| P-256 | 41,390 sign/s |
| P-384 | 25,042 sign/s |
| P-521 | 15,930 sign/s |
