### PR TITLE
[build] add retry logic to setup steps

### DIFF
--- a/.github/actions/ubuntu-setup/action.yml
+++ b/.github/actions/ubuntu-setup/action.yml
@@ -8,7 +8,7 @@ runs:
   using: composite
   steps:
     - name: Install apt packages
-      uses: nick-fields/retry@v3
+      uses: nick-fields/retry@v4
       with:
         timeout_minutes: 5
         max_attempts: 3
@@ -28,7 +28,7 @@ runs:
         key: ${{ runner.os }}-cargo-${{ env.CACHE_KEY_ID }}
     - name: Setup on cache miss
       if: steps.cargo-cache.outputs.cache-hit != 'true'
-      uses: nick-fields/retry@v3
+      uses: nick-fields/retry@v4
       with:
         timeout_minutes: 20
         max_attempts: 3

--- a/.github/actions/ubuntu-setup/action.yml
+++ b/.github/actions/ubuntu-setup/action.yml
@@ -8,10 +8,14 @@ runs:
   using: composite
   steps:
     - name: Install apt packages
-      shell: bash
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y pkg-config libbsd-dev
+      uses: nick-fields/retry@v3
+      with:
+        timeout_minutes: 5
+        max_attempts: 3
+        shell: bash
+        command: |
+          sudo apt-get update
+          sudo apt-get install -y pkg-config libbsd-dev
     - name: Restore Cargo cache
       id: cargo-cache
       uses: actions/cache/restore@v5
@@ -24,5 +28,9 @@ runs:
         key: ${{ runner.os }}-cargo-${{ env.CACHE_KEY_ID }}
     - name: Setup on cache miss
       if: steps.cargo-cache.outputs.cache-hit != 'true'
-      shell: bash
-      run: cargo xtask precheck --setup
+      uses: nick-fields/retry@v3
+      with:
+        timeout_minutes: 20
+        max_attempts: 3
+        shell: bash
+        command: cargo xtask precheck --setup

--- a/.github/actions/windows-setup/action.yml
+++ b/.github/actions/windows-setup/action.yml
@@ -19,7 +19,7 @@ runs:
         key: ${{ runner.os }}-cargo-${{ env.CACHE_KEY_ID }}
     - name: Setup on cache miss
       if: steps.cargo-cache.outputs.cache-hit != 'true'
-      uses: nick-fields/retry@v3
+      uses: nick-fields/retry@v4
       with:
         timeout_minutes: 20
         max_attempts: 3

--- a/.github/actions/windows-setup/action.yml
+++ b/.github/actions/windows-setup/action.yml
@@ -19,5 +19,9 @@ runs:
         key: ${{ runner.os }}-cargo-${{ env.CACHE_KEY_ID }}
     - name: Setup on cache miss
       if: steps.cargo-cache.outputs.cache-hit != 'true'
-      shell: pwsh
-      run: cargo xtask precheck --setup
+      uses: nick-fields/retry@v3
+      with:
+        timeout_minutes: 20
+        max_attempts: 3
+        shell: pwsh
+        command: cargo xtask precheck --setup

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -44,7 +44,7 @@ jobs:
       uses: actions/checkout@v6
 
     - name: Install apt packages
-      uses: nick-fields/retry@v3
+      uses: nick-fields/retry@v4
       with:
         timeout_minutes: 5
         max_attempts: 3
@@ -66,7 +66,7 @@ jobs:
 
     - name: Setup
       if: steps.cargo-cache.outputs.cache-hit != 'true'
-      uses: nick-fields/retry@v3
+      uses: nick-fields/retry@v4
       with:
         timeout_minutes: 20
         max_attempts: 3

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -44,9 +44,14 @@ jobs:
       uses: actions/checkout@v6
 
     - name: Install apt packages
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y pkg-config libbsd-dev libssl-dev
+      uses: nick-fields/retry@v3
+      with:
+        timeout_minutes: 5
+        max_attempts: 3
+        shell: bash
+        command: |
+          sudo apt-get update
+          sudo apt-get install -y pkg-config libbsd-dev libssl-dev
 
     - name: Restore Cargo cache
       id: cargo-cache
