### PR TITLE
Tbor DDI tests update

### DIFF
--- a/ddi/tbor/types/tests/SPEC_COVERAGE.md
+++ b/ddi/tbor/types/tests/SPEC_COVERAGE.md
@@ -75,12 +75,12 @@ All test names below are relative to the
 
 | Requirement | Status | Test | Notes |
 |---|---|---|---|
-| Happy path on Active CU session | ✅ | `session_close::session_close_cu_plaintext_active_emu` |  |
-| Happy path on Active CO session | ✅ | `session_close::session_close_co_authenticated_active_emu` |  |
-| Close a Pending-only slot (between Init and Finish) | ✅ | `session_close::session_close_pending_slot_emu` |  |
-| Unknown `session_id` → FW rejection | 🟡 | `session_close::session_close_unknown_id_emu` | Asserts `DdiError::DdiError(_)` |
-| Double-close of the same id → FW rejection | 🟡 | `session_close::session_close_double_close_emu` | Asserts `DdiError::DdiError(_)` |
-| Slot is freed for subsequent open after close | ✅ | `session_close::session_close_then_reopen_emu` |  |
+| Happy path on Active CU session | ✅ | `session_close::session_close_cu_plaintext_active` |  |
+| Happy path on Active CO session | ✅ | `session_close::session_close_co_authenticated_active` |  |
+| Close a Pending-only slot (between Init and Finish) | ✅ | `session_close::session_close_pending_slot` |  |
+| Unknown `session_id` → FW rejection | 🟡 | `session_close::session_close_unknown_id` | Asserts `DdiError::DdiError(_)` |
+| Double-close of the same id → FW rejection | 🟡 | `session_close::session_close_double_close` | Asserts `DdiError::DdiError(_)` |
+| Slot is freed for subsequent open after close | ✅ | `session_close::session_close_then_reopen` |  |
 | Default-PSK gate bypass (E2, both roles) | ✅ | `default_psk_gate::default_psk_gate_session_close_bypass_emu` |  |
 
 ## `PskChange` (opcode in-session, allow-listed)
@@ -106,9 +106,9 @@ All test names below are relative to the
 
 | Requirement | Status | Test | Notes |
 |---|---|---|---|
-| CO session with default PSK → `DefaultPskMustRotate` (dispatcher gate) | ✅ | `part_init::fw_rejects::part_init_reject_default_psk_co_emu` |  |
-| CU session (under rotated PSK) → `InvalidPermissions` (handler role gate) | ✅ | `part_init::fw_rejects::part_init_reject_cu_session_emu` | CU PSK rotated up-front so default-PSK gate doesn't fire first |
-| Rotated CO session with malformed `PartPolicy` (all zeros) → `InvalidArg` (`policy::from_bytes` decode gate) | ✅ | `part_init::fw_rejects::part_init_reject_bad_policy_emu` |  |
+| CO session with default PSK → `DefaultPskMustRotate` (dispatcher gate) | ✅ | `part_init::fw_rejects::part_init_reject_default_psk_co` |  |
+| CU session (under rotated PSK) → `InvalidPermissions` (handler role gate) | ✅ | `part_init::fw_rejects::part_init_reject_cu_session` | CU PSK rotated up-front so default-PSK gate doesn't fire first |
+| Rotated CO session with malformed `PartPolicy` (all zeros) → `InvalidArg` (`policy::from_bytes` decode gate) | ✅ | `part_init::fw_rejects::part_init_reject_bad_policy` |  |
 | Second `PartInit` after a successful one → `PtaKeyAlreadySet` (one-shot `part_set_pta_key` guard) | ✅ | `part_init::happy_path::part_init_smoke_roundtrip_emu` | Verified as step 2 of the smoke roundtrip |
 
 ### Happy-path invariants
@@ -126,11 +126,11 @@ All test names below are relative to the
 
 | Requirement | Status | Test | Notes |
 |---|---|---|---|
