### PR TITLE
uno: RsaUnwrap bring-up — OAEP endianness fix + non-CRT RSA private-key import

### DIFF
--- a/fw/plat/uno/fw/Cargo.toml
+++ b/fw/plat/uno/fw/Cargo.toml
@@ -112,6 +112,7 @@ static_assertions = "1.1.0"
 syn = { features = ["full"], version = "2" }
 tock-registers = { git = "https://github.com/tock/tock.git", rev = "release-2.2" }
 zerocopy = "0.8.48"
+zeroize = { default-features = false, version = "1.8.1" }
 
 [workspace.lints.rust]
 future_incompatible = { level = "deny", priority = -1 }

--- a/fw/plat/uno/fw/Cargo.toml
+++ b/fw/plat/uno/fw/Cargo.toml
@@ -95,6 +95,10 @@ cortex-m = "0.7.7"
 cortex-m-rt = "0.7.5"
 critical-section = "1.2.0"
 darling = "0.20"
+der = { default-features = false, features = [
+  "derive",
+  "oid",
+], version = "0.8" }
 embassy-executor = "0.10.0"
 embassy-futures = "0.1.2"
 embassy-sync = "0.8.0"

--- a/fw/plat/uno/fw/pal/Cargo.toml
+++ b/fw/plat/uno/fw/pal/Cargo.toml
@@ -46,7 +46,10 @@ embassy-time = { workspace = true }
 tock-registers = { workspace = true }
 
 bitfield-struct = { workspace = true }
-der = { version = "0.8", default-features = false, features = ["derive", "oid"] }
+der = { default-features = false, features = [
+  "derive",
+  "oid",
+], version = "0.8" }
 open-enum = { workspace = true }
 zerocopy = { workspace = true }
 zeroize = { workspace = true }

--- a/fw/plat/uno/fw/pal/Cargo.toml
+++ b/fw/plat/uno/fw/pal/Cargo.toml
@@ -46,10 +46,7 @@ embassy-time = { workspace = true }
 tock-registers = { workspace = true }
 
 bitfield-struct = { workspace = true }
-der = { default-features = false, features = [
-  "derive",
-  "oid",
-], version = "0.8" }
+der = { workspace = true }
 open-enum = { workspace = true }
 zerocopy = { workspace = true }
 zeroize = { workspace = true }

--- a/fw/plat/uno/fw/pal/Cargo.toml
+++ b/fw/plat/uno/fw/pal/Cargo.toml
@@ -46,6 +46,7 @@ embassy-time = { workspace = true }
 tock-registers = { workspace = true }
 
 bitfield-struct = { workspace = true }
+der = { version = "0.8", default-features = false, features = ["derive", "oid"] }
 open-enum = { workspace = true }
 zerocopy = { workspace = true }
 zeroize = { workspace = true }

--- a/fw/plat/uno/fw/pal/Cargo.toml
+++ b/fw/plat/uno/fw/pal/Cargo.toml
@@ -48,6 +48,7 @@ tock-registers = { workspace = true }
 bitfield-struct = { workspace = true }
 open-enum = { workspace = true }
 zerocopy = { workspace = true }
+zeroize = { workspace = true }
 
 [features]
 default = []

--- a/fw/plat/uno/fw/pal/src/asn1.rs
+++ b/fw/plat/uno/fw/pal/src/asn1.rs
@@ -73,7 +73,7 @@ pub(crate) struct RsaPrivateKeyAsn1<'a> {
     pub(crate) coefficient: UintRef<'a>,
 }
 
-/// Decodes a recovered RSA private key — a PKCS#8 `PrivateKeyInfo` or a bare
+/// Decodes a recovered RSA private key — a PKCS#8 `PrivateKeyInfo` wrapping a
 /// PKCS#1 `RSAPrivateKey` — into the validated [`RsaPrivateKeyAsn1`].
 ///
 /// The `der` crate enforces canonical DER (definite minimal-length encodings,
@@ -83,17 +83,17 @@ pub(crate) struct RsaPrivateKeyAsn1<'a> {
 /// sizes (modulus width, exponent width) are a PKA concern and are checked by
 /// the caller during operand assembly.
 pub(crate) fn parse_rsa_private_key(der_bytes: &[u8]) -> Option<RsaPrivateKeyAsn1<'_>> {
-    let key = if let Ok(pki) = RsaPrivateKeyInfo::from_der(der_bytes) {
-        // RFC 5208 §5: PrivateKeyInfo `version` is v1 (= 0). RFC 5958 adds v2
-        // (= 1) with public-key / attributes, which this parser does not model
-        // — reject rather than silently drop the extra fields.
-        if pki.version != 0 || pki.algorithm.oid != RSA_ENCRYPTION {
-            return None;
-        }
-        RsaPrivateKeyAsn1::from_der(pki.private_key.as_bytes()).ok()?
-    } else {
-        RsaPrivateKeyAsn1::from_der(der_bytes).ok()?
-    };
+    // The recovered wire key is always a PKCS#8 PrivateKeyInfo (the format the
+    // RsaUnwrap collateral is generated in); a bare PKCS#1 RSAPrivateKey is not
+    // accepted.
+    let pki = RsaPrivateKeyInfo::from_der(der_bytes).ok()?;
+    // RFC 5208 §5: PrivateKeyInfo `version` is v1 (= 0). RFC 5958 adds v2
+    // (= 1) with public-key / attributes, which this parser does not model
+    // — reject rather than silently drop the extra fields.
+    if pki.version != 0 || pki.algorithm.oid != RSA_ENCRYPTION {
+        return None;
+    }
+    let key = RsaPrivateKeyAsn1::from_der(pki.private_key.as_bytes()).ok()?;
     // RFC 8017 §A.1.2: `version` is 0 for two-prime keys. Version 1 (multi-prime)
     // would require `otherPrimeInfos`, which our SEQUENCE does not declare.
     if key.version != 0 {

--- a/fw/plat/uno/fw/pal/src/asn1.rs
+++ b/fw/plat/uno/fw/pal/src/asn1.rs
@@ -1,0 +1,103 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! ASN.1 / DER decoders for imported private keys, built on the no-alloc
+//! [`der`] crate (the same dependency `fw/core/crypto/x509-chain` already uses).
+//!
+//! The wrapped-key import paths (`RsaUnwrap`) recover a plaintext DER private
+//! key and must decode it into the raw components the PKA vault operand is
+//! assembled from. This module owns only the **pure ASN.1 decode** (PKCS#8 / PKCS#1, and — as they land — SEC1 EC); the
+//! platform-specific little-endian PKA operand layout lives in the
+//! per-algorithm modules ([`rsa`](crate::crypto::rsa), [`ecc`](crate::crypto::ecc)) so this
+//! stays a small, hardware-agnostic parsing layer.
+//!
+//! ## Scope and forward-looking extension points
+//!
+//! - **RSA non-CRT (today):** [`parse_rsa_private_key`] →
+//!   [`RsaPrivateKeyAsn1`]; `rsa` assembles `[d ‖ n ‖ e]`.
+//! - **RSA CRT (#608):** reuses [`RsaPrivateKeyAsn1`] as-is — it already decodes
+//!   the CRT fields (`prime1`, `prime2`, `exponent1`, `exponent2`,
+//!   `coefficient`). Only the CRT operand assembly (and the derived `n1q`/`n2p`
+//!   PKA math) is added in `rsa`; **no change is needed here**.
+//! - **ECC (#604):** add the SEC1 `ECPrivateKey` / PKCS#8 EC `PrivateKeyInfo`
+//!   decoders alongside the RSA ones below, plus a `parse_ec_private_key`
+//!   returning the scalar + curve OID; consumed by `ecc`.
+
+use der::Decode;
+use der::Sequence;
+use der::asn1::Null;
+use der::asn1::ObjectIdentifier;
+use der::asn1::OctetStringRef;
+use der::asn1::UintRef;
+
+// ── RSA (PKCS#8 PrivateKeyInfo / PKCS#1 RSAPrivateKey) ─────────────────────
+
+/// rsaEncryption OID (1.2.840.113549.1.1.1) — the algorithm identifier of an
+/// RSA key inside a PKCS#8 `PrivateKeyInfo`.
+const RSA_ENCRYPTION: ObjectIdentifier = ObjectIdentifier::new_unwrap("1.2.840.113549.1.1.1");
+
+/// PKCS#8 `AlgorithmIdentifier` for RSA: the `rsaEncryption` OID with the
+/// explicit `NULL` parameters required by RFC 3279 §2.3.1.
+#[derive(Sequence)]
+struct RsaAlgorithmIdentifier {
+    oid: ObjectIdentifier,
+    parameters: Null,
+}
+
+/// PKCS#8 `PrivateKeyInfo` (RFC 5208) whose `privateKey` OCTET STRING wraps a
+/// PKCS#1 `RSAPrivateKey`.
+#[derive(Sequence)]
+struct RsaPrivateKeyInfo<'a> {
+    version: u8,
+    algorithm: RsaAlgorithmIdentifier,
+    private_key: &'a OctetStringRef,
+}
+
+/// PKCS#1 `RSAPrivateKey` (RFC 8017 A.1.2), two-prime form (version 0).
+///
+/// The full SEQUENCE is decoded so the `der` reader validates every field. The
+/// non-CRT import path reads only `modulus` / `public_exponent` /
+/// `private_exponent`; the CRT import path (#608) additionally reads the CRT
+/// quintuple (`prime1`, `prime2`, `exponent1`, `exponent2`, `coefficient`),
+/// which is why they are decoded and exposed here rather than skipped.
+#[derive(Sequence)]
+pub(crate) struct RsaPrivateKeyAsn1<'a> {
+    pub(crate) version: u8,
+    pub(crate) modulus: UintRef<'a>,
+    pub(crate) public_exponent: UintRef<'a>,
+    pub(crate) private_exponent: UintRef<'a>,
+    pub(crate) prime1: UintRef<'a>,
+    pub(crate) prime2: UintRef<'a>,
+    pub(crate) exponent1: UintRef<'a>,
+    pub(crate) exponent2: UintRef<'a>,
+    pub(crate) coefficient: UintRef<'a>,
+}
+
+/// Decodes a recovered RSA private key — a PKCS#8 `PrivateKeyInfo` or a bare
+/// PKCS#1 `RSAPrivateKey` — into the validated [`RsaPrivateKeyAsn1`].
+///
+/// The `der` crate enforces canonical DER (definite minimal-length encodings,
+/// no trailing bytes via `from_der`) and rejects negative / non-minimal
+/// INTEGERs. On top of that this rejects key versions the two-prime SEQUENCE
+/// does not model, so callers get a fully-structurally-validated key. Field
+/// sizes (modulus width, exponent width) are a PKA concern and are checked by
+/// the caller during operand assembly.
+pub(crate) fn parse_rsa_private_key(der_bytes: &[u8]) -> Option<RsaPrivateKeyAsn1<'_>> {
+    let key = if let Ok(pki) = RsaPrivateKeyInfo::from_der(der_bytes) {
+        // RFC 5208 §5: PrivateKeyInfo `version` is v1 (= 0). RFC 5958 adds v2
+        // (= 1) with public-key / attributes, which this parser does not model
+        // — reject rather than silently drop the extra fields.
+        if pki.version != 0 || pki.algorithm.oid != RSA_ENCRYPTION {
+            return None;
+        }
+        RsaPrivateKeyAsn1::from_der(pki.private_key.as_bytes()).ok()?
+    } else {
+        RsaPrivateKeyAsn1::from_der(der_bytes).ok()?
+    };
+    // RFC 8017 §A.1.2: `version` is 0 for two-prime keys. Version 1 (multi-prime)
+    // would require `otherPrimeInfos`, which our SEQUENCE does not declare.
+    if key.version != 0 {
+        return None;
+    }
+    Some(key)
+}

--- a/fw/plat/uno/fw/pal/src/crypto/ecc_det.rs
+++ b/fw/plat/uno/fw/pal/src/crypto/ecc_det.rs
@@ -38,6 +38,7 @@ use azihsm_fw_uno_drivers_upka::UpkaEccCurve;
 use azihsm_fw_uno_drivers_upka::mont_operand_size;
 
 use super::ecc::PRIME384_LE;
