### PR TITLE
fix(capi-tests): select TPM sources via AZIHSM_USE_TPM

### DIFF
--- a/plugins/ossl_prov/integration-tests/openssl-capi/cpp/openssl_capi_integration_tests.rs
+++ b/plugins/ossl_prov/integration-tests/openssl-capi/cpp/openssl_capi_integration_tests.rs
@@ -299,8 +299,9 @@ mod integration {
         let provider_so = provider_path.join("azihsm_provider.so");
         let conf_path = keymat_dir.join("openssl.cnf");
 
-        // TPM sources when AZIHSM_USE_TPM is set, caller sources otherwise.
-        let (obk_source, pota_source) = if env::var("AZIHSM_USE_TPM").is_ok() {
+        // TPM sources when AZIHSM_USE_TPM=1, caller sources otherwise.
+        let (obk_source, pota_source) = if env::var("AZIHSM_USE_TPM").is_ok_and(|value| value == "1")
+        {
             ("tpm", "tpm")
         } else {
             ("caller", "caller")

--- a/plugins/ossl_prov/integration-tests/openssl-capi/cpp/openssl_capi_integration_tests.rs
+++ b/plugins/ossl_prov/integration-tests/openssl-capi/cpp/openssl_capi_integration_tests.rs
@@ -299,6 +299,13 @@ mod integration {
         let provider_so = provider_path.join("azihsm_provider.so");
         let conf_path = keymat_dir.join("openssl.cnf");
 
+        // TPM sources when AZIHSM_USE_TPM is set, caller sources otherwise.
+        let (obk_source, pota_source) = if env::var("AZIHSM_USE_TPM").is_ok() {
+            ("tpm", "tpm")
+        } else {
+            ("caller", "caller")
+        };
+
         let content = format!(
             "\
 openssl_conf = openssl_init
@@ -320,8 +327,8 @@ azihsm-bmk-path = {dir}/bmk.bin
 azihsm-muk-path = {dir}/muk.bin
 azihsm-obk-path = {dir}/obk.bin
 azihsm-mobk-path = {dir}/mobk.bin
-azihsm-obk-source = caller
-azihsm-pota-source = caller
+azihsm-obk-source = {obk_source}
+azihsm-pota-source = {pota_source}
 azihsm-pota-private-key-path = {dir}/pota_private_key.der
 azihsm-pota-public-key-path = {dir}/pota_public_key.der
 azihsm-api-revision = 1.0

--- a/plugins/ossl_prov/integration-tests/openssl-capi/cpp/openssl_capi_integration_tests.rs
+++ b/plugins/ossl_prov/integration-tests/openssl-capi/cpp/openssl_capi_integration_tests.rs
@@ -299,9 +299,8 @@ mod integration {
         let provider_so = provider_path.join("azihsm_provider.so");
         let conf_path = keymat_dir.join("openssl.cnf");
 
-        // TPM sources when AZIHSM_USE_TPM=1, caller sources otherwise.
-        let (obk_source, pota_source) = if env::var("AZIHSM_USE_TPM").is_ok_and(|value| value == "1")
-        {
+        // TPM sources when AZIHSM_USE_TPM is set, caller sources otherwise.
+        let (obk_source, pota_source) = if env::var("AZIHSM_USE_TPM").is_ok() {
             ("tpm", "tpm")
         } else {
             ("caller", "caller")


### PR DESCRIPTION
Update the OpenSSL C API integration test configuration to use TPM-backed OBK and POTA sources when `AZIHSM_USE_TPM` is set.

Caller-provided sources remain the default when the variable is unset.