-| Ciphertext bit-flip → `AeadEnvelopeAuthFailed` | ✅ | `part_init::crypto_rejects::part_init_envelope_tampered_emu` |  |
-| AAD encodes wrong session id → `AeadEnvelopeAuthFailed` | ✅ | `part_init::crypto_rejects::part_init_wrong_session_id_in_aad_emu` | Constant-compare path in `build_part_init_mach_seed_aad` |
-| Envelope from a different session's `param_key` | ✅ | `part_init::crypto_rejects::part_init_envelope_from_other_session_emu` | Two CO sessions sequentially (close A, open B); CO + Authenticated cannot run concurrent because of `VaultSessionLimitReached` |
-| AAD length ≠ `PART_INIT_MACH_SEED_AAD_LEN` | ✅ | `part_init::crypto_rejects::part_init_wrong_aad_length_emu` | 64-byte AAD; FW length-checks before AAD compare |
-| `mach_seed` plaintext length ≠ `MACH_SEED_LEN` | ✅ 🔁 | `part_init::crypto_rejects::part_init_wrong_mach_seed_length_emu` | Loop over `[MACH_SEED_LEN - 1, MACH_SEED_LEN + 1]`; one rotated-CO session reused across iterations (length check fires before any partition mutation) |
+| Ciphertext bit-flip → `AeadEnvelopeAuthFailed` | ✅ | `part_init::crypto_rejects::part_init_envelope_tampered` |  |
+| AAD encodes wrong session id → `AeadEnvelopeAuthFailed` | ✅ | `part_init::crypto_rejects::part_init_wrong_session_id_in_aad` | Constant-compare path in `build_part_init_mach_seed_aad` |
+| Envelope from a different session's `param_key` | ✅ | `part_init::crypto_rejects::part_init_envelope_from_other_session` | Two CO sessions sequentially (close A, open B); CO + Authenticated cannot run concurrent because of `VaultSessionLimitReached` |
+| AAD length ≠ `PART_INIT_MACH_SEED_AAD_LEN` | ✅ | `part_init::crypto_rejects::part_init_wrong_aad_length` | 64-byte AAD; FW length-checks before AAD compare |
+| `mach_seed` plaintext length ≠ `MACH_SEED_LEN` | ✅ 🔁 | `part_init::crypto_rejects::part_init_wrong_mach_seed_length` | Loop over `[MACH_SEED_LEN - 1, MACH_SEED_LEN + 1]`; one rotated-CO session reused across iterations (length check fires before any partition mutation) |
 | Malformed `pota_thumbprint` length | ⚠️ | — | Wire field is fixed-size; FW reaction not exercised |
 
 ## Default-PSK dispatcher gate (cross-cutting)
@@ -144,7 +144,7 @@ role's partition PSK still matches the compiled-in default.
 | E1: `PskChange` is allow-listed (CO) | ✅ | `default_psk_gate::default_psk_gate_psk_change_bypass_emu` | CU implicitly via `psk_change_happy_cu_emu` |
 | E2: `SessionClose` is allow-listed (both roles) | ✅ | `default_psk_gate::default_psk_gate_session_close_bypass_emu` |  |
 | E3: `SessionOpenInit` is out-of-session (both roles) | ✅ | `default_psk_gate::default_psk_gate_session_open_init_bypass_emu` |  |
-| E4: A non-allow-listed in-session command under default PSK is rejected with `DefaultPskMustRotate` | ✅ | `part_init::fw_rejects::part_init_reject_default_psk_co_emu` | `PartInit` is currently the only such opcode; this row collapses what `default_psk_gate.rs` calls E4 |
+| E4: A non-allow-listed in-session command under default PSK is rejected with `DefaultPskMustRotate` | ✅ | `part_init::fw_rejects::part_init_reject_default_psk_co` | `PartInit` is currently the only such opcode; this row collapses what `default_psk_gate.rs` calls E4 |
 | E5: `ApiRev` is out-of-session | ✅ | `default_psk_gate::default_psk_gate_api_rev_bypass_emu` |  |
 
 ## Host-side TBOR codec (no FW round-trip required)
@@ -170,8 +170,8 @@ The rows marked ⚠️ above, consolidated:
 Indirect coverage (🟡) — these rows assert only `DdiError::DdiError(_)`
 and could be tightened to assert a specific `TborStatus`:
 
