### PR TITLE
fw(uno): TestAction bring-up under mcr_test_hooks / fips_validation_hooks

### DIFF
--- a/fw/core/ddi/mbor/types/Cargo.toml
+++ b/fw/core/ddi/mbor/types/Cargo.toml
@@ -17,5 +17,9 @@ azihsm_fw_hsm_pal_traits.workspace = true
 open-enum.workspace = true
 pastey.workspace = true
 
+[features]
+fips_validation_hooks = []
+mcr_test_hooks = []
+
 [lints]
 workspace = true

--- a/fw/core/ddi/mbor/types/src/lib.rs
+++ b/fw/core/ddi/mbor/types/src/lib.rs
@@ -42,6 +42,8 @@ pub mod rsa_mod_exp;
 pub mod rsa_unwrap;
 pub mod set_sealed_bk3;
 pub mod sha_digest;
+#[cfg(any(feature = "mcr_test_hooks", feature = "fips_validation_hooks"))]
+pub mod test_action;
 pub mod unmask_key;
 
 // Re-export codec types.
@@ -95,6 +97,7 @@ pub enum DdiOp {
     InitBk3 = 1111,
     GetSealedBk3 = 1112,
     SetSealedBk3 = 1113,
+    TestAction = 2004,
     ShaDigest = 2006,
 }
 

--- a/fw/core/ddi/mbor/types/src/test_action.rs
+++ b/fw/core/ddi/mbor/types/src/test_action.rs
@@ -1,0 +1,122 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! DDI `TestAction` wire types (op 2004).
+//!
+//! `TestAction` multiplexes a family of validation / fault-injection
+//! sub-actions selected by [`DdiTestAction`].  This refactor bring-up
+//! stands up the **framework**: the request mirrors the mainline host wire
+//! layout (`Martichoras/api/ddi/test_hooks/src/test_ops.rs`) up to the slot
+//! this firmware actually consumes (`force_pka_instance`, id 5), so the host
+//! ABI decodes correctly.  Only `ForcePkaInstance` is handled today; other
+//! action variants and their request sub-structs are ported incrementally as
+//! each action is brought up.
+//!
+//! ## Wire-layout invariant
+//! The `#[ddi(map)]` derive requires **contiguous** field ids and decodes
+//! optional fields by *peeking* the next on-wire id, decoding only on an exact
+//! match.  Any on-wire entry left unconsumed is a hard `InvalidLen` error.
+//! Therefore every id up to the highest one this firmware needs must exist as a
+//! declared field — even the intermediate slots we don't yet interpret — with
+//! the **same id and type shape the host sends**.
+
+use azihsm_fw_ddi_mbor_derive::Ddi;
+use open_enum::open_enum;
+
+use crate::*;
+
+/// TestAction selector.  Discriminants MUST match mainline `DdiTestAction`
+/// (`serde/ddi/types/src/test_ops.rs`) for host ABI parity.  Only the variants
+/// this firmware handles are declared; `#[open_enum]` tolerates the other
+/// on-wire values, which the handler rejects with `UnsupportedCmd`.
+#[open_enum]
+#[derive(Debug, Ddi, Copy, Clone, PartialEq, Eq)]
+#[repr(u32)]
+#[ddi(enumeration)]
+pub enum DdiTestAction {
+    /// Skip IO with a Level-1 abort trigger.
+    Level1SkipIo = 1,
+}
+
+/// TestAction request.
+///
+/// Field ids mirror mainline `DdiTestActionReq` (`serde/ddi/types/src/test_ops.rs`)
+/// so the host's request decodes byte-for-byte.  MBOR maps are *sparse* — only
+/// `Some` fields are serialized — so an action that carries no parameter (like
+/// `Level1SkipIo`) rides the wire as just `[id 1 -> action]`.  This bring-up
+/// therefore declares only `action`; parameterized actions add their fields as
+/// contiguous id slots (matching the host's ids/types) as they are ported.
+#[derive(Debug, Ddi)]
+#[ddi(map)]
+pub struct DdiTestActionReq {
+    /// Selected test action.
+    #[ddi(id = 1)]
+    pub action: DdiTestAction,
+}
+
+/// TestAction response.  `result` is an optional reusable 4-byte out param used
+/// by certain actions; `None` for parameterless actions like `Level1SkipIo`.
+/// Host id 1.
+#[derive(Debug, Ddi)]
+#[ddi(map)]
+pub struct DdiTestActionResp {
+    #[ddi(id = 1)]
+    pub result: Option<u32>,
+}
+
+ddi_op_req_resp!(DdiTestAction);
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, unsafe_code)]
+mod tests {
+    extern crate std;
+
+    use azihsm_fw_ddi_mbor::DmaBuf;
+    use azihsm_fw_ddi_mbor::MborDecode;
+    use azihsm_fw_ddi_mbor::MborDecoder;
+    use azihsm_fw_ddi_mbor::MborEncode;
+    use azihsm_fw_ddi_mbor::MborEncoder;
+
+    use super::*;
+
+    /// Brand a plain test buffer as `&mut DmaBuf` so it can drive a decoder.
+    fn dma(buf: &mut [u8]) -> &mut DmaBuf {
+        // SAFETY: No real DMA hardware is involved in tests; the buffer is
+        // only read/written by the codec, never submitted to a DMA engine.
+        unsafe { DmaBuf::from_raw_mut(buf) }
+    }
+
+    /// A `Level1SkipIo` request carries only `action` on the wire
+    /// (`[id 1 -> 1]`) and must round-trip through the exact host-encode ->
+    /// firmware-decode path the dispatch handler runs.
+    #[test]
+    fn level1_skip_io_round_trips() {
+        let req = DdiTestActionReq {
+            action: DdiTestAction::Level1SkipIo,
+        };
+        let mut buf = [0u8; 32];
+        let n = {
+            let mut enc = MborEncoder::new(&mut buf);
+            req.mbor_encode(&mut enc).unwrap();
+            enc.position()
+        };
+        let mut dec = MborDecoder::new(dma(&mut buf[..n]));
+        let got = DdiTestActionReq::mbor_decode(&mut dec).unwrap();
+        assert_eq!(got.action, DdiTestAction::Level1SkipIo);
+    }
+
+    /// The response type round-trips its optional `result` out-param.
+    #[test]
+    fn resp_round_trips() {
+        let mut buf = [0u8; 32];
+        let resp = DdiTestActionResp { result: Some(0) };
+        let n = {
+            let mut enc = MborEncoder::new(&mut buf);
+            resp.mbor_encode(&mut enc).unwrap();
+            enc.position()
+        };
+        let mut dec = MborDecoder::new(dma(&mut buf[..n]));
+        let got = DdiTestActionResp::mbor_decode(&mut dec).unwrap();
+        assert_eq!(got.result, Some(0));
+    }
+}

