### PR TITLE
feat(uno): bring up AES key generation

### DIFF
--- a/fw/plat/uno/fw/drivers/rng/src/api.rs
+++ b/fw/plat/uno/fw/drivers/rng/src/api.rs
@@ -11,8 +11,9 @@
 //!
 //! * Returns `HsmResult<()>` from `fill_bytes` to match the existing
 //!   `HsmRng` trait shape used by the Uno PAL.
-//! * The post-enable settling delay is reduced from 100 ms to a
-//!   nominal value — see `RNG_INIT_DELAY_NOPS` below for rationale.
+//! * The post-enable settling delay matches the reference firmware's
+//!   `cpu_stall(100_000 µs)` (≈100 ms) — see `RNG_INIT_DELAY_NOPS`
+//!   below for rationale.
 
 use azihsm_fw_hsm_pal_traits::DmaBuf;
 use azihsm_fw_static_ref::StaticRef;
@@ -36,12 +37,21 @@ const REGS: StaticRef<RngRegs> = unsafe { StaticRef::new(RNG_BASE as *const RngR
 
 /// Settling delay (in `nop` iterations) applied after `CTRL.ENABLE`.
 ///
-/// On real silicon, the analog TRBG clock may require 100 ms
-/// (≈22.5 M nops at 450 MHz) to stabilize. This Uno PAL reduces the
-/// delay to a token value to keep boot time bounded — production
-/// builds running on the actual analog block must raise this back to
-/// the silicon-recommended 100 ms.
-const RNG_INIT_DELAY_NOPS: u32 = 64;
+/// On real silicon the analog TRBG clock requires ~100 ms to stabilize
+/// after the RNG is enabled.
+///
+/// At the 450 MHz core clock, counting ~2 cycles per `nop` loop iteration
+/// (one `nop` + the loop's subtract/branch), that is:
+///
+/// ```text
+///   100_000 µs × 450 MHz ÷ 2 = 22_500_000 iterations
+/// ```
+///
+/// An insufficient delay here lets `wait_for_random_data` re-enable the
+/// block before it settles; under sustained load (e.g. rapid key
+/// generation) this degenerates into a tight enable/disable toggle loop
+/// and an imprecise bus fault on the `CTRL` MMIO write.
+const RNG_INIT_DELAY_NOPS: u32 = 100_000 * 450 / 2;
 
 /// TRBG / DRBG calibration parameters.
 ///

--- a/fw/plat/uno/fw/pal/src/crypto/aes.rs
+++ b/fw/plat/uno/fw/pal/src/crypto/aes.rs
@@ -20,6 +20,7 @@ use azihsm_fw_hsm_pal_traits::HsmAlloc;
 use azihsm_fw_hsm_pal_traits::HsmError;
 use azihsm_fw_hsm_pal_traits::HsmIo;
 use azihsm_fw_hsm_pal_traits::HsmResult;
+use azihsm_fw_hsm_pal_traits::HsmRng;
 use azihsm_fw_hsm_pal_traits::HsmScopedAlloc;
 use azihsm_fw_uno_drivers_aes::AesMode;
 use azihsm_fw_uno_drivers_aes::AesOp as DriverAesOp;
@@ -51,23 +52,6 @@ fn aes_op(op: PalAesOp) -> DriverAesOp {
         PalAesOp::Encrypt => DriverAesOp::Encrypt,
         PalAesOp::Decrypt => DriverAesOp::Decrypt,
     }
-}
-
-/// Build the canonical “unsupported operation” error result.
-///
-/// Used by trait methods that this PAL does not implement (currently only
-/// [`HsmAes::aes_gen_key`]).
-///
-/// # Type parameters
-/// * `T` — the success payload of the returned [`HsmResult`]. Inferred at
-///   the call site so this helper can be used to short-circuit any
-///   `HsmResult<_>`-returning function.
-///
-/// # Returns
-/// * Always [`Err`] containing [`HsmError::UnsupportedCmd`].
-#[inline]
-fn unsupported<T>() -> HsmResult<T> {
-    Err(HsmError::UnsupportedCmd)
 }
 
 /// Validate that a buffer pair is acceptable for an AES-ECB / AES-CBC
@@ -244,11 +228,22 @@ impl UnoHsmPal {
 // validation and the building blocks each method delegates to.
 
 impl HsmAes for UnoHsmPal {
-    /// Not implemented: returns [`HsmError::UnsupportedCmd`].
+    /// Generate a random AES key by filling `key` from the on-chip
+    /// hardware RNG.
     ///
-    /// AES key generation is performed in higher layers via the RNG trait.
-    async fn aes_gen_key(&self, _io: &impl HsmIo, _key: &mut [u8]) -> HsmResult<()> {
-        unsupported()
+    /// The key size is taken from `key.len()`: 16 / 24 / 32 bytes for
+    /// AES-128 / 192 / 256 respectively. Any other length is rejected
+    /// before touching the RNG.
+    ///
+    /// # Errors
+    /// * [`HsmError::InvalidArg`] — `key.len()` is not 16, 24, or 32.
+    /// * Any [`HsmError`] surfaced by the RNG driver.
+    async fn aes_gen_key(&self, io: &impl HsmIo, key: &mut [u8]) -> HsmResult<()> {
+        match key.len() {
+            16 | 24 | 32 => {}
+            _ => return Err(HsmError::InvalidArg),
+        }
+        self.rng_fill_bytes(io, key)
     }
 
     /// Validates `iv_in` / `iv_out` lengths and that `input` / `output`


### PR DESCRIPTION
## Summary

Brings up **AES key generation** on the uno platform and restores the RNG post-enable settling delay to reference-firmware parity, which together unblock the full AES-CBC key lifecycle (generate → encrypt/decrypt → delete) on hardware.

Two coupled pieces:

1. **AES key generation (uno PAL).** Implements `UnoHsmPal::aes_gen_key` (previously `UnsupportedCmd`). The key is filled directly from the on-chip hardware RNG, with the key size taken from `key.len()` — 16 / 24 / 32 bytes for AES-128 / 192 / 256. Any other length is rejected with `InvalidArg` **before** touching the RNG. This removes the `unsupported()` shim and lets the session-scoped masking path mask a generated AES key into vault storage (building on `session_masking_key` from the ECDH bring-up).

2. **RNG settling-delay parity (uno RNG driver).** Restores the post-`CTRL.ENABLE` settling delay to the reference firmware's `cpu_stall(100_000 µs)` — ≈100 ms, or `100_000 × 450 MHz ÷ 2 = 22_500_000` nop iterations at the 450 MHz core clock — up from a token 64-nop value. The short delay let `wait_for_random_data` re-enable the analog TRBG block before it had stabilized; under sustained load (rapid key generation in the `mcr_perf` harness) this degenerated into a tight enable/disable toggle loop and an **imprecise BusFault** on the `CTRL` MMIO write. Single operations passed because the block was already settled; only the perf path exposed it.

### Changes

- `fw/plat/uno/fw/pal/src/crypto/aes.rs` — implement `aes_gen_key` (fill key from HW RNG; validate `key.len()` ∈ {16, 24, 32}, else `InvalidArg`); remove the `unsupported()` helper.
- `fw/plat/uno/fw/drivers/rng/src/api.rs` — set `RNG_INIT_DELAY_NOPS` to the reference `cpu_stall(100 ms)` equivalent (`100_000 * 450 / 2`); documents the BusFault-under-load rationale. Fixes the HardFault seen during AES-CBC-256 generate-and-delete perf runs.

## Test report

AES key-generation, AES-CBC, and masked-key-generation DDI integration suites (`ddi/mbor/types/tests/integration`), emu backend (in-process std-PAL firmware):

| Suite (`--filter`) | Backend | Result |
|---|---|---|
| `aes_generate` (+ smoke) | emu | **11 / 11 pass** |
| `aes_cbc` (+ smoke) | emu | **14 / 14 pass** |
| `masked_key_aes_gen` | emu | **5 / 5 pass** |
| all of the above (combined run) | emu | **30 / 30 pass** |

DDI tests validated on uno hardware (Manticore EVB):

| Suite | Backend | Result |
|---|---|---|
| `aes_generate` | uno HW | **11 / 11 pass**|
| `aes_cbc` | uno HW | ** 14 / 14 pass** |


## Performance (uno HW, `mcr_perf`, 128 threads, 5 s stabilize, 60 s)

| Operation | Throughput | Reference |
|---|---|---|
| AES-256 generate + delete | **5823 op/s** | 5439 op/s |
| AES-CBC-256 encrypt | **27883 op/s** | 23466 op/s |
| AES-CBC-256 decrypt | **27880 op/s** | 23466 op/s |