-1. `session_close::session_close_unknown_id_emu` — likely `SessionNotFound`.
-2. `session_close::session_close_double_close_emu` — likely `SessionNotFound`.
+1. `session_close::session_close_unknown_id` — likely `SessionNotFound`.
+2. `session_close::session_close_double_close` — likely `SessionNotFound`.
 3. `open_session::session_open_finish_unknown_session_id_emu` — likely `SessionNotFound` or `SessionNotPending`.
 4. `open_session::open_session_double_finish_emu` — likely `SessionNotPending`.
 

--- a/ddi/tbor/types/tests/commands/part_info.rs
+++ b/ddi/tbor/types/tests/commands/part_info.rs
@@ -8,7 +8,7 @@
 //! `part_info_repeated_stable` and
 //! `part_info_independent_of_session_state` guard against per-call
 //! or session-scoped state leaking into the out-of-session handler.
-//! `part_info_reflects_part_init_transition_emu` covers the
+//! `part_info_reflects_part_init_transition` covers the
 //! `Enabled → Initializing` lifecycle transition (emu only, since it
 //! is destructive to partition state).
 //!
@@ -28,7 +28,6 @@ const PART_STATE_ENABLED: u8 = 2;
 
 /// `PartState::Initializing` discriminant — the state a partition enters
 /// after a successful `PartInit` binds its PTA / policy / POTA thumb.
-#[cfg(feature = "emu")]
 const PART_STATE_INITIALIZING: u8 = 4;
 
 /// Assert the invariant device-level fields PartInfo reports for the
