### PR TITLE
test(engine): cover all ECC curves and pin long-digest ECDSA behavior

### DIFF
--- a/plugins/ossl_engine/azihsm_ossl_engine/src/context/tests.rs
+++ b/plugins/ossl_engine/azihsm_ossl_engine/src/context/tests.rs
@@ -54,17 +54,17 @@ fn new_test_engine() -> (Engine, *mut ffi::ENGINE) {
     }
 }
 
-/// Sign `msg` (SHA-384) through `pkey` via OpenSSL's EVP interface — the same
-/// path the ABI and `openssl dgst -sign` take. Exercises the loaded key's
-/// `EC_KEY_METHOD` `sign_sig` (→ HSM). Shared by the mock and hardware sign tests.
+/// Sign `msg` (hashed with `md`) through `pkey` via OpenSSL's EVP interface —
+/// the same path the ABI and `openssl dgst -sign` take. Exercises the loaded
+/// key's `EC_KEY_METHOD` `sign_sig` (→ HSM). Shared by the mock and hardware
+/// sign tests.
 #[allow(unsafe_code)]
-fn evp_digest_sign_sha384(pkey: *mut ffi::EVP_PKEY, msg: &[u8]) -> Vec<u8> {
-    // SAFETY: pkey is a valid EVP_PKEY; the calls follow the EVP_DigestSign
-    // contract and every return code is checked.
+fn evp_digest_sign(pkey: *mut ffi::EVP_PKEY, msg: &[u8], md: *const ffi::EVP_MD) -> Vec<u8> {
+    // SAFETY: pkey is a valid EVP_PKEY and md a process-lifetime EVP_MD; the
+    // calls follow the EVP_DigestSign contract and every return code is checked.
     unsafe {
         let ctx = ffi::EVP_MD_CTX_new();
         assert!(!ctx.is_null());
-        let md = ffi::EVP_sha384();
         assert_eq!(
             ffi::EVP_DigestSignInit(ctx, std::ptr::null_mut(), md, std::ptr::null_mut(), pkey),
             1,
@@ -112,14 +112,42 @@ mod round_trips {
 
     use super::*;
 
-    /// Generate a persistent EC P-384 key pair on the open HSM and return its
-    /// masked blob plus the public-key DER.
-    fn generate_masked_p384(data: &EngineData) -> EngineResult<(Vec<u8>, Vec<u8>)> {
+    /// All curves the SDK supports; the round trips below run once per curve.
+    pub(super) const CURVES: [HsmEccCurve; 3] =
+        [HsmEccCurve::P256, HsmEccCurve::P384, HsmEccCurve::P521];
+
+    /// Short tag for file names and messages.
+    fn curve_tag(curve: HsmEccCurve) -> &'static str {
+        match curve {
+            HsmEccCurve::P256 => "p256",
+            HsmEccCurve::P384 => "p384",
+            HsmEccCurve::P521 => "p521",
+        }
+    }
+
+    /// The conventional digest pairing for `curve`, as the raw `EVP_MD` (for
+    /// `EVP_DigestSign*`) and the `openssl` crate's `MessageDigest` (for the
+    /// software `Verifier`).
+    #[allow(unsafe_code)]
+    fn curve_md(curve: HsmEccCurve) -> (*const ffi::EVP_MD, MessageDigest) {
+        // SAFETY: the EVP_sha* accessors return process-lifetime constants.
+        unsafe {
+            match curve {
+                HsmEccCurve::P256 => (ffi::EVP_sha256(), MessageDigest::sha256()),
+                HsmEccCurve::P384 => (ffi::EVP_sha384(), MessageDigest::sha384()),
+                HsmEccCurve::P521 => (ffi::EVP_sha512(), MessageDigest::sha512()),
+            }
+        }
+    }
+
+    /// Generate a persistent EC key pair on `curve` on the open HSM and return
+    /// its masked blob plus the public-key DER.
+    fn generate_masked(data: &EngineData, curve: HsmEccCurve) -> EngineResult<(Vec<u8>, Vec<u8>)> {
         data.with_session(|session| {
             let priv_props = HsmKeyPropsBuilder::default()
                 .class(HsmKeyClass::Private)
                 .key_kind(HsmKeyKind::Ecc)
-                .ecc_curve(HsmEccCurve::P384)
+                .ecc_curve(curve)
                 .is_session(false)
                 .can_sign(true)
                 .build()
@@ -127,7 +155,7 @@ mod round_trips {
             let pub_props = HsmKeyPropsBuilder::default()
                 .class(HsmKeyClass::Public)
                 .key_kind(HsmKeyKind::Ecc)
-                .ecc_curve(HsmEccCurve::P384)
+                .ecc_curve(curve)
                 .is_session(false)
                 .can_verify(true)
                 .build()
@@ -152,13 +180,13 @@ mod round_trips {
         std::env::temp_dir().join(format!("engine-roundtrip-{tag}-{}.bin", std::process::id()))
     }
 
-    /// Generate a key on `data`'s HSM, load it back through the engine, and
-    /// verify the returned public key matches. Backend-agnostic: the caller
-    /// opens `data` against the mock or a real device.
+    /// Generate a key on `curve` on `data`'s HSM, load it back through the
+    /// engine, and verify the returned public key matches. Backend-agnostic:
+    /// the caller opens `data` against the mock or a real device.
     #[allow(unsafe_code)]
-    pub(super) fn run_load(data: &EngineData) -> EngineResult<()> {
-        let (masked, expected_pub_der) = generate_masked_p384(data)?;
-        let path = blob_path("load");
+    pub(super) fn run_load(data: &EngineData, curve: HsmEccCurve) -> EngineResult<()> {
+        let (masked, expected_pub_der) = generate_masked(data, curve)?;
+        let path = blob_path(&format!("load-{}", curve_tag(curve)));
         let _ = std::fs::remove_file(&path);
         write_key_material(&path, &masked)
             .map_err(|e| EngineError::wrap(format!("write masked blob {}", path.display()), e))?;
@@ -182,13 +210,26 @@ mod round_trips {
         Ok(())
     }
 
-    /// Generate a key on `data`'s HSM, load it back through the engine, sign a
-    /// digest through it (HSM `sign_sig` via `EVP_DigestSign*`), and verify the
-    /// signature against the public half in software. Backend-agnostic.
+    /// Generate a key on `curve` on `data`'s HSM, load it back through the
+    /// engine, sign a digest through it (HSM `sign_sig` via `EVP_DigestSign*`,
+    /// using the curve's conventional digest), and verify the signature against
+    /// the public half in software. Backend-agnostic.
+    pub(super) fn run_sign(data: &EngineData, curve: HsmEccCurve) -> EngineResult<()> {
+        let (evp_md, verifier_md) = curve_md(curve);
+        run_sign_with_md(data, curve, evp_md, verifier_md)
+    }
+
+    /// [`run_sign`] with an explicit digest, so a digest/curve mismatch (e.g. a
+    /// digest longer than the curve order) can be exercised deliberately.
     #[allow(unsafe_code)]
-    pub(super) fn run_sign(data: &EngineData) -> EngineResult<()> {
-        let (masked, expected_pub_der) = generate_masked_p384(data)?;
-        let path = blob_path("sign");
+    pub(super) fn run_sign_with_md(
+        data: &EngineData,
+        curve: HsmEccCurve,
+        evp_md: *const ffi::EVP_MD,
+        verifier_md: MessageDigest,
+    ) -> EngineResult<()> {
+        let (masked, expected_pub_der) = generate_masked(data, curve)?;
+        let path = blob_path(&format!("sign-{}", curve_tag(curve)));
         let _ = std::fs::remove_file(&path);
         write_key_material(&path, &masked)
             .map_err(|e| EngineError::wrap(format!("write masked blob {}", path.display()), e))?;
@@ -199,14 +240,14 @@ mod round_trips {
         assert!(!raw.is_null(), "load_key returned a NULL EVP_PKEY");
 
         let msg = b"engine ecdsa signing over the EVP/ABI path";
-        let sig = evp_digest_sign_sha384(raw, msg);
+        let sig = evp_digest_sign(raw, msg, evp_md);
         assert!(!sig.is_empty(), "engine produced an empty signature");
         // SAFETY: raw is an owning *mut EVP_PKEY returned by load_key.
         let loaded: PKey<Public> = unsafe { PKey::from_ptr(raw.cast()) };
 
         let pubkey = PKey::public_key_from_der(&expected_pub_der)
             .map_err(|e| EngineError::wrap("parse public key", e))?;
-        let mut verifier = Verifier::new(MessageDigest::sha384(), &pubkey)
+        let mut verifier = Verifier::new(verifier_md, &pubkey)
             .map_err(|e| EngineError::wrap("init verifier", e))?;
         verifier
             .update(msg)
@@ -235,8 +276,10 @@ mod mock {
     use std::sync::atomic::AtomicU64;
     use std::sync::atomic::Ordering;
 
+    use azihsm_api::HsmEccCurve;
     use openssl::ec::EcGroup;
     use openssl::ec::EcKey;
+    use openssl::hash::MessageDigest;
     use openssl::nid::Nid;
     use openssl::pkey::PKey;
     use serial_test::serial;
@@ -335,7 +378,9 @@ mod mock {
             HsmCredentials::new(&DEFAULT_CRED_ID, &DEFAULT_CRED_PIN),
         )
         .unwrap();
-        round_trips::run_load(&data).unwrap();
+        for curve in round_trips::CURVES {
+            round_trips::run_load(&data, curve).unwrap();
+        }
     }
 
     // A signature produced through a loaded key (HSM sign via our EC_KEY_METHOD,
@@ -351,7 +396,31 @@ mod mock {
             HsmCredentials::new(&DEFAULT_CRED_ID, &DEFAULT_CRED_PIN),
         )
         .unwrap();
-        round_trips::run_sign(&data).unwrap();
+        for curve in round_trips::CURVES {
+            round_trips::run_sign(&data, curve).unwrap();
+        }
+    }
+
+    // A digest longer than the curve order (SHA-512 over P-384, 64 > 48
+    // bytes): software OpenSSL truncates the digest per the ECDSA spec, and the
+    // HSM must agree — the signature it produces must verify in software with
+    // the same digest. Pins the behavior so a firmware change breaking the
+    // truncation convention is caught.
+    #[test]
+    #[serial]
+    #[allow(unsafe_code)]
+    fn sign_with_digest_longer_than_curve_order_verifies() {
+        let scratch = Scratch::new("digestlen");
+        let data = EngineData::new();
+        data.open_hsm_with(
+            caller_settings(&scratch),
+            HsmCredentials::new(&DEFAULT_CRED_ID, &DEFAULT_CRED_PIN),
+        )
+        .unwrap();
+        // SAFETY: EVP_sha512 returns a process-lifetime constant.
+        let md = unsafe { ffi::EVP_sha512() };
+        round_trips::run_sign_with_md(&data, HsmEccCurve::P384, md, MessageDigest::sha512())
+            .unwrap();
     }
 
     #[test]
@@ -445,7 +514,8 @@ mod hw_tests {
         Ok(())
     }
 
-    /// Hardware key-loading round trip against a real device — the same flow
+    /// Hardware key-loading round trips against a real device, one per
+    /// supported curve — the same flow
     /// `mock::load_ec_key_round_trips_through_engine` runs on the mock (see
     /// [`super::round_trips::run_load`]).
     ///
@@ -459,10 +529,14 @@ mod hw_tests {
     fn load_ec_key_from_env_smoke() -> EngineResult<()> {
         let data = EngineData::new();
         data.open_hsm_from_env()?;
-        round_trips::run_load(&data)
+        for curve in round_trips::CURVES {
+            round_trips::run_load(&data, curve)?;
+        }
+        Ok(())
     }
 
-    /// Hardware ECDSA signing round trip against a real device — the same flow
+    /// Hardware ECDSA signing round trips against a real device, one per
+    /// supported curve — the same flow
     /// `mock::sign_through_loaded_key_verifies` runs on the mock (see
     /// [`super::round_trips::run_sign`]). Proves the device produces a valid
     /// ECDSA signature.
@@ -477,6 +551,9 @@ mod hw_tests {
     fn sign_ec_key_from_env_smoke() -> EngineResult<()> {
         let data = EngineData::new();
         data.open_hsm_from_env()?;
-        round_trips::run_sign(&data)
+        for curve in round_trips::CURVES {
+            round_trips::run_sign(&data, curve)?;
+        }
+        Ok(())
     }
 }

--- a/plugins/ossl_engine/azihsm_ossl_engine/src/integration.rs
+++ b/plugins/ossl_engine/azihsm_ossl_engine/src/integration.rs
@@ -19,11 +19,11 @@ use azihsm_ossl_engine_core::error::EngineResult;
 use crate::context::EngineData;
 
 /// Open the HSM from the ambient `AZIHSM_*` environment, generate a persistent
-/// EC P-384 key, and return its masked blob — the form the loader consumes.
-/// Reuses the engine's real open path so a generated blob and a later
+/// EC key on `curve`, and return its masked blob — the form the loader
+/// consumes. Reuses the engine's real open path so a generated blob and a later
 /// `ENGINE_load_private_key` share the same masking (via the persisted BMK under
 /// the shared resiliency storage dir).
-pub fn generate_masked_ec_p384_from_env() -> EngineResult<Vec<u8>> {
+pub fn generate_masked_ec_from_env(curve: HsmEccCurve) -> EngineResult<Vec<u8>> {
     let data = EngineData::new();
     data.open_hsm_from_env()?;
     data.with_session(|session| {
@@ -31,7 +31,7 @@ pub fn generate_masked_ec_p384_from_env() -> EngineResult<Vec<u8>> {
             HsmKeyPropsBuilder::default()
                 .class(class)
                 .key_kind(HsmKeyKind::Ecc)
-                .ecc_curve(HsmEccCurve::P384)
+                .ecc_curve(curve)
                 .is_session(false)
                 .can_sign(sign)
                 .can_verify(!sign)

--- a/plugins/ossl_engine/integration-tests/masked-keygen/Cargo.toml
+++ b/plugins/ossl_engine/integration-tests/masked-keygen/Cargo.toml
@@ -15,9 +15,10 @@ path = "src/main.rs"
 # cells) doesn't pull the OpenSSL 1.1.x engine; the integration harness builds
 # this with `--features integration`.
 [features]
-integration = ["dep:azihsm_ossl_engine"]
+integration = ["dep:azihsm_api", "dep:azihsm_ossl_engine"]
 
 [dependencies]
+azihsm_api = { optional = true, workspace = true }
 azihsm_ossl_engine = { features = [
   "engine",
   "integration",

--- a/plugins/ossl_engine/integration-tests/masked-keygen/src/main.rs
+++ b/plugins/ossl_engine/integration-tests/masked-keygen/src/main.rs
@@ -1,24 +1,33 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-//! Generate a masked EC P-384 key blob for the engine integration tests.
+//! Generate a masked EC key blob for the engine integration tests.
 //!
 //! Opens the mock HSM from the ambient `AZIHSM_*` environment — the same
 //! environment the engine-loading `openssl` process uses — generates a
-//! persistent EC key, and writes its masked blob to the path given as the first
-//! argument. Because both processes share the resiliency storage dir (the
-//! persisted BMK), the OBK, and the POTA keypair, the engine can later unmask
-//! this blob via `ENGINE_load_private_key`.
+//! persistent EC key on the requested curve (default P-384), and writes its
+//! masked blob to the path given as the first argument. Because both processes
+//! share the resiliency storage dir (the persisted BMK), the OBK, and the POTA
+//! keypair, the engine can later unmask this blob via
+//! `ENGINE_load_private_key`.
 
 #[cfg(feature = "integration")]
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     use std::io::Write;
     use std::os::unix::fs::OpenOptionsExt;
 
+    use azihsm_api::HsmEccCurve;
+
     let out = std::env::args()
         .nth(1)
-        .ok_or("usage: masked-keygen <output-blob-path>")?;
-    let blob = azihsm_ossl_engine::integration::generate_masked_ec_p384_from_env()?;
+        .ok_or("usage: masked-keygen <output-blob-path> [p256|p384|p521]")?;
+    let curve = match std::env::args().nth(2).as_deref() {
+        None | Some("p384") => HsmEccCurve::P384,
+        Some("p256") => HsmEccCurve::P256,
+        Some("p521") => HsmEccCurve::P521,
+        Some(other) => return Err(format!("unknown curve: {other}").into()),
+    };
+    let blob = azihsm_ossl_engine::integration::generate_masked_ec_from_env(curve)?;
     // Owner-only: the blob is key material.
     let mut f = std::fs::OpenOptions::new()
         .write(true)

--- a/plugins/ossl_engine/integration-tests/openssl-cli/testfiles/load/load.sh
+++ b/plugins/ossl_engine/integration-tests/openssl-cli/testfiles/load/load.sh
@@ -2,17 +2,24 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 #
-# Stage a masked EC key blob, then load it through the engine's
-# ENGINE_load_private_key path and print its public half.
+# For each supported curve: stage a masked EC key blob, then load it through
+# the engine's ENGINE_load_private_key path and print its public half.
 source "$(dirname "${BASH_SOURCE[0]}")/../env.sh"
 
-blob="$KEYDIR/ec_key.bin"
-rm -f "$blob"
+for curve in p256 p384 p521; do
+    blob="$KEYDIR/ec_key_$curve.bin"
+    rm -f "$blob"
 
-# Generate the masked blob out-of-process (shares the keymat set above).
-"$MASKED_KEYGEN" "$blob"
+    # Generate the masked blob out-of-process (shares the keymat set above).
+    "$MASKED_KEYGEN" "$blob" "$curve"
 
-# Load it via the engine (real ENGINE_load_private_key) and emit the public key.
-"$OPENSSL_BIN" pkey -engine azihsm -inform engine -in "azihsm://$blob;type=ec" -pubout
+    # Load it via the engine (real ENGINE_load_private_key) and emit the
+    # public key.
+    "$OPENSSL_BIN" pkey -engine azihsm -inform engine \
+        -in "azihsm://$blob;type=ec" -pubout > /dev/null
+    echo "load ok: $curve"
+done
 
-# CHECK: BEGIN PUBLIC KEY
+# CHECK: load ok: p256
+# CHECK: load ok: p384
+# CHECK: load ok: p521

--- a/plugins/ossl_engine/integration-tests/openssl-cli/testfiles/sign/sign.sh
+++ b/plugins/ossl_engine/integration-tests/openssl-cli/testfiles/sign/sign.sh
@@ -2,51 +2,57 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 #
-# Stage a masked EC key blob, sign through the engine (HSM ECDSA), and verify
-# the signatures in software with the extracted public key. Covers both sign
-# entry points: hash-and-sign (dgst -sign -> EVP_DigestSign) and pre-hashed
+# For each supported curve (with its conventional digest): stage a masked EC
+# key blob, sign through the engine (HSM ECDSA), and verify the signatures in
+# software with the extracted public key. Covers both sign entry points:
+# hash-and-sign (dgst -sign -> EVP_DigestSign) and pre-hashed
 # (pkeyutl -sign -> EVP_PKEY_sign).
 source "$(dirname "${BASH_SOURCE[0]}")/../env.sh"
 
-blob="$KEYDIR/ec_sign_key.bin"
-msg="$KEYDIR/sign_msg.txt"
-pub="$KEYDIR/sign_pub.pem"
-sig="$KEYDIR/sign_sig.bin"
-digest="$KEYDIR/sign_digest.bin"
-psig="$KEYDIR/sign_pkeyutl_sig.bin"
-rm -f "$blob" "$msg" "$msg.tampered" "$pub" "$sig" "$digest" "$psig"
+for pair in "p256 sha256" "p384 sha384" "p521 sha512"; do
+    read -r curve md <<< "$pair"
+    blob="$KEYDIR/ec_sign_key_$curve.bin"
+    msg="$KEYDIR/sign_msg_$curve.txt"
+    pub="$KEYDIR/sign_pub_$curve.pem"
+    sig="$KEYDIR/sign_sig_$curve.bin"
+    digest="$KEYDIR/sign_digest_$curve.bin"
+    psig="$KEYDIR/sign_pkeyutl_sig_$curve.bin"
+    rm -f "$blob" "$msg" "$msg.tampered" "$pub" "$sig" "$digest" "$psig"
 
-uri="azihsm://$blob;type=ec"
+    uri="azihsm://$blob;type=ec"
 
-# Generate the masked blob out-of-process (shares the keymat set above).
-"$MASKED_KEYGEN" "$blob"
+    # Generate the masked blob out-of-process (shares the keymat set above).
+    "$MASKED_KEYGEN" "$blob" "$curve"
 
-printf 'engine ecdsa signing over the CLI path' > "$msg"
+    printf 'engine ecdsa signing over the CLI path (%s)' "$curve" > "$msg"
 
-# Extract the public half in a software-verifiable form.
-"$OPENSSL_BIN" pkey -engine azihsm -inform engine -in "$uri" -pubout -out "$pub"
+    # Extract the public half in a software-verifiable form.
+    "$OPENSSL_BIN" pkey -engine azihsm -inform engine -in "$uri" -pubout -out "$pub"
 
-# Hash-and-sign through the engine (EVP_DigestSign -> the engine's sign_sig ->
-# HSM), then verify in software (no engine): proves the HSM signed the digest
-# with the key matching the public half.
-"$OPENSSL_BIN" dgst -sha384 -engine azihsm -keyform engine -sign "$uri" -out "$sig" "$msg"
-"$OPENSSL_BIN" dgst -sha384 -verify "$pub" -signature "$sig" "$msg"
-# CHECK: Verified OK
+    # Hash-and-sign through the engine (EVP_DigestSign -> the engine's
+    # sign_sig -> HSM), then verify in software (no engine): proves the HSM
+    # signed the digest with the key matching the public half.
+    "$OPENSSL_BIN" dgst "-$md" -engine azihsm -keyform engine -sign "$uri" \
+        -out "$sig" "$msg"
+    "$OPENSSL_BIN" dgst "-$md" -verify "$pub" -signature "$sig" "$msg"
 
-# Pre-hashed path: sign the raw SHA-384 digest via pkeyutl (EVP_PKEY_sign),
-# then verify it in software.
-"$OPENSSL_BIN" dgst -sha384 -binary -out "$digest" "$msg"
-"$OPENSSL_BIN" pkeyutl -sign -engine azihsm -keyform engine -inkey "$uri" \
-    -in "$digest" -out "$psig"
-"$OPENSSL_BIN" pkeyutl -verify -pubin -inkey "$pub" -sigfile "$psig" -in "$digest"
-# CHECK: Signature Verified Successfully
+    # Pre-hashed path: sign the raw digest via pkeyutl (EVP_PKEY_sign), then
+    # verify it in software.
+    "$OPENSSL_BIN" dgst "-$md" -binary -out "$digest" "$msg"
+    "$OPENSSL_BIN" pkeyutl -sign -engine azihsm -keyform engine -inkey "$uri" \
+        -in "$digest" -out "$psig"
+    "$OPENSSL_BIN" pkeyutl -verify -pubin -inkey "$pub" -sigfile "$psig" \
+        -in "$digest"
 
-# A tampered message must fail verification.
-printf 'engine ecdsa signing over the CLI path?' > "$msg.tampered"
-if "$OPENSSL_BIN" dgst -sha384 -verify "$pub" -signature "$sig" "$msg.tampered"; then
-    echo "tampered message unexpectedly verified"
-    exit 1
-else
-    echo "tampered message rejected"
-fi
-# CHECK: tampered message rejected
+    # A tampered message must fail verification.
+    printf 'engine ecdsa signing over the CLI path (%s)?' "$curve" > "$msg.tampered"
+    if "$OPENSSL_BIN" dgst "-$md" -verify "$pub" -signature "$sig" "$msg.tampered"; then
+        echo "tampered message unexpectedly verified: $curve"
+        exit 1
+    fi
+    echo "sign round trip ok: $curve"
+done
+
+# CHECK: sign round trip ok: p256
+# CHECK: sign round trip ok: p384
+# CHECK: sign round trip ok: p521


### PR DESCRIPTION
## Summary

Follow-up to #599, hardening the ECDSA test coverage in two ways:

- **All supported curves.** The EC load/sign round trips only ever exercised P-384. The masked-key generator and the shared round-trip bodies are now parameterized over the curve and run for **P-256, P-384, and P-521** — each with its conventional digest (SHA-256/-384/-512) — in the mock unit tests, the hardware smokes, and the CLI integration scripts. `masked-keygen` gains an optional curve argument (`p256|p384|p521`, default `p384`).
- **Digest-length edge pinned.** For a digest longer than the curve order (SHA-512 over P-384, 64 > 48 bytes), the HSM truncates per the ECDSA spec exactly like software OpenSSL — the signature verifies in software with the same digest. A new test pins that behavior so a firmware change breaking the truncation convention is caught.

No production code changes — test and test-tooling only.

## Testing

Full suite on OpenSSL 1.1.x (Ubuntu 20.04 / 1.1.1f): build, clippy `-D warnings` (with and without `mock`), 34 engine unit tests (round trips × 3 curves + the digest-length pin), 21 engine-core tests, CLI integration (load + sign × 3 curves, both `dgst`/`pkeyutl` entry points, tamper negatives per curve), ABI integration.

The hardware smokes (`load_ec_key_from_env_smoke`, `sign_ec_key_from_env_smoke`) now also loop all three curves; run commands are unchanged (see #599's description).
