### PR TITLE
[API] [TBOR] SD Restore Remote API C-FFI 

### DIFF
--- a/api/native/cbindgen.toml
+++ b/api/native/cbindgen.toml
@@ -55,6 +55,7 @@ include = [
   "AzihsmSessExPartInitParams",
   "AzihsmSessExSdCreateRemoteBackupParams",
   "AzihsmSessExSdResealRemoteBackupParams",
+  "AzihsmSessExSdRestoreRemoteBackupParams",
   "AzihsmSessionPsk",
   "HsmEccCurve",
   "HsmError",
@@ -112,6 +113,7 @@ item_types = ["constants", "enums", "functions", "structs", "typedefs"]
 "AzihsmSessExPartInitParams" = "azihsm_sess_ex_part_init_params"
 "AzihsmSessExSdCreateRemoteBackupParams" = "azihsm_sess_ex_sd_create_remote_backup_params"
 "AzihsmSessExSdResealRemoteBackupParams" = "azihsm_sess_ex_sd_reseal_remote_backup_params"
+"AzihsmSessExSdRestoreRemoteBackupParams" = "azihsm_sess_ex_sd_restore_remote_backup_params"
 "AzihsmSessionExType" = "azihsm_session_ex_type"
 "AzihsmSessionProp" = "azihsm_session_prop"
 "AzihsmSessionPropId" = "azihsm_session_prop_id"

--- a/api/native/doc/chapter_09_sd.md
+++ b/api/native/doc/chapter_09_sd.md
@@ -354,6 +354,70 @@ struct azihsm_sess_ex_sd_reseal_remote_backup_params {
  | policy             | [azihsm_buffer*](#azihsm_buffer)           | unified partition-policy image (484 B)             |
  | src_remote_backup  | [azihsm_buffer*](#azihsm_buffer)           | source remote backup to reseal (161 B)             |
 
+## azihsm_sess_ex_sd_restore_remote_backup
+
+Restore a security domain from a remote backup over a security-domain
+session.
+
+HPKE-opens the remote backup with the receiver's masked SD-sealing key
+(authenticated by the sender in `sender_evidence`), recovers the
+security-domain masking key from `prev_sd_mk_backup`, and returns the
+refreshed device-local backups: the local partition-owner-key backup
+(180 bytes) and the security-domain masking-key backup (164 bytes).
+
+The inputs are grouped into an
+[`azihsm_sess_ex_sd_restore_remote_backup_params`](#azihsm_sess_ex_sd_restore_remote_backup_params)
+structure. Both output buffers follow the two-call size-probe contract and
+are validated **before** the restore is performed. A NULL `params` pointer
+is rejected with `AZIHSM_STATUS_INVALID_ARGUMENT`. Restore is a
+once-per-partition operation; a restore on an already-initialized partition
+returns `AZIHSM_STATUS_SD_ALREADY_INITIALIZED`.
+
+```cpp
+azihsm_status azihsm_sess_ex_sd_restore_remote_backup(
+    azihsm_handle sess_handle,
+    const struct azihsm_sess_ex_sd_restore_remote_backup_params *params,
+    struct azihsm_buffer *pok_local_backup,
+    struct azihsm_buffer *sd_mk_backup
+    );
+```
+
+**Parameters**
+
+ | Parameter                  | Name                                                                                                      | Description                                       |
+ | -------------------------- | --------------------------------------------------------------------------------------------------------- | ------------------------------------------------- |
+ | [in] sess_handle           | [azihsm_handle](#azihsm_handle)                                                                           | security-domain session handle                    |
+ | [in] params                | [azihsm_sess_ex_sd_restore_remote_backup_params*](#azihsm_sess_ex_sd_restore_remote_backup_params)        | restore-backup input buffers                      |
+ | [in, out] pok_local_backup | [azihsm_buffer *](#azihsm_buffer)                                                                         | output buffer for the local pok backup (180 B)    |
+ | [in, out] sd_mk_backup     | [azihsm_buffer *](#azihsm_buffer)                                                                         | output buffer for the sd masking-key backup (164 B) &nbsp; |
+
+**Returns**
+
+`AZIHSM_STATUS_SUCCESS` on success, error code otherwise
+
+### azihsm_sess_ex_sd_restore_remote_backup_params
+
+Input buffers for
+[`azihsm_sess_ex_sd_restore_remote_backup`](#azihsm_sess_ex_sd_restore_remote_backup).
+
+```cpp
+struct azihsm_sess_ex_sd_restore_remote_backup_params {
+    const struct azihsm_buffer *masked_sealing_key;
+    const struct azihsm_sd_evidence *sender_evidence;
+    const struct azihsm_buffer *policy;
+    const struct azihsm_buffer *src_remote_backup;
+    const struct azihsm_buffer *prev_sd_mk_backup;
+};
+```
+
+ | Field              | Name                                       | Description                                        |
+ | ------------------ | ------------------------------------------ | -------------------------------------------------- |
+ | masked_sealing_key | [azihsm_buffer*](#azihsm_buffer)           | receiver's masked SD-sealing key (180 B)           |
+ | sender_evidence    | [azihsm_sd_evidence*](#azihsm_sd_evidence) | sender attestation evidence                        |
+ | policy             | [azihsm_buffer*](#azihsm_buffer)           | unified partition-policy image (484 B)             |
+ | src_remote_backup  | [azihsm_buffer*](#azihsm_buffer)           | remote backup to restore (161 B)                   |
+ | prev_sd_mk_backup  | [azihsm_buffer*](#azihsm_buffer)           | previous security-domain masking-key backup (164 B)|
+
 ### azihsm_sd_evidence
 
 Attestation evidence for one security-domain-backup party: three certificate

--- a/api/native/src/session_ex.rs
+++ b/api/native/src/session_ex.rs
@@ -440,10 +440,11 @@ fn unpack_cert_chain(chain: &AzihsmSdCertChain) -> Result<Vec<api::HsmCert<'_>>,
 
 /// Owned, validated decode of one C [`AzihsmSdEvidence`]: the three cert
 /// chains materialized as `HsmCert` vectors plus the report slice (the DER
-/// bytes stay borrowed from the caller's buffers). Convert a reference with
-/// `HsmSdEvidence::from` for the borrowing [`api::HsmSdEvidence`] view the
-/// session API expects; that view borrows these owned vectors, so it cannot
-/// be produced from the C struct in a single step.
+/// bytes stay borrowed from the caller's buffers). Convert a reference
+/// with `api::HsmSdEvidence::from` for the borrowing
+/// [`api::HsmSdEvidence`] view the session API expects; that view
+/// borrows these owned vectors, so it cannot be produced from the C
+/// struct in a single step.
 struct SdEvidence<'a> {
     mfgr: Vec<api::HsmCert<'a>>,
     owner: Vec<api::HsmCert<'a>>,

--- a/api/native/src/session_ex.rs
+++ b/api/native/src/session_ex.rs
@@ -438,6 +438,43 @@ fn unpack_cert_chain(chain: &AzihsmSdCertChain) -> Result<Vec<api::HsmCert<'_>>,
     Ok(certs)
 }
 
+/// Owned, validated decode of one C [`AzihsmSdEvidence`]: the three cert
+/// chains materialized as `HsmCert` vectors plus the report slice (the DER
+/// bytes stay borrowed from the caller's buffers). Convert a reference with
+/// `HsmSdEvidence::from` for the borrowing [`api::HsmSdEvidence`] view the
+/// session API expects; that view borrows these owned vectors, so it cannot
+/// be produced from the C struct in a single step.
+struct SdEvidence<'a> {
+    mfgr: Vec<api::HsmCert<'a>>,
+    owner: Vec<api::HsmCert<'a>>,
+    part_owner: Vec<api::HsmCert<'a>>,
+    report: &'a [u8],
+}
+
+impl<'a> TryFrom<&'a AzihsmSdEvidence> for SdEvidence<'a> {
+    type Error = AzihsmStatus;
+
+    fn try_from(ev: &'a AzihsmSdEvidence) -> Result<Self, Self::Error> {
+        Ok(Self {
+            mfgr: unpack_cert_chain(&ev.mfgr_cert_chain)?,
+            owner: unpack_cert_chain(&ev.owner_cert_chain)?,
+            part_owner: unpack_cert_chain(&ev.part_owner_cert_chain)?,
+            report: deref_ptr(ev.report)?.try_into()?,
+        })
+    }
+}
+
+impl<'a: 'b, 'b> From<&'b SdEvidence<'a>> for api::HsmSdEvidence<'b> {
+    fn from(ev: &'b SdEvidence<'a>) -> Self {
+        api::HsmSdEvidence {
+            mfgr_cert_chain: &ev.mfgr,
+            owner_cert_chain: &ev.owner,
+            part_owner_cert_chain: &ev.part_owner,
+            report: ev.report,
+        }
+    }
+}
+
 /// @brief Create a new security domain and its remote backup
 ///
 /// Creates a security domain under the calling session's partition from
@@ -483,17 +520,9 @@ pub unsafe extern "C" fn azihsm_sess_ex_sd_create_remote_backup(
         let masked_sealing_key: &[u8] = deref_ptr(params.masked_sealing_key)?.try_into()?;
         let policy: &[u8] = deref_ptr(params.policy)?.try_into()?;
 
-        let ev = deref_ptr(params.receiver_evidence)?;
-        let mfgr = unpack_cert_chain(&ev.mfgr_cert_chain)?;
-        let owner = unpack_cert_chain(&ev.owner_cert_chain)?;
-        let part_owner = unpack_cert_chain(&ev.part_owner_cert_chain)?;
-        let report: &[u8] = deref_ptr(ev.report)?.try_into()?;
-        let receiver = api::HsmSdEvidence {
-            mfgr_cert_chain: &mfgr,
-            owner_cert_chain: &owner,
-            part_owner_cert_chain: &part_owner,
-            report,
-        };
+        let receiver = deref_ptr(params.receiver_evidence)?;
+        let receiver = SdEvidence::try_from(receiver)?;
+        let receiver = api::HsmSdEvidence::from(&receiver);
 
         // Reject null/misaligned or aliasing output pointers before taking a
         // `&mut` to each: two `&mut` references to the same `azihsm_buffer`
@@ -575,29 +604,12 @@ pub unsafe extern "C" fn azihsm_sess_ex_sd_reseal_remote_backup(
         let policy: &[u8] = deref_ptr(params.policy)?.try_into()?;
         let src_remote_backup: &[u8] = deref_ptr(params.src_remote_backup)?.try_into()?;
 
-        let src_ev = deref_ptr(params.src_evidence)?;
-        let src_mfgr = unpack_cert_chain(&src_ev.mfgr_cert_chain)?;
-        let src_owner = unpack_cert_chain(&src_ev.owner_cert_chain)?;
-        let src_part_owner = unpack_cert_chain(&src_ev.part_owner_cert_chain)?;
-        let src_report: &[u8] = deref_ptr(src_ev.report)?.try_into()?;
-        let src_evidence = api::HsmSdEvidence {
-            mfgr_cert_chain: &src_mfgr,
-            owner_cert_chain: &src_owner,
-            part_owner_cert_chain: &src_part_owner,
-            report: src_report,
-        };
-
-        let dest_ev = deref_ptr(params.dest_evidence)?;
-        let dest_mfgr = unpack_cert_chain(&dest_ev.mfgr_cert_chain)?;
-        let dest_owner = unpack_cert_chain(&dest_ev.owner_cert_chain)?;
-        let dest_part_owner = unpack_cert_chain(&dest_ev.part_owner_cert_chain)?;
-        let dest_report: &[u8] = deref_ptr(dest_ev.report)?.try_into()?;
-        let dest_evidence = api::HsmSdEvidence {
-            mfgr_cert_chain: &dest_mfgr,
-            owner_cert_chain: &dest_owner,
-            part_owner_cert_chain: &dest_part_owner,
-            report: dest_report,
-        };
+        let src_evidence = deref_ptr(params.src_evidence)?;
+        let dest_evidence = deref_ptr(params.dest_evidence)?;
+        let src_evidence = SdEvidence::try_from(src_evidence)?;
+        let dest_evidence = SdEvidence::try_from(dest_evidence)?;
+        let src_evidence = api::HsmSdEvidence::from(&src_evidence);
+        let dest_evidence = api::HsmSdEvidence::from(&dest_evidence);
 
         // Validate the output buffer before resealing.
         validate_ptr(dst_remote_backup)?;
@@ -613,6 +625,96 @@ pub unsafe extern "C" fn azihsm_sess_ex_sd_reseal_remote_backup(
         )?;
 
         copy_to_buffer(dst_remote_backup, &result)?;
+
+        Ok(())
+    })
+}
+
+/// Input buffers for [`azihsm_sess_ex_sd_restore_remote_backup`].
+#[repr(C)]
+pub struct AzihsmSessExSdRestoreRemoteBackupParams {
+    /// Receiver's masked SD-sealing key (from `azihsm_key_gen`) that
+    /// unseals the backup, exactly `MASKED_SEALING_KEY_LEN` (180 B).
+    pub masked_sealing_key: *const AzihsmBuffer,
+    /// Sender attestation evidence.
+    pub sender_evidence: *const AzihsmSdEvidence,
+    /// Unified partition-policy image (484 B) describing the domain.
+    pub policy: *const AzihsmBuffer,
+    /// Remote backup to restore, exactly `POK_REMOTE_BACKUP_LEN` (161 B).
+    pub src_remote_backup: *const AzihsmBuffer,
+    /// Previous security-domain masking-key backup, exactly
+    /// `SD_MK_BACKUP_LEN` (164 B).
+    pub prev_sd_mk_backup: *const AzihsmBuffer,
+}
+
+/// @brief Restore a security domain from a remote backup
+///
+/// HPKE-opens `params.src_remote_backup` with the receiver's masked sealing
+/// key (authenticated by the sender in `params.sender_evidence`), recovers
+/// the security-domain masking key from `params.prev_sd_mk_backup`, and
+/// returns the refreshed device-local backups.
+///
+/// @param[in] sess_handle Handle to the security-domain session
+/// @param[in] params Restore-backup input buffers
+/// @param[in,out] pok_local_backup Output buffer for the local
+///                partition-owner-key backup (180 B).
+/// @param[in,out] sd_mk_backup Output buffer for the security-domain
+///                masking-key backup (164 B).
+///
+/// Both output buffers follow the probe/fill convention and are validated
+/// **before** the restore is performed.
+///
+/// @return `AzihsmStatus` indicating the result of the operation
+///
+/// # Safety
+///
+/// - `sess_handle` must be a valid security-domain session handle.
+/// - `params` and each of its buffer/evidence pointers must be valid; each
+///   `AzihsmSdCertChain.certs` must point to `len` valid `azihsm_buffer`s.
+/// - Each output buffer must be a valid `azihsm_buffer` with writable
+///   backing storage of the advertised length.
+#[unsafe(no_mangle)]
+#[allow(unsafe_code)]
+pub unsafe extern "C" fn azihsm_sess_ex_sd_restore_remote_backup(
+    sess_handle: AzihsmHandle,
+    params: *const AzihsmSessExSdRestoreRemoteBackupParams,
+    pok_local_backup: *mut AzihsmBuffer,
+    sd_mk_backup: *mut AzihsmBuffer,
+) -> AzihsmStatus {
+    abi_boundary(|| {
+        let session = api::HsmSession::try_from(sess_handle)?;
+        let params = deref_ptr(params)?;
+
+        let masked_sealing_key: &[u8] = deref_ptr(params.masked_sealing_key)?.try_into()?;
+        let policy: &[u8] = deref_ptr(params.policy)?.try_into()?;
+        let src_remote_backup: &[u8] = deref_ptr(params.src_remote_backup)?.try_into()?;
+        let prev_sd_mk_backup: &[u8] = deref_ptr(params.prev_sd_mk_backup)?.try_into()?;
+
+        let sender = deref_ptr(params.sender_evidence)?;
+        let sender = SdEvidence::try_from(sender)?;
+        let sender = api::HsmSdEvidence::from(&sender);
+
+        // Reject null/misaligned or aliasing output pointers before taking a
+        // `&mut` to each: two `&mut` references to the same `azihsm_buffer`
+        // would be undefined behavior.
+        validate_distinct_output_buffers(&[pok_local_backup, sd_mk_backup])?;
+
+        let pok_local_backup = deref_mut_ptr(pok_local_backup)?;
+        validate_output_buffer(pok_local_backup, api::MASKED_SD_LEN)?;
+
+        let sd_mk_backup = deref_mut_ptr(sd_mk_backup)?;
+        validate_output_buffer(sd_mk_backup, api::SD_MK_BACKUP_LEN)?;
+
+        let result = session.sd_restore_remote_backup(
+            masked_sealing_key,
+            &sender,
+            policy,
+            src_remote_backup,
+            prev_sd_mk_backup,
+        )?;
+
+        copy_to_buffer(pok_local_backup, &result.pok_local_backup)?;
+        copy_to_buffer(sd_mk_backup, &result.sd_mk_backup)?;
 
         Ok(())
     })

--- a/api/tests/cpp/CMakeLists.txt
+++ b/api/tests/cpp/CMakeLists.txt
@@ -99,6 +99,7 @@ set(SOURCE
     algo/sealing/keygen_tests.cpp
     sd/create_backup_tests.cpp
     sd/reseal_tests.cpp
+    sd/restore_tests.cpp
     resiliency/init_stress_tests.cpp
     resiliency/aes_stress_tests.cpp
     resiliency/ecc_stress_tests.cpp

--- a/api/tests/cpp/sd/restore_tests.cpp
+++ b/api/tests/cpp/sd/restore_tests.cpp
@@ -1,0 +1,325 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+// api-level `SdRestoreRemoteBackup` round trip against the emulator.
+//
+// Self-backup "reboot" flow on one physical partition: a first incarnation
+// finalizes and creates a remote backup (capturing its `pok_remote_backup`
+// and `sd_mk_backup`, plus the `local_mk_backup` from `PartFinal`), then the
+// same partition is factory-reset (a simulated reboot) and re-provisioned as
+// a restore target — reusing the policy and SATA/POTA anchors and supplying
+// the captured `local_mk_backup` so the sealing key unmasks — and the
+// security domain is restored from the remote backup via
+// `azihsm_sess_ex_sd_restore_remote_backup`. A successful restore is itself
+// the correctness check: the HPKE open only succeeds if the receiver key and
+// the attested sender key match those that sealed the backup.
+//
+// Like the create/reseal tests this needs the two-phase TBOR HPKE handshake
+// and a fully provisioned partition, which the mock backend does not
+// implement, so it is excluded from the mock lane and runs on the emu and
+// hardware backends.
+#if !defined(AZIHSM_FEATURE_MOCK)
+
+#include <array>
+#include <azihsm_api.h>
+#include <cstdint>
+#include <cstring>
+#include <gtest/gtest.h>
+#include <scope_guard.hpp>
+#include <vector>
+
+#include "handle/part_list_handle.hpp"
+#include "utils/sd_provision.hpp"
+#include "utils/utils.hpp"
+
+namespace
+{
+// Pinned wire lengths. Mirror the `azihsm_ddi_tbor_types` constants
+// (`MASKED_SEALING_KEY_LEN`, `POK_REMOTE_BACKUP_LEN`, `MASKED_SD_LEN`,
+// `SD_MK_BACKUP_LEN`), which are not exposed in the C header.
+constexpr uint32_t kMaskedSealingKeyLen = 180;
+constexpr uint32_t kPokRemoteBackupLen = 161;
+constexpr uint32_t kMaskedSdLen = 180;
+constexpr uint32_t kSdMkBackupLen = 164;
+
+bool any_nonzero(const std::vector<uint8_t> &bytes)
+{
+    for (uint8_t b : bytes)
+    {
+        if (b != 0)
+        {
+            return true;
+        }
+    }
+    return false;
+}
+
+// Create a real remote backup sealed to `receiver`'s attested key by
+// `masked`, capturing both the 161-byte remote backup and the 164-byte
+// masking-key backup needed to drive a later restore. Sizes the three output
+// buffers via the probe/fill convention. Records a gtest failure and returns
+// false on error.
+bool create_backup_capture(
+    azihsm_handle session,
+    std::vector<uint8_t> &masked,
+    const azihsm_sd_evidence &receiver,
+    const std::vector<uint8_t> &policy,
+    std::vector<uint8_t> &out_remote,
+    std::vector<uint8_t> &out_mk
+)
+{
+    azihsm_buffer masked_buf{ masked.data(), static_cast<uint32_t>(masked.size()) };
+    azihsm_buffer policy_buf{ const_cast<uint8_t *>(policy.data()),
+                              static_cast<uint32_t>(policy.size()) };
+    azihsm_sess_ex_sd_create_remote_backup_params params{
+        &masked_buf,
+        &receiver,
+        &policy_buf,
+    };
+
+    std::vector<uint8_t> remote;
+    std::vector<uint8_t> local;
+    std::vector<uint8_t> mk;
+    azihsm_buffer remote_buf{ nullptr, 0 };
+    azihsm_buffer local_buf{ nullptr, 0 };
+    azihsm_buffer mk_buf{ nullptr, 0 };
+    azihsm_status err = AZIHSM_STATUS_BUFFER_TOO_SMALL;
+    for (int attempt = 0; attempt < 4; ++attempt)
+    {
+        err = azihsm_sess_ex_sd_create_remote_backup(
+            session,
+            &params,
+            &remote_buf,
+            &local_buf,
+            &mk_buf
+        );
+        if (err != AZIHSM_STATUS_BUFFER_TOO_SMALL)
+        {
+            break;
+        }
+        if (remote_buf.len > remote.size())
+        {
+            remote.resize(remote_buf.len);
+        }
+        if (local_buf.len > local.size())
+        {
+            local.resize(local_buf.len);
+        }
+        if (mk_buf.len > mk.size())
+        {
+            mk.resize(mk_buf.len);
+        }
+        remote_buf = { remote.data(), static_cast<uint32_t>(remote.size()) };
+        local_buf = { local.data(), static_cast<uint32_t>(local.size()) };
+        mk_buf = { mk.data(), static_cast<uint32_t>(mk.size()) };
+    }
+    if (err != AZIHSM_STATUS_SUCCESS)
+    {
+        ADD_FAILURE() << "create remote backup failed: " << err;
+        return false;
+    }
+    remote.resize(remote_buf.len);
+    mk.resize(mk_buf.len);
+    out_remote = std::move(remote);
+    out_mk = std::move(mk);
+    return true;
+}
+
+// Run the restore call, sizing both output buffers via the probe/fill
+// convention. The FFI validates the output buffers before restoring, so a
+// too-small buffer never performs the restore. Returns the final status and,
+// on success, sizes `pok_local` / `sd_mk` to the bytes written.
+azihsm_status restore_fill(
+    azihsm_handle session,
+    const azihsm_sess_ex_sd_restore_remote_backup_params *params,
+    std::vector<uint8_t> &pok_local,
+    std::vector<uint8_t> &sd_mk
+)
+{
+    azihsm_buffer pok_buf{ nullptr, 0 };
+    azihsm_buffer mk_buf{ nullptr, 0 };
+    azihsm_status err = AZIHSM_STATUS_BUFFER_TOO_SMALL;
+    for (int attempt = 0; attempt < 4; ++attempt)
+    {
+        err = azihsm_sess_ex_sd_restore_remote_backup(session, params, &pok_buf, &mk_buf);
+        if (err != AZIHSM_STATUS_BUFFER_TOO_SMALL)
+        {
+            break;
+        }
+        if (pok_buf.len > pok_local.size())
+        {
+            pok_local.resize(pok_buf.len);
+        }
+        if (mk_buf.len > sd_mk.size())
+        {
+            sd_mk.resize(mk_buf.len);
+        }
+        pok_buf = { pok_local.data(), static_cast<uint32_t>(pok_local.size()) };
+        mk_buf = { sd_mk.data(), static_cast<uint32_t>(sd_mk.size()) };
+    }
+    if (err == AZIHSM_STATUS_SUCCESS)
+    {
+        pok_local.resize(pok_buf.len);
+        sd_mk.resize(mk_buf.len);
+    }
+    return err;
+}
+} // namespace
+
+/// Test fixture for security-domain restore-remote-backup
+/// (`azihsm_sess_ex_sd_restore_remote_backup`).
+class azihsm_sd_restore_backup : public ::testing::Test
+{
+  protected:
+    PartitionListHandle part_list_ = PartitionListHandle{};
+
+    // Open and factory-reset a partition into a clean state. Records a
+    // gtest failure and returns 0 on error; the returned handle must be
+    // closed by the caller.
+    static azihsm_handle open_reset_partition(std::vector<azihsm_char> &path)
+    {
+        azihsm_str path_str;
+        path_str.str = path.data();
+        path_str.len = static_cast<uint32_t>(path.size());
+
+        azihsm_handle part_handle = 0;
+        auto err = azihsm_part_open(&path_str, &part_handle, test_api_rev());
+        if (err != AZIHSM_STATUS_SUCCESS)
+        {
+            ADD_FAILURE() << "azihsm_part_open failed: " << err;
+            return 0;
+        }
+
+        err = azihsm_part_reset(part_handle);
+        if (err != AZIHSM_STATUS_SUCCESS)
+        {
+            ADD_FAILURE() << "azihsm_part_reset failed: " << err;
+            azihsm_part_close(part_handle);
+            return 0;
+        }
+
+        return part_handle;
+    }
+};
+
+// Happy path: create a remote backup on one incarnation, then restore it on
+// a rebooted (factory-reset, re-provisioned) incarnation of the same
+// partition; the restore returns non-zero refreshed device-local backups of
+// the pinned lengths.
+TEST_F(azihsm_sd_restore_backup, restore_backup_roundtrip)
+{
+    part_list_.for_each_part([](std::vector<azihsm_char> &path) {
+        azihsm_handle part_handle = open_reset_partition(path);
+        if (part_handle == 0)
+        {
+            return;
+        }
+        auto part_guard =
+            scope_guard::make_scope_exit([&part_handle] { azihsm_part_close(part_handle); });
+
+        // Device 1: provision, mint a sealing key, and create a remote
+        // backup, capturing the remote backup and its masking-key backup.
+        SdBackingContext dev1 = provision_sd_backing_co_session(part_handle);
+        if (dev1.session == 0)
+        {
+            return; // provisioning recorded its own failure
+        }
+        // Safety net for an early ASSERT exit; the happy path closes the
+        // session explicitly before the reboot (zeroing the handle), which
+        // makes this guard a no-op.
+        auto dev1_guard = scope_guard::make_scope_exit([&dev1] {
+            if (dev1.session != 0)
+            {
+                azihsm_sess_close(dev1.session);
+            }
+        });
+
+        SealingKeyMaterial key = sealing_key_and_report(dev1.session);
+        ASSERT_EQ(key.masked.size(), kMaskedSealingKeyLen);
+        ASSERT_FALSE(key.report.empty());
+
+        // Self-backup: the same attested key is both sender and receiver.
+        SdEvidenceHolder evidence = build_receiver_evidence(dev1, key.report);
+
+        std::vector<uint8_t> remote_backup;
+        std::vector<uint8_t> prev_sd_mk;
+        ASSERT_TRUE(create_backup_capture(
+            dev1.session,
+            key.masked,
+            evidence.get(),
+            dev1.policy,
+            remote_backup,
+            prev_sd_mk
+        ));
+        ASSERT_EQ(remote_backup.size(), kPokRemoteBackupLen);
+        ASSERT_EQ(prev_sd_mk.size(), kSdMkBackupLen);
+
+        // Close device 1's session before the reboot.
+        azihsm_sess_close(dev1.session);
+        dev1.session = 0;
+
+        // Device 2 (reboot): factory-reset the same partition and
+        // re-provision it as a restore target, reusing device 1's policy
+        // and anchors and its captured local_mk backup.
+        auto err = azihsm_part_reset(part_handle);
+        ASSERT_EQ(err, AZIHSM_STATUS_SUCCESS) << "reboot reset failed";
+        SdBackingContext dev2 = provision_sd_restore_target(part_handle, dev1);
+        if (dev2.session == 0)
+        {
+            return; // provisioning recorded its own failure
+        }
+        auto sess_guard =
+            scope_guard::make_scope_exit([&dev2] { azihsm_sess_close(dev2.session); });
+
+        // Restore the security domain from device 1's remote backup.
+        azihsm_buffer masked_buf{ key.masked.data(), static_cast<uint32_t>(key.masked.size()) };
+        azihsm_buffer policy_buf{ dev2.policy.data(), static_cast<uint32_t>(dev2.policy.size()) };
+        azihsm_buffer remote_buf{ remote_backup.data(),
+                                  static_cast<uint32_t>(remote_backup.size()) };
+        azihsm_buffer prev_mk_buf{ prev_sd_mk.data(), static_cast<uint32_t>(prev_sd_mk.size()) };
+        azihsm_sess_ex_sd_restore_remote_backup_params params{
+            &masked_buf, &evidence.get(), &policy_buf, &remote_buf, &prev_mk_buf,
+        };
+
+        std::vector<uint8_t> pok_local;
+        std::vector<uint8_t> sd_mk;
+        ASSERT_EQ(restore_fill(dev2.session, &params, pok_local, sd_mk), AZIHSM_STATUS_SUCCESS);
+
+        // Refreshed device-local backups: 180-byte local pok backup and
+        // 164-byte masking-key backup, both non-zero.
+        ASSERT_EQ(pok_local.size(), kMaskedSdLen);
+        ASSERT_TRUE(any_nonzero(pok_local)) << "pok_local_backup must not be all-zero";
+        ASSERT_EQ(sd_mk.size(), kSdMkBackupLen);
+        ASSERT_TRUE(any_nonzero(sd_mk)) << "sd_mk_backup must not be all-zero";
+    });
+}
+
+// A NULL params pointer is rejected with `INVALID_ARGUMENT` after the
+// session resolves and before the restore is performed.
+TEST_F(azihsm_sd_restore_backup, restore_backup_null_params)
+{
+    part_list_.for_each_part([](std::vector<azihsm_char> &path) {
+        azihsm_handle part_handle = open_reset_partition(path);
+        if (part_handle == 0)
+        {
+            return;
+        }
+        auto part_guard =
+            scope_guard::make_scope_exit([&part_handle] { azihsm_part_close(part_handle); });
+
+        SdBackingContext ctx = provision_sd_backing_co_session(part_handle);
+        if (ctx.session == 0)
+        {
+            return;
+        }
+        auto sess_guard = scope_guard::make_scope_exit([&ctx] { azihsm_sess_close(ctx.session); });
+
+        azihsm_buffer pok_local{ nullptr, 0 };
+        azihsm_buffer sd_mk{ nullptr, 0 };
+        auto err =
+            azihsm_sess_ex_sd_restore_remote_backup(ctx.session, nullptr, &pok_local, &sd_mk);
+        ASSERT_EQ(err, AZIHSM_STATUS_INVALID_ARGUMENT);
+    });
+}
+
+#endif // !defined(AZIHSM_FEATURE_MOCK)

--- a/api/tests/cpp/utils/sd_provision.cpp
+++ b/api/tests/cpp/utils/sd_provision.cpp
@@ -953,7 +953,15 @@ azihsm_handle provision_sd_co_session(azihsm_handle part_handle)
     return session;
 }
 
-SdBackingContext provision_sd_backing_co_session(azihsm_handle part_handle)
+// Core backing-partition provisioning. When `reuse` is null a fresh policy
+// and SATA/POTA anchors are minted (the create / device-1 side). When
+// non-null the policy and anchors are reused and `reuse->local_mk_backup`
+// is supplied to `PartFinal`, re-provisioning the same partition as a
+// restore target (the device-2 side).
+static SdBackingContext provision_backing_impl(
+    azihsm_handle part_handle,
+    const SdBackingContext *reuse
+)
 {
     // 1. Bootstrap a CO session under the default PSK and rotate it.
     azihsm_handle bootstrap = open_co_session(part_handle, nullptr);
@@ -1019,25 +1027,44 @@ SdBackingContext provision_sd_backing_co_session(azihsm_handle part_handle)
         return fail("PartInfo PID public key has unexpected length", AZIHSM_STATUS_INTERNAL_ERROR);
     }
 
-    // 4. Mint the POTA anchor (for the PTA chain) and the SATA anchor (which
-    // roots the partition-owner evidence chain), then build the backing
-    // policy. The SATA key is handed back to the caller as an opaque handle.
-    std::unique_ptr<CaKey> pota_ca = CaKey::generate();
-    if (!pota_ca)
+    // 4. Mint (or reuse) the POTA anchor (for the PTA chain) and the SATA
+    // anchor (which roots the partition-owner evidence chain), then build
+    // (or reuse) the backing policy. A restore target must re-provision
+    // under the exact same policy and anchors as the original.
+    std::shared_ptr<CaKey> pota_ca;
+    std::shared_ptr<CaKey> sata_key;
+    std::vector<uint8_t> policy;
+    if (reuse != nullptr)
     {
-        return fail("POTA CA key generation failed", AZIHSM_STATUS_INTERNAL_ERROR);
+        pota_ca = reuse->pota_key;
+        sata_key = reuse->sata_key;
+        policy = reuse->policy;
+        if (!pota_ca || !sata_key || policy.empty())
+        {
+            return fail(
+                "restore target reuse context is incomplete",
+                AZIHSM_STATUS_INVALID_ARGUMENT
+            );
+        }
     }
-    std::shared_ptr<CaKey> sata_key = CaKey::generate();
-    if (!sata_key)
+    else
     {
-        return fail("SATA CA key generation failed", AZIHSM_STATUS_INTERNAL_ERROR);
+        pota_ca = CaKey::generate();
+        if (!pota_ca)
+        {
+            return fail("POTA CA key generation failed", AZIHSM_STATUS_INTERNAL_ERROR);
+        }
+        sata_key = CaKey::generate();
+        if (!sata_key)
+        {
+            return fail("SATA CA key generation failed", AZIHSM_STATUS_INTERNAL_ERROR);
+        }
+        uint8_t pota_raw[kRawPubLen];
+        std::memcpy(pota_raw, pota_ca->sec1().data() + 1, kRawPubLen);
+        uint8_t sata_raw[kRawPubLen];
+        std::memcpy(sata_raw, sata_key->sec1().data() + 1, kRawPubLen);
+        policy = build_backing_part_policy(pid.data(), pid_pub.data(), sata_raw, pota_raw);
     }
-    uint8_t pota_raw[kRawPubLen];
-    std::memcpy(pota_raw, pota_ca->sec1().data() + 1, kRawPubLen);
-    uint8_t sata_raw[kRawPubLen];
-    std::memcpy(sata_raw, sata_key->sec1().data() + 1, kRawPubLen);
-    std::vector<uint8_t> policy =
-        build_backing_part_policy(pid.data(), pid_pub.data(), sata_raw, pota_raw);
 
     // Deterministic provisioning fixtures (thumbprints are stored, not
     // chain-validated in this flow).
@@ -1101,11 +1128,21 @@ SdBackingContext provision_sd_backing_co_session(azihsm_handle part_handle)
         { chain.root_der.data(), static_cast<uint32_t>(chain.root_der.size()) },
         { chain.pta_der.data(), static_cast<uint32_t>(chain.pta_der.size()) },
     };
+    azihsm_buffer prev_mk_buf{};
     azihsm_sess_ex_part_final_params final_params{};
     final_params.part_policy = &policy_buf;
     final_params.pta_cert_chain = chain_bufs;
     final_params.pta_cert_chain_len = 2;
-    final_params.prev_local_mk_backup = nullptr;
+    if (reuse != nullptr)
+    {
+        prev_mk_buf = { const_cast<uint8_t *>(reuse->local_mk_backup.data()),
+                        static_cast<uint32_t>(reuse->local_mk_backup.size()) };
+        final_params.prev_local_mk_backup = &prev_mk_buf;
+    }
+    else
+    {
+        final_params.prev_local_mk_backup = nullptr;
+    }
 
     azihsm_buffer mk_backup{ nullptr, 0 };
     auto fin_probe = azihsm_sess_ex_part_final(session, &final_params, &mk_backup);
@@ -1121,7 +1158,27 @@ SdBackingContext provision_sd_backing_co_session(azihsm_handle part_handle)
         return fail("PartFinal failed", final_err);
     }
 
-    return SdBackingContext{ session, std::move(policy), std::move(pid_pub), std::move(sata_key) };
+    SdBackingContext ctx;
+    ctx.session = session;
+    ctx.policy = std::move(policy);
+    ctx.pid_pub = std::move(pid_pub);
+    ctx.sata_key = std::move(sata_key);
+    ctx.pota_key = std::move(pota_ca);
+    ctx.local_mk_backup = std::move(mk_bytes);
+    return ctx;
+}
+
+SdBackingContext provision_sd_backing_co_session(azihsm_handle part_handle)
+{
+    return provision_backing_impl(part_handle, nullptr);
+}
+
+SdBackingContext provision_sd_restore_target(
+    azihsm_handle part_handle,
+    const SdBackingContext &prev
+)
+{
+    return provision_backing_impl(part_handle, &prev);
 }
 
 SealingKeyMaterial sealing_key_and_report(azihsm_handle session)

--- a/api/tests/cpp/utils/sd_provision.cpp
+++ b/api/tests/cpp/utils/sd_provision.cpp
@@ -1133,7 +1133,7 @@ static SdBackingContext provision_backing_impl(
     final_params.part_policy = &policy_buf;
     final_params.pta_cert_chain = chain_bufs;
     final_params.pta_cert_chain_len = 2;
-    if (reuse != nullptr)
+    if (reuse != nullptr && !reuse->local_mk_backup.empty())
     {
         prev_mk_buf = { const_cast<uint8_t *>(reuse->local_mk_backup.data()),
                         static_cast<uint32_t>(reuse->local_mk_backup.size()) };

--- a/api/tests/cpp/utils/sd_provision.hpp
+++ b/api/tests/cpp/utils/sd_provision.hpp
@@ -52,6 +52,11 @@ struct SdBackingContext
     std::vector<uint8_t> pid_pub;
     /// SATA anchor key that roots the partition-owner evidence chain.
     std::shared_ptr<CaKey> sata_key;
+    /// POTA anchor key that roots the CSR -> PTA chain. Retained so a
+    /// restore target can re-provision under the same policy.
+    std::shared_ptr<CaKey> pota_key;
+    /// Device-local partition-owner-key backup emitted by `PartFinal`.
+    std::vector<uint8_t> local_mk_backup;
 };
 
 /// Provision `part_handle` with a backing-partition policy that names this
@@ -62,6 +67,21 @@ struct SdBackingContext
 /// (`session == 0`) on error. The caller owns `session` and must close it
 /// with `azihsm_sess_close`.
 SdBackingContext provision_sd_backing_co_session(azihsm_handle part_handle);
+
+/// Re-provision `part_handle` — the same physical backing partition after a
+/// simulated reboot (`azihsm_part_reset`) — as a restore target, reusing
+/// `prev`'s policy and SATA/POTA anchors and supplying
+/// `prev.local_mk_backup` to `PartFinal` for device-local master-key
+/// continuity. This reproduces the receiver (device-2) side of a restore
+/// round trip.
+///
+/// Records a gtest failure and returns a default `SdBackingContext`
+/// (`session == 0`) on error. The caller owns `session` and must close it
+/// with `azihsm_sess_close`.
+SdBackingContext provision_sd_restore_target(
+    azihsm_handle part_handle,
+    const SdBackingContext &prev
+);
 
 /// A minted SD sealing key: its masked private-key blob and a COSE_Sign1
 /// `KeyReport` attesting it.

--- a/api/tests/cpp/utils/sd_provision.hpp
+++ b/api/tests/cpp/utils/sd_provision.hpp
@@ -55,7 +55,7 @@ struct SdBackingContext
     /// POTA anchor key that roots the CSR -> PTA chain. Retained so a
     /// restore target can re-provision under the same policy.
     std::shared_ptr<CaKey> pota_key;
-    /// Device-local partition-owner-key backup emitted by `PartFinal`.
+    /// Device-local master-key (`local_mk`) backup emitted by `PartFinal`.
     std::vector<uint8_t> local_mk_backup;
 };
 


### PR DESCRIPTION
This pull request adds support for restoring a security domain from a remote backup and refactors evidence handling for backup-related APIs. The main changes include the introduction of the `azihsm_sess_ex_sd_restore_remote_backup` API, its parameters and documentation, improved handling of security domain evidence, and corresponding test coverage.

**New API for Security Domain Restore:**

* Introduced the `azihsm_sess_ex_sd_restore_remote_backup` API, including its parameter struct (`AzihsmSessExSdRestoreRemoteBackupParams`), C API binding, and comprehensive documentation. This enables restoring a security domain from a remote backup, handling all required input and output buffers, and error conditions. [[1]](diffhunk://#diff-114b039b60c9d947a36f8557f713014a18950dd39a5ec4c92a116a1d6d17eaccR357-R420) [[2]](diffhunk://#diff-232c2f139edf33114268a3c3d42395b58de503817fab05f4d50a5caa4c049490R632-R721)

**Security Domain Evidence Handling Refactor:**

* Added the `SdEvidence` struct to encapsulate decoding and validation of security domain evidence, and refactored `azihsm_sess_ex_sd_create_remote_backup` and `azihsm_sess_ex_sd_reseal_remote_backup` to use this struct for safer and more maintainable code. [[1]](diffhunk://#diff-232c2f139edf33114268a3c3d42395b58de503817fab05f4d50a5caa4c049490R441-R477) [[2]](diffhunk://#diff-232c2f139edf33114268a3c3d42395b58de503817fab05f4d50a5caa4c049490L486-R525) [[3]](diffhunk://#diff-232c2f139edf33114268a3c3d42395b58de503817fab05f4d50a5caa4c049490L578-R612)

**Bindings and Configuration Updates:**

* Updated `cbindgen.toml` to include the new API and parameter struct for C header generation. [[1]](diffhunk://#diff-565b71c0317062acfa948978344423a48027bff4b1521697226e22fe5560716aR58) [[2]](diffhunk://#diff-565b71c0317062acfa948978344423a48027bff4b1521697226e22fe5560716aR116)

**Testing:**

* Added a new C++ test file, `sd/restore_tests.cpp`, to cover the new restore functionality.