@@ -61,7 +66,12 @@ jobs:
 
     - name: Setup
       if: steps.cargo-cache.outputs.cache-hit != 'true'
-      run: cargo xtask setup
+      uses: nick-fields/retry@v3
+      with:
+        timeout_minutes: 20
+        max_attempts: 3
+        shell: bash
+        command: cargo xtask precheck --setup
 
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v4

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -37,9 +37,14 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Install Linux packages
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y clang-format-18 libbsd-dev libssl-dev pkg-config
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 5
+          max_attempts: 3
+          shell: bash
+          command: |
+            sudo apt-get update
+            sudo apt-get install -y clang-format-18 libbsd-dev libssl-dev pkg-config
       - name: Restore Cargo cache
         uses: actions/cache/restore@v5
         with:
@@ -51,6 +56,16 @@ jobs:
           key: ${{ runner.os }}-cargo-${{ env.CACHE_KEY_ID }}
           fail-on-cache-miss: false # If the cache is missing, we can still proceed as copilot can always do cargo xtask precheck --setup.
       - name: Install nightly rustfmt
-        run: cargo xtask rustup-component-add --component rustfmt --toolchain nightly
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 5
+          max_attempts: 3
+          shell: bash
+          command: cargo xtask rustup-component-add --component rustfmt --toolchain nightly
       - name: Install clippy
-        run: cargo xtask rustup-component-add --component clippy
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 5
+          max_attempts: 3
+          shell: bash
+          command: cargo xtask rustup-component-add --component clippy

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -37,7 +37,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Install Linux packages
-        uses: nick-fields/retry@v3
+        uses: nick-fields/retry@v4
         with:
           timeout_minutes: 5
           max_attempts: 3
@@ -56,14 +56,14 @@ jobs:
           key: ${{ runner.os }}-cargo-${{ env.CACHE_KEY_ID }}
           fail-on-cache-miss: false # If the cache is missing, we can still proceed as copilot can always do cargo xtask precheck --setup.
       - name: Install nightly rustfmt
-        uses: nick-fields/retry@v3
+        uses: nick-fields/retry@v4
         with:
           timeout_minutes: 5
           max_attempts: 3
           shell: bash
           command: cargo xtask rustup-component-add --component rustfmt --toolchain nightly
       - name: Install clippy
-        uses: nick-fields/retry@v3
+        uses: nick-fields/retry@v4
         with:
           timeout_minutes: 5
           max_attempts: 3

--- a/.github/workflows/create_new_cache.yml
+++ b/.github/workflows/create_new_cache.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
     - uses: actions/checkout@v6
     - name: Run Setup
-      uses: nick-fields/retry@v3
+      uses: nick-fields/retry@v4
       with:
         timeout_minutes: 20
         max_attempts: 3
@@ -48,7 +48,7 @@ jobs:
     steps:
     - uses: actions/checkout@v6
     - name: Run Setup
-      uses: nick-fields/retry@v3
+      uses: nick-fields/retry@v4
       with:
         timeout_minutes: 20
         max_attempts: 3

--- a/.github/workflows/create_new_cache.yml
+++ b/.github/workflows/create_new_cache.yml
@@ -21,7 +21,12 @@ jobs:
     steps:
     - uses: actions/checkout@v6
     - name: Run Setup
-      run: cargo xtask precheck --setup
+      uses: nick-fields/retry@v3
+      with:
+        timeout_minutes: 20
+        max_attempts: 3
+        shell: bash
+        command: cargo xtask precheck --setup
     - name: Save Cargo cache
       uses: actions/cache/save@v5
       with:
@@ -43,7 +48,12 @@ jobs:
     steps:
     - uses: actions/checkout@v6
     - name: Run Setup