+use super::reverse_copy;
 use crate::UnoHsmPal;
 
 // =============================================================================
@@ -481,8 +482,7 @@ impl UnoHsmPal {
                     let v_be: &[u8] = &drbg.v[..];
                     if ct_in_range(&v_be[..field], &drbg.n_be[..field]) {
                         // Candidate `k` (big-endian) in [1, n-1]; emit little-endian.
-                        k[..field].copy_from_slice(&drbg.v[..field]);
-                        k[..field].reverse();
+                        reverse_copy(&mut k[..field], &drbg.v[..field]);
                         return Ok(());
                     }
                     self.rfc6979_reseed(io, &mut drbg).await?;
@@ -562,8 +562,7 @@ impl UnoHsmPal {
                     let v_be: &[u8] = &drbg.v[..];
                     if ct_in_range(&v_be[..field], &drbg.n_be[..field]) {
                         // Candidate k in [1, n-1]; stage little-endian and sign.
-                        k[..field].copy_from_slice(&drbg.v[..field]);
-                        k[..field].reverse();
+                        reverse_copy(&mut k[..field], &drbg.v[..field]);
                         match self.ecc_sign_with_k(io, curve, k, digest, d, r, s).await {
                             Ok(()) => return Ok(()),
                             // Degenerate r/s — advance the DRBG and retry.
@@ -610,14 +609,12 @@ impl UnoHsmPal {
         // msg = V ‖ 0x00 ‖ int2octets(x) ‖ bits2octets(h1).
         drbg.msg[..field].copy_from_slice(&drbg.v[..field]);
         drbg.msg[field] = 0x00;
-        drbg.msg[field + 1..field + 1 + field].copy_from_slice(&d[..field]);
-        drbg.msg[field + 1..field + 1 + field].reverse();
+        reverse_copy(&mut drbg.msg[field + 1..field + 1 + field], &d[..field]);
         {
             // h1 = bits2octets(digest): big-endian digest reduced mod n.
             let (_, tail) = drbg.msg.split_at_mut(field + 1 + field);
             let h1: &mut [u8] = &mut tail[..field];
-            h1.copy_from_slice(&digest[..field]);
-            h1.reverse();
+            reverse_copy(h1, &digest[..field]);
             if h1[..] >= drbg.n_be[..] {
                 be_sub_assign(h1, &drbg.n_be);
             }

--- a/fw/plat/uno/fw/pal/src/crypto/mod.rs
+++ b/fw/plat/uno/fw/pal/src/crypto/mod.rs
@@ -51,3 +51,28 @@ use azihsm_fw_hsm_pal_traits::HsmCrypto;
 use crate::UnoHsmPal;
 
 impl HsmCrypto for UnoHsmPal {}
+
+/// Copies `src` into `dst[..src.len()]` in reverse byte order.
+///
+/// The crypto drivers cross two endian conventions constantly: PKA operands
+/// and the vault layout are little-endian, while DER/SEC1 integers and the
+/// RFC 6979 DRBG work big-endian. Converting between them is always "copy
+/// these bytes backwards", so the loop lives here once instead of being
+/// rewritten per call site.
+///
+/// `src` and `dst` must not overlap; use `copy_within` plus an in-place
+/// `reverse` when they can. Bytes of `dst` beyond `src.len()` are left
+/// untouched, so a caller needing a fixed-width zero-padded field must clear
+/// them itself.
+///
+/// # Panics
+///
+/// Debug builds assert that `dst` is at least as long as `src`; a shorter
+/// `dst` silently truncates, which is a caller bug.
+#[inline]
+pub(crate) fn reverse_copy(dst: &mut [u8], src: &[u8]) {
+    debug_assert!(dst.len() >= src.len());
+    for (d, s) in dst.iter_mut().zip(src.iter().rev()) {
+        *d = *s;
+    }
+}

--- a/fw/plat/uno/fw/pal/src/crypto/rsa.rs
+++ b/fw/plat/uno/fw/pal/src/crypto/rsa.rs
@@ -441,6 +441,13 @@ impl HsmRsa for UnoHsmPal {
         self.mod_exp_priv(io, key_size, priv_key, ciphertext, em)
             .await?;
 
+        // `mod_exp_priv` is little-endian (PKA-native): both the ciphertext
+        // operand and the `em` result are LE wire form. The RSA-OAEP decode
+        // below (RFC 8017 EME-OAEP) operates on the big-endian encoded message
+        // `EM = 0x00 ‖ maskedSeed ‖ maskedDB`, so flip the result LE→BE first
+        // (the std PAL does the same flip around OpenSSL, in its driver).
+        em[..k].reverse();
+
         if em[0] != 0x00 {
             return Err(HsmError::RsaDecryptFailed);
         }

--- a/fw/plat/uno/fw/pal/src/crypto/rsa.rs
+++ b/fw/plat/uno/fw/pal/src/crypto/rsa.rs
@@ -23,15 +23,11 @@ use azihsm_fw_hsm_pal_traits::HsmRsaKey;
 use azihsm_fw_hsm_pal_traits::HsmRsaPct;
 use azihsm_fw_hsm_pal_traits::HsmScopedAlloc;
 use azihsm_fw_uno_drivers_upka::UpkaRsaKeyType;
-use der::Decode;
-use der::Sequence;
-use der::asn1::Null;
-use der::asn1::ObjectIdentifier;
-use der::asn1::OctetStringRef;
-use der::asn1::UintRef;
 use zeroize::Zeroize;
 
 use crate::UnoHsmPal;
+use crate::asn1::RsaPrivateKeyAsn1;
+use crate::asn1::parse_rsa_private_key;
 
 // =============================================================================
 // Helper functions
@@ -75,78 +71,18 @@ fn digest_info_prefix(algo: HsmHashAlgo) -> &'static [u8] {
 }
 
 // =============================================================================
-// DER parsing for RSA private-key import (PKCS#8 / PKCS#1 RSAPrivateKey)
+// Vault operand assembly (imported RSA private key → PKA layout)
 // =============================================================================
 
 /// Maximum RSA modulus length in bytes (RSA-4096).
 const MAX_RSA_MODULUS_LEN: usize = 512;
 
-/// rsaEncryption OID (1.2.840.113549.1.1.1) — the algorithm identifier of an
-/// RSA key inside a PKCS#8 `PrivateKeyInfo`.
-const RSA_ENCRYPTION: ObjectIdentifier = ObjectIdentifier::new_unwrap("1.2.840.113549.1.1.1");
-
-/// PKCS#8 `AlgorithmIdentifier` for RSA: the `rsaEncryption` OID with the
-/// explicit `NULL` parameters required by RFC 3279 §2.3.1.
-#[derive(Sequence)]
-struct RsaAlgorithmIdentifier {
-    algorithm: ObjectIdentifier,
-    parameters: Null,
-}
-
-/// PKCS#8 `PrivateKeyInfo` (RFC 5208) whose `privateKey` OCTET STRING wraps a
-/// PKCS#1 `RSAPrivateKey`.
-#[derive(Sequence)]
-struct RsaPrivateKeyInfo<'a> {
-    version: u8,
-    algorithm: RsaAlgorithmIdentifier,
-    private_key: &'a OctetStringRef,
-}
-
-/// PKCS#1 `RSAPrivateKey` (RFC 8017 A.1.2), two-prime form (version 0). The full
-/// SEQUENCE is decoded so the `der` reader validates every field; only
-/// `modulus`, `public_exponent`, and `private_exponent` feed the non-CRT vault
-/// operand.
-#[derive(Sequence)]
-struct RsaPrivateKeyDer<'a> {
-    version: u8,
-    modulus: UintRef<'a>,
-    public_exponent: UintRef<'a>,
-    private_exponent: UintRef<'a>,
-    prime1: UintRef<'a>,
-    prime2: UintRef<'a>,
-    exponent1: UintRef<'a>,
-    exponent2: UintRef<'a>,
-    coefficient: UintRef<'a>,
-}
-
-/// Decodes a recovered RSA private key — a PKCS#8 `PrivateKeyInfo` or a bare
-/// PKCS#1 `RSAPrivateKey` — and assembles the little-endian PKA vault operand
-/// `[d(k) ‖ n(k) ‖ e(4)]` into `out`, returning `(vault_len, modulus_len)`.
-///
-/// The `der` crate enforces canonical DER (definite minimal-length encodings, no
-/// trailing bytes via `from_der`) and rejects negative / non-minimal INTEGERs,
-/// so this carries no hand-rolled TLV / INTEGER validation. Reads `der_bytes`
-/// only; the caller scrubs the recovered plaintext on any error.
-fn rsa_der_to_vault_operand(der_bytes: &[u8], out: &mut [u8]) -> Option<(usize, usize)> {
-    // Assemble inside each arm while the decoded `RSAPrivateKey` — and the
-    // `UintRef`s borrowing `der_bytes` — is still alive.
-    if let Ok(pki) = RsaPrivateKeyInfo::from_der(der_bytes) {
-        if pki.algorithm.algorithm != RSA_ENCRYPTION {
-            return None;
-        }
-        let inner = RsaPrivateKeyDer::from_der(pki.private_key.as_bytes()).ok()?;
-        assemble_rsa_operand(&inner, out)
-    } else {
-        let inner = RsaPrivateKeyDer::from_der(der_bytes).ok()?;
-        assemble_rsa_operand(&inner, out)
-    }
-}
-
 /// Validates the RSA field sizes and writes `[d ‖ n ‖ e]` little-endian into
 /// `out`, returning `(vault_len, modulus_len)`. Rejects moduli that are not
 /// 2048/3072/4096-bit, an exponent wider than 4 bytes, or a `d` wider than the
-/// modulus.
-fn assemble_rsa_operand(key: &RsaPrivateKeyDer<'_>, out: &mut [u8]) -> Option<(usize, usize)> {
+/// modulus. Structural validation (versions, algorithm OID) is done upstream by
+/// [`parse_rsa_private_key`](super::asn1::parse_rsa_private_key).
+fn assemble_rsa_operand(key: &RsaPrivateKeyAsn1<'_>, out: &mut [u8]) -> Option<(usize, usize)> {
     let n = key.modulus.as_bytes();
     let e = key.public_exponent.as_bytes();
     let d = key.private_exponent.as_bytes();
@@ -279,10 +215,13 @@ impl HsmRsa for UnoHsmPal {
             return Err(HsmError::UnsupportedCmd);
         }
         // Decode + assemble the little-endian vault operand `[d(k) ‖ n(k) ‖ e(4)]`
-        // into a scratch buffer. This only reads `buf` (the recovered plaintext
-        // DER); the borrow ends before the in-place rewrite below.
+        // into a scratch buffer. Only `buf` is read (the recovered plaintext
+        // DER); the decoded `UintRef`s alias into it, and the borrow ends
+        // before the in-place rewrite below.
         let mut out = [0u8; MAX_RSA_MODULUS_LEN * 2 + 4];
-        let Some((vault_len, modulus_len)) = rsa_der_to_vault_operand(&buf[..], &mut out) else {
+        let assembled =
+            parse_rsa_private_key(&buf[..]).and_then(|key| assemble_rsa_operand(&key, &mut out));
+        let Some((vault_len, modulus_len)) = assembled else {
             buf.zeroize();
             out.zeroize();
             return Err(HsmError::InvalidArg);

--- a/fw/plat/uno/fw/pal/src/crypto/rsa.rs
+++ b/fw/plat/uno/fw/pal/src/crypto/rsa.rs
@@ -23,6 +23,12 @@ use azihsm_fw_hsm_pal_traits::HsmRsaKey;
 use azihsm_fw_hsm_pal_traits::HsmRsaPct;
 use azihsm_fw_hsm_pal_traits::HsmScopedAlloc;
 use azihsm_fw_uno_drivers_upka::UpkaRsaKeyType;
+use der::Decode;
+use der::Sequence;
+use der::asn1::Null;
+use der::asn1::ObjectIdentifier;
+use der::asn1::OctetStringRef;
+use der::asn1::UintRef;
 use zeroize::Zeroize;
 
 use crate::UnoHsmPal;
@@ -75,127 +81,87 @@ fn digest_info_prefix(algo: HsmHashAlgo) -> &'static [u8] {
 /// Maximum RSA modulus length in bytes (RSA-4096).
 const MAX_RSA_MODULUS_LEN: usize = 512;
 
-/// DER value bytes of the rsaEncryption OID (1.2.840.113549.1.1.1), i.e. the
-/// content of the `OBJECT IDENTIFIER` inside a PKCS#8 `AlgorithmIdentifier`.
-const RSA_ENCRYPTION_OID: [u8; 9] = [0x2a, 0x86, 0x48, 0x86, 0xf7, 0x0d, 0x01, 0x01, 0x01];
+/// rsaEncryption OID (1.2.840.113549.1.1.1) — the algorithm identifier of an
+/// RSA key inside a PKCS#8 `PrivateKeyInfo`.
+const RSA_ENCRYPTION: ObjectIdentifier = ObjectIdentifier::new_unwrap("1.2.840.113549.1.1.1");
 
-/// Reads one DER TLV at `der[pos..]`. Returns `(tag, content_start,
-/// content_len, next)` where the value is `der[content_start..][..content_len]`
-/// and `next` is the offset just past this TLV. Handles short- and long-form
-/// definite lengths (DER never uses indefinite length).
-fn der_tlv(der: &[u8], pos: usize) -> Option<(u8, usize, usize, usize)> {
-    let tag = *der.get(pos)?;
-    let len_byte = *der.get(pos + 1)?;
-    let (len, hdr_len) = if len_byte < 0x80 {
-        (len_byte as usize, 2)
+/// PKCS#8 `AlgorithmIdentifier` for RSA: the `rsaEncryption` OID with the
+/// explicit `NULL` parameters required by RFC 3279 §2.3.1.
+#[derive(Sequence)]
+struct RsaAlgorithmIdentifier {
+    algorithm: ObjectIdentifier,
+    parameters: Null,
+}
+
+/// PKCS#8 `PrivateKeyInfo` (RFC 5208) whose `privateKey` OCTET STRING wraps a
+/// PKCS#1 `RSAPrivateKey`.
+#[derive(Sequence)]
+struct RsaPrivateKeyInfo<'a> {
+    version: u8,
+    algorithm: RsaAlgorithmIdentifier,
+    private_key: &'a OctetStringRef,
+}
+
+/// PKCS#1 `RSAPrivateKey` (RFC 8017 A.1.2), two-prime form (version 0). The full
+/// SEQUENCE is decoded so the `der` reader validates every field; only
+/// `modulus`, `public_exponent`, and `private_exponent` feed the non-CRT vault
+/// operand.
+#[derive(Sequence)]
+struct RsaPrivateKeyDer<'a> {
+    version: u8,
+    modulus: UintRef<'a>,
+    public_exponent: UintRef<'a>,
+    private_exponent: UintRef<'a>,
+    prime1: UintRef<'a>,
+    prime2: UintRef<'a>,
+    exponent1: UintRef<'a>,
+    exponent2: UintRef<'a>,
+    coefficient: UintRef<'a>,
+}
+
+/// Decodes a recovered RSA private key — a PKCS#8 `PrivateKeyInfo` or a bare
+/// PKCS#1 `RSAPrivateKey` — and assembles the little-endian PKA vault operand
+/// `[d(k) ‖ n(k) ‖ e(4)]` into `out`, returning `(vault_len, modulus_len)`.
+///
+/// The `der` crate enforces canonical DER (definite minimal-length encodings, no
+/// trailing bytes via `from_der`) and rejects negative / non-minimal INTEGERs,
+/// so this carries no hand-rolled TLV / INTEGER validation. Reads `der_bytes`
+/// only; the caller scrubs the recovered plaintext on any error.
+fn rsa_der_to_vault_operand(der_bytes: &[u8], out: &mut [u8]) -> Option<(usize, usize)> {
+    // Assemble inside each arm while the decoded `RSAPrivateKey` — and the
+    // `UintRef`s borrowing `der_bytes` — is still alive.
+    if let Ok(pki) = RsaPrivateKeyInfo::from_der(der_bytes) {
+        if pki.algorithm.algorithm != RSA_ENCRYPTION {
+            return None;
+        }
+        let inner = RsaPrivateKeyDer::from_der(pki.private_key.as_bytes()).ok()?;
+        assemble_rsa_operand(&inner, out)
     } else {
-        let n = (len_byte & 0x7f) as usize;
-        if n == 0 || n > 4 {
-            return None;
-        }
-        // DER requires minimal length encoding: the most-significant length
-        // byte must be non-zero (no leading-zero padding).
-        if *der.get(pos + 2)? == 0 {
-            return None;
-        }
-        let mut len = 0usize;
-        for i in 0..n {
-            len = (len << 8) | (*der.get(pos + 2 + i)? as usize);
-        }
-        // Long form must not be used for lengths that fit in short form.
-        if len < 0x80 {
-            return None;
-        }
-        (len, 2 + n)
-    };
-    let content_start = pos.checked_add(hdr_len)?;
-    let next = content_start.checked_add(len)?;
-    if next > der.len() {
-        return None;
+        let inner = RsaPrivateKeyDer::from_der(der_bytes).ok()?;
+        assemble_rsa_operand(&inner, out)
     }
-    Some((tag, content_start, len, next))
 }
 
-/// Reads a DER INTEGER at `pos`, returning its positive value `(start, len)`
-/// with the leading `0x00` sign pad (if present) stripped, plus the offset just
-/// past it. Because the input is untrusted recovered key material, this rejects
-/// negative integers (MSB set on the first content byte, i.e. no sign pad) and
-/// non-minimal encodings; the integer zero (a lone `0x00`) is still accepted so
-/// the PKCS#8/PKCS#1 `version` fields parse.
-fn der_int(der: &[u8], pos: usize) -> Option<(usize, usize, usize)> {
-    let (tag, start, len, next) = der_tlv(der, pos)?;
-    if tag != 0x02 || len == 0 {
+/// Validates the RSA field sizes and writes `[d ‖ n ‖ e]` little-endian into
+/// `out`, returning `(vault_len, modulus_len)`. Rejects moduli that are not
+/// 2048/3072/4096-bit, an exponent wider than 4 bytes, or a `d` wider than the
+/// modulus.
+fn assemble_rsa_operand(key: &RsaPrivateKeyDer<'_>, out: &mut [u8]) -> Option<(usize, usize)> {
+    let n = key.modulus.as_bytes();
+    let e = key.public_exponent.as_bytes();
+    let d = key.private_exponent.as_bytes();
+    let modulus_len = n.len();
+    if !matches!(modulus_len, 256 | 384 | 512) || e.len() > 4 || d.len() > modulus_len {
         return None;
     }
-    let first = der[start];
-    // A negative INTEGER (two's-complement: MSB of the first byte set, with no
-    // `0x00` sign pad) is never a valid RSA field.
-    if first & 0x80 != 0 {
+    let vault_len = 2 * modulus_len + 4;
+    if vault_len > out.len() {
         return None;
     }
-    // A leading `0x00` is a sign pad; per DER it is minimal only when the next
-    // byte has its MSB set. The sole exception is the integer zero, encoded as
-    // a single `0x00` byte.
-    if first == 0x00 && len > 1 {
-        if der[start + 1] & 0x80 == 0 {
-            return None;
-        }
-        return Some((start + 1, len - 1, next));
-    }
-    Some((start, len, next))
-}
-
-/// Big-endian value ranges `((start, len), ...)` for the RSA `n`, `e`, `d`
-/// integers within a parsed DER buffer.
-type RsaDerRanges = ((usize, usize), (usize, usize), (usize, usize));
-
-/// Parses a DER RSA private key — PKCS#8 `PrivateKeyInfo` or a bare PKCS#1
-/// `RSAPrivateKey` — and returns the big-endian value ranges `(start, len)` of
-/// the modulus `n`, public exponent `e`, and private exponent `d`.
-fn parse_rsa_priv_der(der: &[u8]) -> Option<RsaDerRanges> {
-    // Outer SEQUENCE — must span the entire input (reject trailing garbage).
-    let (tag, seq_start, _seq_len, outer_next) = der_tlv(der, 0)?;
-    if tag != 0x30 || outer_next != der.len() {
-        return None;
-    }
-    // version INTEGER (skip).
-    let (_vs, _vl, after_ver) = der_int(der, seq_start)?;
-    let mut p = after_ver;
-    // A SEQUENCE here is the PKCS#8 algorithm id — validate it is
-    // `rsaEncryption` and descend through the OCTET STRING into the inner
-    // PKCS#1 key; an INTEGER is the PKCS#1 `n` directly.
-    let (peek_tag, alg_start, _acl, after_alg) = der_tlv(der, p)?;
-    if peek_tag == 0x30 {
-        // AlgorithmIdentifier ::= SEQUENCE { algorithm OID, parameters NULL }.
-        let (oid_tag, oid_start, oid_len, after_oid) = der_tlv(der, alg_start)?;
-        if oid_tag != 0x06 || der[oid_start..oid_start + oid_len] != RSA_ENCRYPTION_OID {
-            return None;
-        }
-        // The rsaEncryption parameters must be NULL (tag 0x05, length 0), and
-        // must be the last field of the AlgorithmIdentifier SEQUENCE (no extra
-        // trailing fields).
-        let (null_tag, _null_start, null_len, null_next) = der_tlv(der, after_oid)?;
-        if null_tag != 0x05 || null_len != 0 || null_next != after_alg {
-            return None;
-        }
-        let (ot, oct_start, _ol, oct_next) = der_tlv(der, after_alg)?;
-        if ot != 0x04 {
-            return None;
-        }
-        // The privateKey OCTET STRING must wrap exactly the inner
-        // RSAPrivateKey SEQUENCE with no trailing bytes.
-        let (st, inner_start, _sl, inner_next) = der_tlv(der, oct_start)?;
-        if st != 0x30 || inner_next != oct_next {
-            return None;
-        }
-        let (_v2s, _v2l, after_v2) = der_int(der, inner_start)?;
-        p = after_v2;
-    }
-    // n, e, d in order (p, q, dp, dq, qinv follow but are unused for non-CRT).
-    let (ns, nl, after_n) = der_int(der, p)?;
-    let (es, el, after_e) = der_int(der, after_n)?;
-    let (ds, dl, _after_d) = der_int(der, after_e)?;
-    Some(((ns, nl), (es, el), (ds, dl)))
+    write_le(&mut out[0..modulus_len], d);
+    write_le(&mut out[modulus_len..2 * modulus_len], n);
+    write_le(&mut out[2 * modulus_len..vault_len], e);
+    Some((vault_len, modulus_len))
 }
 
 /// Writes the big-endian bytes `be` as little-endian into `dst`, zero-padding
@@ -312,34 +278,24 @@ impl HsmRsa for UnoHsmPal {
             buf.zeroize();
             return Err(HsmError::UnsupportedCmd);
         }
-        // Parse the recovered DER (PKCS#8 or bare PKCS#1) into the big-endian
-        // value ranges of the modulus `n`, public exponent `e`, and private
-        // exponent `d`. The ranges alias `buf`.
-        let Some(((ns, nl), (es, el), (ds, dl))) = parse_rsa_priv_der(&buf[..]) else {
+        // Decode + assemble the little-endian vault operand `[d(k) ‖ n(k) ‖ e(4)]`
+        // into a scratch buffer. This only reads `buf` (the recovered plaintext
+        // DER); the borrow ends before the in-place rewrite below.
+        let mut out = [0u8; MAX_RSA_MODULUS_LEN * 2 + 4];
+        let Some((vault_len, modulus_len)) = rsa_der_to_vault_operand(&buf[..], &mut out) else {
             buf.zeroize();
+            out.zeroize();
             return Err(HsmError::InvalidArg);
         };
-        let modulus_len = nl;
-        if !matches!(modulus_len, 256 | 384 | 512) || el > 4 || dl > modulus_len {
-            buf.zeroize();
-            return Err(HsmError::InvalidArg);
-        }
-        // Assemble the vault operand `[d(k) ‖ n(k) ‖ e(4)]` little-endian in a
-        // scratch buffer, then write it back in place — the vault form is
-        // smaller than the source DER, so the overwrite is safe.
-        let vault_len = 2 * modulus_len + 4;
-        // The in-place rewrite requires the vault operand to fit within `buf`.
-        // A malformed / truncated DER (e.g. a very short `d`) can make
-        // `vault_len` exceed `buf.len()`; reject rather than panic on the
-        // slices below. `buf` still holds recovered plaintext, so scrub first.
+        // The vault form is smaller than the source DER, so the in-place rewrite
+        // is safe — but reject rather than panic if a malformed DER made
+        // `vault_len` exceed `buf`. `buf` holds recovered plaintext, so scrub
+        // first.
         if vault_len > buf.len() {
             buf.zeroize();
+            out.zeroize();
             return Err(HsmError::InvalidArg);
         }
-        let mut out = [0u8; MAX_RSA_MODULUS_LEN * 2 + 4];
-        write_le(&mut out[0..modulus_len], &buf[ds..ds + dl]);
-        write_le(&mut out[modulus_len..2 * modulus_len], &buf[ns..ns + nl]);
-        write_le(&mut out[2 * modulus_len..vault_len], &buf[es..es + el]);
         buf[..vault_len].copy_from_slice(&out[..vault_len]);
         // Scrub the leftover source DER in the tail of `buf` — for a full
         // RSAPrivateKey it still holds secret CRT components (`p`, `q`, `dp`,

--- a/fw/plat/uno/fw/pal/src/crypto/rsa.rs
+++ b/fw/plat/uno/fw/pal/src/crypto/rsa.rs
@@ -93,9 +93,18 @@ fn der_tlv(der: &[u8], pos: usize) -> Option<(u8, usize, usize, usize)> {
         if n == 0 || n > 4 {
             return None;
         }
+        // DER requires minimal length encoding: the most-significant length
+        // byte must be non-zero (no leading-zero padding).
+        if *der.get(pos + 2)? == 0 {
+            return None;
+        }
         let mut len = 0usize;
         for i in 0..n {
             len = (len << 8) | (*der.get(pos + 2 + i)? as usize);
+        }
+        // Long form must not be used for lengths that fit in short form.
+        if len < 0x80 {
+            return None;
         }
         (len, 2 + n)
     };

--- a/fw/plat/uno/fw/pal/src/crypto/rsa.rs
+++ b/fw/plat/uno/fw/pal/src/crypto/rsa.rs
@@ -24,6 +24,7 @@ use azihsm_fw_hsm_pal_traits::HsmRsaPct;
 use azihsm_fw_hsm_pal_traits::HsmScopedAlloc;
 use azihsm_fw_uno_drivers_upka::UpkaRsaKeyType;
 
+use super::reverse_copy;
 use crate::UnoHsmPal;
 use crate::asn1::parse_rsa_private_key;
 
@@ -117,9 +118,7 @@ fn rsa_operand_layout(buf: &[u8]) -> Option<RsaOperandLayout> {
     // DER `e` is big-endian and minimally encoded; the operand slot is a fixed
     // little-endian `EXP_WIRE_LEN` field, so reverse into a zeroed array.
     let mut e_le = [0u8; EXP_WIRE_LEN];
-    for (dst, &src) in e_le.iter_mut().zip(e.iter().rev()) {
-        *dst = src;
-    }
+    reverse_copy(&mut e_le, e);
     Some(RsaOperandLayout {
         modulus_len,
         n_off: offset_in(buf, n),
@@ -134,10 +133,12 @@ fn rsa_operand_layout(buf: &[u8]) -> Option<RsaOperandLayout> {
 ///
 /// The operand overlaps the DER field offsets it reads from (`d` and `n` mutually
 /// clobber each other's source), so `d` is first staged into `buf`'s tail scratch
-/// (`[vault_len..]`) via `copy_within` (memmove — safe on overlap); `n` is then
-/// moved and reversed big-endian→little-endian into place, followed by the staged
-/// `d` and the saved `e`. Requires `buf.len() >= vault_len + d_len` (checked by
-/// the caller). The tail is left dirty; the per-IO teardown scrub wipes it.
+/// (`[vault_len..]`) via `copy_within` (memmove — safe on overlap). `n`'s source
+/// may overlap its destination too, so it is moved with `copy_within` and then
+/// reversed in place; `d`'s staged copy is disjoint from the front of the buffer,
+/// so it is folded into a single [`reverse_copy`]. Requires
+/// `buf.len() >= vault_len + d_len` (checked by the caller). The tail is left
+/// dirty; the per-IO teardown scrub wipes it.
 fn assemble_rsa_operand_in_place(buf: &mut [u8], layout: &RsaOperandLayout) {
     let k = layout.modulus_len;
     let vault_len = 2 * k + EXP_WIRE_LEN;
@@ -146,17 +147,21 @@ fn assemble_rsa_operand_in_place(buf: &mut [u8], layout: &RsaOperandLayout) {
     //    clobbered by the `n` move below.
     buf.copy_within(layout.d_off..layout.d_off + d_len, vault_len);
     // 2. vault `n` at [k, 2k): move DER `n` (big-endian, exactly k bytes) into
-    //    place, then reverse to little-endian.
+    //    place, then reverse to little-endian. Source and destination can
+    //    overlap, so this stays a memmove plus an in-place reverse.
     buf.copy_within(layout.n_off..layout.n_off + k, k);
     buf[k..2 * k].reverse();
-    // 3. vault `d` at [0, k): move the staged big-endian `d` to the front,
-    //    reverse to little-endian, and zero-pad the high bytes.
-    buf.copy_within(vault_len..vault_len + d_len, 0);
-    buf[0..d_len].reverse();
-    buf[d_len..k].fill(0);
+    // 3. vault `d` at [0, k): the staged copy at `vault_len` is disjoint from
+    //    `[0, d_len)`, so split the buffer and reverse-copy it to the front in
+    //    one pass. `d` may be shorter than the modulus (DER strips leading
+    //    zeros), and the bytes above it still hold DER, so zero the high end —
+    //    the vault field is a fixed k bytes.
+    let (front, staged) = buf.split_at_mut(vault_len);
+    reverse_copy(&mut front[..d_len], &staged[..d_len]);
+    front[d_len..k].fill(0);
     // 4. vault `e` at [2k, 2k+EXP_WIRE_LEN): already little-endian and
     //    zero-padded, so a single copy fills the fixed slot.
-    buf[2 * k..vault_len].copy_from_slice(&layout.e);
+    front[2 * k..vault_len].copy_from_slice(&layout.e);
 }
 
 // =============================================================================

--- a/fw/plat/uno/fw/pal/src/crypto/rsa.rs
+++ b/fw/plat/uno/fw/pal/src/crypto/rsa.rs
@@ -144,9 +144,9 @@ type RsaDerRanges = ((usize, usize), (usize, usize), (usize, usize));
 /// `RSAPrivateKey` — and returns the big-endian value ranges `(start, len)` of
 /// the modulus `n`, public exponent `e`, and private exponent `d`.
 fn parse_rsa_priv_der(der: &[u8]) -> Option<RsaDerRanges> {
-    // Outer SEQUENCE.
-    let (tag, seq_start, _seq_len, _next) = der_tlv(der, 0)?;
-    if tag != 0x30 {
+    // Outer SEQUENCE — must span the entire input (reject trailing garbage).
+    let (tag, seq_start, _seq_len, outer_next) = der_tlv(der, 0)?;
+    if tag != 0x30 || outer_next != der.len() {
         return None;
     }
     // version INTEGER (skip).
@@ -168,12 +168,14 @@ fn parse_rsa_priv_der(der: &[u8]) -> Option<RsaDerRanges> {
         if null_tag != 0x05 || null_len != 0 {
             return None;
         }
-        let (ot, oct_start, _ol, _on) = der_tlv(der, after_alg)?;
+        let (ot, oct_start, _ol, oct_next) = der_tlv(der, after_alg)?;
         if ot != 0x04 {
             return None;
         }
-        let (st, inner_start, _sl, _sn) = der_tlv(der, oct_start)?;
-        if st != 0x30 {
+        // The privateKey OCTET STRING must wrap exactly the inner
+        // RSAPrivateKey SEQUENCE with no trailing bytes.
+        let (st, inner_start, _sl, inner_next) = der_tlv(der, oct_start)?;
+        if st != 0x30 || inner_next != oct_next {
             return None;
         }
         let (_v2s, _v2l, after_v2) = der_int(der, inner_start)?;
@@ -314,6 +316,11 @@ impl HsmRsa for UnoHsmPal {
         write_le(&mut out[modulus_len..2 * modulus_len], &buf[ns..ns + nl]);
         write_le(&mut out[2 * modulus_len..vault_len], &buf[es..es + el]);
         buf[..vault_len].copy_from_slice(&out[..vault_len]);
+        // Scrub the leftover source DER in the tail of `buf` — for a full
+        // RSAPrivateKey it still holds secret CRT components (`p`, `q`, `dp`,
+        // `dq`, `qinv`). The scoped DMA buffer is reused without automatic
+        // wiping, so scrub it here before returning.
+        buf[vault_len..].zeroize();
         // Scrub the assembled operand (holds the private exponent `d`) from the
         // stack scratch. `Zeroize` uses volatile writes so the wipe is not
         // elided as a dead store.

--- a/fw/plat/uno/fw/pal/src/crypto/rsa.rs
+++ b/fw/plat/uno/fw/pal/src/crypto/rsa.rs
@@ -107,16 +107,31 @@ fn der_tlv(der: &[u8], pos: usize) -> Option<(u8, usize, usize, usize)> {
     Some((tag, content_start, len, next))
 }
 
-/// Reads a DER INTEGER at `pos`, returning its value `(start, len)` with any
-/// leading `0x00` sign/pad byte stripped, plus the offset just past it.
+/// Reads a DER INTEGER at `pos`, returning its positive value `(start, len)`
+/// with the leading `0x00` sign pad (if present) stripped, plus the offset just
+/// past it. Because the input is untrusted recovered key material, this rejects
+/// negative integers (MSB set on the first content byte, i.e. no sign pad) and
+/// non-minimal encodings; the integer zero (a lone `0x00`) is still accepted so
+/// the PKCS#8/PKCS#1 `version` fields parse.
 fn der_int(der: &[u8], pos: usize) -> Option<(usize, usize, usize)> {
-    let (tag, mut start, mut len, next) = der_tlv(der, pos)?;
+    let (tag, start, len, next) = der_tlv(der, pos)?;
     if tag != 0x02 || len == 0 {
         return None;
     }
-    while len > 1 && der[start] == 0x00 {
-        start += 1;
-        len -= 1;
+    let first = der[start];
+    // A negative INTEGER (two's-complement: MSB of the first byte set, with no
+    // `0x00` sign pad) is never a valid RSA field.
+    if first & 0x80 != 0 {
+        return None;
+    }
+    // A leading `0x00` is a sign pad; per DER it is minimal only when the next
+    // byte has its MSB set. The sole exception is the integer zero, encoded as
+    // a single `0x00` byte.
+    if first == 0x00 && len > 1 {
+        if der[start + 1] & 0x80 == 0 {
+            return None;
+        }
+        return Some((start + 1, len - 1, next));
     }
     Some((start, len, next))
 }
@@ -574,61 +589,73 @@ impl HsmRsa for UnoHsmPal {
         let em = alloc.dma_alloc(k)?;
         let label_hash = alloc.dma_alloc(h_len)?;
 
-        self.mod_exp_priv(io, key_size, priv_key, ciphertext, em)
-            .await?;
+        // `em` holds the decrypted encoded message and then the recovered DB —
+        // both secret. The scoped allocator only rewinds its watermark on drop
+        // and never clears freed DMA, so scrub `em` on *every* exit path
+        // (including `?`-propagated errors) before it can be handed to a later
+        // per-IO allocation. The fallible decode runs in an inner block so the
+        // single `em.zeroize()` below covers all of them.
+        let result = async {
+            self.mod_exp_priv(io, key_size, priv_key, ciphertext, em)
+                .await?;
 
-        // `mod_exp_priv` is little-endian (PKA-native): both the ciphertext
-        // operand and the `em` result are LE wire form. The RSA-OAEP decode
-        // below (RFC 8017 EME-OAEP) operates on the big-endian encoded message
-        // `EM = 0x00 ‖ maskedSeed ‖ maskedDB`, so flip the result LE→BE first
-        // (the std PAL does the same flip around OpenSSL, in its driver).
-        em[..k].reverse();
+            // `mod_exp_priv` is little-endian (PKA-native): both the ciphertext
+            // operand and the `em` result are LE wire form. The RSA-OAEP decode
+            // below (RFC 8017 EME-OAEP) operates on the big-endian encoded
+            // message `EM = 0x00 ‖ maskedSeed ‖ maskedDB`, so flip the result
+            // LE→BE first (the std PAL does the same flip around OpenSSL).
+            em[..k].reverse();
 
-        if em[0] != 0x00 {
-            return Err(HsmError::RsaDecryptFailed);
+            if em[0] != 0x00 {
+                return Err(HsmError::RsaDecryptFailed);
+            }
+
+            // Recover seed: seed = maskedSeed XOR MGF(maskedDB, hLen)
+            {
+                let (seed, db) = em[1..k].split_at_mut(h_len);
+                self.mgf1_xor(io, algo, db, seed).await?;
+            }
+
+            // Recover DB: DB = maskedDB XOR MGF(seed, dbLen)
+            {
+                let (seed, db) = em[1..k].split_at_mut(h_len);
+                self.mgf1_xor(io, algo, seed, db).await?;
+            }
+
+            // Verify lHash using reusable scratch allocated from the alloc.
+            let db = &em[1 + h_len..k];
+            self.hash(io, algo, label, label_hash, true).await?;
+            let db_hash: &[u8] = &db[..h_len];
+            let label_hash_slice: &[u8] = &label_hash[..h_len];
+            if db_hash != label_hash_slice {
+                return Err(HsmError::RsaDecryptFailed);
+            }
+
+            // Find 0x01 separator in DB after lHash
+            let ps_and_m = &db[h_len..];
+            let sep = ps_and_m.iter().position(|&b| b == 0x01);
+            let sep = match sep {
+                Some(s) if ps_and_m[..s].iter().all(|&b| b == 0x00) => s,
+                _ => return Err(HsmError::RsaDecryptFailed),
+            };
+
+            let m_start = h_len + sep + 1;
+            let m_len = db_len - m_start;
+            // Contract (matches the std PAL): a recovered message longer than
+            // the caller's output buffer is a key/output-length error, reported
+            // as `RsaInvalidKeyLength`. The RsaUnwrap KEK path relies on this to
+            // map an oversized recovered KEK to `RsaUnwrapInvalidKek`.
+            if output.len() < m_len {
+                return Err(HsmError::RsaInvalidKeyLength);
+            }
+
+            output[..m_len].copy_from_slice(&db[m_start..]);
+            Ok(m_len)
         }
+        .await;
 
-        // Recover seed: seed = maskedSeed XOR MGF(maskedDB, hLen)
-        {
-            let (seed, db) = em[1..k].split_at_mut(h_len);
-            self.mgf1_xor(io, algo, db, seed).await?;
-        }
-
-        // Recover DB: DB = maskedDB XOR MGF(seed, dbLen)
-        {
-            let (seed, db) = em[1..k].split_at_mut(h_len);
-            self.mgf1_xor(io, algo, seed, db).await?;
-        }
-
-        // Verify lHash using reusable scratch allocated from the alloc.
-        let db = &em[1 + h_len..k];
-        self.hash(io, algo, label, label_hash, true).await?;
-        let db_hash: &[u8] = &db[..h_len];
-        let label_hash_slice: &[u8] = &label_hash[..h_len];
-        if db_hash != label_hash_slice {
-            return Err(HsmError::RsaDecryptFailed);
-        }
-
-        // Find 0x01 separator in DB after lHash
-        let ps_and_m = &db[h_len..];
-        let sep = ps_and_m.iter().position(|&b| b == 0x01);
-        let sep = match sep {
-            Some(s) if ps_and_m[..s].iter().all(|&b| b == 0x00) => s,
-            _ => return Err(HsmError::RsaDecryptFailed),
-        };
-
-        let m_start = h_len + sep + 1;
-        let m_len = db_len - m_start;
-        // Contract (matches the std PAL): a recovered message longer than the
-        // caller's output buffer is a key/output-length error, reported as
-        // `RsaInvalidKeyLength`. The RsaUnwrap KEK path relies on this to map an
-        // oversized recovered KEK to `RsaUnwrapInvalidKek`.
-        if output.len() < m_len {
-            return Err(HsmError::RsaInvalidKeyLength);
-        }
-
-        output[..m_len].copy_from_slice(&db[m_start..]);
-        Ok(m_len)
+        em.zeroize();
+        result
     }
 
     // ── PSS signatures ─────────────────────────────────────────────

--- a/fw/plat/uno/fw/pal/src/crypto/rsa.rs
+++ b/fw/plat/uno/fw/pal/src/crypto/rsa.rs
@@ -23,10 +23,8 @@ use azihsm_fw_hsm_pal_traits::HsmRsaKey;
 use azihsm_fw_hsm_pal_traits::HsmRsaPct;
 use azihsm_fw_hsm_pal_traits::HsmScopedAlloc;
 use azihsm_fw_uno_drivers_upka::UpkaRsaKeyType;
-use zeroize::Zeroize;
 
 use crate::UnoHsmPal;
-use crate::asn1::RsaPrivateKeyAsn1;
 use crate::asn1::parse_rsa_private_key;
 
 // =============================================================================
@@ -74,15 +72,33 @@ fn digest_info_prefix(algo: HsmHashAlgo) -> &'static [u8] {
 // Vault operand assembly (imported RSA private key → PKA layout)
 // =============================================================================
 
-/// Maximum RSA modulus length in bytes (RSA-4096).
-const MAX_RSA_MODULUS_LEN: usize = 512;
+/// Big-endian layout of the three RSA fields the non-CRT vault operand needs,
+/// recovered from a parsed DER: the byte offsets of the modulus `n` and private
+/// exponent `d` within the source buffer, plus a copy of the (short) public
+/// exponent `e`. `n` is exactly `modulus_len` bytes; `d` is `d_len ≤ modulus_len`.
+struct RsaOperandLayout {
+    modulus_len: usize,
+    n_off: usize,
+    d_off: usize,
+    d_len: usize,
+    e: [u8; 4],
+    e_len: usize,
+}
 
-/// Validates the RSA field sizes and writes `[d ‖ n ‖ e]` little-endian into
-/// `out`, returning `(vault_len, modulus_len)`. Rejects moduli that are not
-/// 2048/3072/4096-bit, an exponent wider than 4 bytes, or a `d` wider than the
-/// modulus. Structural validation (versions, algorithm OID) is done upstream by
-/// [`parse_rsa_private_key`](super::asn1::parse_rsa_private_key).
-fn assemble_rsa_operand(key: &RsaPrivateKeyAsn1<'_>, out: &mut [u8]) -> Option<(usize, usize)> {
+/// Byte offset of `field` within `buf`. Sound because `field` is a `UintRef`
+/// sub-slice of `buf` (same allocation), so the pointer difference is in range.
+fn offset_in(buf: &[u8], field: &[u8]) -> usize {
+    (field.as_ptr() as usize) - (buf.as_ptr() as usize)
+}
+
+/// Parses and validates the RSA key in `buf`, returning the [`RsaOperandLayout`]
+/// for in-place operand assembly. Rejects moduli that are not 2048/3072/4096-bit,
+/// an exponent wider than 4 bytes, or a `d` wider than the modulus. `e` is copied
+/// out (it is tiny and its DER slot is overwritten during assembly); `n`/`d` are
+/// located by offset so the assembler can move them once the borrow of `buf`
+/// (held by the decoded `UintRef`s) is released.
+fn rsa_operand_layout(buf: &[u8]) -> Option<RsaOperandLayout> {
+    let key = parse_rsa_private_key(buf)?;
     let n = key.modulus.as_bytes();
     let e = key.public_exponent.as_bytes();
     let d = key.private_exponent.as_bytes();
@@ -90,23 +106,48 @@ fn assemble_rsa_operand(key: &RsaPrivateKeyAsn1<'_>, out: &mut [u8]) -> Option<(
     if !matches!(modulus_len, 256 | 384 | 512) || e.len() > 4 || d.len() > modulus_len {
         return None;
     }
-    let vault_len = 2 * modulus_len + 4;
-    if vault_len > out.len() {
-        return None;
-    }
-    write_le(&mut out[0..modulus_len], d);
-    write_le(&mut out[modulus_len..2 * modulus_len], n);
-    write_le(&mut out[2 * modulus_len..vault_len], e);
-    Some((vault_len, modulus_len))
+    let mut e_arr = [0u8; 4];
+    e_arr[..e.len()].copy_from_slice(e);
+    Some(RsaOperandLayout {
+        modulus_len,
+        n_off: offset_in(buf, n),
+        d_off: offset_in(buf, d),
+        d_len: d.len(),
+        e: e_arr,
+        e_len: e.len(),
+    })
 }
 
-/// Writes the big-endian bytes `be` as little-endian into `dst`, zero-padding
-/// the remaining high bytes. Requires `be.len() <= dst.len()`.
-fn write_le(dst: &mut [u8], be: &[u8]) {
-    for (i, &b) in be.iter().rev().enumerate() {
-        dst[i] = b;
-    }
-    dst[be.len()..].fill(0);
+/// Assembles the little-endian vault operand `[d(k) ‖ n(k) ‖ e(4)]` into the
+/// front of `buf`, entirely in place.
+///
+/// The operand overlaps the DER field offsets it reads from (`d` and `n` mutually
+/// clobber each other's source), so `d` is first staged into `buf`'s tail scratch
+/// (`[vault_len..]`, which the caller scrubs) via `copy_within` (memmove — safe on
+/// overlap); `n` is then moved and reversed big-endian→little-endian into place,
+/// followed by the staged `d` and the saved `e`. Requires `buf.len() >=
+/// vault_len + d_len` (checked by the caller).
+fn assemble_rsa_operand_in_place(buf: &mut [u8], layout: &RsaOperandLayout) {
+    let k = layout.modulus_len;
+    let vault_len = 2 * k + 4;
+    let d_len = layout.d_len;
+    // 1. Stage big-endian `d` into the tail scratch before its source is
+    //    clobbered by the `n` move below.
+    buf.copy_within(layout.d_off..layout.d_off + d_len, vault_len);
+    // 2. vault `n` at [k, 2k): move DER `n` (big-endian, exactly k bytes) into
+    //    place, then reverse to little-endian.
+    buf.copy_within(layout.n_off..layout.n_off + k, k);
+    buf[k..2 * k].reverse();
+    // 3. vault `d` at [0, k): move the staged big-endian `d` to the front,
+    //    reverse to little-endian, and zero-pad the high bytes.
+    buf.copy_within(vault_len..vault_len + d_len, 0);
+    buf[0..d_len].reverse();
+    buf[d_len..k].fill(0);
+    // 4. vault `e` at [2k, 2k+4): write the saved exponent little-endian.
+    let e_len = layout.e_len;
+    buf[2 * k..2 * k + e_len].copy_from_slice(&layout.e[..e_len]);
+    buf[2 * k..2 * k + e_len].reverse();
+    buf[2 * k + e_len..vault_len].fill(0);
 }
 
 // =============================================================================
@@ -205,8 +246,9 @@ impl HsmRsa for UnoHsmPal {
         buf: &mut DmaBuf,
         crt: bool,
     ) -> HsmResult<(usize, usize)> {
-        // CRT import needs the derived PKA operands (n1q, n2p) computed from
-        // p/q/n via PKA modular arithmetic — not yet brought up on Uno.
+        // TODO(RSA-CRT bring-up): derive the CRT PKA operands (n1q = qInv·q and
+        // n2p = (p⁻¹ mod q)·p) from p/q/n via PKA modular arithmetic and assemble
+        // the CRT vault operand. Not yet brought up on Uno, so reject CRT keys.
         if crt {
             // `buf` still holds the recovered plaintext DER; scrub it before
             // any early return so no secret key material lingers in the reused
@@ -214,38 +256,29 @@ impl HsmRsa for UnoHsmPal {
             buf.zeroize();
             return Err(HsmError::UnsupportedCmd);
         }
-        // Decode + assemble the little-endian vault operand `[d(k) ‖ n(k) ‖ e(4)]`
-        // into a scratch buffer. Only `buf` is read (the recovered plaintext
-        // DER); the decoded `UintRef`s alias into it, and the borrow ends
-        // before the in-place rewrite below.
-        let mut out = [0u8; MAX_RSA_MODULUS_LEN * 2 + 4];
-        let assembled =
-            parse_rsa_private_key(&buf[..]).and_then(|key| assemble_rsa_operand(&key, &mut out));
-        let Some((vault_len, modulus_len)) = assembled else {
+        // Parse + validate + capture the field layout. The `key` borrow of `buf`
+        // (held by the decoded `UintRef`s) is released before the in-place
+        // rewrite below.
+        let Some(layout) = rsa_operand_layout(&buf[..]) else {
             buf.zeroize();
-            out.zeroize();
             return Err(HsmError::InvalidArg);
         };
-        // The vault form is smaller than the source DER, so the in-place rewrite
-        // is safe — but reject rather than panic if a malformed DER made
-        // `vault_len` exceed `buf`. `buf` holds recovered plaintext, so scrub
-        // first.
-        if vault_len > buf.len() {
+        let k = layout.modulus_len;
+        let vault_len = 2 * k + 4;
+        // In-place assembly stages `d` into `buf[vault_len..]`, so the recovered
+        // DER must be at least `vault_len + d_len` bytes. A full RSAPrivateKey is
+        // always larger, but reject rather than panic on a malformed / truncated
+        // DER. `buf` holds recovered plaintext, so scrub first.
+        if buf.len() < vault_len + layout.d_len {
             buf.zeroize();
-            out.zeroize();
             return Err(HsmError::InvalidArg);
         }
-        buf[..vault_len].copy_from_slice(&out[..vault_len]);
-        // Scrub the leftover source DER in the tail of `buf` — for a full
-        // RSAPrivateKey it still holds secret CRT components (`p`, `q`, `dp`,
-        // `dq`, `qinv`). The scoped DMA buffer is reused without automatic
-        // wiping, so scrub it here before returning.
+        assemble_rsa_operand_in_place(&mut buf[..], &layout);
+        // Scrub the tail — the staged `d` plus the leftover DER CRT components
+        // (`p`, `q`, `dp`, `dq`, `qinv`). The scoped DMA buffer is reused without
+        // automatic wiping, so scrub it here before returning.
         buf[vault_len..].zeroize();
-        // Scrub the assembled operand (holds the private exponent `d`) from the
-        // stack scratch. `Zeroize` uses volatile writes so the wipe is not
-        // elided as a dead store.
-        out.zeroize();
-        Ok((vault_len, modulus_len))
+        Ok((vault_len, k))
     }
 
     // ── PKCS#1 v1.5 encryption ─────────────────────────────────────

--- a/fw/plat/uno/fw/pal/src/crypto/rsa.rs
+++ b/fw/plat/uno/fw/pal/src/crypto/rsa.rs
@@ -72,17 +72,24 @@ fn digest_info_prefix(algo: HsmHashAlgo) -> &'static [u8] {
 // Vault operand assembly (imported RSA private key → PKA layout)
 // =============================================================================
 
+/// Width of the public-exponent slot in the Uno vault's RSA private-key
+/// operand `d(k) ‖ n(k) ‖ e(EXP_WIRE_LEN)`. Fixed and zero-padded, so `e` is
+/// always stored in exactly this many little-endian bytes regardless of how
+/// few significant bytes the DER carries.
+const EXP_WIRE_LEN: usize = 4;
+
 /// Big-endian layout of the three RSA fields the non-CRT vault operand needs,
 /// recovered from a parsed DER: the byte offsets of the modulus `n` and private
-/// exponent `d` within the source buffer, plus a copy of the (short) public
-/// exponent `e`. `n` is exactly `modulus_len` bytes; `d` is `d_len ≤ modulus_len`.
+/// exponent `d` within the source buffer, plus the (short) public exponent `e`.
+/// `n` is exactly `modulus_len` bytes; `d` is `d_len ≤ modulus_len`.
 struct RsaOperandLayout {
     modulus_len: usize,
     n_off: usize,
     d_off: usize,
     d_len: usize,
-    e: [u8; 4],
-    e_len: usize,
+    /// `e` already in the operand's wire form: little-endian, zero-padded to the
+    /// fixed [`EXP_WIRE_LEN`]-byte slot, so assembly is a single copy.
+    e: [u8; EXP_WIRE_LEN],
 }
 
 /// Byte offset of `field` within `buf`. Sound because `field` is a `UintRef`
@@ -93,8 +100,9 @@ fn offset_in(buf: &[u8], field: &[u8]) -> usize {
 
 /// Parses and validates the RSA key in `buf`, returning the [`RsaOperandLayout`]
 /// for in-place operand assembly. Rejects moduli that are not 2048/3072/4096-bit,
-/// an exponent wider than 4 bytes, or a `d` wider than the modulus. `e` is copied
-/// out (it is tiny and its DER slot is overwritten during assembly); `n`/`d` are
+/// an exponent wider than [`EXP_WIRE_LEN`], or a `d` wider than the modulus. `e`
+/// is copied out (it is tiny and its DER slot is overwritten during assembly),
+/// converted to the operand's little-endian wire form as it goes; `n`/`d` are
 /// located by offset so the assembler can move them once the borrow of `buf`
 /// (held by the decoded `UintRef`s) is released.
 fn rsa_operand_layout(buf: &[u8]) -> Option<RsaOperandLayout> {
@@ -103,33 +111,36 @@ fn rsa_operand_layout(buf: &[u8]) -> Option<RsaOperandLayout> {
     let e = key.public_exponent.as_bytes();
     let d = key.private_exponent.as_bytes();
     let modulus_len = n.len();
-    if !matches!(modulus_len, 256 | 384 | 512) || e.len() > 4 || d.len() > modulus_len {
+    if !matches!(modulus_len, 256 | 384 | 512) || e.len() > EXP_WIRE_LEN || d.len() > modulus_len {
         return None;
     }
-    let mut e_arr = [0u8; 4];
-    e_arr[..e.len()].copy_from_slice(e);
+    // DER `e` is big-endian and minimally encoded; the operand slot is a fixed
+    // little-endian `EXP_WIRE_LEN` field, so reverse into a zeroed array.
+    let mut e_le = [0u8; EXP_WIRE_LEN];
+    for (dst, &src) in e_le.iter_mut().zip(e.iter().rev()) {
+        *dst = src;
+    }
     Some(RsaOperandLayout {
         modulus_len,
         n_off: offset_in(buf, n),
         d_off: offset_in(buf, d),
         d_len: d.len(),
-        e: e_arr,
-        e_len: e.len(),
+        e: e_le,
     })
 }
 
-/// Assembles the little-endian vault operand `[d(k) ‖ n(k) ‖ e(4)]` into the
-/// front of `buf`, entirely in place.
+/// Assembles the little-endian vault operand
+/// `[d(k) ‖ n(k) ‖ e(EXP_WIRE_LEN)]` into the front of `buf`, entirely in place.
 ///
 /// The operand overlaps the DER field offsets it reads from (`d` and `n` mutually
 /// clobber each other's source), so `d` is first staged into `buf`'s tail scratch
-/// (`[vault_len..]`, which the caller scrubs) via `copy_within` (memmove — safe on
-/// overlap); `n` is then moved and reversed big-endian→little-endian into place,
-/// followed by the staged `d` and the saved `e`. Requires `buf.len() >=
-/// vault_len + d_len` (checked by the caller).
+/// (`[vault_len..]`) via `copy_within` (memmove — safe on overlap); `n` is then
+/// moved and reversed big-endian→little-endian into place, followed by the staged
+/// `d` and the saved `e`. Requires `buf.len() >= vault_len + d_len` (checked by
+/// the caller). The tail is left dirty; the per-IO teardown scrub wipes it.
 fn assemble_rsa_operand_in_place(buf: &mut [u8], layout: &RsaOperandLayout) {
     let k = layout.modulus_len;
-    let vault_len = 2 * k + 4;
+    let vault_len = 2 * k + EXP_WIRE_LEN;
     let d_len = layout.d_len;
     // 1. Stage big-endian `d` into the tail scratch before its source is
     //    clobbered by the `n` move below.
@@ -143,11 +154,9 @@ fn assemble_rsa_operand_in_place(buf: &mut [u8], layout: &RsaOperandLayout) {
     buf.copy_within(vault_len..vault_len + d_len, 0);
     buf[0..d_len].reverse();
     buf[d_len..k].fill(0);
-    // 4. vault `e` at [2k, 2k+4): write the saved exponent little-endian.
-    let e_len = layout.e_len;
-    buf[2 * k..2 * k + e_len].copy_from_slice(&layout.e[..e_len]);
-    buf[2 * k..2 * k + e_len].reverse();
-    buf[2 * k + e_len..vault_len].fill(0);
+    // 4. vault `e` at [2k, 2k+EXP_WIRE_LEN): already little-endian and
+    //    zero-padded, so a single copy fills the fixed slot.
+    buf[2 * k..vault_len].copy_from_slice(&layout.e);
 }
 
 // =============================================================================
@@ -224,7 +233,6 @@ impl HsmRsa for UnoHsmPal {
         // public key is `n_le ‖ e_le` (`k + 4` bytes) — already little-endian,
         // so it is exactly the trailing `priv_key[k..]` slice with no
         // endianness flip and no PKA operation.
-        const EXP_WIRE_LEN: usize = 4;
         let total = priv_key.len();
         if total <= EXP_WIRE_LEN || !(total - EXP_WIRE_LEN).is_multiple_of(2) {
             return Err(HsmError::InvalidArg);
@@ -246,38 +254,34 @@ impl HsmRsa for UnoHsmPal {
         buf: &mut DmaBuf,
         crt: bool,
     ) -> HsmResult<(usize, usize)> {
+        // Note: `buf` holds recovered plaintext DER (and, after assembly, the
+        // staged `d` plus the leftover CRT components `p`/`q`/`dp`/`dq`/`qinv`)
+        // on every path through this function. It is not scrubbed here — the
+        // per-IO teardown scrub wipes the whole slot, so a local wipe would be
+        // redundant work that has to be removed again.
+        //
         // TODO(RSA-CRT bring-up): derive the CRT PKA operands (n1q = qInv·q and
         // n2p = (p⁻¹ mod q)·p) from p/q/n via PKA modular arithmetic and assemble
         // the CRT vault operand. Not yet brought up on Uno, so reject CRT keys.
         if crt {
-            // `buf` still holds the recovered plaintext DER; scrub it before
-            // any early return so no secret key material lingers in the reused
-            // DMA SRAM after a failed import.
-            buf.zeroize();
             return Err(HsmError::UnsupportedCmd);
         }
         // Parse + validate + capture the field layout. The `key` borrow of `buf`
         // (held by the decoded `UintRef`s) is released before the in-place
         // rewrite below.
         let Some(layout) = rsa_operand_layout(&buf[..]) else {
-            buf.zeroize();
             return Err(HsmError::InvalidArg);
         };
         let k = layout.modulus_len;
-        let vault_len = 2 * k + 4;
+        let vault_len = 2 * k + EXP_WIRE_LEN;
         // In-place assembly stages `d` into `buf[vault_len..]`, so the recovered
         // DER must be at least `vault_len + d_len` bytes. A full RSAPrivateKey is
         // always larger, but reject rather than panic on a malformed / truncated
-        // DER. `buf` holds recovered plaintext, so scrub first.
+        // DER.
         if buf.len() < vault_len + layout.d_len {
-            buf.zeroize();
             return Err(HsmError::InvalidArg);
         }
         assemble_rsa_operand_in_place(&mut buf[..], &layout);
-        // Scrub the tail — the staged `d` plus the leftover DER CRT components
-        // (`p`, `q`, `dp`, `dq`, `qinv`). The scoped DMA buffer is reused without
-        // automatic wiping, so scrub it here before returning.
-        buf[vault_len..].zeroize();
         Ok((vault_len, k))
     }
 
@@ -549,73 +553,61 @@ impl HsmRsa for UnoHsmPal {
         let em = alloc.dma_alloc(k)?;
         let label_hash = alloc.dma_alloc(h_len)?;
 
-        // `em` holds the decrypted encoded message and then the recovered DB —
-        // both secret. The scoped allocator only rewinds its watermark on drop
-        // and never clears freed DMA, so scrub `em` on *every* exit path
-        // (including `?`-propagated errors) before it can be handed to a later
-        // per-IO allocation. The fallible decode runs in an inner block so the
-        // single `em.zeroize()` below covers all of them.
-        let result = async {
-            self.mod_exp_priv(io, key_size, priv_key, ciphertext, em)
-                .await?;
+        self.mod_exp_priv(io, key_size, priv_key, ciphertext, em)
+            .await?;
 
-            // `mod_exp_priv` is little-endian (PKA-native): both the ciphertext
-            // operand and the `em` result are LE wire form. The RSA-OAEP decode
-            // below (RFC 8017 EME-OAEP) operates on the big-endian encoded
-            // message `EM = 0x00 ‖ maskedSeed ‖ maskedDB`, so flip the result
-            // LE→BE first (the std PAL does the same flip around OpenSSL).
-            em[..k].reverse();
+        // `mod_exp_priv` is little-endian (PKA-native): both the ciphertext
+        // operand and the `em` result are LE wire form. The RSA-OAEP decode
+        // below (RFC 8017 EME-OAEP) operates on the big-endian encoded
+        // message `EM = 0x00 ‖ maskedSeed ‖ maskedDB`, so flip the result
+        // LE→BE first (the std PAL does the same flip around OpenSSL).
+        em[..k].reverse();
 
-            if em[0] != 0x00 {
-                return Err(HsmError::RsaDecryptFailed);
-            }
-
-            // Recover seed: seed = maskedSeed XOR MGF(maskedDB, hLen)
-            {
-                let (seed, db) = em[1..k].split_at_mut(h_len);
-                self.mgf1_xor(io, algo, db, seed).await?;
-            }
-
-            // Recover DB: DB = maskedDB XOR MGF(seed, dbLen)
-            {
-                let (seed, db) = em[1..k].split_at_mut(h_len);
-                self.mgf1_xor(io, algo, seed, db).await?;
-            }
-
-            // Verify lHash using reusable scratch allocated from the alloc.
-            let db = &em[1 + h_len..k];
-            self.hash(io, algo, label, label_hash, true).await?;
-            let db_hash: &[u8] = &db[..h_len];
-            let label_hash_slice: &[u8] = &label_hash[..h_len];
-            if db_hash != label_hash_slice {
-                return Err(HsmError::RsaDecryptFailed);
-            }
-
-            // Find 0x01 separator in DB after lHash
-            let ps_and_m = &db[h_len..];
-            let sep = ps_and_m.iter().position(|&b| b == 0x01);
-            let sep = match sep {
-                Some(s) if ps_and_m[..s].iter().all(|&b| b == 0x00) => s,
-                _ => return Err(HsmError::RsaDecryptFailed),
-            };
-
-            let m_start = h_len + sep + 1;
-            let m_len = db_len - m_start;
-            // Contract (matches the std PAL): a recovered message longer than
-            // the caller's output buffer is a key/output-length error, reported
-            // as `RsaInvalidKeyLength`. The RsaUnwrap KEK path relies on this to
-            // map an oversized recovered KEK to `RsaUnwrapInvalidKek`.
-            if output.len() < m_len {
-                return Err(HsmError::RsaInvalidKeyLength);
-            }
-
-            output[..m_len].copy_from_slice(&db[m_start..]);
-            Ok(m_len)
+        if em[0] != 0x00 {
+            return Err(HsmError::RsaDecryptFailed);
         }
-        .await;
 
-        em.zeroize();
-        result
+        // Recover seed: seed = maskedSeed XOR MGF(maskedDB, hLen)
+        {
+            let (seed, db) = em[1..k].split_at_mut(h_len);
+            self.mgf1_xor(io, algo, db, seed).await?;
+        }
+
+        // Recover DB: DB = maskedDB XOR MGF(seed, dbLen)
+        {
+            let (seed, db) = em[1..k].split_at_mut(h_len);
+            self.mgf1_xor(io, algo, seed, db).await?;
+        }
+
+        // Verify lHash using reusable scratch allocated from the alloc.
+        let db = &em[1 + h_len..k];
+        self.hash(io, algo, label, label_hash, true).await?;
+        let db_hash: &[u8] = &db[..h_len];
+        let label_hash_slice: &[u8] = &label_hash[..h_len];
+        if db_hash != label_hash_slice {
+            return Err(HsmError::RsaDecryptFailed);
+        }
+
+        // Find 0x01 separator in DB after lHash
+        let ps_and_m = &db[h_len..];
+        let sep = ps_and_m.iter().position(|&b| b == 0x01);
+        let sep = match sep {
+            Some(s) if ps_and_m[..s].iter().all(|&b| b == 0x00) => s,
+            _ => return Err(HsmError::RsaDecryptFailed),
+        };
+
+        let m_start = h_len + sep + 1;
+        let m_len = db_len - m_start;
+        // Contract (matches the std PAL): a recovered message longer than
+        // the caller's output buffer is a key/output-length error, reported
+        // as `RsaInvalidKeyLength`. The RsaUnwrap KEK path relies on this to
+        // map an oversized recovered KEK to `RsaUnwrapInvalidKek`.
+        if output.len() < m_len {
+            return Err(HsmError::RsaInvalidKeyLength);
+        }
+
+        output[..m_len].copy_from_slice(&db[m_start..]);
+        Ok(m_len)
     }
 
     // ── PSS signatures ─────────────────────────────────────────────

--- a/fw/plat/uno/fw/pal/src/crypto/rsa.rs
+++ b/fw/plat/uno/fw/pal/src/crypto/rsa.rs
@@ -164,10 +164,9 @@ fn parse_rsa_priv_der(der: &[u8]) -> Option<RsaDerRanges> {
     // A SEQUENCE here is the PKCS#8 algorithm id — validate it is
     // `rsaEncryption` and descend through the OCTET STRING into the inner
     // PKCS#1 key; an INTEGER is the PKCS#1 `n` directly.
-    let (peek_tag, ..) = der_tlv(der, p)?;
+    let (peek_tag, alg_start, _acl, after_alg) = der_tlv(der, p)?;
     if peek_tag == 0x30 {
         // AlgorithmIdentifier ::= SEQUENCE { algorithm OID, parameters NULL }.
-        let (_at, alg_start, _acl, after_alg) = der_tlv(der, p)?;
         let (oid_tag, oid_start, oid_len, after_oid) = der_tlv(der, alg_start)?;
         if oid_tag != 0x06 || der[oid_start..oid_start + oid_len] != RSA_ENCRYPTION_OID {
             return None;
@@ -202,10 +201,10 @@ fn parse_rsa_priv_der(der: &[u8]) -> Option<RsaDerRanges> {
 /// Writes the big-endian bytes `be` as little-endian into `dst`, zero-padding
 /// the remaining high bytes. Requires `be.len() <= dst.len()`.
 fn write_le(dst: &mut [u8], be: &[u8]) {
-    dst.fill(0);
     for (i, &b) in be.iter().rev().enumerate() {
         dst[i] = b;
     }
+    dst[be.len()..].fill(0);
 }
 
 // =============================================================================

--- a/fw/plat/uno/fw/pal/src/crypto/rsa.rs
+++ b/fw/plat/uno/fw/pal/src/crypto/rsa.rs
@@ -23,6 +23,7 @@ use azihsm_fw_hsm_pal_traits::HsmRsaKey;
 use azihsm_fw_hsm_pal_traits::HsmRsaPct;
 use azihsm_fw_hsm_pal_traits::HsmScopedAlloc;
 use azihsm_fw_uno_drivers_upka::UpkaRsaKeyType;
+use zeroize::Zeroize;
 
 use crate::UnoHsmPal;
 
@@ -64,6 +65,118 @@ fn digest_info_prefix(algo: HsmHashAlgo) -> &'static [u8] {
             0x30, 0x21, 0x30, 0x09, 0x06, 0x05, 0x2B, 0x0E, 0x03, 0x02, 0x1A, 0x05, 0x00, 0x04,
             0x14,
         ],
+    }
+}
+
+// =============================================================================
+// DER parsing for RSA private-key import (PKCS#8 / PKCS#1 RSAPrivateKey)
+// =============================================================================
+
+/// Maximum RSA modulus length in bytes (RSA-4096).
+const MAX_RSA_MODULUS_LEN: usize = 512;
+
+/// DER value bytes of the rsaEncryption OID (1.2.840.113549.1.1.1), i.e. the
+/// content of the `OBJECT IDENTIFIER` inside a PKCS#8 `AlgorithmIdentifier`.
+const RSA_ENCRYPTION_OID: [u8; 9] = [0x2a, 0x86, 0x48, 0x86, 0xf7, 0x0d, 0x01, 0x01, 0x01];
+
+/// Reads one DER TLV at `der[pos..]`. Returns `(tag, content_start,
+/// content_len, next)` where the value is `der[content_start..][..content_len]`
+/// and `next` is the offset just past this TLV. Handles short- and long-form
+/// definite lengths (DER never uses indefinite length).
+fn der_tlv(der: &[u8], pos: usize) -> Option<(u8, usize, usize, usize)> {
+    let tag = *der.get(pos)?;
+    let len_byte = *der.get(pos + 1)?;
+    let (len, hdr_len) = if len_byte < 0x80 {
+        (len_byte as usize, 2)
+    } else {
+        let n = (len_byte & 0x7f) as usize;
+        if n == 0 || n > 4 {
+            return None;
+        }
+        let mut len = 0usize;
+        for i in 0..n {
+            len = (len << 8) | (*der.get(pos + 2 + i)? as usize);
+        }
+        (len, 2 + n)
+    };
+    let content_start = pos.checked_add(hdr_len)?;
+    let next = content_start.checked_add(len)?;
+    if next > der.len() {
+        return None;
+    }
+    Some((tag, content_start, len, next))
+}
+
+/// Reads a DER INTEGER at `pos`, returning its value `(start, len)` with any
+/// leading `0x00` sign/pad byte stripped, plus the offset just past it.
+fn der_int(der: &[u8], pos: usize) -> Option<(usize, usize, usize)> {
+    let (tag, mut start, mut len, next) = der_tlv(der, pos)?;
+    if tag != 0x02 || len == 0 {
+        return None;
+    }
+    while len > 1 && der[start] == 0x00 {
+        start += 1;
+        len -= 1;
+    }
+    Some((start, len, next))
+}
+
+/// Big-endian value ranges `((start, len), ...)` for the RSA `n`, `e`, `d`
+/// integers within a parsed DER buffer.
+type RsaDerRanges = ((usize, usize), (usize, usize), (usize, usize));
+
+/// Parses a DER RSA private key — PKCS#8 `PrivateKeyInfo` or a bare PKCS#1
+/// `RSAPrivateKey` — and returns the big-endian value ranges `(start, len)` of
+/// the modulus `n`, public exponent `e`, and private exponent `d`.
+fn parse_rsa_priv_der(der: &[u8]) -> Option<RsaDerRanges> {
+    // Outer SEQUENCE.
+    let (tag, seq_start, _seq_len, _next) = der_tlv(der, 0)?;
+    if tag != 0x30 {
+        return None;
+    }
+    // version INTEGER (skip).
+    let (_vs, _vl, after_ver) = der_int(der, seq_start)?;
+    let mut p = after_ver;
+    // A SEQUENCE here is the PKCS#8 algorithm id — validate it is
+    // `rsaEncryption` and descend through the OCTET STRING into the inner
+    // PKCS#1 key; an INTEGER is the PKCS#1 `n` directly.
+    let (peek_tag, ..) = der_tlv(der, p)?;
+    if peek_tag == 0x30 {
+        // AlgorithmIdentifier ::= SEQUENCE { algorithm OID, parameters NULL }.
+        let (_at, alg_start, _acl, after_alg) = der_tlv(der, p)?;
+        let (oid_tag, oid_start, oid_len, after_oid) = der_tlv(der, alg_start)?;
+        if oid_tag != 0x06 || der[oid_start..oid_start + oid_len] != RSA_ENCRYPTION_OID {
+            return None;
+        }
+        // The rsaEncryption parameters must be NULL (tag 0x05, length 0).
+        let (null_tag, _null_start, null_len, _null_next) = der_tlv(der, after_oid)?;
+        if null_tag != 0x05 || null_len != 0 {
+            return None;
+        }
+        let (ot, oct_start, _ol, _on) = der_tlv(der, after_alg)?;
+        if ot != 0x04 {
+            return None;
+        }
+        let (st, inner_start, _sl, _sn) = der_tlv(der, oct_start)?;
+        if st != 0x30 {
+            return None;
+        }
+        let (_v2s, _v2l, after_v2) = der_int(der, inner_start)?;
+        p = after_v2;
+    }
+    // n, e, d in order (p, q, dp, dq, qinv follow but are unused for non-CRT).
+    let (ns, nl, after_n) = der_int(der, p)?;
+    let (es, el, after_e) = der_int(der, after_n)?;
+    let (ds, dl, _after_d) = der_int(der, after_e)?;
+    Some(((ns, nl), (es, el), (ds, dl)))
+}
+
+/// Writes the big-endian bytes `be` as little-endian into `dst`, zero-padding
+/// the remaining high bytes. Requires `be.len() <= dst.len()`.
+fn write_le(dst: &mut [u8], be: &[u8]) {
+    dst.fill(0);
+    for (i, &b) in be.iter().rev().enumerate() {
+        dst[i] = b;
     }
 }
 
@@ -160,14 +273,37 @@ impl HsmRsa for UnoHsmPal {
     fn rsa_priv_der_to_vault(
         &self,
         _io: &impl HsmIo,
-        _buf: &mut DmaBuf,
-        _crt: bool,
+        buf: &mut DmaBuf,
+        crt: bool,
     ) -> HsmResult<(usize, usize)> {
-        // TODO: parse the recovered RSA private-key DER on Uno and rewrite
-        // it in place into the vault representation — the raw non-CRT
-        // (`n`/`e`/`d`) or the custom CRT layout selected by `crt`
-        // (RsaUnwrap RSA import).
-        Err(HsmError::UnsupportedCmd)
+        // CRT import needs the derived PKA operands (n1q, n2p) computed from
+        // p/q/n via PKA modular arithmetic — not yet brought up on Uno.
+        if crt {
+            return Err(HsmError::UnsupportedCmd);
+        }
+        // Parse the recovered DER (PKCS#8 or bare PKCS#1) into the big-endian
+        // value ranges of the modulus `n`, public exponent `e`, and private
+        // exponent `d`. The ranges alias `buf`.
+        let ((ns, nl), (es, el), (ds, dl)) =
+            parse_rsa_priv_der(&buf[..]).ok_or(HsmError::InvalidArg)?;
+        let modulus_len = nl;
+        if !matches!(modulus_len, 256 | 384 | 512) || el > 4 || dl > modulus_len {
+            return Err(HsmError::InvalidArg);
+        }
+        // Assemble the vault operand `[d(k) ‖ n(k) ‖ e(4)]` little-endian in a
+        // scratch buffer, then write it back in place — the vault form is
+        // smaller than the source DER, so the overwrite is safe.
+        let vault_len = 2 * modulus_len + 4;
+        let mut out = [0u8; MAX_RSA_MODULUS_LEN * 2 + 4];
+        write_le(&mut out[0..modulus_len], &buf[ds..ds + dl]);
+        write_le(&mut out[modulus_len..2 * modulus_len], &buf[ns..ns + nl]);
+        write_le(&mut out[2 * modulus_len..vault_len], &buf[es..es + el]);
+        buf[..vault_len].copy_from_slice(&out[..vault_len]);
+        // Scrub the assembled operand (holds the private exponent `d`) from the
+        // stack scratch. `Zeroize` uses volatile writes so the wipe is not
+        // elided as a dead store.
+        out.zeroize();
+        Ok((vault_len, modulus_len))
     }
 
     // ── PKCS#1 v1.5 encryption ─────────────────────────────────────

--- a/fw/plat/uno/fw/pal/src/crypto/rsa.rs
+++ b/fw/plat/uno/fw/pal/src/crypto/rsa.rs
@@ -172,9 +172,11 @@ fn parse_rsa_priv_der(der: &[u8]) -> Option<RsaDerRanges> {
         if oid_tag != 0x06 || der[oid_start..oid_start + oid_len] != RSA_ENCRYPTION_OID {
             return None;
         }
-        // The rsaEncryption parameters must be NULL (tag 0x05, length 0).
-        let (null_tag, _null_start, null_len, _null_next) = der_tlv(der, after_oid)?;
-        if null_tag != 0x05 || null_len != 0 {
+        // The rsaEncryption parameters must be NULL (tag 0x05, length 0), and
+        // must be the last field of the AlgorithmIdentifier SEQUENCE (no extra
+        // trailing fields).
+        let (null_tag, _null_start, null_len, null_next) = der_tlv(der, after_oid)?;
+        if null_tag != 0x05 || null_len != 0 || null_next != after_alg {
             return None;
         }
         let (ot, oct_start, _ol, oct_next) = der_tlv(der, after_alg)?;
@@ -327,6 +329,14 @@ impl HsmRsa for UnoHsmPal {
         // scratch buffer, then write it back in place — the vault form is
         // smaller than the source DER, so the overwrite is safe.
         let vault_len = 2 * modulus_len + 4;
+        // The in-place rewrite requires the vault operand to fit within `buf`.
+        // A malformed / truncated DER (e.g. a very short `d`) can make
+        // `vault_len` exceed `buf.len()`; reject rather than panic on the
+        // slices below. `buf` still holds recovered plaintext, so scrub first.
+        if vault_len > buf.len() {
+            buf.zeroize();
+            return Err(HsmError::InvalidArg);
+        }
         let mut out = [0u8; MAX_RSA_MODULUS_LEN * 2 + 4];
         write_le(&mut out[0..modulus_len], &buf[ds..ds + dl]);
         write_le(&mut out[modulus_len..2 * modulus_len], &buf[ns..ns + nl]);

--- a/fw/plat/uno/fw/pal/src/crypto/rsa.rs
+++ b/fw/plat/uno/fw/pal/src/crypto/rsa.rs
@@ -619,8 +619,12 @@ impl HsmRsa for UnoHsmPal {
 
         let m_start = h_len + sep + 1;
         let m_len = db_len - m_start;
+        // Contract (matches the std PAL): a recovered message longer than the
+        // caller's output buffer is a key/output-length error, reported as
+        // `RsaInvalidKeyLength`. The RsaUnwrap KEK path relies on this to map an
+        // oversized recovered KEK to `RsaUnwrapInvalidKek`.
         if output.len() < m_len {
-            return Err(HsmError::InvalidArg);
+            return Err(HsmError::RsaInvalidKeyLength);
         }
 
         output[..m_len].copy_from_slice(&db[m_start..]);

--- a/fw/plat/uno/fw/pal/src/crypto/rsa.rs
+++ b/fw/plat/uno/fw/pal/src/crypto/rsa.rs
@@ -305,15 +305,22 @@ impl HsmRsa for UnoHsmPal {
         // CRT import needs the derived PKA operands (n1q, n2p) computed from
         // p/q/n via PKA modular arithmetic — not yet brought up on Uno.
         if crt {
+            // `buf` still holds the recovered plaintext DER; scrub it before
+            // any early return so no secret key material lingers in the reused
+            // DMA SRAM after a failed import.
+            buf.zeroize();
             return Err(HsmError::UnsupportedCmd);
         }
         // Parse the recovered DER (PKCS#8 or bare PKCS#1) into the big-endian
         // value ranges of the modulus `n`, public exponent `e`, and private
         // exponent `d`. The ranges alias `buf`.
-        let ((ns, nl), (es, el), (ds, dl)) =
-            parse_rsa_priv_der(&buf[..]).ok_or(HsmError::InvalidArg)?;
+        let Some(((ns, nl), (es, el), (ds, dl))) = parse_rsa_priv_der(&buf[..]) else {
+            buf.zeroize();
+            return Err(HsmError::InvalidArg);
+        };
         let modulus_len = nl;
         if !matches!(modulus_len, 256 | 384 | 512) || el > 4 || dl > modulus_len {
+            buf.zeroize();
             return Err(HsmError::InvalidArg);
         }
         // Assemble the vault operand `[d(k) ‖ n(k) ‖ e(4)]` little-endian in a

--- a/fw/plat/uno/fw/pal/src/lib.rs
+++ b/fw/plat/uno/fw/pal/src/lib.rs
@@ -36,6 +36,7 @@
 #![no_std]
 
 mod alloc;
+mod asn1;
 mod cert;
 mod crypto;
 mod dev_id_cblob;


### PR DESCRIPTION
## Summary

Brings up the RSA paths of `RsaUnwrap` on the **uno** HSM firmware. Three changes:

1. **OAEP endianness fix** — `rsa_oaep_decrypt` now flips the `mod_exp_priv` result LE→BE before the RFC 8017 EME-OAEP decode. The uno PKA is little-endian native (LE ciphertext in, LE result out), but the OAEP encoded message `0x00 ‖ maskedSeed ‖ maskedDB` is big-endian; the std PAL does the same flip around OpenSSL. Without it, every RsaUnwrap failed with `RsaDecryptFailed (0x08700012)`. This fixes the AES-key unwrap path.

2. **Non-CRT RSA private-key import** — implements `rsa_priv_der_to_vault`. Adds a small `no_std` DER parser (`der_tlv`, `der_int`, `parse_rsa_priv_der`) handling PKCS#8 `PrivateKeyInfo` and bare PKCS#1 `RSAPrivateKey`. The PKCS#8 `AlgorithmIdentifier` is validated to be `rsaEncryption` (OID 1.2.840.113549.1.1.1 + NULL params), mirroring mcr-hsm's `Asn1RsaEncryptionInfo`. The parsed `n/e/d` are assembled into the PKA vault operand `[d(k) ‖ n(k) ‖ e(4)]` little-endian — matching mcr-hsm's `RsaPrivKey::to_pka_bytes` and what `rsa_priv_pub_key` reads back. The stack scratch holding the private exponent is scrubbed with `zeroize`. CRT import returns `UnsupportedCmd` (deferred — needs PKA-derived `n1q`/`n2p`).

3. **OAEP oversized-output error contract** — `rsa_oaep_decrypt` now returns `RsaInvalidKeyLength` (not `InvalidArg`) when the recovered message exceeds the caller's output buffer, matching the std PAL. The shared key-unwrap path maps this to `RsaUnwrapInvalidKek`, so an oversized recovered KEK is now reported correctly.

## Testing

**Hardware (Manticore EVB):**
- `rsa_unwrap_generated_key`: 12/17 (was 9/17)
- `rsa_unwrap_smoke`: 3/5 (was 2/5) — `oversized_kek_smoke` now passes
- `get_unwrapping_key`: 7/7 (unchanged)

**Emu:** `precheck --nextest --package azihsm_ddi_mbor_types --features emu --filter smoke --profile ci-emu-smoke` → 94/94 passed.

fmt / clippy (`-D warnings`, ms-nightly) / taplo all clean.

## Deferred to follow-up PRs

The remaining `rsa_unwrap` failures each map cleanly to one of:
- **CRT RSA import** — needs PKA-derived `n1q`/`n2p` (mcr-hsm computes these separately).
- **uno ECC key import** — blocks `ecc_key_smoke`, `ecc_keys_with_key_tag`.
- **OpenKey-by-tag** — a full SDK-wide DDI (op 1015 has no handler); needs a shared PAL-trait + vault change (the uno vault `Entry` already carries a `session_or_tag` field).

## Base

Stacked on #601 (`user/radutta/get-unwrapping-key`), which is not yet merged — this PR targets that branch, not `main`.
