### PR TITLE
perf(uno/ecc-det): table-drive the deterministic ECDSA-P384 sign

### DIFF
--- a/fw/plat/uno/fw/drivers/upka/src/engine.rs
+++ b/fw/plat/uno/fw/drivers/upka/src/engine.rs
@@ -34,6 +34,65 @@ impl<const DEPTH: usize, const ENGINES: usize> core::fmt::Debug for UpkaEngine<'
     }
 }
 
+/// PKA operation selector for an [`EccStep`], mapped to a per-curve opcode by
+/// [`UpkaEngine::ecc_run`]. These are the modular / elliptic-curve primitives
+/// the PAL composes into the deterministic ECDSA sign.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum EccStepOp {
+    /// Compute the Montgomery constant for `arg1` (a modulus) and leave it
+    /// resident in the engine for the steps that follow.
+    MontConstCalc,
+    /// Elliptic-curve point multiply `result = arg2 * arg1` (`arg1` is the
+    /// affine `x ‖ y` point, `arg2` the scalar).
+    PointMul,
+    /// Modular reduction `result = arg1 mod n` (double-width `arg1`).
+    ModReduction,
+    /// Convert `arg1` into Montgomery representation.
+    MontReprIn,
+    /// Convert `arg1` out of Montgomery representation.
+    MontReprOut,
+    /// Modular inverse `result = arg1^-1 mod n`.
+    ModInverse,
+    /// Modular multiply `result = arg1 * arg2 mod n` (Montgomery form).
+    ModMul,
+    /// Modular add `result = arg1 + arg2 mod n` (Montgomery form).
+    ModAdd,
+}
+
+/// One step of a PKA sequence executed by [`UpkaEngine::ecc_run`].
+///
+/// Carries pre-resolved operand DMA addresses: `result` is the output address
+/// (`buf.as_mut_ptr() as u32`) and `arg1`/`arg2` are input addresses
+/// (`buf.as_ptr() as u32`, `arg2 == 0` when the op takes a single input). The
+/// caller owns the buffers and is responsible for their DMA-accessibility and
+/// per-op sizing (mirroring the checks in the typed step wrappers).
+#[derive(Clone, Copy, Debug)]
+pub struct EccStep {
+    /// The modular / EC operation to issue.
+    pub op: EccStepOp,
+    /// Output operand DMA address.
+    pub result: u32,
+    /// First input operand DMA address.
+    pub arg1: u32,
+    /// Second input operand DMA address, or 0 if the op takes one input.
+    pub arg2: u32,
+}
+
+impl EccStep {
+    /// Construct a step from an op and its pre-resolved operand DMA addresses
+    /// (`arg2 == 0` for single-input ops). A terse constructor so the sign's
+    /// step tables stay one line per step.
+    #[inline(always)]
+    pub const fn new(op: EccStepOp, result: u32, arg1: u32, arg2: u32) -> Self {
+        Self {
+            op,
+            result,
+            arg1,
+            arg2,
+        }
+    }
+}
+
 impl<const DEPTH: usize, const ENGINES: usize> UpkaEngine<'_, DEPTH, ENGINES> {
     const RESULT_WORD_LEN: usize = 4;
 
@@ -631,6 +690,52 @@ impl<const DEPTH: usize, const ENGINES: usize> UpkaEngine<'_, DEPTH, ENGINES> {
             0,
         )
         .await
