### PR TITLE
[feat][API] SD Create Peer C-FFI

### DIFF
--- a/api/native/cbindgen.toml
+++ b/api/native/cbindgen.toml
@@ -53,6 +53,7 @@ include = [
   "AzihsmSdEvidence",
   "AzihsmSessExPartFinalParams",
   "AzihsmSessExPartInitParams",
+  "AzihsmSessExSdCreatePeerBackupParams",
   "AzihsmSessExSdCreateRemoteBackupParams",
   "AzihsmSessExSdResealRemoteBackupParams",
   "AzihsmSessExSdRestoreRemoteBackupParams",
@@ -111,6 +112,7 @@ item_types = ["constants", "enums", "functions", "structs", "typedefs"]
 "AzihsmSdEvidence" = "azihsm_sd_evidence"
 "AzihsmSessExPartFinalParams" = "azihsm_sess_ex_part_final_params"
 "AzihsmSessExPartInitParams" = "azihsm_sess_ex_part_init_params"
+"AzihsmSessExSdCreatePeerBackupParams" = "azihsm_sess_ex_sd_create_peer_backup_params"
 "AzihsmSessExSdCreateRemoteBackupParams" = "azihsm_sess_ex_sd_create_remote_backup_params"
 "AzihsmSessExSdResealRemoteBackupParams" = "azihsm_sess_ex_sd_reseal_remote_backup_params"
 "AzihsmSessExSdRestoreRemoteBackupParams" = "azihsm_sess_ex_sd_restore_remote_backup_params"

--- a/api/native/doc/chapter_09_sd.md
+++ b/api/native/doc/chapter_09_sd.md
@@ -418,6 +418,63 @@ struct azihsm_sess_ex_sd_restore_remote_backup_params {
  | src_remote_backup  | [azihsm_buffer*](#azihsm_buffer)           | remote backup to restore (161 B)                   |
  | prev_sd_mk_backup  | [azihsm_buffer*](#azihsm_buffer)           | previous security-domain masking-key backup (164 B)|
 
+## azihsm_sess_ex_sd_create_peer_backup
+
+Create a peer-transferable backup of a security domain over a
+security-domain session.
+
+Recovers BKS3 from `pok_local_backup` and HPKE-Auth-seals it to the
+destination peer named by `dst_evidence` (authenticated by the sender's
+masked SD-sealing key), returning the peer backup (161 bytes). Peer
+cloning is gated by the security domain's `allow_peer_cloning` policy flag.
+
+The inputs are grouped into an
+[`azihsm_sess_ex_sd_create_peer_backup_params`](#azihsm_sess_ex_sd_create_peer_backup_params)
+structure. The output buffer follows the two-call size-probe contract and
+is validated **before** the peer backup is created. A NULL `params` pointer
+is rejected with `AZIHSM_STATUS_INVALID_ARGUMENT`.
+
+```cpp
+azihsm_status azihsm_sess_ex_sd_create_peer_backup(
+    azihsm_handle sess_handle,
+    const struct azihsm_sess_ex_sd_create_peer_backup_params *params,
+    struct azihsm_buffer *pok_peer_backup
+    );
+```
+
+**Parameters**
+
+ | Parameter                | Name                                                                                              | Description                                     |
+ | ------------------------ | ------------------------------------------------------------------------------------------------- | ----------------------------------------------- |
+ | [in] sess_handle         | [azihsm_handle](#azihsm_handle)                                                                   | security-domain session handle                  |
+ | [in] params              | [azihsm_sess_ex_sd_create_peer_backup_params*](#azihsm_sess_ex_sd_create_peer_backup_params)      | create-peer-backup input buffers                |
+ | [in, out] pok_peer_backup | [azihsm_buffer *](#azihsm_buffer)                                                                | output buffer for the peer backup (161 B) &nbsp; |
+
+**Returns**
+
+`AZIHSM_STATUS_SUCCESS` on success, error code otherwise
+
+### azihsm_sess_ex_sd_create_peer_backup_params
+
+Input buffers for
+[`azihsm_sess_ex_sd_create_peer_backup`](#azihsm_sess_ex_sd_create_peer_backup).
+
+```cpp
+struct azihsm_sess_ex_sd_create_peer_backup_params {
+    const struct azihsm_buffer *masked_sealing_key;
+    const struct azihsm_sd_evidence *dst_evidence;
+    const struct azihsm_buffer *policy;
+    const struct azihsm_buffer *pok_local_backup;
+};
+```
+
+ | Field              | Name                                       | Description                                        |
+ | ------------------ | ------------------------------------------ | -------------------------------------------------- |
+ | masked_sealing_key | [azihsm_buffer*](#azihsm_buffer)           | sender's masked SD-sealing key (180 B)             |
+ | dst_evidence       | [azihsm_sd_evidence*](#azihsm_sd_evidence) | destination (peer) attestation evidence            |
+ | policy             | [azihsm_buffer*](#azihsm_buffer)           | unified partition-policy image (484 B)             |
+ | pok_local_backup   | [azihsm_buffer*](#azihsm_buffer)           | device-local partition-owner-key backup (180 B)    |
+
 ### azihsm_sd_evidence
 
 Attestation evidence for one security-domain-backup party: three certificate

--- a/api/native/src/session_ex.rs
+++ b/api/native/src/session_ex.rs
@@ -720,3 +720,75 @@ pub unsafe extern "C" fn azihsm_sess_ex_sd_restore_remote_backup(
         Ok(())
     })
 }
+
+/// Input buffers for [`azihsm_sess_ex_sd_create_peer_backup`].
+#[repr(C)]
+pub struct AzihsmSessExSdCreatePeerBackupParams {
+    /// Sender's masked SD-sealing key (from `azihsm_key_gen`), exactly
+    /// `MASKED_SEALING_KEY_LEN` (180 B).
+    pub masked_sealing_key: *const AzihsmBuffer,
+    /// Destination (peer) attestation evidence.
+    pub dst_evidence: *const AzihsmSdEvidence,
+    /// Unified partition-policy image (484 B) describing the domain.
+    pub policy: *const AzihsmBuffer,
+    /// Device-local partition-owner-key backup (180 B) from which BKS3 is
+    /// recovered.
+    pub pok_local_backup: *const AzihsmBuffer,
+}
+
+/// @brief Create a peer-transferable backup of a security domain
+///
+/// Recovers BKS3 from `params.pok_local_backup` and HPKE-Auth-seals it to
+/// the destination peer named by `params.dst_evidence` (authenticated by
+/// the sender's masked sealing key), returning the peer backup. Gated by
+/// the security domain's `allow_peer_cloning` policy flag.
+///
+/// @param[in] sess_handle Handle to the security-domain session
+/// @param[in] params Create-peer-backup input buffers
+/// @param[in,out] pok_peer_backup Output buffer for the peer
+///                partition-owner-key backup (161 B).
+///
+/// The output buffer follows the probe/fill convention and is validated
+/// **before** the peer backup is created.
+///
+/// @return `AzihsmStatus` indicating the result of the operation
+///
+/// # Safety
+///
+/// - `sess_handle` must be a valid security-domain session handle.
+/// - `params` and each of its buffer/evidence pointers must be valid; each
+///   `AzihsmSdCertChain.certs` must point to `len` valid `azihsm_buffer`s.
+/// - `pok_peer_backup` must be a valid `azihsm_buffer` with writable
+///   backing storage of the advertised length.
+#[unsafe(no_mangle)]
+#[allow(unsafe_code)]
+pub unsafe extern "C" fn azihsm_sess_ex_sd_create_peer_backup(
+    sess_handle: AzihsmHandle,
+    params: *const AzihsmSessExSdCreatePeerBackupParams,
+    pok_peer_backup: *mut AzihsmBuffer,
+) -> AzihsmStatus {
+    abi_boundary(|| {
+        let session = api::HsmSession::try_from(sess_handle)?;
+        let params = deref_ptr(params)?;
+
+        let masked_sealing_key: &[u8] = deref_ptr(params.masked_sealing_key)?.try_into()?;
+        let policy: &[u8] = deref_ptr(params.policy)?.try_into()?;
+        let pok_local_backup: &[u8] = deref_ptr(params.pok_local_backup)?.try_into()?;
+
+        let dst = deref_ptr(params.dst_evidence)?;
+        let dst = SdEvidence::try_from(dst)?;
+        let dst = api::HsmSdEvidence::from(&dst);
+
+        // Validate the output buffer before creating the peer backup.
+        validate_ptr(pok_peer_backup)?;
+        let pok_peer_backup = deref_mut_ptr(pok_peer_backup)?;
+        validate_output_buffer(pok_peer_backup, api::POK_REMOTE_BACKUP_LEN)?;
+
+        let result =
+            session.sd_create_peer_backup(masked_sealing_key, &dst, policy, pok_local_backup)?;
+
+        copy_to_buffer(pok_peer_backup, &result)?;
+
+        Ok(())
+    })
+}

--- a/api/tests/cpp/CMakeLists.txt
+++ b/api/tests/cpp/CMakeLists.txt
@@ -98,6 +98,7 @@ set(SOURCE
     algo/kdf/kbkdf_tests.cpp
     algo/sealing/keygen_tests.cpp
     sd/create_backup_tests.cpp
+    sd/create_peer_tests.cpp
     sd/reseal_tests.cpp
     sd/restore_tests.cpp
     resiliency/init_stress_tests.cpp

--- a/api/tests/cpp/sd/create_backup_tests.cpp
+++ b/api/tests/cpp/sd/create_backup_tests.cpp
@@ -39,18 +39,6 @@ constexpr uint32_t kPokLocalBackupLen = 180;
 constexpr uint32_t kSdMkBackupLen = 164;
 constexpr uint32_t kMaskedSealingKeyLen = 180;
 
-bool any_nonzero(const std::vector<uint8_t> &bytes)
-{
-    for (uint8_t b : bytes)
-    {
-        if (b != 0)
-        {
-            return true;
-        }
-    }
-    return false;
-}
-
 // Run the create-backup call, sizing the three output buffers via the
 // probe/fill convention. The FFI validates each output buffer in sequence
 // and reports the first that is too small, so a single len=0 probe only

--- a/api/tests/cpp/sd/create_peer_tests.cpp
+++ b/api/tests/cpp/sd/create_peer_tests.cpp
@@ -1,0 +1,272 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+// api-level `SdCreatePeerBackup` round trip against the emulator.
+//
+// Self-peer backup on one partition: provision a peer-cloning-enabled
+// backing partition, mint an SD sealing key, `CreateSD`
+// (`azihsm_sess_ex_sd_create_remote_backup`) to obtain the device-local
+// backup, then `azihsm_sess_ex_sd_create_peer_backup` to HPKE-Auth-seal
+// BKS3 to the destination peer (our own attested identity). A successful
+// seal is itself the correctness check.
+//
+// Like the create/reseal/restore tests this needs the two-phase TBOR HPKE
+// handshake and a fully provisioned partition, which the mock backend does
+// not implement, so it is excluded from the mock lane and runs on the emu
+// and hardware backends.
+#if !defined(AZIHSM_FEATURE_MOCK)
+
+#include <array>
+#include <azihsm_api.h>
+#include <cstdint>
+#include <cstring>
+#include <gtest/gtest.h>
+#include <scope_guard.hpp>
+#include <vector>
+
+#include "handle/part_list_handle.hpp"
+#include "utils/sd_provision.hpp"
+#include "utils/utils.hpp"
+
+namespace
+{
+// Pinned wire lengths. Mirror the `azihsm_ddi_tbor_types` constants
+// (`MASKED_SEALING_KEY_LEN`, `MASKED_SD_LEN`, `POK_REMOTE_BACKUP_LEN`),
+// which are not exposed in the C header.
+constexpr uint32_t kMaskedSealingKeyLen = 180;
+constexpr uint32_t kMaskedSdLen = 180;
+constexpr uint32_t kPokRemoteBackupLen = 161;
+
+bool any_nonzero(const std::vector<uint8_t> &bytes)
+{
+    for (uint8_t b : bytes)
+    {
+        if (b != 0)
+        {
+            return true;
+        }
+    }
+    return false;
+}
+
+// Create the security domain and capture the 180-byte device-local backup
+// that CreatePeerBackup recovers BKS3 from. Sizes the three output buffers
+// via the probe/fill convention. Records a gtest failure and returns false
+// on error.
+bool create_sd_local_backup(
+    azihsm_handle session,
+    std::vector<uint8_t> &masked,
+    const azihsm_sd_evidence &receiver,
+    const std::vector<uint8_t> &policy,
+    std::vector<uint8_t> &out_local
+)
+{
+    azihsm_buffer masked_buf{ masked.data(), static_cast<uint32_t>(masked.size()) };
+    azihsm_buffer policy_buf{ const_cast<uint8_t *>(policy.data()),
+                              static_cast<uint32_t>(policy.size()) };
+    azihsm_sess_ex_sd_create_remote_backup_params params{
+        &masked_buf,
+        &receiver,
+        &policy_buf,
+    };
+
+    std::vector<uint8_t> remote;
+    std::vector<uint8_t> local;
+    std::vector<uint8_t> mk;
+    azihsm_buffer remote_buf{ nullptr, 0 };
+    azihsm_buffer local_buf{ nullptr, 0 };
+    azihsm_buffer mk_buf{ nullptr, 0 };
+    azihsm_status err = AZIHSM_STATUS_BUFFER_TOO_SMALL;
+    for (int attempt = 0; attempt < 4; ++attempt)
+    {
+        err = azihsm_sess_ex_sd_create_remote_backup(
+            session,
+            &params,
+            &remote_buf,
+            &local_buf,
+            &mk_buf
+        );
+        if (err != AZIHSM_STATUS_BUFFER_TOO_SMALL)
+        {
+            break;
+        }
+        if (remote_buf.len > remote.size())
+        {
+            remote.resize(remote_buf.len);
+        }
+        if (local_buf.len > local.size())
+        {
+            local.resize(local_buf.len);
+        }
+        if (mk_buf.len > mk.size())
+        {
+            mk.resize(mk_buf.len);
+        }
+        remote_buf = { remote.data(), static_cast<uint32_t>(remote.size()) };
+        local_buf = { local.data(), static_cast<uint32_t>(local.size()) };
+        mk_buf = { mk.data(), static_cast<uint32_t>(mk.size()) };
+    }
+    if (err != AZIHSM_STATUS_SUCCESS)
+    {
+        ADD_FAILURE() << "create remote backup failed: " << err;
+        return false;
+    }
+    local.resize(local_buf.len);
+    out_local = std::move(local);
+    return true;
+}
+
+// Run the create-peer-backup call, sizing the single output buffer via the
+// probe/fill convention. The FFI validates the output buffer before
+// sealing, so a too-small buffer never performs the seal. Returns the final
+// status and, on success, sizes `dst` to the bytes written.
+azihsm_status create_peer_fill(
+    azihsm_handle session,
+    const azihsm_sess_ex_sd_create_peer_backup_params *params,
+    std::vector<uint8_t> &dst
+)
+{
+    azihsm_buffer dst_buf{ nullptr, 0 };
+    azihsm_status err = AZIHSM_STATUS_BUFFER_TOO_SMALL;
+    for (int attempt = 0; attempt < 4; ++attempt)
+    {
+        err = azihsm_sess_ex_sd_create_peer_backup(session, params, &dst_buf);
+        if (err != AZIHSM_STATUS_BUFFER_TOO_SMALL)
+        {
+            break;
+        }
+        if (dst_buf.len > dst.size())
+        {
+            dst.resize(dst_buf.len);
+        }
+        dst_buf = { dst.data(), static_cast<uint32_t>(dst.size()) };
+    }
+    if (err == AZIHSM_STATUS_SUCCESS)
+    {
+        dst.resize(dst_buf.len);
+    }
+    return err;
+}
+} // namespace
+
+/// Test fixture for security-domain create-peer-backup
+/// (`azihsm_sess_ex_sd_create_peer_backup`).
+class azihsm_sd_create_peer_backup : public ::testing::Test
+{
+  protected:
+    PartitionListHandle part_list_ = PartitionListHandle{};
+
+    // Open and factory-reset a partition into a clean state. Records a
+    // gtest failure and returns 0 on error; the returned handle must be
+    // closed by the caller.
+    static azihsm_handle open_reset_partition(std::vector<azihsm_char> &path)
+    {
+        azihsm_str path_str;
+        path_str.str = path.data();
+        path_str.len = static_cast<uint32_t>(path.size());
+
+        azihsm_handle part_handle = 0;
+        auto err = azihsm_part_open(&path_str, &part_handle, test_api_rev());
+        if (err != AZIHSM_STATUS_SUCCESS)
+        {
+            ADD_FAILURE() << "azihsm_part_open failed: " << err;
+            return 0;
+        }
+
+        err = azihsm_part_reset(part_handle);
+        if (err != AZIHSM_STATUS_SUCCESS)
+        {
+            ADD_FAILURE() << "azihsm_part_reset failed: " << err;
+            azihsm_part_close(part_handle);
+            return 0;
+        }
+
+        return part_handle;
+    }
+};
+
+// Happy path: create the security domain, then a peer backup of it; the
+// peer backup is a fresh 161-byte, non-zero HPKE-Auth seal.
+TEST_F(azihsm_sd_create_peer_backup, create_peer_backup_roundtrip)
+{
+    part_list_.for_each_part([](std::vector<azihsm_char> &path) {
+        azihsm_handle part_handle = open_reset_partition(path);
+        if (part_handle == 0)
+        {
+            return;
+        }
+        auto part_guard =
+            scope_guard::make_scope_exit([&part_handle] { azihsm_part_close(part_handle); });
+
+        SdBackingContext ctx = provision_sd_backing_co_session(part_handle);
+        if (ctx.session == 0)
+        {
+            return; // provisioning recorded its own failure
+        }
+        auto sess_guard = scope_guard::make_scope_exit([&ctx] { azihsm_sess_close(ctx.session); });
+
+        SealingKeyMaterial key = sealing_key_and_report(ctx.session);
+        ASSERT_EQ(key.masked.size(), kMaskedSealingKeyLen);
+        ASSERT_FALSE(key.report.empty());
+
+        // Self-peer backup: the same attested key is sender and destination.
+        SdEvidenceHolder evidence = build_receiver_evidence(ctx, key.report);
+
+        // Create the security domain to obtain the device-local backup.
+        std::vector<uint8_t> local_backup;
+        ASSERT_TRUE(create_sd_local_backup(
+            ctx.session,
+            key.masked,
+            evidence.get(),
+            ctx.policy,
+            local_backup
+        ));
+        ASSERT_EQ(local_backup.size(), kMaskedSdLen);
+
+        // Seal a peer backup to our own attested identity as destination.
+        azihsm_buffer masked_buf{ key.masked.data(), static_cast<uint32_t>(key.masked.size()) };
+        azihsm_buffer policy_buf{ ctx.policy.data(), static_cast<uint32_t>(ctx.policy.size()) };
+        azihsm_buffer local_buf{ local_backup.data(), static_cast<uint32_t>(local_backup.size()) };
+        azihsm_sess_ex_sd_create_peer_backup_params params{
+            &masked_buf,
+            &evidence.get(),
+            &policy_buf,
+            &local_buf,
+        };
+
+        std::vector<uint8_t> peer_backup;
+        ASSERT_EQ(create_peer_fill(ctx.session, &params, peer_backup), AZIHSM_STATUS_SUCCESS);
+
+        // Peer backup: HPKE-Auth seal of BKS3, 161 B, non-zero.
+        ASSERT_EQ(peer_backup.size(), kPokRemoteBackupLen);
+        ASSERT_TRUE(any_nonzero(peer_backup)) << "pok_peer_backup must not be all-zero";
+    });
+}
+
+// A NULL params pointer is rejected with `INVALID_ARGUMENT` after the
+// session resolves and before the peer backup is created.
+TEST_F(azihsm_sd_create_peer_backup, create_peer_backup_null_params)
+{
+    part_list_.for_each_part([](std::vector<azihsm_char> &path) {
+        azihsm_handle part_handle = open_reset_partition(path);
+        if (part_handle == 0)
+        {
+            return;
+        }
+        auto part_guard =
+            scope_guard::make_scope_exit([&part_handle] { azihsm_part_close(part_handle); });
+
+        SdBackingContext ctx = provision_sd_backing_co_session(part_handle);
+        if (ctx.session == 0)
+        {
+            return;
+        }
+        auto sess_guard = scope_guard::make_scope_exit([&ctx] { azihsm_sess_close(ctx.session); });
+
+        azihsm_buffer out{ nullptr, 0 };
+        auto err = azihsm_sess_ex_sd_create_peer_backup(ctx.session, nullptr, &out);
+        ASSERT_EQ(err, AZIHSM_STATUS_INVALID_ARGUMENT);
+    });
+}
+
+#endif // !defined(AZIHSM_FEATURE_MOCK)

--- a/api/tests/cpp/sd/create_peer_tests.cpp
+++ b/api/tests/cpp/sd/create_peer_tests.cpp
@@ -37,18 +37,6 @@ constexpr uint32_t kMaskedSealingKeyLen = 180;
 constexpr uint32_t kMaskedSdLen = 180;
 constexpr uint32_t kPokRemoteBackupLen = 161;
 
-bool any_nonzero(const std::vector<uint8_t> &bytes)
-{
-    for (uint8_t b : bytes)
-    {
-        if (b != 0)
-        {
-            return true;
-        }
-    }
-    return false;
-}
-
 // Create the security domain and capture the 180-byte device-local backup
 // that CreatePeerBackup recovers BKS3 from. Sizes the three output buffers
 // via the probe/fill convention. Records a gtest failure and returns false

--- a/api/tests/cpp/sd/reseal_tests.cpp
+++ b/api/tests/cpp/sd/reseal_tests.cpp
@@ -37,18 +37,6 @@ namespace
 constexpr uint32_t kPokRemoteBackupLen = 161;
 constexpr uint32_t kMaskedSealingKeyLen = 180;
 
-bool any_nonzero(const std::vector<uint8_t> &bytes)
-{
-    for (uint8_t b : bytes)
-    {
-        if (b != 0)
-        {
-            return true;
-        }
-    }
-    return false;
-}
-
 // Create a real source backup: a fresh BKS3 sealed to the receiver's
 // attested public key (`receiver_report`) by `masked_sender`. Returns the
 // 161-byte remote backup, or an empty vector on failure (recording a gtest

--- a/api/tests/cpp/sd/restore_tests.cpp
+++ b/api/tests/cpp/sd/restore_tests.cpp
@@ -42,18 +42,6 @@ constexpr uint32_t kPokRemoteBackupLen = 161;
 constexpr uint32_t kMaskedSdLen = 180;
 constexpr uint32_t kSdMkBackupLen = 164;
 
-bool any_nonzero(const std::vector<uint8_t> &bytes)
-{
-    for (uint8_t b : bytes)
-    {
-        if (b != 0)
-        {
-            return true;
-        }
-    }
-    return false;
-}
-
 // Create a real remote backup sealed to `receiver`'s attested key by
 // `masked`, capturing both the 161-byte remote backup and the 164-byte
 // masking-key backup needed to drive a later restore. Sizes the three output

--- a/api/tests/cpp/utils/sd_provision.cpp
+++ b/api/tests/cpp/utils/sd_provision.cpp
@@ -776,7 +776,11 @@ std::vector<uint8_t> build_part_policy(const uint8_t pota_raw[kRawPubLen])
     }
     write_key_slot(policy, kOffSata, sata_fill);
 
-    policy[kOffFlags] = 0;
+    // Enable allow_peer_cloning (bit 2) so this one backing policy also
+    // drives the SdCreatePeerBackup / SdRestorePeerBackup tests; the flag is
+    // inert for the remote/reseal/restore commands, which don't gate on it.
+    constexpr uint8_t kAllowPeerCloning = 1 << 2;
+    policy[kOffFlags] = kAllowPeerCloning;
     for (size_t i = 0; i < 64; ++i)
     {
         policy[kOffInfo + i] = 0xAB;

--- a/api/tests/cpp/utils/utils.hpp
+++ b/api/tests/cpp/utils/utils.hpp
@@ -4,8 +4,10 @@
 #pragma once
 
 #include <azihsm_api.h>
+#include <cstdint>
 #include <filesystem>
 #include <gtest/gtest.h>
+#include <vector>
 
 /// Returns the standard test API revision (1.0) used across all C++ tests.
 inline azihsm_api_rev test_api_rev()
@@ -25,4 +27,17 @@ inline std::filesystem::path get_test_tmp_dir()
         return {};
     }
     return dir;
+}
+
+/// Returns true if any byte in `bytes` is non-zero (i.e. not all-zero).
+inline bool any_nonzero(const std::vector<uint8_t> &bytes)
+{
+    for (uint8_t b : bytes)
+    {
+        if (b != 0)
+        {
+            return true;
+        }
+    }
+    return false;
 }


### PR DESCRIPTION
This pull request introduces support for creating peer-transferable backups of security domains, including the implementation of a new API, its documentation, and comprehensive tests. The main changes add the `azihsm_sess_ex_sd_create_peer_backup` function, which enables securely exporting a backup to a peer, and ensure the feature is properly gated by policy.

**New API and Implementation:**

* Added the `azihsm_sess_ex_sd_create_peer_backup` C API, including the `AzihsmSessExSdCreatePeerBackupParams` struct and its Rust FFI implementation in `session_ex.rs`. This function allows creating a peer-transferable backup, authenticated and sealed to a specified peer, and validates all inputs before proceeding.
* Registered the new API and struct in `cbindgen.toml` for C header generation. [[1]](diffhunk://#diff-565b71c0317062acfa948978344423a48027bff4b1521697226e22fe5560716aR56) [[2]](diffhunk://#diff-565b71c0317062acfa948978344423a48027bff4b1521697226e22fe5560716aR115)

**Documentation:**

* Documented the new API and its parameters, usage, and safety requirements in the markdown reference (`chapter_09_sd.md`).

**Testing:**

* Added a new test suite `create_peer_tests.cpp` to exercise the peer-backup API, covering round-trip creation, output validation, and error handling. The test provisions a partition, enables the required policy flag, and verifies that the backup is correctly sealed and nonzero. [[1]](diffhunk://#diff-b8ffe3a41d22f9d8c3fc28c299d8a0273cfe516375fa92d30e319c6a3a45f41dR1-R272) [[2]](diffhunk://#diff-0963aa2c54607410c92eb3718a66f6531cf20cc1d8e0a27ddbfaf026195fcad9R101)

**Policy:**

* Updated the partition policy construction utility to enable the `allow_peer_cloning` flag, ensuring tests and the new API are exercised under correct policy conditions.