--- a/fw/core/ddi/mbor/types/src/test_action.rs
+++ b/fw/core/ddi/mbor/types/src/test_action.rs
@@ -5,12 +5,11 @@
 //!
 //! `TestAction` multiplexes a family of validation / fault-injection
 //! sub-actions selected by [`DdiTestAction`].  This refactor bring-up
-//! stands up the **framework**: the request mirrors the mainline host wire
-//! layout (`Martichoras/api/ddi/test_hooks/src/test_ops.rs`) up to the slot
-//! this firmware actually consumes (`force_pka_instance`, id 5), so the host
-//! ABI decodes correctly.  Only `ForcePkaInstance` is handled today; other
-//! action variants and their request sub-structs are ported incrementally as
-//! each action is brought up.
+//! stands up the **framework**: the request mirrors the host wire layout for
+//! the fields this firmware currently consumes. For the bring-up, the request
+//! is just the `action` selector (id 1) and only `Level1SkipIo` is supported.
+//! Other action variants and their parameter fields are ported incrementally
+//! as each action is brought up.
 //!
 //! ## Wire-layout invariant
 //! The `#[ddi(map)]` derive requires **contiguous** field ids and decodes

--- a/fw/core/lib/Cargo.toml
+++ b/fw/core/lib/Cargo.toml
@@ -36,5 +36,7 @@ zerocopy.workspace = true
 
 [features]
 default = ["std"]
+fips_validation_hooks = ["azihsm_fw_ddi_mbor_types/fips_validation_hooks"]
+mcr_test_hooks = ["azihsm_fw_ddi_mbor_types/mcr_test_hooks"]
 std = []
 tracing = []

--- a/fw/core/lib/src/ddi/mbor/mod.rs
+++ b/fw/core/lib/src/ddi/mbor/mod.rs
@@ -34,6 +34,8 @@ pub(crate) mod rsa_mod_exp;
 pub(crate) mod rsa_unwrap;
 pub(crate) mod set_sealed_bk3;
 pub(crate) mod sha_digest;
+#[cfg(any(feature = "mcr_test_hooks", feature = "fips_validation_hooks"))]
+pub(crate) mod test_action;
 pub(crate) mod unmask_key;
 
 pub(crate) use aes_encrypt_decrypt::*;
@@ -69,6 +71,8 @@ pub(crate) use rsa_mod_exp::*;
 pub(crate) use rsa_unwrap::*;
 pub(crate) use set_sealed_bk3::*;
 pub(crate) use sha_digest::*;
+#[cfg(any(feature = "mcr_test_hooks", feature = "fips_validation_hooks"))]
+pub(crate) use test_action::*;
 pub(crate) use unmask_key::*;
 
 use super::*;
@@ -166,6 +170,8 @@ pub(crate) async fn dispatch<'p, P: HsmPal>(
         DdiOp::GetCertChainInfo => get_cert_chain_info(pal, io, decoder, hdr).await,
         DdiOp::GetCertificate => get_certificate(pal, io, decoder, hdr).await,
         DdiOp::ShaDigest => sha_digest(pal, io, decoder, hdr).await,