-      run: cargo xtask precheck --setup
+      uses: nick-fields/retry@v3
+      with:
+        timeout_minutes: 20
+        max_attempts: 3
+        shell: pwsh
+        command: cargo xtask precheck --setup
     - name: Save Cargo cache
       uses: actions/cache/save@v5
       with:

--- a/.github/workflows/engine-matrix.yml
+++ b/.github/workflows/engine-matrix.yml
@@ -65,7 +65,7 @@ jobs:
         if: matrix.family == 'debian'
         env:
           DEBIAN_FRONTEND: noninteractive
-        uses: nick-fields/retry@v3
+        uses: nick-fields/retry@v4
         with:
           timeout_minutes: 5
           max_attempts: 3
@@ -89,7 +89,7 @@ jobs:
       # its lifetime, so no repo pinning (unlike the provider's el9 cells).
       - name: Bootstrap (rhel)
         if: matrix.family == 'rhel'
-        uses: nick-fields/retry@v3
+        uses: nick-fields/retry@v4
         with:
           timeout_minutes: 5
           max_attempts: 3

--- a/.github/workflows/engine-matrix.yml
+++ b/.github/workflows/engine-matrix.yml
@@ -65,18 +65,23 @@ jobs:
         if: matrix.family == 'debian'
         env:
           DEBIAN_FRONTEND: noninteractive
-        run: |
-          apt-get update
-          apt-get install -y --no-install-recommends \
-            ca-certificates curl git gnupg \
-            build-essential pkg-config clang libclang-dev \
-            openssl libssl-dev
-          curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key \
-            | gpg --dearmor -o /usr/share/keyrings/nodesource.gpg
-          echo "deb [signed-by=/usr/share/keyrings/nodesource.gpg] https://deb.nodesource.com/node_20.x nodistro main" \
-            > /etc/apt/sources.list.d/nodesource.list
-          apt-get update
-          apt-get install -y --no-install-recommends nodejs
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 5
+          max_attempts: 3
+          shell: bash
+          command: |
+            apt-get update
+            apt-get install -y --no-install-recommends \
+              ca-certificates curl git gnupg \
+              build-essential pkg-config clang libclang-dev \
+              openssl libssl-dev
+            curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key \
+              | gpg --dearmor -o /usr/share/keyrings/nodesource.gpg
+            echo "deb [signed-by=/usr/share/keyrings/nodesource.gpg] https://deb.nodesource.com/node_20.x nodistro main" \
+              > /etc/apt/sources.list.d/nodesource.list
+            apt-get update
+            apt-get install -y --no-install-recommends nodejs
 
       # clang + clang-devel provide libclang for bindgen (build.rs).  el8's
       # default nodejs module is Node 10, too old for the JS actions under
@@ -84,13 +89,18 @@ jobs:
       # its lifetime, so no repo pinning (unlike the provider's el9 cells).
       - name: Bootstrap (rhel)
         if: matrix.family == 'rhel'
-        run: |
-          dnf module reset -y nodejs
-          dnf module enable -y nodejs:20
-          dnf install -y --setopt=install_weak_deps=False \
-            ca-certificates curl git \
-            gcc gcc-c++ make pkgconf-pkg-config clang clang-devel \
-            openssl openssl-devel nodejs
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 5
+          max_attempts: 3
+          shell: bash
+          command: |
+            dnf module reset -y nodejs
+            dnf module enable -y nodejs:20
+            dnf install -y --setopt=install_weak_deps=False \
+              ca-certificates curl git \
+              gcc gcc-c++ make pkgconf-pkg-config clang clang-devel \
+              openssl openssl-devel nodejs
 
       - uses: actions/checkout@v6
 

--- a/.github/workflows/fw_uno.yml
+++ b/.github/workflows/fw_uno.yml
@@ -48,7 +48,9 @@ jobs:
         timeout_minutes: 20
         max_attempts: 3
         shell: bash
-        command: cargo xtask precheck --setup
+        command: |
+          cd fw/plat/uno
+          cargo xtask precheck --setup
 
     - name: Add required cross-compilation targets
       if: steps.cargo-cache.outputs.cache-hit == 'true'
