### PR TITLE
Delete HSM key handles explicitly in the engine

### DIFF
--- a/plugins/ossl_engine/azihsm_ossl_engine/src/context.rs
+++ b/plugins/ossl_engine/azihsm_ossl_engine/src/context.rs
@@ -12,6 +12,7 @@ use std::path::Path;
 use azihsm_api::HsmCredentials;
 use azihsm_api::HsmEccPrivateKey;
 use azihsm_api::HsmError;
+use azihsm_api::HsmKeyDeleteOp;
 use azihsm_api::HsmOwnerBackupKey;
 use azihsm_api::HsmOwnerBackupKeyConfig;
 use azihsm_api::HsmOwnerBackupKeySource;
@@ -142,11 +143,12 @@ impl EngineData {
     }
 
     /// Take ownership of a loaded HSM private key so it lives until the engine
-    /// is destroyed (its `Drop` deletes it from the HSM), and return a stable
-    /// non-owning pointer to it for stashing in `EC_KEY` ex_data. Boxing keeps
-    /// the address stable across `Vec` growth; the returned pointer stays valid
-    /// until this `EngineData` is dropped by the destroy handler, or until
-    /// [`release_loaded_key`](Self::release_loaded_key) drops it early.
+    /// is destroyed (deleted from the HSM at teardown — HSM keys are not
+    /// deleted by their own drop), and return a stable non-owning pointer to
+    /// it for stashing in `EC_KEY` ex_data. Boxing keeps the address stable
+    /// across `Vec` growth; the returned pointer stays valid until this
+    /// `EngineData` is dropped by the destroy handler, or until
+    /// [`release_loaded_key`](Self::release_loaded_key) deletes it early.
     ///
     /// Crate-internal: an implementation detail of the key loader.
     pub(crate) fn retain_loaded_key(&self, key: HsmEccPrivateKey) -> *const HsmEccPrivateKey {
@@ -156,16 +158,39 @@ impl EngineData {
         ptr
     }
 
-    /// Drop a key previously handed to [`retain_loaded_key`](Self::retain_loaded_key),
+    /// Delete a key previously handed to [`retain_loaded_key`](Self::retain_loaded_key),
     /// identified by the pointer it returned. Used to roll back on a partial
     /// load failure (e.g. if stashing the ex_data pointer fails) so the key
     /// doesn't linger in the HSM until engine teardown. A no-op if the pointer
-    /// isn't currently retained. Dropping the box deletes the key from the HSM.
+    /// isn't currently retained.
     pub(crate) fn release_loaded_key(&self, ptr: *const HsmEccPrivateKey) {
-        let mut keys = self.loaded_keys.lock();
-        if let Some(pos) = keys.iter().position(|k| std::ptr::eq(k.as_ref(), ptr)) {
-            keys.remove(pos);
+        let removed = {
+            let mut keys = self.loaded_keys.lock();
+            keys.iter()
+                .position(|k| std::ptr::eq(k.as_ref(), ptr))
+                .map(|pos| keys.remove(pos))
+        };
+        if let Some(key) = removed {
+            delete_hsm_key(*key, "released EC private key");
         }
+    }
+}
+
+impl Drop for EngineData {
+    /// HSM keys are not deleted by their own drop: delete every retained key
+    /// explicitly at engine teardown.
+    fn drop(&mut self) {
+        for key in self.loaded_keys.get_mut().drain(..) {
+            delete_hsm_key(*key, "retained EC private key");
+        }
+    }
+}
+
+/// Best-effort HSM key deletion for cleanup paths: failures are logged, never
+/// propagated (the caller's operation should not fail over cleanup).
+pub(crate) fn delete_hsm_key<K: HsmKeyDeleteOp>(key: K, what: &str) {
+    if let Err(e) = key.delete_key() {
+        tracing::warn!(target: "azihsm", "failed to delete {what} from the HSM: {e}");
     }
 }
 

--- a/plugins/ossl_engine/azihsm_ossl_engine/src/context.rs
+++ b/plugins/ossl_engine/azihsm_ossl_engine/src/context.rs
@@ -53,10 +53,10 @@ pub struct EngineData {
     /// HSM private keys loaded via the engine's `load_private_key` path. Owned
     /// here — never via an `EC_KEY` ex_data free callback, which would leave a
     /// libcrypto-held function pointer into this `.so` (see the module docs of
-    /// [`azihsm_ossl_engine_core::exdata`]). Each key's `Drop` deletes it from
-    /// the HSM; that runs when this `EngineData` is dropped by the destroy
-    /// handler, while the `.so` is loaded. Declared before `hsm` so it drops
-    /// first, while the session is still open.
+    /// [`azihsm_ossl_engine_core::exdata`]). HSM keys are not deleted by their
+    /// own drop: they are deleted explicitly, on `release_loaded_key` and by
+    /// this type's `Drop` at engine teardown (which runs while the `.so` is
+    /// loaded and the session still open).
     ///
     /// Keys therefore accumulate for the engine's lifetime: repeated loads (even
     /// of the same URI) each retain a handle. That is fine for the usual load-key-

--- a/plugins/ossl_engine/azihsm_ossl_engine/src/keygen.rs
+++ b/plugins/ossl_engine/azihsm_ossl_engine/src/keygen.rs
@@ -172,12 +172,11 @@ impl EcKeygenHandler for AzihsmEcKeygen {
                 .build()
                 .map_err(|e| EngineError::wrap("build public key props", e))?;
             let mut algo = HsmEccKeyGenAlgo::default();
-            let (priv_key, pub_key) =
+            // The public half is a software wrapper without a device-side
+            // handle (its delete_key is a documented no-op).
+            let (priv_key, _pub) =
                 HsmKeyManager::generate_key_pair(session, &mut algo, priv_props, pub_props)
                     .map_err(|e| EngineError::wrap("generate EC key pair", e))?;
-            // The EC_KEY carries the public point (pub_key_der_vec on the
-            // private handle); the public HSM handle is unused.
-            crate::context::delete_hsm_key(pub_key, "generated EC public key");
             let exported = priv_key
                 .masked_key_vec()
                 .map_err(|e| EngineError::wrap("export masked key", e))

--- a/plugins/ossl_engine/azihsm_ossl_engine/src/keygen.rs
+++ b/plugins/ossl_engine/azihsm_ossl_engine/src/keygen.rs
@@ -172,22 +172,37 @@ impl EcKeygenHandler for AzihsmEcKeygen {
                 .build()
                 .map_err(|e| EngineError::wrap("build public key props", e))?;
             let mut algo = HsmEccKeyGenAlgo::default();
-            let (priv_key, _pub) =
+            let (priv_key, pub_key) =
                 HsmKeyManager::generate_key_pair(session, &mut algo, priv_props, pub_props)
                     .map_err(|e| EngineError::wrap("generate EC key pair", e))?;
-            let masked = priv_key
+            // The EC_KEY carries the public point (pub_key_der_vec on the
+            // private handle); the public HSM handle is unused.
+            crate::context::delete_hsm_key(pub_key, "generated EC public key");
+            let exported = priv_key
                 .masked_key_vec()
-                .map_err(|e| EngineError::wrap("export masked key", e))?;
-            let pub_der = priv_key
-                .pub_key_der_vec()
-                .map_err(|e| EngineError::wrap("read public key DER", e))?;
-            Ok((priv_key, masked, pub_der))
+                .map_err(|e| EngineError::wrap("export masked key", e))
+                .and_then(|masked| {
+                    priv_key
+                        .pub_key_der_vec()
+                        .map(|pub_der| (masked, pub_der))
+                        .map_err(|e| EngineError::wrap("read public key DER", e))
+                });
+            match exported {
+                Ok((masked, pub_der)) => Ok((priv_key, masked, pub_der)),
+                Err(e) => {
+                    crate::context::delete_hsm_key(priv_key, "generated EC private key");
+                    Err(e)
+                }
+            }
         })?;
 
         // Persist the blob before touching `pkey`, so a write failure surfaces
         // cleanly. (The blob stays valid independently of this key handle: a
         // later unmask imports it as a fresh handle.)
-        write_masked_blob(&params.masked_key_path, &masked)?;
+        if let Err(e) = write_masked_blob(&params.masked_key_path, &masked) {
+            crate::context::delete_hsm_key(priv_key, "generated EC private key");
+            return Err(e);
+        }
 
         // Same engine-bound EC_KEY + retained-HSM-key construction as the
         // loader, then hand it to the caller's EVP_PKEY. set1 up-refs `ec`.

--- a/plugins/ossl_engine/azihsm_ossl_engine/src/keyload.rs
+++ b/plugins/ossl_engine/azihsm_ossl_engine/src/keyload.rs
@@ -135,13 +135,22 @@ fn load_ec(engine: &Engine, data: &EngineData, masked: &[u8]) -> EngineResult<*m
     let priv_key = data.with_session(|session| {
         let mut algo = HsmEccKeyUnmaskAlgo {};
         HsmKeyManager::unmask_key_pair(session, &mut algo, masked)
-            .map(|(private, _public)| private)
+            .map(|(private, public)| {
+                // The EC_KEY carries the public point (pub_key_der_vec on the
+                // private handle); the public HSM handle is unused.
+                crate::context::delete_hsm_key(public, "unmasked EC public key");
+                private
+            })
             .map_err(|e| EngineError::wrap("EC key unmask", e))
     })?;
 
-    let der = priv_key
-        .pub_key_der_vec()
-        .map_err(|e| EngineError::wrap("read EC public key DER", e))?;
+    let der = match priv_key.pub_key_der_vec() {
+        Ok(der) => der,
+        Err(e) => {
+            crate::context::delete_hsm_key(priv_key, "unmasked EC private key");
+            return Err(EngineError::wrap("read EC public key DER", e));
+        }
+    };
 
     build_ec_pkey(engine, data, &der, priv_key)
 }
@@ -157,6 +166,27 @@ pub(crate) fn build_bound_ec_key(
     der: &[u8],
     key: HsmEccPrivateKey,
 ) -> EngineResult<*mut ffi::EC_KEY> {
+    // Pre-attach failures must delete the HSM key (attach_ec's rollback
+    // covers post-attach ones).
+    let ec = match bound_public_ec_key(engine, der) {
+        Ok(ec) => ec,
+        Err(e) => {
+            crate::context::delete_hsm_key(key, "EC private key");
+            return Err(e);
+        }
+    };
+    if let Err(e) = attach_ec(data, ec, key) {
+        // SAFETY: ec is ours and not yet handed out.
+        unsafe { ffi::EC_KEY_free(ec) };
+        return Err(e);
+    }
+    Ok(ec)
+}
+
+/// Parse the SPKI `der` and build an engine-bound `EC_KEY` carrying its group
+/// and public point.
+#[allow(unsafe_code)]
+fn bound_public_ec_key(engine: &Engine, der: &[u8]) -> EngineResult<*mut ffi::EC_KEY> {
     // Parse the SPKI DER into a temporary key just to recover the curve group
     // and public point.
     let parsed =
@@ -198,13 +228,6 @@ pub(crate) fn build_bound_ec_key(
         ));
     }
 
