### PR TITLE
[feat][API] SD Restore Local API - CFFI 

### DIFF
--- a/api/native/cbindgen.toml
+++ b/api/native/cbindgen.toml
@@ -56,6 +56,7 @@ include = [
   "AzihsmSessExSdCreatePeerBackupParams",
   "AzihsmSessExSdCreateRemoteBackupParams",
   "AzihsmSessExSdResealRemoteBackupParams",
+  "AzihsmSessExSdRestoreLocalBackupParams",
   "AzihsmSessExSdRestorePeerBackupParams",
   "AzihsmSessExSdRestoreRemoteBackupParams",
   "AzihsmSessionPsk",
@@ -116,6 +117,7 @@ item_types = ["constants", "enums", "functions", "structs", "typedefs"]
 "AzihsmSessExSdCreatePeerBackupParams" = "azihsm_sess_ex_sd_create_peer_backup_params"
 "AzihsmSessExSdCreateRemoteBackupParams" = "azihsm_sess_ex_sd_create_remote_backup_params"
 "AzihsmSessExSdResealRemoteBackupParams" = "azihsm_sess_ex_sd_reseal_remote_backup_params"
+"AzihsmSessExSdRestoreLocalBackupParams" = "azihsm_sess_ex_sd_restore_local_backup_params"
 "AzihsmSessExSdRestorePeerBackupParams" = "azihsm_sess_ex_sd_restore_peer_backup_params"
 "AzihsmSessExSdRestoreRemoteBackupParams" = "azihsm_sess_ex_sd_restore_remote_backup_params"
 "AzihsmSessionExType" = "azihsm_session_ex_type"

--- a/api/native/doc/chapter_09_sd.md
+++ b/api/native/doc/chapter_09_sd.md
@@ -540,6 +540,65 @@ struct azihsm_sess_ex_sd_restore_peer_backup_params {
  | pok_peer_backup    | [azihsm_buffer*](#azihsm_buffer)           | peer backup to restore (161 B)                     |
  | prev_sd_mk_backup  | [azihsm_buffer*](#azihsm_buffer)           | previous security-domain masking-key backup (164 B)|
 
+## azihsm_sess_ex_sd_restore_local_backup
+
+Restore a security domain from its device-local backups over a
+security-domain session.
+
+Restores the security domain from the device-local partition-owner-key
+backup and security-domain masking-key backup, returning the refreshed
+device-local backups: the local partition-owner-key backup (180 bytes) and
+the security-domain masking-key backup (164 bytes). Unlike the remote/peer
+restores, this carries no attestation evidence — the backups are masked
+under the device-local key.
+
+The inputs are grouped into an
+[`azihsm_sess_ex_sd_restore_local_backup_params`](#azihsm_sess_ex_sd_restore_local_backup_params)
+structure. Both output buffers follow the two-call size-probe contract and
+are validated **before** the restore is performed. A NULL `params` pointer
+is rejected with `AZIHSM_STATUS_INVALID_ARGUMENT`. Restore is a
+once-per-partition operation; a restore on an already-initialized partition
+returns `AZIHSM_STATUS_SD_ALREADY_INITIALIZED`.
+
+```cpp
+azihsm_status azihsm_sess_ex_sd_restore_local_backup(
+    azihsm_handle sess_handle,
+    const struct azihsm_sess_ex_sd_restore_local_backup_params *params,
+    struct azihsm_buffer *pok_local_backup,
+    struct azihsm_buffer *sd_mk_backup
+    );
+```
+
+**Parameters**
+
+ | Parameter                  | Name                                                                                                    | Description                                       |
+ | -------------------------- | ------------------------------------------------------------------------------------------------------- | ------------------------------------------------- |
+ | [in] sess_handle           | [azihsm_handle](#azihsm_handle)                                                                         | security-domain session handle                    |
+ | [in] params                | [azihsm_sess_ex_sd_restore_local_backup_params*](#azihsm_sess_ex_sd_restore_local_backup_params)        | restore-backup input buffers                      |
+ | [in, out] pok_local_backup | [azihsm_buffer *](#azihsm_buffer)                                                                       | output buffer for the local pok backup (180 B)    |
+ | [in, out] sd_mk_backup     | [azihsm_buffer *](#azihsm_buffer)                                                                       | output buffer for the sd masking-key backup (164 B) &nbsp; |
+
+**Returns**
+
+`AZIHSM_STATUS_SUCCESS` on success, error code otherwise
+
+### azihsm_sess_ex_sd_restore_local_backup_params
+
+Input buffers for
+[`azihsm_sess_ex_sd_restore_local_backup`](#azihsm_sess_ex_sd_restore_local_backup).
+
+```cpp
+struct azihsm_sess_ex_sd_restore_local_backup_params {
+    const struct azihsm_buffer *pok_local_backup;
+    const struct azihsm_buffer *sd_mk_backup;
+};
+```
+
+ | Field             | Name                             | Description                                        |
+ | ----------------- | -------------------------------- | -------------------------------------------------- |
+ | pok_local_backup  | [azihsm_buffer*](#azihsm_buffer) | device-local partition-owner-key backup (180 B)    |
+ | sd_mk_backup      | [azihsm_buffer*](#azihsm_buffer) | security-domain masking-key backup (164 B)         |
+
 ### azihsm_sd_evidence
 
 Attestation evidence for one security-domain-backup party: three certificate

--- a/api/native/src/session_ex.rs
+++ b/api/native/src/session_ex.rs
@@ -882,3 +882,73 @@ pub unsafe extern "C" fn azihsm_sess_ex_sd_restore_peer_backup(
         Ok(())
     })
 }
+
+/// Input buffers for [`azihsm_sess_ex_sd_restore_local_backup`].
+#[repr(C)]
+pub struct AzihsmSessExSdRestoreLocalBackupParams {
+    /// Device-local partition-owner-key backup to restore, exactly
+    /// `MASKED_SD_LEN` (180 B).
+    pub pok_local_backup: *const AzihsmBuffer,
+    /// Security-domain masking-key backup, exactly `SD_MK_BACKUP_LEN`
+    /// (164 B).
+    pub sd_mk_backup: *const AzihsmBuffer,
+}
+
+/// @brief Restore a security domain from its device-local backups
+///
+/// Restores the security domain from the device-local
+/// `params.pok_local_backup` and `params.sd_mk_backup`, returning the
+/// refreshed device-local backups. No attestation evidence is involved.
+///
+/// @param[in] sess_handle Handle to the security-domain session
+/// @param[in] params Restore-backup input buffers
+/// @param[in,out] pok_local_backup Output buffer for the refreshed local
+///                partition-owner-key backup (180 B).
+/// @param[in,out] sd_mk_backup Output buffer for the refreshed
+///                security-domain masking-key backup (164 B).
+///
+/// Both output buffers follow the probe/fill convention and are validated
+/// **before** the restore is performed.
+///
+/// @return `AzihsmStatus` indicating the result of the operation
+///
+/// # Safety
+///
+/// - `sess_handle` must be a valid security-domain session handle.
+/// - `params` and each of its buffer pointers must be valid.
+/// - Each output buffer must be a valid `azihsm_buffer` with writable
+///   backing storage of the advertised length.
+#[unsafe(no_mangle)]
+#[allow(unsafe_code)]
+pub unsafe extern "C" fn azihsm_sess_ex_sd_restore_local_backup(
+    sess_handle: AzihsmHandle,
+    params: *const AzihsmSessExSdRestoreLocalBackupParams,
+    pok_local_backup: *mut AzihsmBuffer,
+    sd_mk_backup: *mut AzihsmBuffer,
+) -> AzihsmStatus {
+    abi_boundary(|| {
+        let session = api::HsmSession::try_from(sess_handle)?;
+        let params = deref_ptr(params)?;
+
+        let pok_local_backup_in: &[u8] = deref_ptr(params.pok_local_backup)?.try_into()?;
+        let sd_mk_backup_in: &[u8] = deref_ptr(params.sd_mk_backup)?.try_into()?;
+
+        // Reject null/misaligned or aliasing output pointers before taking a
+        // `&mut` to each: two `&mut` references to the same `azihsm_buffer`
+        // would be undefined behavior.
+        validate_distinct_output_buffers(&[pok_local_backup, sd_mk_backup])?;
+
+        let pok_local_backup = deref_mut_ptr(pok_local_backup)?;
+        validate_output_buffer(pok_local_backup, api::MASKED_SD_LEN)?;
+
+        let sd_mk_backup = deref_mut_ptr(sd_mk_backup)?;
+        validate_output_buffer(sd_mk_backup, api::SD_MK_BACKUP_LEN)?;
+
+        let result = session.sd_restore_local_backup(pok_local_backup_in, sd_mk_backup_in)?;
+
+        copy_to_buffer(pok_local_backup, &result.pok_local_backup)?;
+        copy_to_buffer(sd_mk_backup, &result.sd_mk_backup)?;
+
+        Ok(())
+    })
+}

--- a/api/tests/cpp/CMakeLists.txt
+++ b/api/tests/cpp/CMakeLists.txt
@@ -100,6 +100,7 @@ set(SOURCE
     sd/create_backup_tests.cpp
     sd/create_peer_tests.cpp
     sd/reseal_tests.cpp
+    sd/restore_local_tests.cpp
     sd/restore_peer_tests.cpp
     sd/restore_tests.cpp
     resiliency/init_stress_tests.cpp

--- a/api/tests/cpp/sd/restore_local_tests.cpp
+++ b/api/tests/cpp/sd/restore_local_tests.cpp
@@ -1,0 +1,364 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+// api-level `SdRestoreLocalBackup` round trip against the emulator.
+//
+// Self-backup "reboot" flow on one physical partition: device 1 provisions a
+// backing partition, creates the security domain (capturing its device-local
+// `pok_local_backup` / `sd_mk_backup` and the `local_mk_backup` from
+// `PartFinal`); the same partition is factory-reset (a simulated reboot) and
+// re-provisioned as a restore target — reusing the policy and SATA/POTA
+// anchors and supplying the captured `local_mk_backup` so `PartLocalMK` is
+// restored — and the security domain is restored from the device-local
+// backups via `azihsm_sess_ex_sd_restore_local_backup`. Unlike the
+// remote/peer restores, this carries no attestation evidence.
+//
+// Like the create/reseal/restore tests this needs the two-phase TBOR HPKE
+// handshake and a fully provisioned partition, which the mock backend does
+// not implement, so it is excluded from the mock lane and runs on the emu
+// and hardware backends.
+#if !defined(AZIHSM_FEATURE_MOCK)
+
+#include <array>
+#include <azihsm_api.h>
+#include <cstdint>
+#include <cstring>
+#include <gtest/gtest.h>
+#include <scope_guard.hpp>
+#include <vector>
+
+#include "handle/part_list_handle.hpp"
+#include "utils/sd_provision.hpp"
+#include "utils/utils.hpp"
+
+namespace
+{
+// Pinned wire lengths. Mirror the `azihsm_ddi_tbor_types` constants
+// (`MASKED_SEALING_KEY_LEN`, `MASKED_SD_LEN`, `SD_MK_BACKUP_LEN`), which are
+// not exposed in the C header.
+constexpr uint32_t kMaskedSealingKeyLen = 180;
+constexpr uint32_t kMaskedSdLen = 180;
+constexpr uint32_t kSdMkBackupLen = 164;
+
+// Create the security domain, capturing the 180-byte device-local backup and
+// the 164-byte masking-key backup that RestoreLocalBackup consumes. Sizes the
+// three output buffers via the probe/fill convention. Records a gtest failure
+// and returns false on error.
+bool create_sd_capture(
+    azihsm_handle session,
+    std::vector<uint8_t> &masked,
+    const azihsm_sd_evidence &receiver,
+    const std::vector<uint8_t> &policy,
+    std::vector<uint8_t> &out_local,
+    std::vector<uint8_t> &out_mk
+)
+{
+    azihsm_buffer masked_buf{ masked.data(), static_cast<uint32_t>(masked.size()) };
+    azihsm_buffer policy_buf{ const_cast<uint8_t *>(policy.data()),
+                              static_cast<uint32_t>(policy.size()) };
+    azihsm_sess_ex_sd_create_remote_backup_params params{
+        &masked_buf,
+        &receiver,
+        &policy_buf,
+    };
+
+    std::vector<uint8_t> remote;
+    std::vector<uint8_t> local;
+    std::vector<uint8_t> mk;
+    azihsm_buffer remote_buf{ nullptr, 0 };
+    azihsm_buffer local_buf{ nullptr, 0 };
+    azihsm_buffer mk_buf{ nullptr, 0 };
+    azihsm_status err = AZIHSM_STATUS_BUFFER_TOO_SMALL;
+    for (int attempt = 0; attempt < 4; ++attempt)
+    {
+        err = azihsm_sess_ex_sd_create_remote_backup(
+            session,
+            &params,
+            &remote_buf,
+            &local_buf,
+            &mk_buf
+        );
+        if (err != AZIHSM_STATUS_BUFFER_TOO_SMALL)
+        {
+            break;
+        }
+        if (remote_buf.len > remote.size())
+        {
+            remote.resize(remote_buf.len);
+        }
+        if (local_buf.len > local.size())
+        {
+            local.resize(local_buf.len);
+        }
+        if (mk_buf.len > mk.size())
+        {
+            mk.resize(mk_buf.len);
+        }
+        remote_buf = { remote.data(), static_cast<uint32_t>(remote.size()) };
+        local_buf = { local.data(), static_cast<uint32_t>(local.size()) };
+        mk_buf = { mk.data(), static_cast<uint32_t>(mk.size()) };
+    }
+    if (err != AZIHSM_STATUS_SUCCESS)
+    {
+        ADD_FAILURE() << "create remote backup failed: " << err;
+        return false;
+    }
+    local.resize(local_buf.len);
+    mk.resize(mk_buf.len);
+    out_local = std::move(local);
+    out_mk = std::move(mk);
+    return true;
+}
+
+// Run the restore-local call, sizing both output buffers via the probe/fill
+// convention. The FFI validates the output buffers before restoring, so a
+// too-small buffer never performs the restore. Returns the final status and,
+// on success, sizes `pok_local` / `sd_mk` to the bytes written.
+azihsm_status restore_local_fill(
+    azihsm_handle session,
+    const azihsm_sess_ex_sd_restore_local_backup_params *params,
+    std::vector<uint8_t> &pok_local,
+    std::vector<uint8_t> &sd_mk
+)
+{
+    azihsm_buffer pok_buf{ nullptr, 0 };
+    azihsm_buffer mk_buf{ nullptr, 0 };
+    azihsm_status err = AZIHSM_STATUS_BUFFER_TOO_SMALL;
+    for (int attempt = 0; attempt < 4; ++attempt)
+    {
+        err = azihsm_sess_ex_sd_restore_local_backup(session, params, &pok_buf, &mk_buf);
+        if (err != AZIHSM_STATUS_BUFFER_TOO_SMALL)
+        {
+            break;
+        }
+        if (pok_buf.len > pok_local.size())
+        {
+            pok_local.resize(pok_buf.len);
+        }
+        if (mk_buf.len > sd_mk.size())
+        {
+            sd_mk.resize(mk_buf.len);
+        }
+        pok_buf = { pok_local.data(), static_cast<uint32_t>(pok_local.size()) };
+        mk_buf = { sd_mk.data(), static_cast<uint32_t>(sd_mk.size()) };
+    }
+    if (err == AZIHSM_STATUS_SUCCESS)
+    {
+        pok_local.resize(pok_buf.len);
+        sd_mk.resize(mk_buf.len);
+    }
+    return err;
+}
+} // namespace
+
+/// Test fixture for security-domain restore-local-backup
+/// (`azihsm_sess_ex_sd_restore_local_backup`).
+class azihsm_sd_restore_local_backup : public ::testing::Test
+{
+  protected:
+    PartitionListHandle part_list_ = PartitionListHandle{};
+
+    // Open and factory-reset a partition into a clean state. Records a
+    // gtest failure and returns 0 on error; the returned handle must be
+    // closed by the caller.
+    static azihsm_handle open_reset_partition(std::vector<azihsm_char> &path)
+    {
+        azihsm_str path_str;
+        path_str.str = path.data();
+        path_str.len = static_cast<uint32_t>(path.size());
+
+        azihsm_handle part_handle = 0;
+        auto err = azihsm_part_open(&path_str, &part_handle, test_api_rev());
+        if (err != AZIHSM_STATUS_SUCCESS)
+        {
+            ADD_FAILURE() << "azihsm_part_open failed: " << err;
+            return 0;
+        }
+
+        err = azihsm_part_reset(part_handle);
+        if (err != AZIHSM_STATUS_SUCCESS)
+        {
+            ADD_FAILURE() << "azihsm_part_reset failed: " << err;
+            azihsm_part_close(part_handle);
+            return 0;
+        }
+
+        return part_handle;
+    }
+};
+
+// Happy path: create the security domain on one incarnation, then restore it
+// from its device-local backups on a rebooted (factory-reset,
+// re-provisioned) incarnation of the same partition; the restore returns
+// non-zero refreshed device-local backups of the pinned lengths.
+TEST_F(azihsm_sd_restore_local_backup, restore_local_backup_roundtrip)
+{
+    part_list_.for_each_part([](std::vector<azihsm_char> &path) {
+        azihsm_handle part_handle = open_reset_partition(path);
+        if (part_handle == 0)
+        {
+            return;
+        }
+        auto part_guard =
+            scope_guard::make_scope_exit([&part_handle] { azihsm_part_close(part_handle); });
+
+        // Device 1: provision and create the SD, capturing the device-local
+        // backups the local restore consumes.
+        SdBackingContext dev1 = provision_sd_backing_co_session(part_handle);
+        if (dev1.session == 0)
+        {
+            return; // provisioning recorded its own failure
+        }
+        // Safety net for an early ASSERT exit; the happy path closes the
+        // session explicitly before the reboot (zeroing the handle), which
+        // makes this guard a no-op.
+        auto dev1_guard = scope_guard::make_scope_exit([&dev1] {
+            if (dev1.session != 0)
+            {
+                azihsm_sess_close(dev1.session);
+            }
+        });
+
+        SealingKeyMaterial key = sealing_key_and_report(dev1.session);
+        ASSERT_EQ(key.masked.size(), kMaskedSealingKeyLen);
+        ASSERT_FALSE(key.report.empty());
+
+        SdEvidenceHolder evidence = build_receiver_evidence(dev1, key.report);
+
+        std::vector<uint8_t> local_backup;
+        std::vector<uint8_t> sd_mk_backup;
+        ASSERT_TRUE(create_sd_capture(
+            dev1.session,
+            key.masked,
+            evidence.get(),
+            dev1.policy,
+            local_backup,
+            sd_mk_backup
+        ));
+        ASSERT_EQ(local_backup.size(), kMaskedSdLen);
+        ASSERT_EQ(sd_mk_backup.size(), kSdMkBackupLen);
+
+        // Close device 1's session before the reboot.
+        azihsm_sess_close(dev1.session);
+        dev1.session = 0;
+
+        // Device 2 (reboot): factory-reset the same partition and
+        // re-provision it as a restore target, reusing device 1's policy
+        // and anchors and its captured local_mk backup.
+        auto err = azihsm_part_reset(part_handle);
+        ASSERT_EQ(err, AZIHSM_STATUS_SUCCESS) << "reboot reset failed";
+        SdBackingContext dev2 = provision_sd_restore_target(part_handle, dev1);
+        if (dev2.session == 0)
+        {
+            return; // provisioning recorded its own failure
+        }
+        auto sess_guard =
+            scope_guard::make_scope_exit([&dev2] { azihsm_sess_close(dev2.session); });
+
+        // Restore the security domain from device 1's device-local backups.
+        azihsm_buffer local_buf{ local_backup.data(), static_cast<uint32_t>(local_backup.size()) };
+        azihsm_buffer mk_in_buf{ sd_mk_backup.data(), static_cast<uint32_t>(sd_mk_backup.size()) };
+        azihsm_sess_ex_sd_restore_local_backup_params params{
+            &local_buf,
+            &mk_in_buf,
+        };
+
+        std::vector<uint8_t> pok_local;
+        std::vector<uint8_t> sd_mk;
+        ASSERT_EQ(
+            restore_local_fill(dev2.session, &params, pok_local, sd_mk),
+            AZIHSM_STATUS_SUCCESS
+        );
+
+        // Refreshed device-local backups: 180-byte local pok backup and
+        // 164-byte masking-key backup, both non-zero.
+        ASSERT_EQ(pok_local.size(), kMaskedSdLen);
+        ASSERT_TRUE(any_nonzero(pok_local)) << "pok_local_backup must not be all-zero";
+        ASSERT_EQ(sd_mk.size(), kSdMkBackupLen);
+        ASSERT_TRUE(any_nonzero(sd_mk)) << "sd_mk_backup must not be all-zero";
+    });
+}
+
+// A NULL params pointer is rejected with `INVALID_ARGUMENT` after the
+// session resolves and before the restore is performed.
+TEST_F(azihsm_sd_restore_local_backup, restore_local_backup_null_params)
+{
+    part_list_.for_each_part([](std::vector<azihsm_char> &path) {
+        azihsm_handle part_handle = open_reset_partition(path);
+        if (part_handle == 0)
+        {
+            return;
+        }
+        auto part_guard =
+            scope_guard::make_scope_exit([&part_handle] { azihsm_part_close(part_handle); });
+
+        SdBackingContext ctx = provision_sd_backing_co_session(part_handle);
+        if (ctx.session == 0)
+        {
+            return;
+        }
+        auto sess_guard = scope_guard::make_scope_exit([&ctx] { azihsm_sess_close(ctx.session); });
+
+        azihsm_buffer pok_local{ nullptr, 0 };
+        azihsm_buffer sd_mk{ nullptr, 0 };
+        auto err = azihsm_sess_ex_sd_restore_local_backup(ctx.session, nullptr, &pok_local, &sd_mk);
+        ASSERT_EQ(err, AZIHSM_STATUS_INVALID_ARGUMENT);
+    });
+}
+
+// One-shot: an incarnation that just created its security domain is already
+// SD-initialized, so a local restore on that same incarnation is rejected by
+// the firmware's one-shot gate.
+TEST_F(azihsm_sd_restore_local_backup, restore_local_backup_is_one_shot)
+{
+    part_list_.for_each_part([](std::vector<azihsm_char> &path) {
+        azihsm_handle part_handle = open_reset_partition(path);
+        if (part_handle == 0)
+        {
+            return;
+        }
+        auto part_guard =
+            scope_guard::make_scope_exit([&part_handle] { azihsm_part_close(part_handle); });
+
+        SdBackingContext ctx = provision_sd_backing_co_session(part_handle);
+        if (ctx.session == 0)
+        {
+            return;
+        }
+        auto sess_guard = scope_guard::make_scope_exit([&ctx] { azihsm_sess_close(ctx.session); });
+
+        SealingKeyMaterial key = sealing_key_and_report(ctx.session);
+        ASSERT_EQ(key.masked.size(), kMaskedSealingKeyLen);
+        ASSERT_FALSE(key.report.empty());
+        SdEvidenceHolder evidence = build_receiver_evidence(ctx, key.report);
+
+        // Create the SD (initializing this incarnation), capturing the
+        // device-local backups the restore would consume.
+        std::vector<uint8_t> local_backup;
+        std::vector<uint8_t> sd_mk_backup;
+        ASSERT_TRUE(create_sd_capture(
+            ctx.session,
+            key.masked,
+            evidence.get(),
+            ctx.policy,
+            local_backup,
+            sd_mk_backup
+        ));
+
+        // Restore on the same already-initialized incarnation is rejected.
+        azihsm_buffer local_buf{ local_backup.data(), static_cast<uint32_t>(local_backup.size()) };
+        azihsm_buffer mk_in_buf{ sd_mk_backup.data(), static_cast<uint32_t>(sd_mk_backup.size()) };
+        azihsm_sess_ex_sd_restore_local_backup_params params{
+            &local_buf,
+            &mk_in_buf,
+        };
+        std::vector<uint8_t> pok_local;
+        std::vector<uint8_t> sd_mk;
+        ASSERT_EQ(
+            restore_local_fill(ctx.session, &params, pok_local, sd_mk),
+            AZIHSM_STATUS_SD_ALREADY_INITIALIZED
+        );
+    });
+}
+
+#endif // !defined(AZIHSM_FEATURE_MOCK)


### PR DESCRIPTION
This pull request adds support for restoring a security domain from device-local backups via the new `azihsm_sess_ex_sd_restore_local_backup` API. The changes include implementation, documentation, configuration, and comprehensive tests for the new feature.

**New API for device-local backup restore:**

* Implemented the `azihsm_sess_ex_sd_restore_local_backup` function and its parameter struct `AzihsmSessExSdRestoreLocalBackupParams` in Rust, enabling restoration of a security domain from device-local backups without attestation evidence.
* Documented the new API and parameter struct in the SDK manual (`chapter_09_sd.md`), including usage details, parameters, and expected behavior.

**Configuration updates:**

* Added `AzihsmSessExSdRestoreLocalBackupParams` to the cbindgen include list and symbol mapping, ensuring it is available in the C header. [[1]](diffhunk://#diff-565b71c0317062acfa948978344423a48027bff4b1521697226e22fe5560716aR59) [[2]](diffhunk://#diff-565b71c0317062acfa948978344423a48027bff4b1521697226e22fe5560716aR120)

**Test coverage:**

* Added a new test file `restore_local_tests.cpp` with thorough tests for the new restore-local-backup API, covering round-trip restore, null pointer handling, and one-shot enforcement.
* Registered the new test file in the CMake build system to ensure it is built and run.