@@ -68,7 +70,9 @@ jobs:
         timeout_minutes: 5
         max_attempts: 3
         shell: bash
-        command: cargo xtask rustup-component-add --component rustfmt --toolchain nightly
+        command: |
+          cd fw/plat/uno
+          cargo xtask rustup-component-add --component rustfmt --toolchain nightly
 
     - name: Install clippy
       if: steps.cargo-cache.outputs.cache-hit == 'true'
@@ -77,7 +81,9 @@ jobs:
         timeout_minutes: 5
         max_attempts: 3
         shell: bash
-        command: cargo xtask rustup-component-add --component clippy
+        command: |
+          cd fw/plat/uno
+          cargo xtask rustup-component-add --component clippy
 
     - name: Install nightly clippy
       if: steps.cargo-cache.outputs.cache-hit == 'true'
@@ -86,7 +92,9 @@ jobs:
         timeout_minutes: 5
         max_attempts: 3
         shell: bash
-        command: cargo xtask rustup-component-add --component clippy --toolchain nightly
+        command: |
+          cd fw/plat/uno
+          cargo xtask rustup-component-add --component clippy --toolchain nightly
 
     - name: Install nightly rust-src
       if: steps.cargo-cache.outputs.cache-hit == 'true'
@@ -95,7 +103,9 @@ jobs:
         timeout_minutes: 5
         max_attempts: 3
         shell: bash
-        command: cargo xtask rustup-component-add --component rust-src --toolchain nightly
+        command: |
+          cd fw/plat/uno
+          cargo xtask rustup-component-add --component rust-src --toolchain nightly
 
     - name: Run reggen check
       run: cargo xtask precheck --reggen

--- a/.github/workflows/fw_uno.yml
+++ b/.github/workflows/fw_uno.yml
@@ -43,29 +43,59 @@ jobs:
 
     - name: Setup
       if: steps.cargo-cache.outputs.cache-hit != 'true' 
-      run: cargo xtask precheck --setup
+      uses: nick-fields/retry@v3
+      with:
+        timeout_minutes: 20
+        max_attempts: 3
+        shell: bash
+        command: cargo xtask precheck --setup
 
     - name: Add required cross-compilation targets
       if: steps.cargo-cache.outputs.cache-hit == 'true'
-      run: |
-        rustup target add thumbv7em-none-eabi
-        rustup +nightly target add thumbv7em-none-eabi
+      uses: nick-fields/retry@v3
+      with:
+        timeout_minutes: 5
+        max_attempts: 3
+        shell: bash
+        command: |
+          rustup target add thumbv7em-none-eabi
+          rustup +nightly target add thumbv7em-none-eabi
 
     - name: Install nightly rustfmt
       if: steps.cargo-cache.outputs.cache-hit == 'true'
-      run: cargo xtask rustup-component-add --component rustfmt --toolchain nightly
+      uses: nick-fields/retry@v3
+      with:
+        timeout_minutes: 5
+        max_attempts: 3
+        shell: bash
+        command: cargo xtask rustup-component-add --component rustfmt --toolchain nightly
 
     - name: Install clippy
       if: steps.cargo-cache.outputs.cache-hit == 'true'
-      run: cargo xtask rustup-component-add --component clippy
+      uses: nick-fields/retry@v3
+      with:
+        timeout_minutes: 5
+        max_attempts: 3
+        shell: bash
+        command: cargo xtask rustup-component-add --component clippy
 
     - name: Install nightly clippy
       if: steps.cargo-cache.outputs.cache-hit == 'true'
-      run: cargo xtask rustup-component-add --component clippy --toolchain nightly
+      uses: nick-fields/retry@v3
+      with:
+        timeout_minutes: 5
+        max_attempts: 3
+        shell: bash
+        command: cargo xtask rustup-component-add --component clippy --toolchain nightly
 
     - name: Install nightly rust-src
       if: steps.cargo-cache.outputs.cache-hit == 'true'