-    // Stash the HSM key in the ex_data (attach_ec rolls the retain back on
-    // failure).
-    if let Err(e) = attach_ec(data, ec, key) {
-        // SAFETY: ec is ours and not yet handed out.
-        unsafe { ffi::EC_KEY_free(ec) };
-        return Err(e);
-    }
     Ok(ec)
 }
 

--- a/plugins/ossl_engine/azihsm_ossl_engine/src/keyload.rs
+++ b/plugins/ossl_engine/azihsm_ossl_engine/src/keyload.rs
@@ -134,13 +134,10 @@ fn read_masked_key(path: &Path) -> EngineResult<Vec<u8>> {
 fn load_ec(engine: &Engine, data: &EngineData, masked: &[u8]) -> EngineResult<*mut ffi::EVP_PKEY> {
     let priv_key = data.with_session(|session| {
         let mut algo = HsmEccKeyUnmaskAlgo {};
+        // The public half is a software wrapper without a device-side handle
+        // (its delete_key is a documented no-op).
         HsmKeyManager::unmask_key_pair(session, &mut algo, masked)
-            .map(|(private, public)| {
-                // The EC_KEY carries the public point (pub_key_der_vec on the
-                // private handle); the public HSM handle is unused.
-                crate::context::delete_hsm_key(public, "unmasked EC public key");
-                private
-            })
+            .map(|(private, _public)| private)
             .map_err(|e| EngineError::wrap("EC key unmask", e))
     })?;
 


### PR DESCRIPTION
## Problem

HSM keys are not deleted by dropping their Rust handles — deletion is an explicit HSM operation (`HsmKeyDeleteOp::delete_key`), and the engine never issued it. Concretely:

- `EngineData::release_loaded_key` and engine teardown only dropped the retained `Box<HsmEccPrivateKey>`, so every loaded or generated private key stayed resident in the HSM (the comments claiming drop-side deletion were incorrect).
- Several failure paths (masked-export errors, blob-persist errors, pre-attach errors in `build_bound_ec_key`) dropped the private handle without deleting it.

The 3.x provider's lifecycle is the reference: its keymgmt explicitly deletes its device handles when a key is freed. Note the public halves need no treatment at this layer: unlike the provider's DDI-level pair, the Rust API's `HsmEccPublicKey` is a software wrapper without a device-side handle (its `delete_key` is a documented no-op).

## Change

Delete explicitly wherever a private handle's owner lets go:

- `EngineData`: `release_loaded_key` deletes the removed key; a new `Drop` impl deletes every retained key at teardown. Docs corrected.
- Keygen: the private handle is deleted on export and persist failures.
- Loader: the private handle is deleted on the DER-export failure and on every pre-attach failure (`build_bound_ec_key` split so parse/build failures funnel through one delete).

Cleanup deletion is best-effort via a shared `delete_hsm_key` helper: failures are logged as warnings, never propagated over the caller's operation.

## Testing

Verified in the Ubuntu 20.04 + OpenSSL 1.1.1f container: build, clippy (`-D warnings`, with and without mock), unit tests, CLI and C-ABI integration suites — all passing. The change is behavior-invisible outside the HSM (no API or output changes), so existing suites cover the regression surface; the deletion itself is exercised on every load/keygen/release path they drive.
