### PR TITLE
[emu] enforce TBOR per-handle session limits

### DIFF
--- a/ddi/emu/src/dev.rs
+++ b/ddi/emu/src/dev.rs
@@ -544,7 +544,9 @@ fn validate_tbor_session_request(
     match kind {
         azihsm_ddi_tbor_types::SessionControlKind::NoSession => {
             if req_session_id.is_some() {
-                Err(DdiError::DdiStatus(DdiStatus::InvalidArg))
+                Err(DdiError::TborStatus(
+                    azihsm_ddi_tbor_types::TborStatus::InvalidArg,
+                ))
             } else {
                 Ok(())
             }
@@ -552,7 +554,9 @@ fn validate_tbor_session_request(
         azihsm_ddi_tbor_types::SessionControlKind::Open => {
             match (current_session_id, req_session_id) {
                 (None, None) => Ok(()),
-                (None, Some(_)) => Err(DdiError::DdiStatus(DdiStatus::InvalidArg)),
+                (None, Some(_)) => Err(DdiError::TborStatus(
+                    azihsm_ddi_tbor_types::TborStatus::InvalidArg,
+                )),
                 (Some(_), _) => Err(DdiError::TborStatus(
                     azihsm_ddi_tbor_types::TborStatus::FileHandleSessionLimitReached,
                 )),

--- a/ddi/emu/src/dev.rs
+++ b/ddi/emu/src/dev.rs
@@ -194,7 +194,8 @@ impl DdiDev for DdiEmuDev {
         // ── 1. Validate against current session state ──────────────
         let opcode = req.get_opcode();
         let req_session_id = req.get_session_id();
-        let current_session_id = self.session.lock().session_id;
+        let mut session = self.session.lock();
+        let current_session_id = session.session_id;
         let session_ctrl: SessionControlKind = opcode.into();
         validate_session_request(opcode, req_session_id, current_session_id)?;
 
@@ -257,8 +258,8 @@ impl DdiDev for DdiEmuDev {
         // ── 6. Update session state on Open / Close success ────────
         let kind: SessionControlKind = opcode.into();
         match kind {
-            SessionControlKind::Open => self.session.lock().session_id = hdr.sess_id,
-            SessionControlKind::Close => self.session.lock().session_id = None,
+            SessionControlKind::Open => session.session_id = hdr.sess_id,
+            SessionControlKind::Close => session.session_id = None,
             SessionControlKind::NoSession | SessionControlKind::InSession => {}
         }
 
@@ -275,7 +276,7 @@ impl DdiDev for DdiEmuDev {
             let mut sniff_dec = MborDecoder::new(resp_buf, post_decode);
             let r = DdiOpenSessionCmdResp::mbor_decode(&mut sniff_dec)
                 .map_err(|_| DdiError::MborError(MborError::DecodeError))?;
-            self.session.lock().short_app_id = Some(r.data.short_app_id);
+            session.short_app_id = Some(r.data.short_app_id);
         }
 
         Ok(resp)
@@ -293,7 +294,8 @@ impl DdiDev for DdiEmuDev {
         // Match the native driver's per-file-descriptor session checks before
         // dispatching to firmware, whose session table is global to the HSM.
         let req_session_id = req.get_session_id();
-        let current_session_id = self.session.lock().session_id;
+        let mut session = self.session.lock();
+        let current_session_id = session.session_id;
         validate_tbor_session_request(req.session_ctrl(), req_session_id, current_session_id)?;
 
         // ── 1. Encode the TBOR request into a 4-KiB scratch buffer ─
@@ -416,11 +418,11 @@ impl DdiDev for DdiEmuDev {
                         })
                     })
                 {
-                    self.session.lock().session_id = Some(id);
+                    session.session_id = Some(id);
                 }
             }
             azihsm_ddi_tbor_types::SessionControlKind::Close => {
-                self.session.lock().session_id = None
+                session.session_id = None
             }
             azihsm_ddi_tbor_types::SessionControlKind::InSession
             | azihsm_ddi_tbor_types::SessionControlKind::NoSession => {}

--- a/ddi/emu/src/dev.rs
+++ b/ddi/emu/src/dev.rs
@@ -194,8 +194,7 @@ impl DdiDev for DdiEmuDev {
         // ── 1. Validate against current session state ──────────────
         let opcode = req.get_opcode();
         let req_session_id = req.get_session_id();
-        let mut session = self.session.lock();
-        let current_session_id = session.session_id;
+        let current_session_id = self.session.lock().session_id;
         let session_ctrl: SessionControlKind = opcode.into();
         validate_session_request(opcode, req_session_id, current_session_id)?;
 
@@ -258,8 +257,8 @@ impl DdiDev for DdiEmuDev {
         // ── 6. Update session state on Open / Close success ────────
         let kind: SessionControlKind = opcode.into();
         match kind {
-            SessionControlKind::Open => session.session_id = hdr.sess_id,
-            SessionControlKind::Close => session.session_id = None,
+            SessionControlKind::Open => self.session.lock().session_id = hdr.sess_id,
+            SessionControlKind::Close => self.session.lock().session_id = None,
             SessionControlKind::NoSession | SessionControlKind::InSession => {}
         }
 
@@ -276,7 +275,7 @@ impl DdiDev for DdiEmuDev {
             let mut sniff_dec = MborDecoder::new(resp_buf, post_decode);
             let r = DdiOpenSessionCmdResp::mbor_decode(&mut sniff_dec)
                 .map_err(|_| DdiError::MborError(MborError::DecodeError))?;
-            session.short_app_id = Some(r.data.short_app_id);
+            self.session.lock().short_app_id = Some(r.data.short_app_id);
         }
 
         Ok(resp)
@@ -294,8 +293,7 @@ impl DdiDev for DdiEmuDev {
         // Match the native driver's per-file-descriptor session checks before
         // dispatching to firmware, whose session table is global to the HSM.
         let req_session_id = req.get_session_id();
-        let mut session = self.session.lock();
-        let current_session_id = session.session_id;
+        let current_session_id = self.session.lock().session_id;
         validate_tbor_session_request(req.session_ctrl(), req_session_id, current_session_id)?;
 
         // ── 1. Encode the TBOR request into a 4-KiB scratch buffer ─
@@ -418,11 +416,11 @@ impl DdiDev for DdiEmuDev {
                         })
                     })
                 {
-                    session.session_id = Some(id);
+                    self.session.lock().session_id = Some(id);
                 }
             }
             azihsm_ddi_tbor_types::SessionControlKind::Close => {
-                session.session_id = None
+                self.session.lock().session_id = None
             }
             azihsm_ddi_tbor_types::SessionControlKind::InSession
             | azihsm_ddi_tbor_types::SessionControlKind::NoSession => {}

--- a/ddi/emu/src/dev.rs
+++ b/ddi/emu/src/dev.rs
@@ -421,9 +421,7 @@ impl DdiDev for DdiEmuDev {
                     session.session_id = Some(id);
                 }
             }
-            azihsm_ddi_tbor_types::SessionControlKind::Close => {
-                session.session_id = None
-            }
+            azihsm_ddi_tbor_types::SessionControlKind::Close => session.session_id = None,
             azihsm_ddi_tbor_types::SessionControlKind::InSession
             | azihsm_ddi_tbor_types::SessionControlKind::NoSession => {}
         }

--- a/ddi/emu/src/dev.rs
+++ b/ddi/emu/src/dev.rs
@@ -421,7 +421,9 @@ impl DdiDev for DdiEmuDev {
                     session.session_id = Some(id);
                 }
             }
-            azihsm_ddi_tbor_types::SessionControlKind::Close => session.session_id = None,
+            azihsm_ddi_tbor_types::SessionControlKind::Close => {
+                session.session_id = None
+            }
             azihsm_ddi_tbor_types::SessionControlKind::InSession
             | azihsm_ddi_tbor_types::SessionControlKind::NoSession => {}
         }