-      run: cargo xtask rustup-component-add --component rust-src --toolchain nightly
+      uses: nick-fields/retry@v3
+      with:
+        timeout_minutes: 5
+        max_attempts: 3
+        shell: bash
+        command: cargo xtask rustup-component-add --component rust-src --toolchain nightly
 
     - name: Run reggen check
       run: cargo xtask precheck --reggen

--- a/.github/workflows/fw_uno.yml
+++ b/.github/workflows/fw_uno.yml
@@ -43,7 +43,7 @@ jobs:
 
     - name: Setup
       if: steps.cargo-cache.outputs.cache-hit != 'true' 
-      uses: nick-fields/retry@v3
+      uses: nick-fields/retry@v4
       with:
         timeout_minutes: 20
         max_attempts: 3
@@ -54,7 +54,7 @@ jobs:
 
     - name: Add required cross-compilation targets
       if: steps.cargo-cache.outputs.cache-hit == 'true'
-      uses: nick-fields/retry@v3
+      uses: nick-fields/retry@v4
       with:
         timeout_minutes: 5
         max_attempts: 3
@@ -65,7 +65,7 @@ jobs:
 
     - name: Install nightly rustfmt
       if: steps.cargo-cache.outputs.cache-hit == 'true'
-      uses: nick-fields/retry@v3
+      uses: nick-fields/retry@v4
       with:
         timeout_minutes: 5
         max_attempts: 3
@@ -76,7 +76,7 @@ jobs:
 
     - name: Install clippy
       if: steps.cargo-cache.outputs.cache-hit == 'true'
-      uses: nick-fields/retry@v3
+      uses: nick-fields/retry@v4
       with:
         timeout_minutes: 5
         max_attempts: 3
@@ -87,7 +87,7 @@ jobs:
 
     - name: Install nightly clippy
       if: steps.cargo-cache.outputs.cache-hit == 'true'
-      uses: nick-fields/retry@v3
+      uses: nick-fields/retry@v4
       with:
         timeout_minutes: 5
         max_attempts: 3
@@ -98,7 +98,7 @@ jobs:
 
     - name: Install nightly rust-src
       if: steps.cargo-cache.outputs.cache-hit == 'true'
-      uses: nick-fields/retry@v3
+      uses: nick-fields/retry@v4
       with:
         timeout_minutes: 5
         max_attempts: 3

--- a/.github/workflows/provider-matrix.yml
+++ b/.github/workflows/provider-matrix.yml
@@ -137,50 +137,60 @@ jobs:
       # before cargo can compile.  Both go in a single bootstrap step.
       - name: Bootstrap (debian)
         if: matrix.family == 'debian'
-        run: |
-          apt-get update
-          # nodejs is for JS-based actions (rust-cache, checkout, etc.) —
-          # GHA auto-injects node in container jobs but `act` does not.
-          # xxd (used by the import_wrapped_key cli test scripts) lives in
-          # its own package on Debian/Ubuntu.
-          apt-get install -y --no-install-recommends \
-            ca-certificates curl git nodejs \
-            build-essential cmake pkg-config perl \
-            openssl libssl-dev libbsd-dev xxd
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 5
+          max_attempts: 3
+          shell: bash
+          command: |
+            apt-get update
+            # nodejs is for JS-based actions (rust-cache, checkout, etc.) —
+            # GHA auto-injects node in container jobs but `act` does not.
+            # xxd (used by the import_wrapped_key cli test scripts) lives in
+            # its own package on Debian/Ubuntu.
+            apt-get install -y --no-install-recommends \
+              ca-certificates curl git nodejs \
+              build-essential cmake pkg-config perl \
+              openssl libssl-dev libbsd-dev xxd
 
       - name: Bootstrap (rhel)
         if: matrix.family == 'rhel'
