### PR TITLE
[feat][API] Added SD Restore Peer C-FFI 

### DIFF
--- a/api/native/cbindgen.toml
+++ b/api/native/cbindgen.toml
@@ -56,6 +56,7 @@ include = [
   "AzihsmSessExSdCreatePeerBackupParams",
   "AzihsmSessExSdCreateRemoteBackupParams",
   "AzihsmSessExSdResealRemoteBackupParams",
+  "AzihsmSessExSdRestorePeerBackupParams",
   "AzihsmSessExSdRestoreRemoteBackupParams",
   "AzihsmSessionPsk",
   "HsmEccCurve",
@@ -115,6 +116,7 @@ item_types = ["constants", "enums", "functions", "structs", "typedefs"]
 "AzihsmSessExSdCreatePeerBackupParams" = "azihsm_sess_ex_sd_create_peer_backup_params"
 "AzihsmSessExSdCreateRemoteBackupParams" = "azihsm_sess_ex_sd_create_remote_backup_params"
 "AzihsmSessExSdResealRemoteBackupParams" = "azihsm_sess_ex_sd_reseal_remote_backup_params"
+"AzihsmSessExSdRestorePeerBackupParams" = "azihsm_sess_ex_sd_restore_peer_backup_params"
 "AzihsmSessExSdRestoreRemoteBackupParams" = "azihsm_sess_ex_sd_restore_remote_backup_params"
 "AzihsmSessionExType" = "azihsm_session_ex_type"
 "AzihsmSessionProp" = "azihsm_session_prop"

--- a/api/native/doc/chapter_09_sd.md
+++ b/api/native/doc/chapter_09_sd.md
@@ -475,6 +475,71 @@ struct azihsm_sess_ex_sd_create_peer_backup_params {
  | policy             | [azihsm_buffer*](#azihsm_buffer)           | unified partition-policy image (484 B)             |
  | pok_local_backup   | [azihsm_buffer*](#azihsm_buffer)           | device-local partition-owner-key backup (180 B)    |
 
+## azihsm_sess_ex_sd_restore_peer_backup
+
+Restore a security domain from a peer backup over a security-domain
+session.
+
+HPKE-opens the peer backup with the receiver's masked SD-sealing key
+(authenticated by the source peer in `src_evidence`), recovers the
+security-domain masking key from `prev_sd_mk_backup`, and returns the
+refreshed device-local backups: the local partition-owner-key backup
+(180 bytes) and the security-domain masking-key backup (164 bytes). Peer
+cloning is gated by the security domain's `allow_peer_cloning` policy flag.
+
+The inputs are grouped into an
+[`azihsm_sess_ex_sd_restore_peer_backup_params`](#azihsm_sess_ex_sd_restore_peer_backup_params)
+structure. Both output buffers follow the two-call size-probe contract and
+are validated **before** the restore is performed. A NULL `params` pointer
+is rejected with `AZIHSM_STATUS_INVALID_ARGUMENT`. Restore is a
+once-per-partition operation; a restore on an already-initialized partition
+returns `AZIHSM_STATUS_SD_ALREADY_INITIALIZED`.
+
+```cpp
+azihsm_status azihsm_sess_ex_sd_restore_peer_backup(
+    azihsm_handle sess_handle,
+    const struct azihsm_sess_ex_sd_restore_peer_backup_params *params,
+    struct azihsm_buffer *pok_local_backup,
+    struct azihsm_buffer *sd_mk_backup
+    );
+```
+
+**Parameters**
+
+ | Parameter                  | Name                                                                                                  | Description                                       |
+ | -------------------------- | ----------------------------------------------------------------------------------------------------- | ------------------------------------------------- |
+ | [in] sess_handle           | [azihsm_handle](#azihsm_handle)                                                                       | security-domain session handle                    |
+ | [in] params                | [azihsm_sess_ex_sd_restore_peer_backup_params*](#azihsm_sess_ex_sd_restore_peer_backup_params)        | restore-backup input buffers                      |
+ | [in, out] pok_local_backup | [azihsm_buffer *](#azihsm_buffer)                                                                     | output buffer for the local pok backup (180 B)    |
+ | [in, out] sd_mk_backup     | [azihsm_buffer *](#azihsm_buffer)                                                                     | output buffer for the sd masking-key backup (164 B) &nbsp; |
+
+**Returns**
+
+`AZIHSM_STATUS_SUCCESS` on success, error code otherwise
+
+### azihsm_sess_ex_sd_restore_peer_backup_params
+
+Input buffers for
+[`azihsm_sess_ex_sd_restore_peer_backup`](#azihsm_sess_ex_sd_restore_peer_backup).
+
+```cpp
+struct azihsm_sess_ex_sd_restore_peer_backup_params {
+    const struct azihsm_buffer *masked_sealing_key;
+    const struct azihsm_sd_evidence *src_evidence;
+    const struct azihsm_buffer *policy;
+    const struct azihsm_buffer *pok_peer_backup;
+    const struct azihsm_buffer *prev_sd_mk_backup;
+};
+```
+
+ | Field              | Name                                       | Description                                        |
+ | ------------------ | ------------------------------------------ | -------------------------------------------------- |
+ | masked_sealing_key | [azihsm_buffer*](#azihsm_buffer)           | receiver's masked SD-sealing key (180 B)           |
+ | src_evidence       | [azihsm_sd_evidence*](#azihsm_sd_evidence) | source (peer) attestation evidence                 |
+ | policy             | [azihsm_buffer*](#azihsm_buffer)           | unified partition-policy image (484 B)             |
+ | pok_peer_backup    | [azihsm_buffer*](#azihsm_buffer)           | peer backup to restore (161 B)                     |
+ | prev_sd_mk_backup  | [azihsm_buffer*](#azihsm_buffer)           | previous security-domain masking-key backup (164 B)|
+
 ### azihsm_sd_evidence
 
 Attestation evidence for one security-domain-backup party: three certificate

--- a/api/native/src/session_ex.rs
+++ b/api/native/src/session_ex.rs
@@ -792,3 +792,93 @@ pub unsafe extern "C" fn azihsm_sess_ex_sd_create_peer_backup(
         Ok(())
     })
 }
+
+/// Input buffers for [`azihsm_sess_ex_sd_restore_peer_backup`].
+#[repr(C)]
+pub struct AzihsmSessExSdRestorePeerBackupParams {
+    /// Receiver's masked SD-sealing key (from `azihsm_key_gen`) that
+    /// unseals the backup, exactly `MASKED_SEALING_KEY_LEN` (180 B).
+    pub masked_sealing_key: *const AzihsmBuffer,
+    /// Source (peer) attestation evidence.
+    pub src_evidence: *const AzihsmSdEvidence,
+    /// Unified partition-policy image (484 B) describing the domain.
+    pub policy: *const AzihsmBuffer,
+    /// Peer backup to restore, exactly `POK_REMOTE_BACKUP_LEN` (161 B).
+    pub pok_peer_backup: *const AzihsmBuffer,
+    /// Previous security-domain masking-key backup, exactly
+    /// `SD_MK_BACKUP_LEN` (164 B).
+    pub prev_sd_mk_backup: *const AzihsmBuffer,
+}
+
+/// @brief Restore a security domain from a peer backup
+///
+/// HPKE-opens `params.pok_peer_backup` with the receiver's masked sealing
+/// key (authenticated by the source peer in `params.src_evidence`), recovers
+/// the security-domain masking key from `params.prev_sd_mk_backup`, and
+/// returns the refreshed device-local backups.
+///
+/// @param[in] sess_handle Handle to the security-domain session
+/// @param[in] params Restore-backup input buffers
+/// @param[in,out] pok_local_backup Output buffer for the local
+///                partition-owner-key backup (180 B).
+/// @param[in,out] sd_mk_backup Output buffer for the security-domain
+///                masking-key backup (164 B).
+///
+/// Both output buffers follow the probe/fill convention and are validated
+/// **before** the restore is performed.
+///
+/// @return `AzihsmStatus` indicating the result of the operation
+///
+/// # Safety
+///
+/// - `sess_handle` must be a valid security-domain session handle.
+/// - `params` and each of its buffer/evidence pointers must be valid; each
+///   `AzihsmSdCertChain.certs` must point to `len` valid `azihsm_buffer`s.
+/// - Each output buffer must be a valid `azihsm_buffer` with writable
+///   backing storage of the advertised length.
+#[unsafe(no_mangle)]
+#[allow(unsafe_code)]
+pub unsafe extern "C" fn azihsm_sess_ex_sd_restore_peer_backup(
+    sess_handle: AzihsmHandle,
+    params: *const AzihsmSessExSdRestorePeerBackupParams,
+    pok_local_backup: *mut AzihsmBuffer,
+    sd_mk_backup: *mut AzihsmBuffer,
+) -> AzihsmStatus {
+    abi_boundary(|| {
+        let session = api::HsmSession::try_from(sess_handle)?;
+        let params = deref_ptr(params)?;
+
+        let masked_sealing_key: &[u8] = deref_ptr(params.masked_sealing_key)?.try_into()?;
+        let policy: &[u8] = deref_ptr(params.policy)?.try_into()?;
+        let pok_peer_backup: &[u8] = deref_ptr(params.pok_peer_backup)?.try_into()?;
+        let prev_sd_mk_backup: &[u8] = deref_ptr(params.prev_sd_mk_backup)?.try_into()?;
+
+        let src = deref_ptr(params.src_evidence)?;
+        let src = SdEvidence::try_from(src)?;
+        let src = api::HsmSdEvidence::from(&src);
+
+        // Reject null/misaligned or aliasing output pointers before taking a
+        // `&mut` to each: two `&mut` references to the same `azihsm_buffer`
+        // would be undefined behavior.
+        validate_distinct_output_buffers(&[pok_local_backup, sd_mk_backup])?;
+
+        let pok_local_backup = deref_mut_ptr(pok_local_backup)?;
+        validate_output_buffer(pok_local_backup, api::MASKED_SD_LEN)?;
+
+        let sd_mk_backup = deref_mut_ptr(sd_mk_backup)?;
+        validate_output_buffer(sd_mk_backup, api::SD_MK_BACKUP_LEN)?;
+
+        let result = session.sd_restore_peer_backup(
+            masked_sealing_key,
+            &src,
+            policy,
+            pok_peer_backup,
+            prev_sd_mk_backup,
+        )?;
+
+        copy_to_buffer(pok_local_backup, &result.pok_local_backup)?;
+        copy_to_buffer(sd_mk_backup, &result.sd_mk_backup)?;
+
+        Ok(())
+    })
+}

--- a/api/tests/cpp/CMakeLists.txt
+++ b/api/tests/cpp/CMakeLists.txt
@@ -100,6 +100,7 @@ set(SOURCE
     sd/create_backup_tests.cpp
     sd/create_peer_tests.cpp
     sd/reseal_tests.cpp
+    sd/restore_peer_tests.cpp
     sd/restore_tests.cpp
     resiliency/init_stress_tests.cpp
     resiliency/aes_stress_tests.cpp

--- a/api/tests/cpp/sd/restore_peer_tests.cpp
+++ b/api/tests/cpp/sd/restore_peer_tests.cpp
@@ -16,9 +16,10 @@
 // and the attested source-peer key match those that sealed the backup.
 //
 // Like the create/reseal/restore tests this needs the two-phase TBOR HPKE
-// handshake and a fully provisioned partition, which only the emu backend
-// provides, so it is gated to `AZIHSM_FEATURE_EMU`.
-#if defined(AZIHSM_FEATURE_EMU)
+// handshake and a fully provisioned partition, which the mock backend does
+// not implement, so it is excluded from the mock lane and runs on the emu
+// and hardware backends.
+#if !defined(AZIHSM_FEATURE_MOCK)
 
 #include <array>
 #include <azihsm_api.h>
@@ -41,18 +42,6 @@ constexpr uint32_t kMaskedSealingKeyLen = 180;
 constexpr uint32_t kPokRemoteBackupLen = 161;
 constexpr uint32_t kMaskedSdLen = 180;
 constexpr uint32_t kSdMkBackupLen = 164;
-
-bool any_nonzero(const std::vector<uint8_t> &bytes)
-{
-    for (uint8_t b : bytes)
-    {
-        if (b != 0)
-        {
-            return true;
-        }
-    }
-    return false;
-}
 
 // Create the security domain, capturing both the 180-byte device-local
 // backup (the input CreatePeerBackup recovers BKS3 from) and the 164-byte
@@ -372,4 +361,4 @@ TEST_F(azihsm_sd_restore_peer_backup, restore_peer_backup_null_params)
     });
 }
 
-#endif // defined(AZIHSM_FEATURE_EMU)
+#endif // !defined(AZIHSM_FEATURE_MOCK)

--- a/api/tests/cpp/sd/restore_peer_tests.cpp
+++ b/api/tests/cpp/sd/restore_peer_tests.cpp
@@ -361,4 +361,118 @@ TEST_F(azihsm_sd_restore_peer_backup, restore_peer_backup_null_params)
     });
 }
 
+// One-shot: an incarnation that just created its security domain is already
+// SD-initialized, so a peer restore on that same incarnation is rejected by
+// the firmware's one-shot gate.
+TEST_F(azihsm_sd_restore_peer_backup, restore_peer_backup_is_one_shot)
+{
+    part_list_.for_each_part([](std::vector<azihsm_char> &path) {
+        azihsm_handle part_handle = open_reset_partition(path);
+        if (part_handle == 0)
+        {
+            return;
+        }
+        auto part_guard =
+            scope_guard::make_scope_exit([&part_handle] { azihsm_part_close(part_handle); });
+
+        SdBackingContext ctx = provision_sd_backing_co_session(part_handle);
+        if (ctx.session == 0)
+        {
+            return;
+        }
+        auto sess_guard = scope_guard::make_scope_exit([&ctx] { azihsm_sess_close(ctx.session); });
+
+        SealingKeyMaterial key = sealing_key_and_report(ctx.session);
+        ASSERT_EQ(key.masked.size(), kMaskedSealingKeyLen);
+        ASSERT_FALSE(key.report.empty());
+        SdEvidenceHolder evidence = build_receiver_evidence(ctx, key.report);
+
+        // Create the SD (initializing this incarnation) and a peer backup of
+        // it, sealed to our own attested identity.
+        std::vector<uint8_t> local_backup;
+        std::vector<uint8_t> prev_sd_mk;
+        ASSERT_TRUE(create_sd_capture(
+            ctx.session,
+            key.masked,
+            evidence.get(),
+            ctx.policy,
+            local_backup,
+            prev_sd_mk
+        ));
+        azihsm_buffer masked_buf{ key.masked.data(), static_cast<uint32_t>(key.masked.size()) };
+        azihsm_buffer policy_buf{ ctx.policy.data(), static_cast<uint32_t>(ctx.policy.size()) };
+        azihsm_buffer local_buf{ local_backup.data(), static_cast<uint32_t>(local_backup.size()) };
+        azihsm_sess_ex_sd_create_peer_backup_params create_params{
+            &masked_buf,
+            &evidence.get(),
+            &policy_buf,
+            &local_buf,
+        };
+        std::vector<uint8_t> peer_backup;
+        ASSERT_EQ(
+            create_peer_fill(ctx.session, &create_params, peer_backup),
+            AZIHSM_STATUS_SUCCESS
+        );
+
+        // Restore on the same already-initialized incarnation is rejected.
+        azihsm_buffer peer_buf{ peer_backup.data(), static_cast<uint32_t>(peer_backup.size()) };
+        azihsm_buffer prev_mk_buf{ prev_sd_mk.data(), static_cast<uint32_t>(prev_sd_mk.size()) };
+        azihsm_sess_ex_sd_restore_peer_backup_params restore_params{
+            &masked_buf, &evidence.get(), &policy_buf, &peer_buf, &prev_mk_buf,
+        };
+        std::vector<uint8_t> pok_local;
+        std::vector<uint8_t> sd_mk;
+        ASSERT_EQ(
+            restore_peer_fill(ctx.session, &restore_params, pok_local, sd_mk),
+            AZIHSM_STATUS_SD_ALREADY_INITIALIZED
+        );
+    });
+}
+
+// Not permitted: a partition finalized with `allow_peer_cloning` cleared
+// rejects the peer restore at the policy gate, which fires before any HPKE
+// work — so a real sealing key and evidence reach the gate but the backup
+// blobs can be zero-filled placeholders.
+TEST_F(azihsm_sd_restore_peer_backup, restore_peer_backup_rejects_without_peer_cloning)
+{
+    part_list_.for_each_part([](std::vector<azihsm_char> &path) {
+        azihsm_handle part_handle = open_reset_partition(path);
+        if (part_handle == 0)
+        {
+            return;
+        }
+        auto part_guard =
+            scope_guard::make_scope_exit([&part_handle] { azihsm_part_close(part_handle); });
+
+        SdBackingContext ctx =
+            provision_sd_backing_co_session(part_handle, /*allow_peer_cloning=*/false);
+        if (ctx.session == 0)
+        {
+            return;
+        }
+        auto sess_guard = scope_guard::make_scope_exit([&ctx] { azihsm_sess_close(ctx.session); });
+
+        SealingKeyMaterial key = sealing_key_and_report(ctx.session);
+        ASSERT_EQ(key.masked.size(), kMaskedSealingKeyLen);
+        ASSERT_FALSE(key.report.empty());
+        SdEvidenceHolder evidence = build_receiver_evidence(ctx, key.report);
+
+        std::vector<uint8_t> peer_backup(kPokRemoteBackupLen, 0);
+        std::vector<uint8_t> prev_sd_mk(kSdMkBackupLen, 0);
+        azihsm_buffer masked_buf{ key.masked.data(), static_cast<uint32_t>(key.masked.size()) };
+        azihsm_buffer policy_buf{ ctx.policy.data(), static_cast<uint32_t>(ctx.policy.size()) };
+        azihsm_buffer peer_buf{ peer_backup.data(), static_cast<uint32_t>(peer_backup.size()) };
+        azihsm_buffer prev_mk_buf{ prev_sd_mk.data(), static_cast<uint32_t>(prev_sd_mk.size()) };
+        azihsm_sess_ex_sd_restore_peer_backup_params restore_params{
+            &masked_buf, &evidence.get(), &policy_buf, &peer_buf, &prev_mk_buf,
+        };
+        std::vector<uint8_t> pok_local;
+        std::vector<uint8_t> sd_mk;
+        ASSERT_EQ(
+            restore_peer_fill(ctx.session, &restore_params, pok_local, sd_mk),
+            AZIHSM_STATUS_SD_PEER_CLONING_NOT_ALLOWED
+        );
+    });
+}
+
 #endif // !defined(AZIHSM_FEATURE_MOCK)

--- a/api/tests/cpp/sd/restore_peer_tests.cpp
+++ b/api/tests/cpp/sd/restore_peer_tests.cpp
@@ -1,0 +1,375 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+// api-level `SdRestorePeerBackup` round trip against the emulator.
+//
+// Self-backup "reboot" flow on one physical partition: device 1 provisions
+// a peer-cloning-enabled backing partition, creates the security domain,
+// and creates a **peer** backup of it (capturing `pok_peer_backup`,
+// `sd_mk_backup`, and the `local_mk_backup` from `PartFinal`); the same
+// partition is factory-reset (a simulated reboot) and re-provisioned as a
+// restore target — reusing the policy and SATA/POTA anchors and supplying
+// the captured `local_mk_backup` so the sealing key unmasks — and the
+// security domain is restored from the peer backup via
+// `azihsm_sess_ex_sd_restore_peer_backup`. A successful restore is itself
+// the correctness check: the HPKE open only succeeds if the receiver key
+// and the attested source-peer key match those that sealed the backup.
+//
+// Like the create/reseal/restore tests this needs the two-phase TBOR HPKE
+// handshake and a fully provisioned partition, which only the emu backend
+// provides, so it is gated to `AZIHSM_FEATURE_EMU`.
+#if defined(AZIHSM_FEATURE_EMU)
+
+#include <array>
+#include <azihsm_api.h>
+#include <cstdint>
+#include <cstring>
+#include <gtest/gtest.h>
+#include <scope_guard.hpp>
+#include <vector>
+
+#include "handle/part_list_handle.hpp"
+#include "utils/sd_provision.hpp"
+#include "utils/utils.hpp"
+
+namespace
+{
+// Pinned wire lengths. Mirror the `azihsm_ddi_tbor_types` constants
+// (`MASKED_SEALING_KEY_LEN`, `POK_REMOTE_BACKUP_LEN`, `MASKED_SD_LEN`,
+// `SD_MK_BACKUP_LEN`), which are not exposed in the C header.
+constexpr uint32_t kMaskedSealingKeyLen = 180;
+constexpr uint32_t kPokRemoteBackupLen = 161;
+constexpr uint32_t kMaskedSdLen = 180;
+constexpr uint32_t kSdMkBackupLen = 164;
+
+bool any_nonzero(const std::vector<uint8_t> &bytes)
+{
+    for (uint8_t b : bytes)
+    {
+        if (b != 0)
+        {
+            return true;
+        }
+    }
+    return false;
+}
+
+// Create the security domain, capturing both the 180-byte device-local
+// backup (the input CreatePeerBackup recovers BKS3 from) and the 164-byte
+// masking-key backup (the previous SDMK backup RestorePeerBackup consumes).
+// Sizes the three output buffers via the probe/fill convention. Records a
+// gtest failure and returns false on error.
+bool create_sd_capture(
+    azihsm_handle session,
+    std::vector<uint8_t> &masked,
+    const azihsm_sd_evidence &receiver,
+    const std::vector<uint8_t> &policy,
+    std::vector<uint8_t> &out_local,
+    std::vector<uint8_t> &out_mk
+)
+{
+    azihsm_buffer masked_buf{ masked.data(), static_cast<uint32_t>(masked.size()) };
+    azihsm_buffer policy_buf{ const_cast<uint8_t *>(policy.data()),
+                              static_cast<uint32_t>(policy.size()) };
+    azihsm_sess_ex_sd_create_remote_backup_params params{
+        &masked_buf,
+        &receiver,
+        &policy_buf,
+    };
+
+    std::vector<uint8_t> remote;
+    std::vector<uint8_t> local;
+    std::vector<uint8_t> mk;
+    azihsm_buffer remote_buf{ nullptr, 0 };
+    azihsm_buffer local_buf{ nullptr, 0 };
+    azihsm_buffer mk_buf{ nullptr, 0 };
+    azihsm_status err = AZIHSM_STATUS_BUFFER_TOO_SMALL;
+    for (int attempt = 0; attempt < 4; ++attempt)
+    {
+        err = azihsm_sess_ex_sd_create_remote_backup(
+            session,
+            &params,
+            &remote_buf,
+            &local_buf,
+            &mk_buf
+        );
+        if (err != AZIHSM_STATUS_BUFFER_TOO_SMALL)
+        {
+            break;
+        }
+        if (remote_buf.len > remote.size())
+        {
+            remote.resize(remote_buf.len);
+        }
+        if (local_buf.len > local.size())
+        {
+            local.resize(local_buf.len);
+        }
+        if (mk_buf.len > mk.size())
+        {
+            mk.resize(mk_buf.len);
+        }
+        remote_buf = { remote.data(), static_cast<uint32_t>(remote.size()) };
+        local_buf = { local.data(), static_cast<uint32_t>(local.size()) };
+        mk_buf = { mk.data(), static_cast<uint32_t>(mk.size()) };
+    }
+    if (err != AZIHSM_STATUS_SUCCESS)
+    {
+        ADD_FAILURE() << "create remote backup failed: " << err;
+        return false;
+    }
+    local.resize(local_buf.len);
+    mk.resize(mk_buf.len);
+    out_local = std::move(local);
+    out_mk = std::move(mk);
+    return true;
+}
+
+// Run the create-peer-backup call, sizing the single output buffer via the
+// probe/fill convention. Returns the final status and, on success, sizes
+// `dst` to the bytes written.
+azihsm_status create_peer_fill(
+    azihsm_handle session,
+    const azihsm_sess_ex_sd_create_peer_backup_params *params,
+    std::vector<uint8_t> &dst
+)
+{
+    azihsm_buffer dst_buf{ nullptr, 0 };
+    azihsm_status err = AZIHSM_STATUS_BUFFER_TOO_SMALL;
+    for (int attempt = 0; attempt < 4; ++attempt)
+    {
+        err = azihsm_sess_ex_sd_create_peer_backup(session, params, &dst_buf);
+        if (err != AZIHSM_STATUS_BUFFER_TOO_SMALL)
+        {
+            break;
+        }
+        if (dst_buf.len > dst.size())
+        {
+            dst.resize(dst_buf.len);
+        }
+        dst_buf = { dst.data(), static_cast<uint32_t>(dst.size()) };
+    }
+    if (err == AZIHSM_STATUS_SUCCESS)
+    {
+        dst.resize(dst_buf.len);
+    }
+    return err;
+}
+
+// Run the restore-peer call, sizing both output buffers via the probe/fill
+// convention. The FFI validates the output buffers before restoring, so a
+// too-small buffer never performs the restore. Returns the final status
+// and, on success, sizes `pok_local` / `sd_mk` to the bytes written.
+azihsm_status restore_peer_fill(
+    azihsm_handle session,
+    const azihsm_sess_ex_sd_restore_peer_backup_params *params,
+    std::vector<uint8_t> &pok_local,
+    std::vector<uint8_t> &sd_mk
+)
+{
+    azihsm_buffer pok_buf{ nullptr, 0 };
+    azihsm_buffer mk_buf{ nullptr, 0 };
+    azihsm_status err = AZIHSM_STATUS_BUFFER_TOO_SMALL;
+    for (int attempt = 0; attempt < 4; ++attempt)
+    {
+        err = azihsm_sess_ex_sd_restore_peer_backup(session, params, &pok_buf, &mk_buf);
+        if (err != AZIHSM_STATUS_BUFFER_TOO_SMALL)
+        {
+            break;
+        }
+        if (pok_buf.len > pok_local.size())
+        {
+            pok_local.resize(pok_buf.len);
+        }
+        if (mk_buf.len > sd_mk.size())
+        {
+            sd_mk.resize(mk_buf.len);
+        }
+        pok_buf = { pok_local.data(), static_cast<uint32_t>(pok_local.size()) };
+        mk_buf = { sd_mk.data(), static_cast<uint32_t>(sd_mk.size()) };
+    }
+    if (err == AZIHSM_STATUS_SUCCESS)
+    {
+        pok_local.resize(pok_buf.len);
+        sd_mk.resize(mk_buf.len);
+    }
+    return err;
+}
+} // namespace
+
+/// Test fixture for security-domain restore-peer-backup
+/// (`azihsm_sess_ex_sd_restore_peer_backup`).
+class azihsm_sd_restore_peer_backup : public ::testing::Test
+{
+  protected:
+    PartitionListHandle part_list_ = PartitionListHandle{};
+
+    // Open and factory-reset a partition into a clean state. Records a
+    // gtest failure and returns 0 on error; the returned handle must be
+    // closed by the caller.
+    static azihsm_handle open_reset_partition(std::vector<azihsm_char> &path)
+    {
+        azihsm_str path_str;
+        path_str.str = path.data();
+        path_str.len = static_cast<uint32_t>(path.size());
+
+        azihsm_handle part_handle = 0;
+        auto err = azihsm_part_open(&path_str, &part_handle, test_api_rev());
+        if (err != AZIHSM_STATUS_SUCCESS)
+        {
+            ADD_FAILURE() << "azihsm_part_open failed: " << err;
+            return 0;
+        }
+
+        err = azihsm_part_reset(part_handle);
+        if (err != AZIHSM_STATUS_SUCCESS)
+        {
+            ADD_FAILURE() << "azihsm_part_reset failed: " << err;
+            azihsm_part_close(part_handle);
+            return 0;
+        }
+
+        return part_handle;
+    }
+};
+
+// Happy path: create a peer backup on one incarnation, then restore it on a
+// rebooted (factory-reset, re-provisioned) incarnation of the same
+// partition; the restore returns non-zero refreshed device-local backups of
+// the pinned lengths.
+TEST_F(azihsm_sd_restore_peer_backup, restore_peer_backup_roundtrip)
+{
+    part_list_.for_each_part([](std::vector<azihsm_char> &path) {
+        azihsm_handle part_handle = open_reset_partition(path);
+        if (part_handle == 0)
+        {
+            return;
+        }
+        auto part_guard =
+            scope_guard::make_scope_exit([&part_handle] { azihsm_part_close(part_handle); });
+
+        // Device 1: provision, create the SD, and create a peer backup,
+        // capturing the peer backup and the previous masking-key backup.
+        SdBackingContext dev1 = provision_sd_backing_co_session(part_handle);
+        if (dev1.session == 0)
+        {
+            return; // provisioning recorded its own failure
+        }
+        // Safety net for an early ASSERT exit; the happy path closes the
+        // session explicitly before the reboot (zeroing the handle), which
+        // makes this guard a no-op.
+        auto dev1_guard = scope_guard::make_scope_exit([&dev1] {
+            if (dev1.session != 0)
+            {
+                azihsm_sess_close(dev1.session);
+            }
+        });
+
+        SealingKeyMaterial key = sealing_key_and_report(dev1.session);
+        ASSERT_EQ(key.masked.size(), kMaskedSealingKeyLen);
+        ASSERT_FALSE(key.report.empty());
+
+        // Self-peer backup: the same attested key is both source and
+        // receiver.
+        SdEvidenceHolder evidence = build_receiver_evidence(dev1, key.report);
+
+        std::vector<uint8_t> local_backup;
+        std::vector<uint8_t> prev_sd_mk;
+        ASSERT_TRUE(create_sd_capture(
+            dev1.session,
+            key.masked,
+            evidence.get(),
+            dev1.policy,
+            local_backup,
+            prev_sd_mk
+        ));
+        ASSERT_EQ(local_backup.size(), kMaskedSdLen);
+        ASSERT_EQ(prev_sd_mk.size(), kSdMkBackupLen);
+
+        // Seal a peer backup to our own attested identity as destination.
+        azihsm_buffer masked_buf{ key.masked.data(), static_cast<uint32_t>(key.masked.size()) };
+        azihsm_buffer policy_buf{ dev1.policy.data(), static_cast<uint32_t>(dev1.policy.size()) };
+        azihsm_buffer local_buf{ local_backup.data(), static_cast<uint32_t>(local_backup.size()) };
+        azihsm_sess_ex_sd_create_peer_backup_params create_params{
+            &masked_buf,
+            &evidence.get(),
+            &policy_buf,
+            &local_buf,
+        };
+        std::vector<uint8_t> peer_backup;
+        ASSERT_EQ(
+            create_peer_fill(dev1.session, &create_params, peer_backup),
+            AZIHSM_STATUS_SUCCESS
+        );
+        ASSERT_EQ(peer_backup.size(), kPokRemoteBackupLen);
+
+        // Close device 1's session before the reboot.
+        azihsm_sess_close(dev1.session);
+        dev1.session = 0;
+
+        // Device 2 (reboot): factory-reset the same partition and
+        // re-provision it as a restore target, reusing device 1's policy
+        // and anchors and its captured local_mk backup.
+        auto err = azihsm_part_reset(part_handle);
+        ASSERT_EQ(err, AZIHSM_STATUS_SUCCESS) << "reboot reset failed";
+        SdBackingContext dev2 = provision_sd_restore_target(part_handle, dev1);
+        if (dev2.session == 0)
+        {
+            return; // provisioning recorded its own failure
+        }
+        auto sess_guard =
+            scope_guard::make_scope_exit([&dev2] { azihsm_sess_close(dev2.session); });
+
+        // Restore the security domain from device 1's peer backup.
+        azihsm_buffer r_masked_buf{ key.masked.data(), static_cast<uint32_t>(key.masked.size()) };
+        azihsm_buffer r_policy_buf{ dev2.policy.data(), static_cast<uint32_t>(dev2.policy.size()) };
+        azihsm_buffer peer_buf{ peer_backup.data(), static_cast<uint32_t>(peer_backup.size()) };
+        azihsm_buffer prev_mk_buf{ prev_sd_mk.data(), static_cast<uint32_t>(prev_sd_mk.size()) };
+        azihsm_sess_ex_sd_restore_peer_backup_params restore_params{
+            &r_masked_buf, &evidence.get(), &r_policy_buf, &peer_buf, &prev_mk_buf,
+        };
+
+        std::vector<uint8_t> pok_local;
+        std::vector<uint8_t> sd_mk;
+        ASSERT_EQ(
+            restore_peer_fill(dev2.session, &restore_params, pok_local, sd_mk),
+            AZIHSM_STATUS_SUCCESS
+        );
+
+        // Refreshed device-local backups: 180-byte local pok backup and
+        // 164-byte masking-key backup, both non-zero.
+        ASSERT_EQ(pok_local.size(), kMaskedSdLen);
+        ASSERT_TRUE(any_nonzero(pok_local)) << "pok_local_backup must not be all-zero";
+        ASSERT_EQ(sd_mk.size(), kSdMkBackupLen);
+        ASSERT_TRUE(any_nonzero(sd_mk)) << "sd_mk_backup must not be all-zero";
+    });
+}
+
+// A NULL params pointer is rejected with `INVALID_ARGUMENT` after the
+// session resolves and before the restore is performed.
+TEST_F(azihsm_sd_restore_peer_backup, restore_peer_backup_null_params)
+{
+    part_list_.for_each_part([](std::vector<azihsm_char> &path) {
+        azihsm_handle part_handle = open_reset_partition(path);
+        if (part_handle == 0)
+        {
+            return;
+        }
+        auto part_guard =
+            scope_guard::make_scope_exit([&part_handle] { azihsm_part_close(part_handle); });
+
+        SdBackingContext ctx = provision_sd_backing_co_session(part_handle);
+        if (ctx.session == 0)
+        {
+            return;
+        }
+        auto sess_guard = scope_guard::make_scope_exit([&ctx] { azihsm_sess_close(ctx.session); });
+
+        azihsm_buffer pok_local{ nullptr, 0 };
+        azihsm_buffer sd_mk{ nullptr, 0 };
+        auto err = azihsm_sess_ex_sd_restore_peer_backup(ctx.session, nullptr, &pok_local, &sd_mk);
+        ASSERT_EQ(err, AZIHSM_STATUS_INVALID_ARGUMENT);
+    });
+}
+
+#endif // defined(AZIHSM_FEATURE_EMU)

--- a/api/tests/cpp/utils/sd_provision.cpp
+++ b/api/tests/cpp/utils/sd_provision.cpp
@@ -755,7 +755,10 @@ void write_key_slot(std::vector<uint8_t> &policy, size_t off, const uint8_t data
 /// Build a 484-byte unified `PartPolicy` image binding the real POTA public
 /// key, mirroring the Rust `part_policy_with_pota` fixture so `PartFinal` can
 /// validate a chain anchored to it.
-std::vector<uint8_t> build_part_policy(const uint8_t pota_raw[kRawPubLen])
+std::vector<uint8_t> build_part_policy(
+    const uint8_t pota_raw[kRawPubLen],
+    bool allow_peer_cloning = true
+)
 {
     constexpr size_t kOffPota = 2;
     constexpr size_t kOffSata = 102;
@@ -776,11 +779,12 @@ std::vector<uint8_t> build_part_policy(const uint8_t pota_raw[kRawPubLen])
     }
     write_key_slot(policy, kOffSata, sata_fill);
 
-    // Enable allow_peer_cloning (bit 2) so this one backing policy also
-    // drives the SdCreatePeerBackup / SdRestorePeerBackup tests; the flag is
-    // inert for the remote/reseal/restore commands, which don't gate on it.
+    // `allow_peer_cloning` (bit 2) gates the peer commands
+    // (SdCreatePeerBackup / SdRestorePeerBackup); it is inert for the
+    // non-peer commands (create/reseal/restore-remote and restore-local),
+    // which don't gate on it.
     constexpr uint8_t kAllowPeerCloning = 1 << 2;
-    policy[kOffFlags] = kAllowPeerCloning;
+    policy[kOffFlags] = allow_peer_cloning ? kAllowPeerCloning : 0;
     for (size_t i = 0; i < 64; ++i)
     {
         policy[kOffInfo + i] = 0xAB;
@@ -796,7 +800,8 @@ std::vector<uint8_t> build_backing_part_policy(
     const uint8_t pid[16],
     const uint8_t pid_pub[kRawPubLen],
     const uint8_t sata_raw[kRawPubLen],
-    const uint8_t pota_raw[kRawPubLen]
+    const uint8_t pota_raw[kRawPubLen],
+    bool allow_peer_cloning = true
 )
 {
     constexpr size_t kOffSata = 102;
@@ -804,7 +809,7 @@ std::vector<uint8_t> build_backing_part_policy(
     constexpr size_t kOffBackupPartPubKey = 318;
     constexpr size_t kBackupPartIdLen = 16;
 
-    std::vector<uint8_t> policy = build_part_policy(pota_raw);
+    std::vector<uint8_t> policy = build_part_policy(pota_raw, allow_peer_cloning);
 
     // Overwrite the placeholder SATA key with the anchor's real P-384 key.
     write_key_slot(policy, kOffSata, sata_raw);
@@ -964,7 +969,8 @@ azihsm_handle provision_sd_co_session(azihsm_handle part_handle)
 // restore target (the device-2 side).
 static SdBackingContext provision_backing_impl(
     azihsm_handle part_handle,
-    const SdBackingContext *reuse
+    const SdBackingContext *reuse,
+    bool allow_peer_cloning = true
 )
 {
     // 1. Bootstrap a CO session under the default PSK and rotate it.
@@ -1067,7 +1073,13 @@ static SdBackingContext provision_backing_impl(
         std::memcpy(pota_raw, pota_ca->sec1().data() + 1, kRawPubLen);
         uint8_t sata_raw[kRawPubLen];
         std::memcpy(sata_raw, sata_key->sec1().data() + 1, kRawPubLen);
-        policy = build_backing_part_policy(pid.data(), pid_pub.data(), sata_raw, pota_raw);
+        policy = build_backing_part_policy(
+            pid.data(),
+            pid_pub.data(),
+            sata_raw,
+            pota_raw,
+            allow_peer_cloning
+        );
     }
 
     // Deterministic provisioning fixtures (thumbprints are stored, not
@@ -1172,9 +1184,9 @@ static SdBackingContext provision_backing_impl(
     return ctx;
 }
 
-SdBackingContext provision_sd_backing_co_session(azihsm_handle part_handle)
+SdBackingContext provision_sd_backing_co_session(azihsm_handle part_handle, bool allow_peer_cloning)
 {
-    return provision_backing_impl(part_handle, nullptr);
+    return provision_backing_impl(part_handle, nullptr, allow_peer_cloning);
 }
 
 SdBackingContext provision_sd_restore_target(

--- a/api/tests/cpp/utils/sd_provision.hpp
+++ b/api/tests/cpp/utils/sd_provision.hpp
@@ -65,8 +65,12 @@ struct SdBackingContext
 ///
 /// Records a gtest failure and returns a default `SdBackingContext`
 /// (`session == 0`) on error. The caller owns `session` and must close it
-/// with `azihsm_sess_close`.
-SdBackingContext provision_sd_backing_co_session(azihsm_handle part_handle);
+/// with `azihsm_sess_close`. `allow_peer_cloning` sets that policy flag
+/// (default `true`); clear it to exercise the peer-cloning policy gate.
+SdBackingContext provision_sd_backing_co_session(
+    azihsm_handle part_handle,
+    bool allow_peer_cloning = true
+);
 
 /// Re-provision `part_handle` — the same physical backing partition after a
 /// simulated reboot (`azihsm_part_reset`) — as a restore target, reusing


### PR DESCRIPTION
This pull request adds support for restoring a security domain from a peer backup via the new `azihsm_sess_ex_sd_restore_peer_backup` API. The main changes include the introduction of the C API, Rust FFI implementation, documentation, and comprehensive tests for the new restore-peer-backup flow.

### Security Domain Peer Backup Restore Feature

**API and FFI Implementation:**
- Added the `azihsm_sess_ex_sd_restore_peer_backup` function and its parameter struct (`AzihsmSessExSdRestorePeerBackupParams`) to the Rust FFI and C API, enabling restoration of a security domain from a peer backup.
- Registered the new API and struct in the C header generation configuration (`cbindgen.toml`). [[1]](diffhunk://#diff-565b71c0317062acfa948978344423a48027bff4b1521697226e22fe5560716aR59) [[2]](diffhunk://#diff-565b71c0317062acfa948978344423a48027bff4b1521697226e22fe5560716aR119)

**Documentation:**
- Documented the new API and its parameters, usage, and expected behavior in the SDK markdown documentation (`chapter_09_sd.md`).

**Testing:**
- Added a new test file, `restore_peer_tests.cpp`, with end-to-end tests for the peer backup restore flow, including round-trip and error handling cases.
- Updated the test build configuration to include the new test file.