### PR TITLE
fw(uno):Added mcr_test_hooks and fips_validation_hooks feature flags

### DIFF
--- a/fw/core/lib/Cargo.toml
+++ b/fw/core/lib/Cargo.toml
@@ -36,5 +36,7 @@ zerocopy.workspace = true
 
 [features]
 default = ["std"]
+fips_validation_hooks = []
+mcr_test_hooks = []
 std = []
 tracing = []

--- a/fw/plat/std/lib/Cargo.toml
+++ b/fw/plat/std/lib/Cargo.toml
@@ -5,6 +5,10 @@ edition = "2021"
 name = "azihsm_fw_hsm_std"
 version = "0.1.0"
 
+[features]
+fips_validation_hooks = ["azihsm_fw_hsm_core/fips_validation_hooks"]
+mcr_test_hooks = ["azihsm_fw_hsm_core/mcr_test_hooks"]
+
 [dependencies]
 async-channel.workspace = true
 azihsm_fw_ddi_mbor_types.workspace = true

--- a/fw/plat/uno/fw/app/Cargo.toml
+++ b/fw/plat/uno/fw/app/Cargo.toml
@@ -35,6 +35,8 @@ embassy-time = { workspace = true }
 [features]
 #default = ["trace-uart"]
 default = []
+fips_validation_hooks = ["azihsm_fw_hsm_core/fips_validation_hooks"]
+mcr_test_hooks = ["azihsm_fw_hsm_core/mcr_test_hooks"]
 
 # Enable ARM semihosting integration for the emulator:
 #   - The PAL emits `SYS_READY` when the boot handshake completes, so the


### PR DESCRIPTION
Adds two Cargo feature flags to the refactored HSM firmware so upcoming
test/validation-only ops can be gated behind them:

- mcr_test_hooks       — for test-hook ops (e.g. der_key_import)
- fips_validation_hooks — for FIPS validation ops (e.g. raw_key_import, get_priv_key)