-        run: |
-          # The 9.2 vault preserves openssl-devel-3.0.7; the rolling el9
-          # repos have been bumped to 3.5.5.
-          sed -i 's/enabled=1/enabled=0/g' /etc/yum.repos.d/*.repo 2>/dev/null || true
-          # Vault packages are signed with the distro key the image ships in
-          # /etc/pki/rpm-gpg/, so signature verification stays on.
-          cat > /etc/yum.repos.d/vault.repo <<EOF
-          [vault-baseos]
-          name=9.2 vault BaseOS
-          baseurl=${{ matrix.vault }}/BaseOS/x86_64/os/
-          enabled=1
-          gpgcheck=1
-          gpgkey=file:///etc/pki/rpm-gpg/${{ matrix.gpgkey }}
-          [vault-appstream]
-          name=9.2 vault AppStream
-          baseurl=${{ matrix.vault }}/AppStream/x86_64/os/
-          enabled=1
-          gpgcheck=1
-          gpgkey=file:///etc/pki/rpm-gpg/${{ matrix.gpgkey }}
-          EOF
-          dnf clean all
-          # nodejs is for JS-based actions (see debian bootstrap).
-          # vim-common provides /usr/bin/xxd (used by the import_wrapped_key
-          # cli test scripts); el9 has no standalone xxd package.
-          dnf install -y --setopt=install_weak_deps=False \
-            gcc gcc-c++ make perl perl-core git nodejs \
-            pkgconf openssl openssl-devel \
-            findutils diffutils python3-pip vim-common
-          # Vault's cmake is 3.20.2; corrosion needs >= 3.22.
-          pip3 install --no-warn-script-location cmake
-          echo /usr/local/bin >> "$GITHUB_PATH"
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 5
+          max_attempts: 3
+          shell: bash
+          command: |
+            # The 9.2 vault preserves openssl-devel-3.0.7; the rolling el9
+            # repos have been bumped to 3.5.5.
+            sed -i 's/enabled=1/enabled=0/g' /etc/yum.repos.d/*.repo 2>/dev/null || true
+            # Vault packages are signed with the distro key the image ships in
+            # /etc/pki/rpm-gpg/, so signature verification stays on.
+            cat > /etc/yum.repos.d/vault.repo <<EOF
+            [vault-baseos]
+            name=9.2 vault BaseOS
+            baseurl=${{ matrix.vault }}/BaseOS/x86_64/os/
+            enabled=1
+            gpgcheck=1
+            gpgkey=file:///etc/pki/rpm-gpg/${{ matrix.gpgkey }}
+            [vault-appstream]
+            name=9.2 vault AppStream
+            baseurl=${{ matrix.vault }}/AppStream/x86_64/os/
+            enabled=1
+            gpgcheck=1
+            gpgkey=file:///etc/pki/rpm-gpg/${{ matrix.gpgkey }}
+            EOF
+            dnf clean all
+            # nodejs is for JS-based actions (see debian bootstrap).
+            # vim-common provides /usr/bin/xxd (used by the import_wrapped_key
+            # cli test scripts); el9 has no standalone xxd package.
+            dnf install -y --setopt=install_weak_deps=False \
+              gcc gcc-c++ make perl perl-core git nodejs \
+              pkgconf openssl openssl-devel \
+              findutils diffutils python3-pip vim-common
+            # Vault's cmake is 3.20.2; corrosion needs >= 3.22.
+            pip3 install --no-warn-script-location cmake
+            echo /usr/local/bin >> "$GITHUB_PATH"
 
       - uses: actions/checkout@v6
 

--- a/.github/workflows/provider-matrix.yml
+++ b/.github/workflows/provider-matrix.yml
@@ -137,7 +137,7 @@ jobs:
       # before cargo can compile.  Both go in a single bootstrap step.
       - name: Bootstrap (debian)
         if: matrix.family == 'debian'
-        uses: nick-fields/retry@v3
+        uses: nick-fields/retry@v4
         with:
           timeout_minutes: 5
           max_attempts: 3
@@ -155,7 +155,7 @@ jobs:
 
       - name: Bootstrap (rhel)
         if: matrix.family == 'rhel'
-        uses: nick-fields/retry@v3
+        uses: nick-fields/retry@v4
         with:
           timeout_minutes: 5
           max_attempts: 3

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -29,10 +29,20 @@ jobs:
       id: ubuntu-setup
     - name: Install nightly rustfmt
       if: steps.ubuntu-setup.outputs.cache-hit == 'true'
-      run: cargo xtask rustup-component-add --component rustfmt --toolchain nightly
+      uses: nick-fields/retry@v3
+      with:
+        timeout_minutes: 5
+        max_attempts: 3
+        shell: bash
+        command: cargo xtask rustup-component-add --component rustfmt --toolchain nightly
     - name: Install clippy
       if: steps.ubuntu-setup.outputs.cache-hit == 'true'
-      run: cargo xtask rustup-component-add --component clippy
+      uses: nick-fields/retry@v3
+      with:
+        timeout_minutes: 5
+        max_attempts: 3
+        shell: bash
+        command: cargo xtask rustup-component-add --component clippy
     - name: Run Copyright
       run: cargo xtask precheck --copyright
     - name: Run Audit
@@ -188,10 +198,20 @@ jobs:
       id: windows-setup
     - name: Install nightly rustfmt
       if: steps.windows-setup.outputs.cache-hit == 'true'
-      run: cargo xtask rustup-component-add --component rustfmt --toolchain nightly
+      uses: nick-fields/retry@v3
+      with:
+        timeout_minutes: 5
+        max_attempts: 3
+        shell: pwsh
+        command: cargo xtask rustup-component-add --component rustfmt --toolchain nightly
     - name: Install clippy
       if: steps.windows-setup.outputs.cache-hit == 'true'
-      run: cargo xtask rustup-component-add --component clippy
+      uses: nick-fields/retry@v3
+      with:
+        timeout_minutes: 5
+        max_attempts: 3
+        shell: pwsh
+        command: cargo xtask rustup-component-add --component clippy
     - name: Run Copyright
       run: cargo xtask precheck --copyright
     - name: Run Audit

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -29,7 +29,7 @@ jobs:
       id: ubuntu-setup
     - name: Install nightly rustfmt
       if: steps.ubuntu-setup.outputs.cache-hit == 'true'
-      uses: nick-fields/retry@v3
+      uses: nick-fields/retry@v4
       with:
         timeout_minutes: 5
         max_attempts: 3
@@ -37,7 +37,7 @@ jobs:
         command: cargo xtask rustup-component-add --component rustfmt --toolchain nightly
     - name: Install clippy
       if: steps.ubuntu-setup.outputs.cache-hit == 'true'
-      uses: nick-fields/retry@v3
+      uses: nick-fields/retry@v4
       with:
         timeout_minutes: 5
         max_attempts: 3
@@ -198,7 +198,7 @@ jobs:
       id: windows-setup
     - name: Install nightly rustfmt
       if: steps.windows-setup.outputs.cache-hit == 'true'
-      uses: nick-fields/retry@v3
+      uses: nick-fields/retry@v4
       with:
         timeout_minutes: 5
         max_attempts: 3
@@ -206,7 +206,7 @@ jobs:
         command: cargo xtask rustup-component-add --component rustfmt --toolchain nightly
     - name: Install clippy
       if: steps.windows-setup.outputs.cache-hit == 'true'
-      uses: nick-fields/retry@v3
+      uses: nick-fields/retry@v4
       with:
         timeout_minutes: 5
         max_attempts: 3


### PR DESCRIPTION
A number of the setup steps in our workflows have encountered periodic failures due to network connectivity issues (for example, https://github.com/Azure/azihsm-sdk/actions/runs/30967000662/job/92183022636 due to https://github.com/rust-lang/rustup/issues/3390). Since the host servers for our dependencies are out of our control and these setup steps aren't validating any of our product code, adding logic to retry on failure is appropriate. This change utilizes https://github.com/marketplace/actions/retry-step to implement the desired retry logic.