### PR TITLE
removed openssl custom path in codeql

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -13,8 +13,12 @@ on:
 env:
   CARGO_TERM_COLOR: always
   CACHE_KEY_ID: 84f8acac52412db91407ab9f85776987da17d42f
-  OPENSSL_VERSION: "3.0.3"
-  OPENSSL_INSTALL: target/openssl-3.0.3
+  # Use the runner's system OpenSSL (ubuntu-24.04 ships OpenSSL 3.0.x), the
+  # same pattern as provider-matrix.yml. openssl-sys / the provider build
+  # resolve headers and libs from these system paths.
+  OPENSSL_DIR: /usr
+  OPENSSL_INCLUDE_DIR: /usr/include
+  OPENSSL_LIB_DIR: /usr/lib/x86_64-linux-gnu
 
 jobs:
   analyze:
@@ -42,14 +46,7 @@ jobs:
     - name: Install apt packages
       run: |
         sudo apt-get update
-        sudo apt-get install -y pkg-config libbsd-dev
-
-    - name: Cache OpenSSL ${{ env.OPENSSL_VERSION }}
-      id: cache-openssl
-      uses: actions/cache@v5
-      with:
-        path: ${{ env.OPENSSL_INSTALL }}
-        key: openssl-${{ env.OPENSSL_VERSION }}-target-linux-x64
+        sudo apt-get install -y pkg-config libbsd-dev libssl-dev
 
     - name: Restore Cargo cache
       id: cargo-cache
@@ -63,7 +60,7 @@ jobs:
         key: ${{ runner.os }}-cargo-${{ env.CACHE_KEY_ID }}
 
     - name: Setup
-      if: steps.cargo-cache.outputs.cache-hit != 'true' || steps.cache-openssl.outputs.cache-hit != 'true'
+      if: steps.cargo-cache.outputs.cache-hit != 'true'
       run: cargo xtask setup
 
     - name: Initialize CodeQL
@@ -80,8 +77,6 @@ jobs:
     - name: Run manual build steps
       if: matrix.build-mode == 'manual'
       shell: bash
-      env:
-        OPENSSL_DIR: ${{ github.workspace }}/${{ env.OPENSSL_INSTALL }}
       run: |
         cargo xtask build --release --package azihsm_ossl_provider
 


### PR DESCRIPTION
This pull request updates the CodeQL GitHub Actions workflow to use the system-provided OpenSSL libraries on Ubuntu 24.04, rather than building and caching a custom OpenSSL installation. This simplifies the workflow and aligns it with the approach used in `provider-matrix.yml`.

**Dependency management simplification:**

* The workflow now uses Ubuntu's system OpenSSL (`libssl-dev`) by setting the `OPENSSL_DIR`, `OPENSSL_INCLUDE_DIR`, and `OPENSSL_LIB_DIR` environment variables to system paths, and removes the custom `OPENSSL_VERSION` and `OPENSSL_INSTALL` variables.
* The step to cache and build a custom OpenSSL is removed; instead, `libssl-dev` is installed directly via `apt`.
* The conditional logic for the `Setup` step is simplified, since the OpenSSL cache is no longer used.
* The manual build step no longer sets a custom `OPENSSL_DIR` environment variable, as the system OpenSSL is now used.