+    }
+
+    /// Execute a pre-built PKA `steps` sequence on this held engine as a single
+    /// awaited command loop.
+    ///
+    /// Every step is issued through the same [`execute_cmd`](Self::execute_cmd)
+    /// await, so the caller's async state machine holds ONE suspend point
+    /// regardless of the sequence length. Written as straight-line `.await`
+    /// calls, the ~14-step deterministic ECDSA sign expands to ~14 distinct
+    /// suspend states and a correspondingly large `.text` state machine; routing
+    /// them through this loop collapses that to one. Signing is a cold,
+    /// PKA-latency-bound path, so the per-step opcode dispatch costs nothing at
+    /// runtime.
+    ///
+    /// The Montgomery constant established by an [`EccStepOp::MontConstCalc`]
+    /// step stays resident for the steps that follow (`execute_cmd` does not
+    /// wipe between commands), so callers order the sequence accordingly. Operand
+    /// sizing/DMA-accessibility is the caller's responsibility (see [`EccStep`]);
+    /// a step with a null (`0`) `result`/`arg1`, or an `arg2` that does not match
+    /// the op's arity, is rejected with [`UpkaError::CMD_ERROR`].
+    pub async fn ecc_run(&mut self, curve: UpkaEccCurve, steps: &[EccStep]) -> HsmResult<()> {
+        for step in steps {
+            let (opcode, takes_arg2) = match step.op {
+                EccStepOp::MontConstCalc => (mont_const_calc_opcode(curve), false),
+                EccStepOp::PointMul => (ecc_point_mul_opcode(curve), true),
+                EccStepOp::ModReduction => (mod_reduction_opcode(curve), false),
+                EccStepOp::MontReprIn => (mont_repr_in_opcode(curve), false),
+                EccStepOp::MontReprOut => (mont_repr_out_opcode(curve), false),
+                EccStepOp::ModInverse => (mod_inverse_opcode(curve), false),
+                EccStepOp::ModMul => (mod_multiplication_opcode(curve), true),
+                EccStepOp::ModAdd => (mod_addition_opcode(curve), true),
+            };
+            // Every op writes `result` and reads `arg1`; a two-input op also reads
+            // `arg2`, while a single-input op must leave it 0. Because `EccStep`
+            // carries raw DMA addresses in public fields and `execute_cmd` does no
+            // validation, a null (`0`) operand or a mismatched `arg2` would
+            // silently submit a malformed hardware command (a null operand address
+            // faults the PKA/AXI bus). Release firmware can't rely on
+            // `debug_assert`, so reject the misuse with an error instead.
+            Self::ensure_cmd_input(
+                step.result != 0 && step.arg1 != 0 && (step.arg2 != 0) == takes_arg2,
+            )?;
+            self.execute_cmd(opcode, step.result, step.arg1, step.arg2, 0)
+                .await?;
+        }
+        Ok(())
     }
 
     /// Wipe the engine's internal state.

--- a/fw/plat/uno/fw/pal/src/crypto/ecc_det.rs
+++ b/fw/plat/uno/fw/pal/src/crypto/ecc_det.rs
@@ -32,6 +32,8 @@ use azihsm_fw_hsm_pal_traits::HsmIo;
 use azihsm_fw_hsm_pal_traits::HsmKdf;
 use azihsm_fw_hsm_pal_traits::HsmResult;
 use azihsm_fw_hsm_pal_traits::HsmScopedAlloc;
+use azihsm_fw_uno_drivers_upka::EccStep;
+use azihsm_fw_uno_drivers_upka::EccStepOp;
 use azihsm_fw_uno_drivers_upka::UpkaEccCurve;
 use azihsm_fw_uno_drivers_upka::mont_operand_size;
 
