### PR TITLE
ci: harden apt against Ubuntu mirror outages

### DIFF
--- a/.github/workflows/engine-matrix.yml
+++ b/.github/workflows/engine-matrix.yml
@@ -66,13 +66,8 @@ jobs:
         env:
           DEBIAN_FRONTEND: noninteractive
         run: |
-          # Use the Azure mirror: archive.ubuntu.com is round-robin DNS where
-          # one dead IP fails the job.  No-op on Debian (deb.debian.org).
-          for f in /etc/apt/sources.list /etc/apt/sources.list.d/*.sources; do
-            [ -f "$f" ] && sed -i \
-              -e 's|http://archive.ubuntu.com|http://azure.archive.ubuntu.com|g' \
-              -e 's|http://security.ubuntu.com|http://azure.archive.ubuntu.com|g' "$f"
-          done
+          # archive.ubuntu.com is round-robin DNS; retry so a single dead IP
+          # doesn't fail the job.
           echo 'Acquire::Retries "3";' > /etc/apt/apt.conf.d/80-retries
           # Fail on an unreachable mirror here instead of as a misleading
           # "no installation candidate" at install time.

--- a/.github/workflows/engine-matrix.yml
+++ b/.github/workflows/engine-matrix.yml
@@ -66,7 +66,17 @@ jobs:
         env:
           DEBIAN_FRONTEND: noninteractive
         run: |
-          apt-get update
+          # Use the Azure mirror: archive.ubuntu.com is round-robin DNS where
+          # one dead IP fails the job.  No-op on Debian (deb.debian.org).
+          for f in /etc/apt/sources.list /etc/apt/sources.list.d/*.sources; do
+            [ -f "$f" ] && sed -i \
+              -e 's|http://archive.ubuntu.com|http://azure.archive.ubuntu.com|g' \
+              -e 's|http://security.ubuntu.com|http://azure.archive.ubuntu.com|g' "$f"
+          done
+          echo 'Acquire::Retries "3";' > /etc/apt/apt.conf.d/80-retries
+          # Fail on an unreachable mirror here instead of as a misleading
+          # "no installation candidate" at install time.
+          apt-get update --error-on=any
           apt-get install -y --no-install-recommends \
             ca-certificates curl git gnupg \
             build-essential pkg-config clang libclang-dev \
@@ -75,7 +85,7 @@ jobs:
             | gpg --dearmor -o /usr/share/keyrings/nodesource.gpg
           echo "deb [signed-by=/usr/share/keyrings/nodesource.gpg] https://deb.nodesource.com/node_20.x nodistro main" \
             > /etc/apt/sources.list.d/nodesource.list
-          apt-get update
+          apt-get update --error-on=any
           apt-get install -y --no-install-recommends nodejs
 
       # clang + clang-devel provide libclang for bindgen (build.rs).  el8's

--- a/.github/workflows/provider-matrix.yml
+++ b/.github/workflows/provider-matrix.yml
@@ -138,7 +138,17 @@ jobs:
       - name: Bootstrap (debian)
         if: matrix.family == 'debian'
         run: |
-          apt-get update
+          # Use the Azure mirror: archive.ubuntu.com is round-robin DNS where
+          # one dead IP fails the job.  No-op on Debian (deb.debian.org).
+          for f in /etc/apt/sources.list /etc/apt/sources.list.d/*.sources; do
+            [ -f "$f" ] && sed -i \
+              -e 's|http://archive.ubuntu.com|http://azure.archive.ubuntu.com|g' \
+              -e 's|http://security.ubuntu.com|http://azure.archive.ubuntu.com|g' "$f"
+          done
+          echo 'Acquire::Retries "3";' > /etc/apt/apt.conf.d/80-retries
+          # Fail on an unreachable mirror here instead of as a misleading
+          # "no installation candidate" at install time.
+          apt-get update --error-on=any
           # nodejs is for JS-based actions (rust-cache, checkout, etc.) —
           # GHA auto-injects node in container jobs but `act` does not.
           # xxd (used by the import_wrapped_key cli test scripts) lives in
@@ -236,7 +246,7 @@ jobs:
       - name: Install nginx 1.29.8 (OpenSSL 3.5)
         if: ${{ matrix.nginx && matrix.openssl_minor == '3.5' }}
         run: |
-          apt-get update
+          apt-get update --error-on=any
           codename=$(. /etc/os-release && echo "$VERSION_CODENAME")
           host=$(. /etc/os-release && echo "$ID")
           curl -fsSL -o /tmp/nginx.deb \

--- a/.github/workflows/provider-matrix.yml
+++ b/.github/workflows/provider-matrix.yml
@@ -138,13 +138,8 @@ jobs:
       - name: Bootstrap (debian)
         if: matrix.family == 'debian'
         run: |
-          # Use the Azure mirror: archive.ubuntu.com is round-robin DNS where
-          # one dead IP fails the job.  No-op on Debian (deb.debian.org).
-          for f in /etc/apt/sources.list /etc/apt/sources.list.d/*.sources; do
-            [ -f "$f" ] && sed -i \
-              -e 's|http://archive.ubuntu.com|http://azure.archive.ubuntu.com|g' \
-              -e 's|http://security.ubuntu.com|http://azure.archive.ubuntu.com|g' "$f"
-          done
+          # archive.ubuntu.com is round-robin DNS; retry so a single dead IP
+          # doesn't fail the job.
           echo 'Acquire::Retries "3";' > /etc/apt/apt.conf.d/80-retries
           # Fail on an unreachable mirror here instead of as a misleading
           # "no installation candidate" at install time.


### PR DESCRIPTION
archive.ubuntu.com resolves round-robin across several IPs, and a single dead one fails a matrix cell. Worse, apt-get update exits 0 when a mirror is unreachable, so the job died later in apt-get install with a misleading "package has no installation candidate" instead of a network error.

For the debian-family container cells:
- retry transient fetches (Acquire::Retries 3)
- run apt-get update with --error-on=any so an unreachable mirror fails the step at the point of failure

The images' stock sources.list is left untouched: archive.ubuntu.com stays the mirror. --error-on=any is supported by every apt in the matrix, oldest being 20.04's 2.0.10.