--- a/ddi/emu/src/dev.rs
+++ b/ddi/emu/src/dev.rs
@@ -564,6 +564,11 @@ fn validate_tbor_session_request(
         }
         azihsm_ddi_tbor_types::SessionControlKind::Close
         | azihsm_ddi_tbor_types::SessionControlKind::InSession => {
+            if req_session_id.is_none() {
+                return Err(DdiError::TborStatus(
+                    azihsm_ddi_tbor_types::TborStatus::SessionNotFound,
+                ));
+            }
             let Some(current) = current_session_id else {
                 return Err(DdiError::TborStatus(
                     azihsm_ddi_tbor_types::TborStatus::SessionNotFound,

--- a/ddi/emu/src/dev.rs
+++ b/ddi/emu/src/dev.rs
@@ -195,6 +195,7 @@ impl DdiDev for DdiEmuDev {
         let opcode = req.get_opcode();
         let req_session_id = req.get_session_id();
         let current_session_id = self.session.lock().session_id;
+        let session_ctrl: SessionControlKind = opcode.into();
         validate_session_request(opcode, req_session_id, current_session_id)?;
 
         // ── 2. Encode DDI request via host MBOR (wire-compat with fw) ─
@@ -212,7 +213,6 @@ impl DdiDev for DdiEmuDev {
 
         // ── 3. Build SQE and submit on the embedded tokio runtime ─────
         let cmd_id = CMD_COUNTER.fetch_add(1, Ordering::Relaxed);
-        let session_ctrl: SessionControlKind = opcode.into();
         let sqe = SqeBuilder::new()
             .cmd(CmdDword::new().with_op(OP_MBOR).with_id(cmd_id))
             .buf_lens(req_len as u32, SCRATCH_LEN as u32)
@@ -290,6 +290,12 @@ impl DdiDev for DdiEmuDev {
         oob_items: Option<&[&[u8]]>,
         _cookie: &mut Option<DdiCookie>,
     ) -> DdiResult<T::OpResp> {
+        // Match the native driver's per-file-descriptor session checks before
+        // dispatching to firmware, whose session table is global to the HSM.
+        let req_session_id = req.get_session_id();
+        let current_session_id = self.session.lock().session_id;
+        validate_tbor_session_request(req.session_ctrl(), req_session_id, current_session_id)?;
+
         // ── 1. Encode the TBOR request into a 4-KiB scratch buffer ─
         let mut src = AlignedBuf::new(SCRATCH_LEN);
         let mut dst = AlignedBuf::new(SCRATCH_LEN);
@@ -336,7 +342,6 @@ impl DdiDev for DdiEmuDev {
 
         // ── 2. Build SQE with OP_TBOR ──────────────────────────────
         let cmd_id = CMD_COUNTER.fetch_add(1, Ordering::Relaxed);
-        let req_session_id = req.get_session_id();
         let session_ctrl = req.session_ctrl();
         let oob_prp = if oob_len != 0 {
             oob_page.as_slice().as_ptr() as u64
@@ -524,6 +529,47 @@ fn validate_session_request(
             } else {
                 Err(DdiError::DdiStatus(
                     DdiStatus::FileHandleSessionIdDoesNotMatch,
+                ))
+            }
+        }
+    }
+}
+
+/// TBOR equivalent of [`validate_session_request`].
+fn validate_tbor_session_request(
+    kind: azihsm_ddi_tbor_types::SessionControlKind,
+    req_session_id: Option<u16>,
+    current_session_id: Option<u16>,
+) -> Result<(), DdiError> {
+    match kind {
+        azihsm_ddi_tbor_types::SessionControlKind::NoSession => {
+            if req_session_id.is_some() {
+                Err(DdiError::DdiStatus(DdiStatus::InvalidArg))
+            } else {
+                Ok(())
+            }
+        }
+        azihsm_ddi_tbor_types::SessionControlKind::Open => {
+            match (current_session_id, req_session_id) {
+                (None, None) => Ok(()),
+                (None, Some(_)) => Err(DdiError::DdiStatus(DdiStatus::InvalidArg)),
+                (Some(_), _) => Err(DdiError::TborStatus(
+                    azihsm_ddi_tbor_types::TborStatus::FileHandleSessionLimitReached,
+                )),
+            }
+        }
+        azihsm_ddi_tbor_types::SessionControlKind::Close
+        | azihsm_ddi_tbor_types::SessionControlKind::InSession => {
+            let Some(current) = current_session_id else {
+                return Err(DdiError::TborStatus(
+                    azihsm_ddi_tbor_types::TborStatus::SessionNotFound,
+                ));
+            };
+            if Some(current) == req_session_id {
+                Ok(())
+            } else {
+                Err(DdiError::TborStatus(
+                    azihsm_ddi_tbor_types::TborStatus::FileHandleSessionIdDoesNotMatch,
                 ))
             }
         }

--- a/ddi/emu/src/dev.rs
+++ b/ddi/emu/src/dev.rs
@@ -39,6 +39,7 @@ use azihsm_ddi_mbor_types::MborError;
 use azihsm_ddi_mbor_types::SessionControlKind;
 use azihsm_ddi_tbor_types::TborOpReq;
 use azihsm_ddi_tbor_types::TborResp;
+use azihsm_ddi_tbor_types::TborStatus;
 use azihsm_fw_hsm_io::CmdDword;
 use azihsm_fw_hsm_io::Cqe;
 use azihsm_fw_hsm_io::SessionFlags;
@@ -541,44 +542,32 @@ fn validate_tbor_session_request(
     req_session_id: Option<u16>,
     current_session_id: Option<u16>,
 ) -> Result<(), DdiError> {
+    // use local alias to avoid collision with the MBOR `SessionControlKind`.
+    use azihsm_ddi_tbor_types::SessionControlKind;
     match kind {
-        azihsm_ddi_tbor_types::SessionControlKind::NoSession => {
+        SessionControlKind::NoSession => {
             if req_session_id.is_some() {
-                Err(DdiError::TborStatus(
-                    azihsm_ddi_tbor_types::TborStatus::InvalidArg,
-                ))
+                Err(DdiError::TborStatus(TborStatus::InvalidArg))
             } else {
                 Ok(())
             }
         }
-        azihsm_ddi_tbor_types::SessionControlKind::Open => {
-            match (current_session_id, req_session_id) {
-                (None, None) => Ok(()),
-                (None, Some(_)) => Err(DdiError::TborStatus(
-                    azihsm_ddi_tbor_types::TborStatus::InvalidArg,
-                )),
-                (Some(_), _) => Err(DdiError::TborStatus(
-                    azihsm_ddi_tbor_types::TborStatus::FileHandleSessionLimitReached,
-                )),
-            }
-        }
-        azihsm_ddi_tbor_types::SessionControlKind::Close
-        | azihsm_ddi_tbor_types::SessionControlKind::InSession => {
-            if req_session_id.is_none() {
-                return Err(DdiError::TborStatus(
-                    azihsm_ddi_tbor_types::TborStatus::SessionNotFound,
-                ));
-            }
+        SessionControlKind::Open => match (current_session_id, req_session_id) {
+            (None, None) => Ok(()),
+            (None, Some(_)) => Err(DdiError::TborStatus(TborStatus::InvalidArg)),
+            (Some(_), _) => Err(DdiError::TborStatus(
+                TborStatus::FileHandleSessionLimitReached,
+            )),
+        },
+        SessionControlKind::Close | SessionControlKind::InSession => {
             let Some(current) = current_session_id else {
-                return Err(DdiError::TborStatus(
-                    azihsm_ddi_tbor_types::TborStatus::SessionNotFound,
-                ));
+                return Err(DdiError::TborStatus(TborStatus::SessionNotFound));
             };
             if Some(current) == req_session_id {
                 Ok(())
             } else {
                 Err(DdiError::TborStatus(
-                    azihsm_ddi_tbor_types::TborStatus::FileHandleSessionIdDoesNotMatch,
+                    TborStatus::FileHandleSessionIdDoesNotMatch,
                 ))
             }
         }

--- a/ddi/tbor/types/tests/commands/open_session.rs
+++ b/ddi/tbor/types/tests/commands/open_session.rs
@@ -257,7 +257,7 @@ fn open_session_multiple_concurrent() {
 }
 
 // ---------------------------------------------------------------------------
-// Per-fd session limit (hw-only)
+// Per-fd session limit
 // ---------------------------------------------------------------------------
 
 /// Guards against a regression to the old "two `open_session` on the
@@ -268,11 +268,6 @@ fn open_session_multiple_concurrent() {
 /// driver-layer rejection to a `TborStatus`, so the caller sees a
 /// TBOR-typed error for a TBOR command.
 ///
-/// Not applicable on emu: emu's `exec_op_tbor` does not run the
-/// per-fd `validate_session_request` shim, so overlapping opens on a
-/// single Dev succeed there — this is precisely the discrepancy that
-/// motivated the multi-fd rewrite of the other overlap tests.
-#[cfg(not(feature = "emu"))]
 #[test]
 fn open_session_second_on_same_fd_rejected() {
     let ctx = TestCtx::new();

--- a/ddi/tbor/types/tests/commands/open_session.rs
+++ b/ddi/tbor/types/tests/commands/open_session.rs
@@ -263,11 +263,10 @@ fn open_session_multiple_concurrent() {
 /// Guards against a regression to the old "two `open_session` on the
 /// same ctx succeed" behavior. On hw the kernel driver enforces
 /// `AZIHSM_MAX_SESSIONS_PER_FD = 1`, so a second open on the fd that
-/// already owns a live session must be rejected before FW is
-/// dispatched. `exec_op_tbor`'s `map_ioctl_status_tbor` remaps that
-/// driver-layer rejection to a `TborStatus`, so the caller sees a
-/// TBOR-typed error for a TBOR command.
-///
+/// already owns a live session must be rejected before firmware is
+/// dispatched. Native backends remap the driver rejection to
+/// `TborStatus`; emu performs the equivalent per-handle validation
+/// directly and returns the same status.
 #[test]
 fn open_session_second_on_same_fd_rejected() {
     let ctx = TestCtx::new();

--- a/ddi/tbor/types/tests/commands/part_init/crypto_rejects.rs
+++ b/ddi/tbor/types/tests/commands/part_init/crypto_rejects.rs
@@ -614,33 +614,6 @@ fn part_init_envelope_rejected_after_session_closed_emu() {
     ctx.expect_fw_reject(&req, TborStatus::SessionNotFound);
 }
 
-/// Submit PartInit using a session id adjacent to the rotated CO session.
-///
-/// The alternate session resolves through the PartInit session path but is
-/// still associated with the default PSK. Firmware must reject the request
-/// at the default-PSK gate with [`TborStatus::DefaultPskMustRotate`].
-///
-/// This test asserts the exact firmware status so an unrelated rejection
-/// cannot make the test pass.
-#[test]
-fn part_init_alternate_session_requires_psk_rotation_emu() {
-    let ctx = TestCtx::new();
-    let session = bootstrap_rotated_co(&ctx, &ROTATED_CO_PSK);
-
-    let envelope =
-        encrypt_mach_seed_envelope(&session, &mach_seed()).expect("seal mach_seed envelope");
-
-    // `session_id` is a u16. Select a different in-range session id.
-    let alternate_session_id = session
-        .session_id
-        .checked_add(1)
-        .expect("test requires session_id to be less than u16::MAX");
-
-    let req = make_part_init_req(alternate_session_id, envelope);
-
-    ctx.expect_fw_reject(&req, TborStatus::DefaultPskMustRotate);
-}
-
 /// Submit the same valid PartInit request twice.
 ///
 /// The first request initializes the partition successfully. The second

--- a/ddi/tbor/types/tests/commands/part_init/fw_rejects.rs
+++ b/ddi/tbor/types/tests/commands/part_init/fw_rejects.rs
@@ -395,9 +395,11 @@ fn part_init_cu_rejection_does_not_mutate_partition_state_emu() {
 
     assert_fw_rejects(&err, TborStatus::InvalidPermissions);
 
-    let co_session = bootstrap_rotated_co(&ctx, &ROTATED_CO_PSK);
+    let co_ctx = TestCtx::new_with_path(ctx.path());
+    let co_session = bootstrap_rotated_co(&co_ctx, &ROTATED_CO_PSK);
 
-    ctx.part_init(&co_session, &seed, &policy, &thumb)
+    co_ctx
+        .part_init(&co_session, &seed, &policy, &thumb)
         .expect("valid CO PartInit must succeed after CU rejection");
 }
 
@@ -589,11 +591,13 @@ fn part_init_multiple_rejections_do_not_mutate_partition_state_emu() {
 
     assert_fw_rejects(&err, TborStatus::InvalidPermissions);
 
-    // Open an authorized CO session for handler-level validation.
-    let co_session = bootstrap_rotated_co(&ctx, &ROTATED_CO_PSK);
+    // Open an authorized CO session on a separate handle: the CU session
+    // remains live, and each hardware handle permits only one session.
+    let co_ctx = TestCtx::new_with_path(ctx.path());
+    let co_session = bootstrap_rotated_co(&co_ctx, &ROTATED_CO_PSK);
 
     // Third rejection: malformed policy.
-    let err = ctx
+    let err = co_ctx
         .part_init(&co_session, &seed, &bad_policy, &thumb)
         .expect_err("malformed PartPolicy must be rejected");
 
@@ -601,7 +605,8 @@ fn part_init_multiple_rejections_do_not_mutate_partition_state_emu() {
 
     // None of the preceding rejections may have initialized or otherwise
     // mutated the partition.
-    ctx.part_init(&co_session, &seed, &policy, &thumb)
+    co_ctx
+        .part_init(&co_session, &seed, &policy, &thumb)
         .expect("valid PartInit must succeed after multiple rejected requests");
 }
 


### PR DESCRIPTION
This pull request improves session validation logic for TBOR commands in the DDI emulator (`DdiEmuDev`), ensuring that session checks match the native driver's behavior and that errors are reported consistently. It also updates related tests to reflect the new logic.

**Session validation improvements:**

* Added a new function `validate_tbor_session_request` to perform per-file-descriptor session checks for TBOR commands, mirroring the logic used for native driver session management. This ensures that TBOR commands enforce session constraints and return the correct TBOR-typed errors.
* Updated `DdiEmuDev::exec_op_tbor` to call `validate_tbor_session_request` before dispatching to firmware, aligning emulator behavior with hardware and preventing multiple concurrent sessions on the same file descriptor.
* Refactored code to remove redundant session validation and to consistently use the session control kind derived from the opcode. [[1]](diffhunk://#diff-76beaabe6538e02a059401f3e4fd3a947401f823efd97f19257b77eddf31adcfR198) [[2]](diffhunk://#diff-76beaabe6538e02a059401f3e4fd3a947401f823efd97f19257b77eddf31adcfL215) [[3]](diffhunk://#diff-76beaabe6538e02a059401f3e4fd3a947401f823efd97f19257b77eddf31adcfL339)

**Test updates:**

* Updated the `open_session` tests to remove the hardware-only restriction, since the emulator now enforces the per-fd session limit, and removed the `#[cfg(not(feature = "emu"))]` attribute from the relevant test. [[1]](diffhunk://#diff-a50d2998c2833ce1dec0de026534ce1afffcb1720b334a95e4e8a419d4c9e747L260-R260) [[2]](diffhunk://#diff-a50d2998c2833ce1dec0de026534ce1afffcb1720b334a95e4e8a419d4c9e747L271-L275)