@@ -312,49 +314,86 @@ impl UnoHsmPal {
             let t_dot_r = scope.dma_alloc(mont)?;
             let s_plus_t = scope.dma_alloc(mont)?;
 
+            // Pre-resolve every operand's DMA address once. The sign issues its
+            // ~14 PKA steps through a single `ecc_run` command loop (run twice,
+            // split only by the CPU-side `xR ‖ 0` staging below) rather than as
+            // ~14 straight-line `.await`s. Each `.await` is a distinct suspend
+            // point in the generated async state machine, so collapsing them into
+            // one loop keeps this future's `.text` small; the sign is a cold,
+            // PKA-latency-bound path, so the loop costs nothing at runtime.
+            let a_prime = prime.as_ptr() as u32;
+            let a_order = order.as_ptr() as u32;
+            let a_base = base_xy.as_ptr() as u32;
+            let a_k = k.as_ptr() as u32;
+            let a_digest = digest.as_ptr() as u32;
+            let a_d = d.as_ptr() as u32;
+            let a_r = r.as_mut_ptr() as u32;
+            let a_s = s.as_mut_ptr() as u32;
+            let a_mont = mont_scratch.as_mut_ptr() as u32;
+            let a_xr = xr.as_mut_ptr() as u32;
+            let a_xr_wide = xr_wide.as_mut_ptr() as u32;
+            let a_k_mont = k_mont.as_mut_ptr() as u32;
+            let a_r_mont = r_mont.as_mut_ptr() as u32;
+            let a_e_mont = e_mont.as_mut_ptr() as u32;
+            let a_d_mont = d_mont.as_mut_ptr() as u32;
+            let a_k_inv = k_inv.as_mut_ptr() as u32;
+            let a_s_mont = s_mont.as_mut_ptr() as u32;
+            let a_t_mont = t_mont.as_mut_ptr() as u32;
+            let a_t_dot_r = t_dot_r.as_mut_ptr() as u32;
+            let a_s_plus_t = s_plus_t.as_mut_ptr() as u32;
+
+            // Phase 1 (Montgomery constant = curve prime p): xR = (k·G).x.
+            let prime_phase = [
+                EccStep::new(EccStepOp::MontConstCalc, a_mont, a_prime, 0),
+                EccStep::new(EccStepOp::PointMul, a_xr, a_base, a_k),
+            ];
+            // Phase 2 (Montgomery constant = order n): r = xR mod n, then
+            // s = k⁻¹·(e + r·d) mod n  (s = k⁻¹·e ; t = k⁻¹·d ; t = t·r ; s = s + t),
+            // finally s back to normal representation.
+            let order_phase = [
+                EccStep::new(EccStepOp::MontConstCalc, a_mont, a_order, 0),
+                EccStep::new(EccStepOp::ModReduction, a_r, a_xr_wide, 0),
+                EccStep::new(EccStepOp::MontReprIn, a_k_mont, a_k, 0),
+                EccStep::new(EccStepOp::MontReprIn, a_r_mont, a_r, 0),
+                EccStep::new(EccStepOp::MontReprIn, a_e_mont, a_digest, 0),
+                EccStep::new(EccStepOp::MontReprIn, a_d_mont, a_d, 0),
+                EccStep::new(EccStepOp::ModInverse, a_k_inv, a_k_mont, 0),
+                EccStep::new(EccStepOp::ModMul, a_s_mont, a_k_inv, a_e_mont),
+                EccStep::new(EccStepOp::ModMul, a_t_mont, a_k_inv, a_d_mont),
+                EccStep::new(EccStepOp::ModMul, a_t_dot_r, a_t_mont, a_r_mont),
+                EccStep::new(EccStepOp::ModAdd, a_s_plus_t, a_s_mont, a_t_dot_r),
+                EccStep::new(EccStepOp::MontReprOut, a_s, a_s_plus_t, 0),
+            ];
+
             // Drive the whole sequence on one held engine so the Montgomery
-            // constant set below stays resident for the ops that follow.
+            // constant set by each phase stays resident for the ops that follow.
             let res = self
                 .pka
                 .with_engine(async |eng| {
-                    // Montgomery constant = curve prime p, then xR = (k·G).x.
-                    eng.ecc_mont_const_calc(curve, prime, mont_scratch).await?;
-                    eng.ecc_point_mul(curve, base_xy, k, xr).await?;
+                    eng.ecc_run(curve, &prime_phase).await?;
 
-                    // Switch the Montgomery constant to the order n for the
-                    // scalar arithmetic, then r = xR mod n (must be non-zero).
-                    // Reduction is double-width: stage xR into the low half of
-                    // the zeroed xr_wide so the hardware reduces `xR ‖ 0`.
-                    eng.ecc_mont_const_calc(curve, order, mont_scratch).await?;
+                    // Reduction is double-width: stage xR into the low half of the
+                    // zeroed xr_wide so the hardware reduces `xR ‖ 0` (its zeroed
+                    // high half is essential, or the reduction yields a wrong `r`).
                     xr_wide[..field].copy_from_slice(&xr[..field]);
-                    eng.ecc_mod_reduction(curve, r, xr_wide).await?;
-                    if r[..field].iter().all(|&b| b == 0) {
-                        return Err(HsmError::InvalidArg);
-                    }
 
-                    // Montgomery form of k, r, e, d.
-                    eng.ecc_mont_repr_in(curve, k_mont, k).await?;
-                    eng.ecc_mont_repr_in(curve, r_mont, r).await?;
-                    eng.ecc_mont_repr_in(curve, e_mont, digest).await?;
-                    eng.ecc_mont_repr_in(curve, d_mont, d).await?;
-
-                    // k⁻¹ mod n, then s = k⁻¹·(e + r·d) mod n:
-                    //   s = k⁻¹·e ; t = k⁻¹·d ; t = t·r ; s = s + t.
-                    eng.ecc_mod_inverse(curve, k_inv, k_mont).await?;
-                    eng.ecc_mod_mul(curve, s_mont, k_inv, e_mont).await?;
-                    eng.ecc_mod_mul(curve, t_mont, k_inv, d_mont).await?;
-                    eng.ecc_mod_mul(curve, t_dot_r, t_mont, r_mont).await?;
-                    eng.ecc_mod_add(curve, s_plus_t, s_mont, t_dot_r).await?;
-
-                    // Back to normal representation (must be non-zero).
-                    eng.ecc_mont_repr_out(curve, s, s_plus_t).await?;
-                    if s[..field].iter().all(|&b| b == 0) {
-                        return Err(HsmError::InvalidArg);
-                    }
-
-                    Ok(())
+                    eng.ecc_run(curve, &order_phase).await
                 })
                 .await;
+
+            // Reject a degenerate signature (`r == 0` or `s == 0`) after the full
+            // sequence — RFC 6979 §3.2 requires advancing to the next candidate,
+            // which the caller does on `InvalidArg`. Deferring the `r == 0` gate
+            // (previously mid-sequence) lets phase 2 run as one uninterrupted
+            // command loop; a zero `r` only wastes the remaining, astronomically
+            // rare PKA ops before this rejects.
+            let res = res.and_then(|()| {
+                if r[..field].iter().all(|&b| b == 0) || s[..field].iter().all(|&b| b == 0) {
+                    Err(HsmError::InvalidArg)
+                } else {
+                    Ok(())
+                }
+            });
 
             // Scrub secret-bearing internal scratch on EVERY exit path (success,
             // degenerate r/s, or a mid-sequence PKA error): the scoped allocator


### PR DESCRIPTION
## What

The deterministic ECDSA-P384 sign (`ecc_sign_with_k`) was written as ~13 straight-line `eng.ecc_*(...).await` calls. Each `.await` is a distinct suspend point in the generated async state machine, so the sign compiled to a dedicated ~14 KiB `.text` symbol (`ecc_sign_deterministic::{{closure}}`) — one of the largest single functions in the image.

This PR adds a table-driven `UpkaEngine::ecc_run(curve, &[EccStep])` primitive that issues a pre-built PKA command sequence through a **single awaited command loop**, collapsing the ~14 suspend states to one. `ecc_sign_with_k` now resolves its operand DMA addresses once and drives the sign as two `EccStep` tables (prime phase, order phase), split only by the CPU-side `xR ‖ 0` staging. The `r == 0` degeneracy gate is deferred to join the `s == 0` check so the order phase runs as one uninterrupted loop (still RFC 6979 §3.2 compliant).

Scope: **deterministic ECDSA only.** `execute_cmd` and the per-op opcode selectors are crate-private, so the loop lives in the upka driver; the typed step wrappers are retained for other callers.

## Why not simpler knobs

Measured on this firmware:
- `#[inline(never)]` on the async fns: **no effect** — an awaited async fn cannot be un-inlined (the child future is structurally stored in the parent state machine).
- per-crate `opt-level="z"`: **−1.7 KiB** — defeated by fat LTO, which re-optimizes whole-program at the top-level `opt-level = 3`.
- No heap allocator, so `Box::pin` (which *would* split the state machine) is unavailable.

A structural change was the only lever that works at `-O3`.

## Result (cargo-bloat, thumbv7em release, -O3 + LTO)

| symbol | before | after |
|---|---|---|
| `ecc_sign_deterministic` | 13.9 KiB | eliminated |
| `generate_pid_cert` | 8.4 KiB | 2.7 KiB |
| total `.text` | 400.9 KiB | 397.6 KiB |

## Validation

- **Boot KATs** (throwaway, not in this PR): NIST CAVP P-384 SigGen + RFC 6979 A.2.6 vectors — all PASS, byte-exact `(r,s)` / `k` on the Uno EVB.
- **DDI e2e** on the Uno EVB: `open_session::test_open_session` and `get_cert_chain::test_get_certificate_chain` both PASS (the cert-chain path signs the PID leaf via `ecc_sign_deterministic`).
- Builds clean under `-D warnings`.