@@ -135,9 +134,8 @@ fn part_info_independent_of_session_state() {
 /// SVN) are unchanged across the transition. This is the property that
 /// makes `PartInfo` more than a static device probe — it is the live
 /// view of the bound partition's posture.
-#[cfg(feature = "emu")]
 #[test]
-fn part_info_reflects_part_init_transition_emu() {
+fn part_info_reflects_part_init_transition() {
     use crate::commands::part_init::bootstrap_rotated_co;
     use crate::commands::part_init::known_good_part_policy;
     use crate::commands::part_init::mach_seed;

--- a/ddi/tbor/types/tests/commands/part_init/crypto_rejects.rs
+++ b/ddi/tbor/types/tests/commands/part_init/crypto_rejects.rs
@@ -60,7 +60,7 @@ fn make_part_init_req(session_id: u16, mach_seed_envelope: Vec<u8>) -> TborPartI
 /// tag verification must fail before any plaintext is exposed, and
 /// the handler surfaces [`TborStatus::AeadEnvelopeAuthFailed`].
 #[test]
-fn part_init_envelope_tampered_emu() {
+fn part_init_envelope_tampered() {
     let ctx = TestCtx::new();
 
     let session = bootstrap_rotated_co(&ctx, &ROTATED_CO_PSK);
@@ -88,7 +88,7 @@ fn part_init_envelope_tampered_emu() {
 /// FW uses B's `param_key` for AEAD-GCM verification, so the tag
 /// mismatches and the handler surfaces
 /// [`TborStatus::AeadEnvelopeAuthFailed`]. Mirrors the equivalent
-/// `psk_change_envelope_from_other_session_emu` test.
+/// `psk_change_envelope_from_other_session` test.
 #[test]
 fn part_init_envelope_from_other_session() {
     let ctx = TestCtx::new();
@@ -100,7 +100,7 @@ fn part_init_envelope_from_other_session() {
     // doesn't trip `VaultSessionLimitReached` (the FW caps
     // concurrent CO + Authenticated sessions tighter than CU
     // PlainText, so the equivalent two-CU pattern used by
-    // `psk_change_envelope_from_other_session_emu` can't be reused
+    // `psk_change_envelope_from_other_session` can't be reused
     // here verbatim).
     let session_a = bootstrap_rotated_co(&ctx, &ROTATED_CO_PSK);
     let param_key_a = session_a.param_key.clone();
@@ -145,7 +145,7 @@ fn part_init_wrong_aad_length() {
 /// decode with [`TborStatus::TborInvalidFixedLength`]. Loop over
 /// `MACH_SEED_LEN ± 1` to cover the shortest excursions on either side
 /// of the canonical length. Mirrors
-/// `psk_change_wrong_plaintext_length_emu`.
+/// `psk_change_wrong_plaintext_length`.
 #[test]
 fn part_init_wrong_mach_seed_length() {
     let ctx = TestCtx::new();
@@ -193,7 +193,7 @@ fn part_init_wrong_session_id_in_aad() {
 /// decrypts using the modified IV, so authentication must fail before the
 /// `mach_seed` plaintext is accepted.
 #[test]
-fn part_init_envelope_iv_tampered_emu() {
+fn part_init_envelope_iv_tampered() {
     let ctx = TestCtx::new();
     let session = bootstrap_rotated_co(&ctx, &ROTATED_CO_PSK);
 
@@ -222,7 +222,7 @@ fn part_init_envelope_iv_tampered_emu() {
 /// must fail before firmware reaches the explicit AAD-versus-request-session
 /// comparison.
 #[test]
-fn part_init_envelope_aad_tampered_emu() {
+fn part_init_envelope_aad_tampered() {
     let ctx = TestCtx::new();
     let session = bootstrap_rotated_co(&ctx, &ROTATED_CO_PSK);
 
@@ -249,7 +249,7 @@ fn part_init_envelope_aad_tampered_emu() {
 /// This directly covers the tag-verification failure path independently from
 /// IV, AAD, and ciphertext corruption.
 #[test]
-fn part_init_envelope_tag_tampered_emu() {
+fn part_init_envelope_tag_tampered() {
     let ctx = TestCtx::new();
     let session = bootstrap_rotated_co(&ctx, &ROTATED_CO_PSK);
 
@@ -272,7 +272,7 @@ fn part_init_envelope_tag_tampered_emu() {
 /// Removing or appending one byte must be rejected by TBOR fixed-length
 /// validation before AEAD parsing or partition-state mutation.
 #[test]
-fn part_init_envelope_wrong_fixed_length_emu() {
+fn part_init_envelope_wrong_fixed_length() {
     let ctx = TestCtx::new();
     let session = bootstrap_rotated_co(&ctx, &ROTATED_CO_PSK);
 
@@ -311,7 +311,7 @@ fn part_init_envelope_wrong_fixed_length_emu() {
 /// the same AEAD rejection rather than failing later because the first request
 /// partially initialized or disabled the partition.
 #[test]
-fn part_init_envelope_rejection_is_repeatable_emu() {
+fn part_init_envelope_rejection_is_repeatable() {
     let ctx = TestCtx::new();
     let session = bootstrap_rotated_co(&ctx, &ROTATED_CO_PSK);
 
@@ -345,7 +345,7 @@ fn part_init_envelope_rejection_is_repeatable_emu() {
 /// follow a separate structural-decoding path and return a status other than
 /// `AeadEnvelopeAuthFailed`.
 #[test]
-fn part_init_every_authenticated_envelope_byte_tampered_emu() {
+fn part_init_every_authenticated_envelope_byte_tampered() {
     let ctx = TestCtx::new();
     let session = bootstrap_rotated_co(&ctx, &ROTATED_CO_PSK);
 
@@ -382,7 +382,7 @@ fn part_init_every_authenticated_envelope_byte_tampered_emu() {
 /// This covers empty, very short, header-only, one-byte-short,
 /// one-byte-long, and substantially oversized envelopes.
 #[test]
-fn part_init_envelope_invalid_length_matrix_emu() {
+fn part_init_envelope_invalid_length_matrix() {
     let ctx = TestCtx::new();
     let session = bootstrap_rotated_co(&ctx, &ROTATED_CO_PSK);
 
@@ -432,7 +432,7 @@ fn part_init_envelope_invalid_length_matrix_emu() {
 /// The existing tag test checks one selected bit. This test covers all eight
 /// bit positions in a tag byte.
 #[test]
-fn part_init_envelope_each_tag_bit_tampered_emu() {
+fn part_init_envelope_each_tag_bit_tampered() {
     let ctx = TestCtx::new();
     let session = bootstrap_rotated_co(&ctx, &ROTATED_CO_PSK);
 
@@ -465,7 +465,7 @@ fn part_init_envelope_each_tag_bit_tampered_emu() {
 /// each rejection must leave both the partition and session usable for the
 /// next independently malformed request.
 #[test]
-fn part_init_multiple_distinct_envelope_rejections_are_isolated_emu() {
+fn part_init_multiple_distinct_envelope_rejections_are_isolated() {
     let ctx = TestCtx::new();
     let session = bootstrap_rotated_co(&ctx, &ROTATED_CO_PSK);
 
@@ -511,7 +511,7 @@ fn part_init_multiple_distinct_envelope_rejections_are_isolated_emu() {
 /// This is stronger than submitting two malformed requests: the second
 /// request must complete the normal PartInit path successfully.
 #[test]
-fn part_init_valid_request_succeeds_after_envelope_rejection_emu() {
+fn part_init_valid_request_succeeds_after_envelope_rejection() {
     let ctx = TestCtx::new();
     let session = bootstrap_rotated_co(&ctx, &ROTATED_CO_PSK);
     let seed = mach_seed();
@@ -548,7 +548,7 @@ fn part_init_valid_request_succeeds_after_envelope_rejection_emu() {
 /// Each case uses its own TestCtx because the final valid request initializes
 /// the partition.
 #[test]
-fn part_init_recovers_after_each_envelope_rejection_stage_emu() {
+fn part_init_recovers_after_each_envelope_rejection_stage() {
     enum RejectionCase {
         InvalidFixedLength,
         InvalidAuthentication,
@@ -599,7 +599,7 @@ fn part_init_recovers_after_each_envelope_rejection_stage_emu() {
 /// exists. Firmware must reject the request rather than accepting an
 /// envelope associated with a closed session.
 #[test]
-fn part_init_envelope_rejected_after_session_closed_emu() {
+fn part_init_envelope_rejected_after_session_closed() {
     let ctx = TestCtx::new();
     let session = bootstrap_rotated_co(&ctx, &ROTATED_CO_PSK);
 
@@ -624,7 +624,7 @@ fn part_init_envelope_rejected_after_session_closed_emu() {
 /// This verifies that a valid `mach_seed_envelope` cannot be replayed after
 /// successful partition initialization.
 #[test]
-fn part_init_valid_envelope_cannot_be_replayed_emu() {
+fn part_init_valid_envelope_cannot_be_replayed() {
     let ctx = TestCtx::new();
     let session = bootstrap_rotated_co(&ctx, &ROTATED_CO_PSK);
 
@@ -646,7 +646,7 @@ fn part_init_valid_envelope_cannot_be_replayed_emu() {
 /// authentication failure demonstrates that session B received fresh
 /// cryptographic key material rather than session A's parameter key.
 #[test]
-fn part_init_stale_envelope_rejected_after_session_reopen_emu() {
+fn part_init_stale_envelope_rejected_after_session_reopen() {
     let ctx = TestCtx::new();
 
     let session_a = bootstrap_rotated_co(&ctx, &ROTATED_CO_PSK);
@@ -676,7 +676,7 @@ fn part_init_stale_envelope_rejected_after_session_reopen_emu() {
 /// Firmware currently treats `mach_seed` as opaque input; an all-zero seed
 /// should be accepted as long as the envelope authenticates correctly.
 #[test]
-fn part_init_all_zero_mach_seed_emu() {
+fn part_init_all_zero_mach_seed() {
     let ctx = TestCtx::new();
     let session = bootstrap_rotated_co(&ctx, &ROTATED_CO_PSK);
 
@@ -698,7 +698,7 @@ fn part_init_all_zero_mach_seed_emu() {
 /// its contents therefore must not cause PartInit to reject an otherwise
 /// valid request.
 #[test]
-fn part_init_accepts_nondefault_pota_thumbprint_emu() {
+fn part_init_accepts_nondefault_pota_thumbprint() {
     let ctx = TestCtx::new();
     let session = bootstrap_rotated_co(&ctx, &ROTATED_CO_PSK);
 
@@ -718,7 +718,7 @@ fn part_init_accepts_nondefault_pota_thumbprint_emu() {
 /// Reject an envelope whose four-byte format magic does not match
 /// [`azihsm_crypto::aead_envelope::FORMAT_TAG`].
 #[test]
-fn part_init_envelope_wrong_magic_rejected_emu() {
+fn part_init_envelope_wrong_magic_rejected() {
     let ctx = TestCtx::new();
     let session = bootstrap_rotated_co(&ctx, &ROTATED_CO_PSK);
 
@@ -745,7 +745,7 @@ fn part_init_envelope_wrong_magic_rejected_emu() {
 /// encoded by the four-byte `FORMAT_TAG`, so changing the tag represents an
 /// unsupported envelope version.
 #[test]
-fn part_init_envelope_unsupported_version_rejected_emu() {
+fn part_init_envelope_unsupported_version_rejected() {
     let ctx = TestCtx::new();
     let session = bootstrap_rotated_co(&ctx, &ROTATED_CO_PSK);
 
@@ -772,7 +772,7 @@ fn part_init_envelope_unsupported_version_rejected_emu() {
 ///
 /// Version 1 supports only AES-256-GCM (`AeadAlg` discriminant `0x03`).
 #[test]
-fn part_init_envelope_unsupported_algorithm_rejected_emu() {
+fn part_init_envelope_unsupported_algorithm_rejected() {
     let ctx = TestCtx::new();
     let session = bootstrap_rotated_co(&ctx, &ROTATED_CO_PSK);
 
@@ -796,7 +796,7 @@ fn part_init_envelope_unsupported_algorithm_rejected_emu() {
 ///
 /// The v1 envelope format requires the reserved byte to remain zero.
 #[test]
-fn part_init_envelope_nonzero_reserved_byte_rejected_emu() {
+fn part_init_envelope_nonzero_reserved_byte_rejected() {
     let ctx = TestCtx::new();
     let session = bootstrap_rotated_co(&ctx, &ROTATED_CO_PSK);
 

--- a/ddi/tbor/types/tests/commands/session_close.rs
+++ b/ddi/tbor/types/tests/commands/session_close.rs
@@ -20,8 +20,6 @@
 //! Cross-test isolation comes from `open_dev`'s factory-reset; no
 //! per-test cleanup is required.
 
-#![cfg(feature = "emu")]
-
 use azihsm_ddi_tbor_types::SessionType;
 
 use crate::harness::TestCtx;
@@ -34,7 +32,7 @@ const CU: u8 = 1;
 // ---------------------------------------------------------------------------
 
 #[test]
-fn session_close_cu_plaintext_active_emu() {
+fn session_close_cu_plaintext_active() {
     let ctx = TestCtx::new();
     let session = ctx
         .open_session(CU, SessionType::PlainText)
@@ -43,7 +41,7 @@ fn session_close_cu_plaintext_active_emu() {
 }
 
 #[test]
-fn session_close_co_authenticated_active_emu() {
+fn session_close_co_authenticated_active() {
     let ctx = TestCtx::new();
     let session = ctx
         .open_session(CO, SessionType::Authenticated)
@@ -57,7 +55,7 @@ fn session_close_co_authenticated_active_emu() {
 // ---------------------------------------------------------------------------
 
 #[test]
-fn session_close_pending_slot_emu() {
+fn session_close_pending_slot() {
     let ctx = TestCtx::new();
     let pending = ctx
         .session_open_init(CU, SessionType::PlainText)
@@ -72,7 +70,7 @@ fn session_close_pending_slot_emu() {
 // ---------------------------------------------------------------------------
 
 #[test]
-fn session_close_unknown_id_emu() {
+fn session_close_unknown_id() {
     let ctx = TestCtx::new();
     let err = ctx
         .session_close(0xFFFF)
@@ -84,7 +82,7 @@ fn session_close_unknown_id_emu() {
 }
 
 #[test]
-fn session_close_double_close_emu() {
+fn session_close_double_close() {
     let ctx = TestCtx::new();
     // Take the `SessionHandshake` out of the guard via `.close()` so
     // we own the lifecycle for the second (failing) call. The first
@@ -108,7 +106,7 @@ fn session_close_double_close_emu() {
 // ---------------------------------------------------------------------------
 
 #[test]
-fn session_close_then_reopen_emu() {
+fn session_close_then_reopen() {
     let ctx = TestCtx::new();
     let first = ctx
         .open_session(CU, SessionType::PlainText)


### PR DESCRIPTION
Remove the suffix `_emu` for the tests that are already supported by the hardware.
Remove bad test cases
Eable more tests on the hardware as long as it is supported. 