+        #[cfg(any(feature = "mcr_test_hooks", feature = "fips_validation_hooks"))]
+        DdiOp::TestAction => test_action(pal, io, decoder, hdr).await,
         DdiOp::GetEstablishCredEncryptionKey => {
             get_establish_cred_encryption_key(pal, io, decoder, hdr).await
         }

--- a/fw/core/lib/src/ddi/mbor/test_action.rs
+++ b/fw/core/lib/src/ddi/mbor/test_action.rs
@@ -1,0 +1,54 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! DDI `TestAction` command handler (op 2004).
+//!
+//! Multiplexes validation / fault-injection sub-actions selected by
+//! [`DdiTestAction`].  This refactor bring-up wires a single placeholder
+//! action, `Level1SkipIo`, to prove the dispatch → decode → encode path end
+//! to end; every other action returns `UnsupportedCmd`.  New actions are
+//! added as one `match` arm (plus a PAL hook if hardware access is needed) —
+//! the dispatch/encode skeleton never changes.
+
+use azihsm_fw_ddi_mbor_types::test_action::DdiTestAction;
+use azihsm_fw_ddi_mbor_types::test_action::DdiTestActionReq;
+use azihsm_fw_ddi_mbor_types::test_action::DdiTestActionResp;
+
+use super::*;
+
+/// Handle `DdiTestActionCmd`.
+pub(crate) async fn test_action<'p, P: HsmPal>(
+    pal: &'p P,
+    io: &impl HsmIo,
+    decoder: &mut DdiDecoder<'_>,
+    hdr: &DdiReqHdr,
+) -> HsmResult<&'p DmaBuf> {
+    let body: DdiTestActionReq = decoder.decode_data()?;
+
+    // Optional 4-byte result some actions return; stays `None` unless an arm
+    // sets it (the placeholder action does not — add `mut` when one does).
+    let result: Option<u32> = None;
+
+    match body.action {
+        DdiTestAction::Level1SkipIo => {
+            // Placeholder bring-up: the request is decoded and dispatched
+            // here, but the Level-1 skip-IO backend is not yet wired.
+            // Returning success lets the host confirm the TestAction hook is
+            // reachable end to end.
+            azihsm_fw_hsm_core_tracing::info!(
+                "test_action",
+                "Level1SkipIo (placeholder) dispatched"
+            );
+        }
+        _ => return Err(HsmError::UnsupportedCmd),
+    }
+
+    let resp = pal.dma_alloc_var(io, |buf| {
+        super::encode_resp(
+            &super::success_hdr(hdr, DdiOp::TestAction),
+            &DdiTestActionResp { result },
+            buf,
+        )
+    })?;
+    Ok(resp)
+}

--- a/fw/plat/uno/fw/app/Cargo.toml
+++ b/fw/plat/uno/fw/app/Cargo.toml
@@ -35,6 +35,8 @@ embassy-time = { workspace = true }
 [features]
 #default = ["trace-uart"]
 default = []
+fips_validation_hooks = ["azihsm_fw_hsm_core/fips_validation_hooks"]
+mcr_test_hooks = ["azihsm_fw_hsm_core/mcr_test_hooks"]
 
 # Enable ARM semihosting integration for the emulator:
 #   - The PAL emits `SYS_READY` when the boot handshake completes, so the


### PR DESCRIPTION
# Summary
Wire the DDI TestAction command (op 2004) end to end through the async
refactor so a host test hook can reach the device. This is a bring-up
skeleton that proves the dispatch → decode → handler → encode path; it is
not a real fault-injection backend. The whole surface is gated behind
mcr_test_hooks / fips_validation_hooks and compiles out of production
builds.

# Supported actions
- Level1SkipIo — placeholder: decoded and dispatched, logs via the tracing
  facade, and returns success so the host can confirm the hook is reachable.
  The Level-1 skip-IO backend is not yet ported (follow-up).
- All other actions return UnsupportedCmd.

# What changed
- azihsm_fw_ddi_mbor_types: add the test_action module — DdiTestActionReq /
  DdiTestActionResp and the DdiTestAction selector. Discriminants match the
  host's mainline DdiTestAction for ABI parity. The request collapses to a
  single `action` field: Level1SkipIo is parameterless, so on the wire it is
  just [id 1 -> 1] and the sparse MBOR map needs no further fields. Declare
  mcr_test_hooks / fips_validation_hooks (the crate had no features) and gate
  the module on them.
- azihsm_fw_hsm_core: add the TestAction handler; gate the handler module,
  its re-export, and the dispatch arm on the same features; forward both
  features down to azihsm_fw_ddi_mbor_types.
- uno app: forward mcr_test_hooks / fips_validation_hooks so an EVB
  test-hook build turns the types on transitively.
- Added a round-trip unit test for the request and response encodings.

# Verified
- On the EVB the request decodes and the handler dispatches
  (UART: "Level1SkipIo (placeholder) dispatched", DdiStatus 0).
