### PR TITLE
fw(uno): compute little-endian SHA digest via software reversal in the PAL

### DIFF
--- a/ddi/mbor/types/tests/integration/sha_digest_smoke.rs
+++ b/ddi/mbor/types/tests/integration/sha_digest_smoke.rs
@@ -161,8 +161,7 @@ fn test_sha_digest_multiblock_smoke() {
             // bytes, SHA-384/512 block = 128 bytes), so the engine runs
             // several compression rounds and the digest is emitted in NIST
             // big-endian byte order. A matching known-answer digest confirms
-            // both the multi-block path and the per-word byte-swap of the
-            // output.
+            // the multi-block path.
 
             // SHA-256 over a 56-byte message (spans two 64-byte blocks).
             check_digest(

--- a/fw/core/crypto/key-report/src/decode.rs
+++ b/fw/core/crypto/key-report/src/decode.rs
@@ -253,8 +253,7 @@ where
     // SHA-384. `ecc_verify` is PKA little-endian native, so hash
     // big-endian and then fully byte-reverse the digest into PKA-LE,
     // matching the other verify callers (establish_credential /
-    // x509-chain). SHA's `big_endian = false` is only a per-word swap,
-    // not the full-digest reversal the PKA needs.
+    // x509-chain).
     let digest = alloc.dma_alloc(SHA384_LEN)?;
     pal.hash(io, HsmHashAlgo::Sha384, sig_struct, digest, true)
         .await?;

--- a/fw/core/crypto/x509-builder/src/cert_builder.rs
+++ b/fw/core/crypto/x509-builder/src/cert_builder.rs
@@ -351,8 +351,8 @@ async fn build_signed_from_template<'a>(
 
     let digest_dma = alloc.dma_alloc(SHA384_DIGEST_LEN)?;
     // Natural big-endian SHA-384 over the TBS; the `TbsSigner` reverses it to
-    // the PKA little-endian message hash (`big_endian = false` would be a
-    // per-word swap, not the full reversal the PKA sign needs).
+    // the PKA little-endian message hash (the full byte reversal of the natural
+    // digest).
     pal.hash(io, HsmHashAlgo::Sha384, tbs_dma, digest_dma, true)
         .await?;
 
@@ -417,9 +417,8 @@ where
     patch(tbs_dma)?;
 
     let digest_dma = alloc.dma_alloc(SHA384_DIGEST_LEN)?;
-    // Natural big-endian SHA-384, then a FULL byte reversal to the PKA-native
-    // little-endian message hash `ecc_sign` consumes. `big_endian = false` is
-    // only a per-word swap on Uno, not the full reversal the PKA path needs.
+    // Natural big-endian SHA-384, then a full byte reversal to the PKA-native
+    // little-endian message hash `ecc_sign` consumes.
     pal.hash(io, HsmHashAlgo::Sha384, tbs_dma, digest_dma, true)
         .await?;
 

--- a/fw/core/lib/src/ddi/mbor/establish_credential.rs
+++ b/fw/core/lib/src/ddi/mbor/establish_credential.rs
@@ -394,10 +394,8 @@ async fn verify_pota_signature<P: HsmPal>(
     pal.hash(io, HsmHashAlgo::Sha384, id_uncompressed, digest, true)
         .await?;
     // The POTA signature was produced over the natural big-endian digest; the
-    // LE-native `ecc_verify` consumes the PKA-LE (fully byte-reversed) digest,
-    // so reverse it here in the handler. (SHA's `big_endian = false` does a
-    // per-word byte-swap, not the full-digest reversal the PKA needs.)
-    // Byte-order conversion lives in the handler now, not the PAL.
+    // LE-native `ecc_verify` consumes the PKA-LE digest, which is the full byte
+    // reversal of the big-endian digest, so reverse it here.
     digest[..HsmHashAlgo::Sha384.digest_len()].reverse();
 
     let verify_result = pal.dma_alloc(io, 4)?;

--- a/fw/docs/traits/crypto.md
+++ b/fw/docs/traits/crypto.md
@@ -93,7 +93,7 @@ pub trait HsmEcc {
 Key parameters are raw byte buffers (DMA-backed `DmaBuf` in the firmware PAL traits — see the note above), all in HSM-native **little-endian** (PKA operand order): raw HSM-format scalar `d` for private keys (32/48/68 bytes, P-521 4-byte aligned), raw x∥y coordinates for public keys, and raw r∥s for signatures (each component little-endian).
 
 Byte order also governs the digest and the ECDH secret:
-- `ecc_sign` / `ecc_verify` take the message `hash` in PKA **little-endian** — a *full byte reversal* of the natural big-endian digest. (This is **not** `HsmHash::hash(.., big_endian = false)`, which only byte-swaps within each 32-bit word.) Callers hash big-endian, then reverse the digest.
+- `ecc_sign` / `ecc_verify` take the message `hash` in PKA **little-endian** — a *full byte reversal* of the natural big-endian digest, which is exactly what `HsmHash::hash(.., big_endian = false)` produces. Callers either hash with `big_endian = false`, or hash big-endian and then reverse the digest.
 - `ecdh_derive` writes `secret` as the shared x-coordinate in **little-endian**. Consumers that need big-endian — e.g. an openssl-matching HKDF, or HPKE/DHKEM per RFC 9180 — must reverse it to big-endian themselves.
 
 **PCT (Pairwise Consistency Test):** After key generation, a self-test is performed:

--- a/fw/pal/traits/src/crypto/ecc.rs
+++ b/fw/pal/traits/src/crypto/ecc.rs
@@ -331,13 +331,11 @@ pub trait HsmEcc {
     ///   coordinate internally.
     /// - `hash` — message digest that was signed, in **little-endian**
     ///   byte order: the natural big-endian digest with **all bytes fully
-    ///   reversed** (BE->LE), at least the curve's digest length.  This is a
-    ///   full-digest reversal, distinct from
-    ///   `HsmHash::hash(.., big_endian = false)`, which only byte-swaps within
-    ///   each 32-bit word.  The digest is PKA-native LE like `pub_key` /
-    ///   `signature`; the DDI handler performs the conversion (hash big-endian,
-    ///   then reverse), so PKA-native PALs consume it as-is while
-    ///   big-endian-native PALs (e.g. OpenSSL) reverse it internally.
+    ///   reversed** (BE->LE), at least the curve's digest length.  This is the
+    ///   full-digest reversal produced by `HsmHash::hash(.., big_endian =
+    ///   false)`.  The digest is PKA-native LE like `pub_key` / `signature`;
+    ///   PKA-native PALs consume it as-is while big-endian-native PALs (e.g.
+    ///   OpenSSL) reverse it internally.
     /// - `signature` — signature to verify; must be exactly
     ///   `curve.wire_sig_len()` bytes (`r || s`).  **Each component
     ///   is in little-endian byte order** with P-521 components

--- a/fw/pal/traits/src/crypto/hash.rs
+++ b/fw/pal/traits/src/crypto/hash.rs
@@ -103,9 +103,10 @@ impl HsmHashAlgo {
 ///   fragments; intermediate state lives in a PAL-allocated context.
 ///
 /// All output digests can be requested in either NIST big-endian or
-/// byte-swapped little-endian order via the `big_endian` flag, to
-/// match what the next consumer (DDI response framing, KDF input,
-/// etc.) expects.
+/// little-endian order via the `big_endian` flag, to match what the
+/// next consumer (DDI response framing, KDF input, etc.) expects. The
+/// little-endian form is the full byte reversal of the big-endian
+/// digest.
 pub trait HsmHash {
     /// Platform-specific multi-step hash context.
     ///
@@ -131,7 +132,8 @@ pub trait HsmHash {
     ///   [`HsmHashAlgo::digest_len`] bytes.  Only the leading
     ///   `digest_len` bytes are written.
     /// - `big_endian` — `true` for NIST big-endian output, `false`
-    ///   for byte-swapped little-endian.
+    ///   for little-endian (the full byte reversal of the big-endian
+    ///   digest, i.e. the PKA `ecc_sign` operand order).
     ///
     /// # Returns
     ///
@@ -218,7 +220,8 @@ pub trait HsmHash {
     /// - `digest` — output buffer; must be at least
     ///   [`HsmHashAlgo::digest_len`] bytes.
     /// - `big_endian` — `true` for NIST big-endian output, `false`
-    ///   for byte-swapped little-endian.
+    ///   for little-endian (the full byte reversal of the big-endian
+    ///   digest, i.e. the PKA `ecc_sign` operand order).
     ///
     /// # Returns
     ///

--- a/fw/plat/std/pal/src/hash.rs
+++ b/fw/plat/std/pal/src/hash.rs
@@ -90,3 +90,134 @@ impl HsmHash for StdHsmPal {
         todo!()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use tokio::runtime::Handle;
+
+    use super::to_hash_algo;
+    use super::*;
+    use crate::drivers::hash::StdHash;
+    use crate::worker::WorkerPool;
+    use crate::StdHsmIo;
+    use crate::StdHsmPal;
+
+    /// NIST FIPS 180-4 "abc" digests in big-endian (standard) byte order.
+    const SHA1_ABC: &str = "a9993e364706816aba3e25717850c26c9cd0d89d";
+    const SHA256_ABC: &str = "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad";
+    const SHA384_ABC: &str = "cb00753f45a35e8bb5a03d699ac65007272c32ab0eded1631a8b605a43ff5bed8086072ba1e7cc2358baeca134c825a7";
+    const SHA512_ABC: &str = "ddaf35a193617abacc417349ae20413112e6fa4e89a97ea20a9eeee64b55d39a2192992a274fc1a836ba3c23a3feebbd454d4423643ce80e2a9ac94fa54ca49f";
+
+    /// Hashes `msg` through the PAL with the requested endianness and returns
+    /// the digest bytes.
+    async fn pal_hash(algo: HsmHashAlgo, msg: &[u8], big_endian: bool) -> Vec<u8> {
+        let (_tx, rx) = async_channel::bounded(1);
+        let pal = StdHsmPal::new(rx, Handle::current());
+        let (reply_tx, _reply_rx) = tokio::sync::oneshot::channel();
+        let io = StdHsmIo::admin(HsmPartId::from(0u8), 0, reply_tx);
+
+        let msg_buf = msg.to_vec();
+        let data = unsafe { DmaBuf::from_raw(&msg_buf) };
+        let digest_len = algo.digest_len();
+        let mut buf = [0u8; 64];
+        let digest = unsafe { DmaBuf::from_raw_mut(&mut buf[..digest_len]) };
+
+        pal.hash(&io, algo, data, digest, big_endian).await.unwrap();
+        buf[..digest_len].to_vec()
+    }
+
+    /// Reference big-endian digest computed by the OpenSSL-backed driver.
+    async fn openssl_digest(algo: HsmHashAlgo, msg: &[u8]) -> Vec<u8> {
+        let driver = StdHash::new(WorkerPool::new(Handle::current()));
+        let mut digest = vec![0u8; algo.digest_len()];
+        driver
+            .hash(to_hash_algo(algo), msg, &mut digest)
+            .await
+            .unwrap();
+        digest
+    }
+
+    /// Deterministic multi-block message used for reference-based checks.
+    fn multiblock_msg() -> Vec<u8> {
+        (0..200u32)
+            .map(|i| i.wrapping_mul(7).wrapping_add(3) as u8)
+            .collect()
+    }
+
+    /// Verifies the PAL hash of `msg` equals `expected_be` in big-endian and
+    /// its full byte reversal in little-endian.
+    async fn verify_endianness(algo: HsmHashAlgo, msg: &[u8], expected_be: &[u8]) {
+        // validate big-endian output
+        let be = pal_hash(algo, msg, true).await;
+        assert_eq!(be, expected_be);
+
+        // validate little-endian output
+        let mut expected_le = expected_be.to_vec();
+        expected_le.reverse();
+        let le = pal_hash(algo, msg, false).await;
+        assert_eq!(le, expected_le);
+    }
+
+    #[tokio::test]
+    async fn sha1_validate_nist() {
+        verify_endianness(HsmHashAlgo::Sha1, b"abc", &hex::decode(SHA1_ABC).unwrap()).await;
+    }
+
+    #[tokio::test]
+    async fn sha256_validate_nist() {
+        verify_endianness(
+            HsmHashAlgo::Sha256,
+            b"abc",
+            &hex::decode(SHA256_ABC).unwrap(),
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn sha384_validate_nist() {
+        verify_endianness(
+            HsmHashAlgo::Sha384,
+            b"abc",
+            &hex::decode(SHA384_ABC).unwrap(),
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn sha512_validate_nist() {
+        verify_endianness(
+            HsmHashAlgo::Sha512,
+            b"abc",
+            &hex::decode(SHA512_ABC).unwrap(),
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn sha1_validate_openssl() {
+        let msg = multiblock_msg();
+        let reference = openssl_digest(HsmHashAlgo::Sha1, &msg).await;
+        verify_endianness(HsmHashAlgo::Sha1, &msg, &reference).await;
+    }
+
+    #[tokio::test]
+    async fn sha256_validate_openssl() {
+        let msg = multiblock_msg();
+        let reference = openssl_digest(HsmHashAlgo::Sha256, &msg).await;
+        verify_endianness(HsmHashAlgo::Sha256, &msg, &reference).await;
+    }
+
+    #[tokio::test]
+    async fn sha384_validate_openssl() {
+        let msg = multiblock_msg();
+        let reference = openssl_digest(HsmHashAlgo::Sha384, &msg).await;
+        verify_endianness(HsmHashAlgo::Sha384, &msg, &reference).await;
+    }
+
+    #[tokio::test]
+    async fn sha512_validate_openssl() {
+        let msg = multiblock_msg();
+        let reference = openssl_digest(HsmHashAlgo::Sha512, &msg).await;
+        verify_endianness(HsmHashAlgo::Sha512, &msg, &reference).await;
+    }
+}

--- a/fw/plat/std/pal/src/hash.rs
+++ b/fw/plat/std/pal/src/hash.rs
@@ -116,14 +116,13 @@ mod tests {
         let (reply_tx, _reply_rx) = tokio::sync::oneshot::channel();
         let io = StdHsmIo::admin(HsmPartId::from(0u8), 0, reply_tx);
 
-        let msg_buf = msg.to_vec();
-        let data = unsafe { DmaBuf::from_raw(&msg_buf) };
         let digest_len = algo.digest_len();
-        let mut buf = [0u8; 64];
-        let digest = unsafe { DmaBuf::from_raw_mut(&mut buf[..digest_len]) };
+        let data = pal.dma_alloc(&io, msg.len()).unwrap();
+        data.copy_from_slice(msg);
+        let digest = pal.dma_alloc(&io, digest_len).unwrap();
 
         pal.hash(&io, algo, data, digest, big_endian).await.unwrap();
-        buf[..digest_len].to_vec()
+        digest[..digest_len].to_vec()
     }
 
     /// Reference big-endian digest computed by the OpenSSL-backed driver.

--- a/fw/plat/uno/fw/pal/src/cert.rs
+++ b/fw/plat/uno/fw/pal/src/cert.rs
@@ -107,10 +107,9 @@ impl TbsSigner for AliasSigner<'_> {
 
                 // `build_signed_from_template` hashes the TBS as a natural
                 // big-endian SHA-384 digest. `ecc_sign_deterministic` consumes
-                // the PKA little-endian message hash — the FULL byte reversal of
-                // the natural digest (not the per-word `big_endian = false`
-                // swap). This mirrors the est-cred POTA verify and matches the
-                // validated deterministic-sign KAT.
+                // the PKA little-endian message hash — the full byte reversal of
+                // the natural digest. This mirrors the est-cred POTA verify and
+                // matches the validated deterministic-sign KAT.
                 let e = scope.dma_alloc(P384_FIELD)?;
                 for i in 0..P384_FIELD {
                     e[i] = digest[P384_FIELD - 1 - i];
@@ -250,8 +249,8 @@ impl UnoHsmPal {
             inp.copy_from_slice(data);
             let outd = scope.dma_alloc(SKI_LEN)?;
             // `big_endian = true`: the SKI is the standard NIST byte-order SHA-1
-            // of the key (RFC 5280). `big_endian = false` would per-word swap the
-            // digest and encode an incorrect Subject Key Identifier.
+            // of the key (RFC 5280). `big_endian = false` would fully byte-reverse
+            // the digest and encode an incorrect Subject Key Identifier.
             self.hash(io, HsmHashAlgo::Sha1, inp, outd, true).await?;
             let mut out = [0u8; SKI_LEN];
             out.copy_from_slice(&outd[..SKI_LEN]);

--- a/fw/plat/uno/fw/pal/src/cert.rs
+++ b/fw/plat/uno/fw/pal/src/cert.rs
@@ -268,7 +268,7 @@ impl UnoHsmPal {
             let outd = scope.dma_alloc(SHA256_LEN)?;
             // `big_endian = true`: emit the standard (natural byte order) SHA-256
             // digest. The host and SP compute cert thumbprints over natural
-            // SHA-256; `false` here would per-word byte-swap the digest (the PKA
+            // SHA-256; `false` here would fully byte-reverse the digest (the PKA
             // operand order) and the chain thumbprint would never match.
             self.hash(io, HsmHashAlgo::Sha256, inp, outd, true).await?;
             let mut out = [0u8; SHA256_LEN];

--- a/fw/plat/uno/fw/pal/src/crypto/ecc.rs
+++ b/fw/plat/uno/fw/pal/src/crypto/ecc.rs
@@ -351,12 +351,11 @@ impl HsmEcc for UnoHsmPal {
         // validation) would otherwise accumulate this scratch and can
         // exhaust the DMA pool.
         self.alloc_scoped_async(io, async |scope| {
-            // The digest arrives PKA-native little-endian: the DDI handler
-            // hashes big-endian and then fully byte-reverses it (a full BE->LE
-            // reversal, not `hash(.., big_endian = false)`, which only swaps
-            // within each 32-bit word). pub_key and signature likewise arrive
-            // LE via the host DDI serde. No byte-order conversion is done below
-            // the PAL.
+            // The digest arrives PKA-native little-endian: it is a full BE->LE
+            // byte reversal of the big-endian hash, which is what
+            // `hash(.., big_endian = false)` produces. pub_key and signature
+            // likewise arrive LE via the host DDI serde. No byte-order
+            // conversion is done below the PAL.
 
             // Per-call Montgomery constant from the curve prime (like
             // ecdh_derive). `mont_result` is transient scratch consumed

--- a/fw/plat/uno/fw/pal/src/crypto/hash.rs
+++ b/fw/plat/uno/fw/pal/src/crypto/hash.rs
@@ -184,8 +184,8 @@ impl HsmHash for UnoHsmPal {
     /// - `digest` — output buffer (must be at least
     ///   [`HsmHashAlgo::digest_len`] bytes).
     /// - `big_endian` — if `true`, the digest is written in big-endian (NIST
-    ///   standard) byte order.  If `false`, the output is byte-swapped to
-    ///   little-endian.
+    ///   standard) byte order.  If `false`, the whole digest is reversed to
+    ///   little-endian byte order.
     ///
     /// # Returns
     ///
@@ -200,7 +200,14 @@ impl HsmHash for UnoHsmPal {
         big_endian: bool,
     ) -> HsmResult<()> {
         let _ = io;
-        self.sha_oneshot(algo, data, digest, !big_endian).await
+        self.sha_oneshot(algo, data, digest, false).await?;
+        if !big_endian {
+            let digest_len = algo.digest_len();
+            if let Some(bytes) = digest.get_mut(..digest_len) {
+                bytes.reverse();
+            }
+        }
+        Ok(())
     }
 
     /// Begins a multi-step hash computation.
@@ -273,8 +280,8 @@ impl HsmHash for UnoHsmPal {
     /// - `digest` — output buffer for the final digest. Must be at least
     ///   [`HsmHashAlgo::digest_len`] bytes.
     /// - `big_endian` — if `true`, the digest is written in big-endian (NIST
-    ///   standard) byte order. If `false`, the output is byte-swapped to
-    ///   little-endian.
+    ///   standard) byte order. If `false`, the whole digest is reversed to
+    ///   little-endian byte order.
     ///
     /// # Returns
     ///
@@ -295,9 +302,12 @@ impl HsmHash for UnoHsmPal {
         }
 
         let len = ctx.pending_len as usize;
-        self.sha_digest_block(&mut ctx, None, len, true, !big_endian)
+        self.sha_digest_block(&mut ctx, None, len, true, false)
             .await?;
         digest[..digest_len].copy_from_slice(&ctx.buf[..digest_len]);
+        if !big_endian {
+            digest[..digest_len].reverse();
+        }
         Ok(())
     }
 }

--- a/fw/plat/uno/fw/pal/src/crypto/hash.rs
+++ b/fw/plat/uno/fw/pal/src/crypto/hash.rs
@@ -200,12 +200,13 @@ impl HsmHash for UnoHsmPal {
         big_endian: bool,
     ) -> HsmResult<()> {
         let _ = io;
+        let digest_len = algo.digest_len();
+        if digest.len() < digest_len {
+            return Err(HsmError::InvalidArg);
+        }
         self.sha_oneshot(algo, data, digest, false).await?;
         if !big_endian {
-            let digest_len = algo.digest_len();
-            if let Some(bytes) = digest.get_mut(..digest_len) {
-                bytes.reverse();
-            }
+            digest[..digest_len].reverse();
         }
         Ok(())
     }

--- a/fw/plat/uno/fw/pal/src/crypto/hash.rs
+++ b/fw/plat/uno/fw/pal/src/crypto/hash.rs
@@ -303,8 +303,7 @@ impl HsmHash for UnoHsmPal {
         }
 
         let len = ctx.pending_len as usize;
-        self.sha_digest_block(&mut ctx, None, len, true)
-            .await?;
+        self.sha_digest_block(&mut ctx, None, len, true).await?;
         digest[..digest_len].copy_from_slice(&ctx.buf[..digest_len]);
         if !big_endian {
             digest[..digest_len].reverse();
@@ -397,8 +396,7 @@ impl UnoHsmPal {
         finalize: bool,
     ) -> HsmResult<()> {
         let len = ctx.pending_len as usize;
-        self.sha_digest_block(ctx, None, len, finalize)
-            .await?;
+        self.sha_digest_block(ctx, None, len, finalize).await?;
         ctx.pending_len = 0;
         Ok(())
     }

--- a/fw/plat/uno/fw/pal/src/crypto/hash.rs
+++ b/fw/plat/uno/fw/pal/src/crypto/hash.rs
@@ -204,7 +204,7 @@ impl HsmHash for UnoHsmPal {
         if digest.len() < digest_len {
             return Err(HsmError::InvalidArg);
         }
-        self.sha_oneshot(algo, data, digest, false).await?;
+        self.sha_oneshot(algo, data, digest).await?;
         if !big_endian {
             digest[..digest_len].reverse();
         }
@@ -303,7 +303,7 @@ impl HsmHash for UnoHsmPal {
         }
 
         let len = ctx.pending_len as usize;
-        self.sha_digest_block(&mut ctx, None, len, true, false)
+        self.sha_digest_block(&mut ctx, None, len, true)
             .await?;
         digest[..digest_len].copy_from_slice(&ctx.buf[..digest_len]);
         if !big_endian {
@@ -358,8 +358,6 @@ impl UnoHsmPal {
     /// - `mode` — SHA hardware algorithm selector.
     /// - `message` — complete input message.
     /// - `digest` — output buffer for the final hash.
-    /// - `byte_swap` — if `true`, the digest is byte-swapped
-    ///   (little-endian output).
     ///
     /// # Returns
     ///
@@ -371,13 +369,9 @@ impl UnoHsmPal {
         algo: HsmHashAlgo,
         message: &DmaBuf,
         digest: &mut DmaBuf,
-        byte_swap: bool,
     ) -> HsmResult<()> {
         let byte_count = u32::try_from(message.len()).map_err(|_| HsmError::InvalidArg)?;
-        let mut req = ShaRequest::new(algo.into(), message, digest).with_auto_pad(byte_count);
-        if byte_swap {
-            req = req.with_byte_swap();
-        }
+        let req = ShaRequest::new(algo.into(), message, digest).with_auto_pad(byte_count);
         self.sha.digest(req).await
     }
 
@@ -403,7 +397,7 @@ impl UnoHsmPal {
         finalize: bool,
     ) -> HsmResult<()> {
         let len = ctx.pending_len as usize;
-        self.sha_digest_block(ctx, None, len, finalize, false)
+        self.sha_digest_block(ctx, None, len, finalize)
             .await?;
         ctx.pending_len = 0;
         Ok(())
@@ -433,7 +427,7 @@ impl UnoHsmPal {
         // hmac_continue, so `blocks` is always a sub-slice of a
         // DMA-accessible caller buffer.
         let blocks = unsafe { DmaBuf::from_raw(blocks) };
-        self.sha_digest_block(ctx, Some(blocks), blocks.len(), false, false)
+        self.sha_digest_block(ctx, Some(blocks), blocks.len(), false)
             .await
     }
 
@@ -457,9 +451,6 @@ impl UnoHsmPal {
     /// - `finalize` — if `true`, automatic SHA padding is applied and the
     ///   engine writes the truncated NIST digest.  If `false`, the engine
     ///   writes the full working-variable state for chaining.
-    /// - `byte_swap` — if `true`, the digest output is byte-swapped
-    ///   (little-endian).  Only meaningful when `finalize` is `true`;
-    ///   intermediate blocks always use byte-swap for state continuity.
     ///
     /// # Returns
     ///
@@ -472,7 +463,6 @@ impl UnoHsmPal {
         external_msg: Option<&DmaBuf>,
         msg_len: usize,
         finalize: bool,
-        byte_swap: bool,
     ) -> HsmResult<()>
     where
         C: ShaDigestContext,
@@ -493,9 +483,6 @@ impl UnoHsmPal {
         let mut req = ShaRequest::new(algo.into(), message, digest);
         if finalize {
             req = req.with_auto_pad(total);
-            if byte_swap {
-                req = req.with_byte_swap();
-            }
         } else {
             req.byte_count = total;
             req = req.with_full_state().with_byte_swap();

--- a/fw/plat/uno/fw/pal/src/crypto/hmac.rs
+++ b/fw/plat/uno/fw/pal/src/crypto/hmac.rs
@@ -485,7 +485,7 @@ impl UnoHsmPal {
             let effective_key = scope.dma_alloc(MAX_BLOCK_LEN)?;
             effective_key.fill(0);
             if key.len() > block_len {
-                self.sha_oneshot(algo, key, &mut effective_key[..algo.digest_len()], false)
+                self.sha_oneshot(algo, key, &mut effective_key[..algo.digest_len()])
                     .await?;
             } else {
                 effective_key[..key.len()].copy_from_slice(key);
@@ -541,7 +541,7 @@ impl UnoHsmPal {
     /// * Any [`HsmError`] surfaced by the SHA driver.
     async fn hmac_flush_pending(&self, ctx: &mut HmacContext<'_>, finalize: bool) -> HsmResult<()> {
         let len = ctx.pending_len as usize;
-        self.sha_digest_block(ctx, None, len, finalize, false)
+        self.sha_digest_block(ctx, None, len, finalize)
             .await?;
         ctx.pending_len = 0;
         Ok(())
@@ -566,7 +566,7 @@ impl UnoHsmPal {
         ctx: &mut HmacContext<'_>,
         blocks: &DmaBuf,
     ) -> HsmResult<()> {
-        self.sha_digest_block(ctx, Some(blocks), blocks.len(), false, false)
+        self.sha_digest_block(ctx, Some(blocks), blocks.len(), false)
             .await
     }
 

--- a/fw/plat/uno/fw/pal/src/crypto/hmac.rs
+++ b/fw/plat/uno/fw/pal/src/crypto/hmac.rs
@@ -541,8 +541,7 @@ impl UnoHsmPal {
     /// * Any [`HsmError`] surfaced by the SHA driver.
     async fn hmac_flush_pending(&self, ctx: &mut HmacContext<'_>, finalize: bool) -> HsmResult<()> {
         let len = ctx.pending_len as usize;
-        self.sha_digest_block(ctx, None, len, finalize)
-            .await?;
+        self.sha_digest_block(ctx, None, len, finalize).await?;
         ctx.pending_len = 0;
         Ok(())
     }


### PR DESCRIPTION
## Summary
On the Uno PAL the little-endian SHA digest is now produced by reversing the
whole digest buffer in software, instead of relying on the SHA hardware
byte-swap flag (which swaps only within each 8-byte word, not the full buffer).
The SHA engine always emits the big-endian (NIST) digest; the PAL reverses the
full buffer when `big_endian = false` is requested. Applies to both paths:
- `hash` (one-shot)
- `hash_finish` (multi-step)

## Tests
Host KATs on the std PAL for SHA-1/256/384/512 (`fw/plat/std/pal/src/hash.rs`):
- `shaXXX_validate_nist`   — big-endian output equals the NIST FIPS 180-4
  vector; little-endian output equals its full byte reversal.
- `shaXXX_validate_openssl` — over a multi-block message, big-endian output
  equals the OpenSSL reference digest; little-endian equals its full reversal.

## Validation
DDI integration suite (`ddi/mbor/types/tests/integration`):

| ddi test filter | emu | uno HW (Manticore EVB) |
|---|---|---|
| sha_digest | **4 / 4 pass** | **pass** |
| hmac | **36 / 36 pass** | **36 / 36 pass** |
| hkdf | **37 / 37 pass** | **37 / 50 pass** (13 failures are aes_gcm/aes_xts/openkey related which are not yet implemented) |
| kbkdf | **37 / 37 pass** | **37 / 50 pass** (13 failures are aes_gcm/aes_xts/openkey related which are not yet implemented) |
| ecc_sign | **17 / 18 pass** | 1 test_attest_ecc_signing_key failing with `UnsupportedCmd` error |
| get_session_encryption_key | **14 / 14 pass** | **pass** |
| test_get_establish_cred_encryption_key_changes_after_reset_with_sig_verify | **1 / 1 fail** | failed with `nonce must change` (pre-existing: partition nonce not re-seeded on reset); it's not a signature/hash issue |

Native crypto KAT (`azihsm_crypto`): sha **97/97**, hmac **18/18**, hkdf **17/17**, kbkdf **14/14**.
