### PR TITLE
tbor(part_final): parse the driver Metadata Page and run the OOB chain on hardware

### DIFF
--- a/ddi/emu/src/dev.rs
+++ b/ddi/emu/src/dev.rs
@@ -74,6 +74,11 @@ const SCRATCH_LEN: usize = 4096;
 /// Size of one NVMe SGL Data Block descriptor in the out-of-band page.
 const OOB_ENTRY_LEN: usize = 16;
 
+/// Size of a per-item SGL segment. The driver allocates segments in
+/// whole pages, and the firmware walks a segment page-wide, so the
+/// emulator must back each one with a full page too.
+const SGL_SEGMENT_LEN: usize = 4096;
+
 /// Size of one OOB Metadata Page entry
 /// (`xfer_length ‖ rsvd ‖ hw_sgl_mem_paddr`).
 const METADATA_ENTRY_LEN: usize = 16;
@@ -352,13 +357,21 @@ impl DdiDev for DdiEmuDev {
                 // Build each item's single-descriptor SGL segment first,
                 // so their addresses are stable before the page records
                 // them.
+                //
+                // Each segment is a full page, matching the driver
+                // (`coh_mem_sz = seg_cnt * PAGE_SIZE`). The firmware
+                // walks a segment page-wide, so a 16-byte allocation
+                // here would be read out of bounds on the std PAL, where
+                // the "DMA" is a raw pointer read.
                 for item in items.iter() {
-                    let mut seg = AlignedBuf::new(OOB_ENTRY_LEN);
+                    let mut seg = AlignedBuf::new(SGL_SEGMENT_LEN);
                     let s = seg.as_mut_slice();
                     s[0..8].copy_from_slice(&(item.as_ptr() as u64).to_le_bytes());
                     s[8..12].copy_from_slice(&(item.len() as u32).to_le_bytes());
                     // [12..16] stay zero: rsvd(3) + SGL type nibble 0
-                    // (Data Block).
+                    // (Data Block). The rest of the page stays zero, so
+                    // the firmware's walk terminates once the item's
+                    // `xfer_length` is satisfied.
                     sgl_segs.push(seg);
                 }
 

--- a/ddi/emu/src/dev.rs
+++ b/ddi/emu/src/dev.rs
@@ -74,6 +74,19 @@ const SCRATCH_LEN: usize = 4096;
 /// Size of one NVMe SGL Data Block descriptor in the out-of-band page.
 const OOB_ENTRY_LEN: usize = 16;
 
+/// Size of one OOB Metadata Page entry
+/// (`xfer_length ‖ rsvd ‖ hw_sgl_mem_paddr`).
+const METADATA_ENTRY_LEN: usize = 16;
+
+/// Byte offset of the first Metadata Page entry, past the
+/// `buffer_count` header.
+const METADATA_ENTRY_OFF: usize = 4;
+
+/// Maximum OOB items the device accepts, matching the firmware's
+/// `MAX_OOB_ITEMS` and the driver's
+/// `AZIHSM_MAX_DATA_XFER_DEVICE_BUFFERS`.
+const MAX_OOB_ITEMS: usize = 16;
+
 /// Page size enforced by the firmware platform.
 const PAGE_4K: usize = 4096;
 
@@ -312,39 +325,63 @@ impl DdiDev for DdiEmuDev {
             &src.as_slice()[..req_len]
         );
 
-        // ── 1b. Build the out-of-band SGL Data Block descriptor page ─
+        // ── 1b. Build the out-of-band Metadata Page ─────────────────
         //
-        // Each caller-supplied item becomes one 16-byte NVMe SGL Data
-        // Block descriptor `addr(8, LE) ‖ length(4, LE) ‖ rsvd(3) ‖
-        // type(1)=0` written into a page-aligned buffer the SQE points
-        // at via `oob_prp`/`oob_len`. The device indexes descriptors by
-        // position; the item slices are borrowed (no copy) and stay live
-        // for the duration of the blocking `io` below.
+        // Mirrors what the Linux driver builds (`azihsm_hsm_data_xfer_
+        // metadata`): a 4 KiB page holding `buffer_count: u32` followed
+        // by one 16-byte entry per item —
+        // `xfer_length(4) ‖ rsvd(4) ‖ hw_sgl_mem_paddr(8)`, all LE.
+        //
+        // `hw_sgl_mem_paddr` does not point at the data: it points at a
+        // per-item NVMe SGL *segment*. The emulator's host buffers are
+        // virtually contiguous, so each segment holds exactly one Data
+        // Block descriptor `addr(8) ‖ length(4) ‖ rsvd(3) ‖ type(1)=0`
+        // covering the whole item — hardware may split an item across
+        // several descriptors and the firmware walks them all.
+        //
+        // Item slices are borrowed (no copy) and stay live for the
+        // duration of the blocking `io` below; `sgl_segs` keeps the
+        // per-item segments alive for the same span.
         let mut oob_page = AlignedBuf::new(SCRATCH_LEN);
-        let oob_len = match oob_items {
+        let mut sgl_segs: Vec<AlignedBuf> = Vec::new();
+        let have_oob = match oob_items {
             Some(items) if !items.is_empty() => {
-                let total = items.len() * OOB_ENTRY_LEN;
-                if total > SCRATCH_LEN {
+                if items.len() > MAX_OOB_ITEMS {
                     return Err(DdiError::InvalidParameter);
                 }
-                let page = oob_page.as_mut_slice();
-                for (i, item) in items.iter().enumerate() {
-                    let off = i * OOB_ENTRY_LEN;
-                    let addr = item.as_ptr() as u64;
-                    page[off..off + 8].copy_from_slice(&addr.to_le_bytes());
-                    page[off + 8..off + 12].copy_from_slice(&(item.len() as u32).to_le_bytes());
-                    // bytes [off+12..off+16] stay zero: rsvd (3) +
-                    // SGL descriptor-type nibble 0 (Data Block).
+                // Build each item's single-descriptor SGL segment first,
+                // so their addresses are stable before the page records
+                // them.
+                for item in items.iter() {
+                    let mut seg = AlignedBuf::new(OOB_ENTRY_LEN);
+                    let s = seg.as_mut_slice();
+                    s[0..8].copy_from_slice(&(item.as_ptr() as u64).to_le_bytes());
+                    s[8..12].copy_from_slice(&(item.len() as u32).to_le_bytes());
+                    // [12..16] stay zero: rsvd(3) + SGL type nibble 0
+                    // (Data Block).
+                    sgl_segs.push(seg);
                 }
-                total as u32
+
+                let page = oob_page.as_mut_slice();
+                page[0..4].copy_from_slice(&(items.len() as u32).to_le_bytes());
+                for (i, item) in items.iter().enumerate() {
+                    let off = METADATA_ENTRY_OFF + i * METADATA_ENTRY_LEN;
+                    let seg_addr = sgl_segs[i].as_slice().as_ptr() as u64;
+                    page[off..off + 4].copy_from_slice(&(item.len() as u32).to_le_bytes());
+                    // [off+4..off+8] stay zero: rsvd.
+                    page[off + 8..off + 16].copy_from_slice(&seg_addr.to_le_bytes());
+                }
+                true
             }
-            _ => 0,
+            _ => false,
         };
 
         // ── 2. Build SQE with OP_TBOR ──────────────────────────────
         let cmd_id = CMD_COUNTER.fetch_add(1, Ordering::Relaxed);
         let session_ctrl = req.session_ctrl();
-        let oob_prp = if oob_len != 0 {
+        // Presence is signalled by a non-null `oob_prp`; `oob_len` (DW15)
+        // is left reserved, matching the driver.
+        let oob_prp = if have_oob {
             oob_page.as_slice().as_ptr() as u64
         } else {
             0
@@ -355,7 +392,7 @@ impl DdiDev for DdiEmuDev {
             .src_prp1(src.as_slice().as_ptr() as u64)
             .dst_prp1(dst.as_mut_slice().as_mut_ptr() as u64)
             .oob_prp(oob_prp)
-            .oob_len(oob_len)
+            .oob_len(0)
             .session_flags(
                 SessionFlags::new()
                     .with_ctrl(u8::from(session_ctrl))

--- a/ddi/emu/src/dev.rs
+++ b/ddi/emu/src/dev.rs
@@ -71,9 +71,6 @@ const EMU_PART_RES_MASK: u128 = 1u128 << EMU_PID;
 /// 4-KiB page bound, so we allocate one full page per direction.
 const SCRATCH_LEN: usize = 4096;
 
-/// Size of one NVMe SGL Data Block descriptor in the out-of-band page.
-const OOB_ENTRY_LEN: usize = 16;
-
 /// Size of a per-item SGL segment. The driver allocates segments in
 /// whole pages, and the firmware walks a segment page-wide, so the
 /// emulator must back each one with a full page too.

--- a/ddi/nix/src/dev.rs
+++ b/ddi/nix/src/dev.rs
@@ -168,6 +168,11 @@ pub struct McrIoctlHeader {
 #[repr(u16)]
 pub enum McrCpCmdSet {
     Generic = 0,
+    /// `CP_CMD_SET_DATA_XFER` — selects the driver's data-transfer
+    /// ioctl, the only path that attaches an out-of-band Metadata Page.
+    /// The firmware routes purely on the SQE opcode, so this does not
+    /// change which handler runs.
+    DataXfer = 1,
 }
 
 #[bitfield(u8)]
@@ -274,6 +279,58 @@ ioctl_readwrite!(
     MCR_HSM_IOC_MAGIC,
     MCR_HSM_IOC_SEQ,
     McrCpGenericCmd
+);
+
+/// Maximum number of out-of-band buffers the data-transfer ioctl
+/// accepts (`AZIHSM_MAX_DATA_XFER_BUFFERS`). Deliberately equal to the
+/// firmware's `MAX_OOB_ITEMS`, so a request the host accepts is one the
+/// device can also describe in a single Metadata Page.
+const AZIHSM_MAX_DATA_XFER_BUFFERS: usize = 16;
+
+/// One entry of `struct azi_hsm_dataxfer_buffers::buffers`.
+///
+/// The C layout is `{ __u32 xfer_length; __u8 *buf_addr; }`, i.e. a
+/// 16-byte stride with 4 bytes of tail padding after `xfer_length`;
+/// `#[repr(C)]` reproduces that exactly (verified with `offsetof`).
+#[repr(C)]
+#[derive(Clone, Copy)]
+struct AzihsmDataXferBuffer {
+    xfer_length: u32,
+    buf_addr: *const u8,
+}
+
+/// `struct azi_hsm_dataxfer_buffers` — the caller-supplied description
+/// of the out-of-band items.
+///
+/// The driver walks `buffers[..buffer_cnt]`, DMA-maps each one, and
+/// builds the device-visible Metadata Page (a `buffer_count` header
+/// plus one `{xfer_length, rsvd, hw_sgl_mem_paddr}` entry per item)
+/// itself. The page's physical address lands in SQE DW13-14, which the
+/// firmware reads as `oob_prp`.
+#[repr(C)]
+struct AzihsmDataXferBuffers {
+    buffer_cnt: u32,
+    buffers: [AzihsmDataXferBuffer; AZIHSM_MAX_DATA_XFER_BUFFERS],
+    rsvd: [u32; 128],
+}
+
+/// `struct azihsm_ctrl_data_xfer_cmd` — the generic command plus the
+/// out-of-band buffer list. The leading `generic_cmd` is layout-
+/// identical to the plain generic ioctl, so opcode/session/src/dst are
+/// populated exactly as on the non-OOB path.
+#[repr(C)]
+struct AzihsmCtrlDataXferCmd {
+    generic_cmd: McrCpGenericCmd,
+    dataxfer_buffers: AzihsmDataXferBuffers,
+}
+
+/// `_IOWR('B', 0x7, struct azihsm_ctrl_data_xfer_cmd)`
+const MCR_HSM_IOC_SEQ_DATA_XFER: u8 = 0x07;
+ioctl_readwrite!(
+    azihsm_ctrl_data_xfer_ioctl,
+    MCR_HSM_IOC_MAGIC,
+    MCR_HSM_IOC_SEQ_DATA_XFER,
+    AzihsmCtrlDataXferCmd
 );
 
 // Fast path ioctl definitions and structures
@@ -905,12 +962,12 @@ impl DdiDev for DdiNixDev {
         /// TBOR dispatcher (see `fw/core/lib/src/op.rs::OP_TBOR`).
         const OP_TBOR: u16 = 2;
 
-        // The nix backend does not (yet) forward out-of-band items as
-        // SGL Data Block descriptors. Reject non-empty `oob_items`
-        // loudly rather than silently dropping payloads — any TBOR
-        // opcode that needs OOB data would otherwise misbehave in a
-        // hard-to-diagnose way.
-        if oob_items.is_some_and(|items| !items.is_empty()) {
+        // Out-of-band items are carried by the data-transfer ioctl,
+        // which takes the same generic command plus a buffer list. The
+        // driver DMA-maps each item and builds the device-visible
+        // Metadata Page, so nothing here needs physical addresses.
+        let oob = oob_items.unwrap_or(&[]);
+        if oob.len() > AZIHSM_MAX_DATA_XFER_BUFFERS {
             return Err(DdiError::InvalidParameter);
         }
 
@@ -961,14 +1018,53 @@ impl DdiDev for DdiNixDev {
 
         // ── 3. Issue the ioctl ───────────────────────────────────
         // SAFETY: src/dst pointers above are valid for the duration
-        // of the ioctl call; the buffers outlive `cmd`.
-        let res = unsafe { mcr_ctrl_cmd_generic_ioctl(self.file.read().as_raw_fd(), &mut cmd) };
-        if res.is_err() {
-            self.map_ioctl_status_tbor(cmd.out_data.ioctl_status)?;
-            res.map_err(DdiError::NixError)?;
-        }
-        if cmd.out_data.status != 0 {
-            return Err(DdiError::DdiError(cmd.out_data.status));
+        // of the ioctl call; the buffers outlive `cmd`. On the OOB
+        // path the borrowed `oob` slices likewise outlive the call.
+        let fd = self.file.read().as_raw_fd();
+        let out_data = if oob.is_empty() {
+            let res = unsafe { mcr_ctrl_cmd_generic_ioctl(fd, &mut cmd) };
+            if res.is_err() {
+                self.map_ioctl_status_tbor(cmd.out_data.ioctl_status)?;
+                res.map_err(DdiError::NixError)?;
+            }
+            cmd.out_data
+        } else {
+            let mut buffers = [AzihsmDataXferBuffer {
+                xfer_length: 0,
+                buf_addr: std::ptr::null(),
+            }; AZIHSM_MAX_DATA_XFER_BUFFERS];
+            for (slot, item) in buffers.iter_mut().zip(oob.iter()) {
+                slot.xfer_length = item.len() as u32;
+                slot.buf_addr = item.as_ptr();
+            }
+
+            let mut xfer_cmd = AzihsmCtrlDataXferCmd {
+                generic_cmd: cmd,
+                dataxfer_buffers: AzihsmDataXferBuffers {
+                    buffer_cnt: oob.len() as u32,
+                    buffers,
+                    rsvd: [0; 128],
+                },
+            };
+            // The driver validates `in.cmdset` against the ioctl it was
+            // reached through, so the OOB path must advertise
+            // `DataXfer`. Routing to the TBOR handler still comes from
+            // the opcode in `rsvd1`.
+            xfer_cmd.generic_cmd.in_data.command_set = McrCpCmdSet::DataXfer;
+            // The driver validates the header against the *whole*
+            // data-transfer command, not just the generic prefix.
+            xfer_cmd.generic_cmd.hdr.ioctl_data_size =
+                mem::size_of::<AzihsmCtrlDataXferCmd>() as u32;
+
+            let res = unsafe { azihsm_ctrl_data_xfer_ioctl(fd, &mut xfer_cmd) };
+            if res.is_err() {
+                self.map_ioctl_status_tbor(xfer_cmd.generic_cmd.out_data.ioctl_status)?;
+                res.map_err(DdiError::NixError)?;
+            }
+            xfer_cmd.generic_cmd.out_data
+        };
+        if out_data.status != 0 {
+            return Err(DdiError::DdiError(out_data.status));
         }
 
         // ── 4. Decode the typed response ─────────────────────────
@@ -976,7 +1072,7 @@ impl DdiDev for DdiNixDev {
         // therefore across a trust boundary — clamp it against the
         // allocated response buffer before indexing to avoid a
         // host-side panic on a bogus device value.
-        let resp_len = cmd.out_data.byte_count as usize;
+        let resp_len = out_data.byte_count as usize;
         if resp_len > RESP_BUF_LEN {
             return Err(DdiError::InvalidParameter);
         }

--- a/ddi/nix/src/dev.rs
+++ b/ddi/nix/src/dev.rs
@@ -1017,11 +1017,12 @@ impl DdiDev for DdiNixDev {
         cmd.in_data.dst_buf = resp_buf.as_mut_ptr();
 
         // ── 3. Issue the ioctl ───────────────────────────────────
-        // SAFETY: src/dst pointers above are valid for the duration
-        // of the ioctl call; the buffers outlive `cmd`. On the OOB
-        // path the borrowed `oob` slices likewise outlive the call.
         let fd = self.file.read().as_raw_fd();
         let out_data = if oob.is_empty() {
+            // SAFETY: `cmd` is a valid, fully-initialised
+            // `McrCpGenericCmd`, and the src/dst pointers it holds stay
+            // valid for the duration of the call because `req_buf` and
+            // `resp_buf` outlive it.
             let res = unsafe { mcr_ctrl_cmd_generic_ioctl(fd, &mut cmd) };
             if res.is_err() {
                 self.map_ioctl_status_tbor(cmd.out_data.ioctl_status)?;
@@ -1056,6 +1057,11 @@ impl DdiDev for DdiNixDev {
             xfer_cmd.generic_cmd.hdr.ioctl_data_size =
                 mem::size_of::<AzihsmCtrlDataXferCmd>() as u32;
 
+            // SAFETY: `xfer_cmd` is a valid, fully-initialised
+            // `AzihsmCtrlDataXferCmd`. Its src/dst pointers and the
+            // borrowed `oob` item slices recorded in `buffers` all
+            // outlive this blocking call, so the driver only ever
+            // dereferences live memory.
             let res = unsafe { azihsm_ctrl_data_xfer_ioctl(fd, &mut xfer_cmd) };
             if res.is_err() {
                 self.map_ioctl_status_tbor(xfer_cmd.generic_cmd.out_data.ioctl_status)?;

--- a/ddi/tbor/types/tests/commands/part_final/chain_path.rs
+++ b/ddi/tbor/types/tests/commands/part_final/chain_path.rs
@@ -1,0 +1,230 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! `PartFinal` tests that supply a real PTA certificate chain.
+//!
+//! Every test here carries certificates **out of band** as SGL Data
+//! Blocks, which only the emulator transport implements
+//! (`ddi/emu/src/dev.rs`); `ddi/nix` rejects non-empty `oob_items`, so
+//! these cannot run on hardware until the driver grows an OOB path. The
+//! gates that fire *before* the chain walk live in [`super::fw_rejects`]
+//! and do run on hardware.
+
+#![cfg(feature = "emu")]
+
+use azihsm_ddi_tbor_types::LOCAL_MK_BACKUP_LEN;
+
+use super::*;
+use crate::commands::part_init::part_policy_with_pota;
+use crate::harness::x509_fixture::make_pta_chain;
+use crate::harness::x509_fixture::pta_pub_from_csr;
+use crate::harness::x509_fixture::CaKey;
+use crate::harness::x509_fixture::PtaChain;
+use crate::harness::SessionHandshake;
+
+/// Run `PartInit` on `session` and issue the resulting PTA chain: read
+/// the PTA public key from the returned CSR and certify it under `pota`
+/// (a POTA root → PTA-intermediate chain).
+fn issue_pta_chain(
+    ctx: &TestCtx,
+    session: &SessionHandshake,
+    pota: &CaKey,
+    seed: &[u8],
+    policy: &[u8],
+    thumb: &[u8],
+) -> PtaChain {
+    let init = ctx
+        .part_init(session, seed, policy, thumb)
+        .expect("PartInit roundtrip");
+    make_pta_chain(pota, &pta_pub_from_csr(&init.pta_csr))
+}
+
+/// Happy path: `PartInit` then a first-instantiation `PartFinal`
+/// (no prior backup) with a valid POTA-anchored PTA chain returns a
+/// `local_mk_backup` of the pinned length.
+#[test]
+fn part_final_smoke_roundtrip_emu() {
+    let ctx = TestCtx::new();
+    let session = bootstrap_rotated_co(&ctx, &ROTATED_CO_PSK);
+
+    // The partition owner's POTA trust anchor: its public key is bound
+    // into the policy so the chain can be validated against it.
+    let pota = CaKey::generate();
+    let policy = part_policy_with_pota(&pota.raw_pub());
+    let chain = issue_pta_chain(
+        &ctx,
+        &session,
+        &pota,
+        &mach_seed(),
+        &policy,
+        &pota_thumbprint(),
+    );
+
+    let resp = ctx
+        .part_final(&session, &policy, &[], &chain.der_items())
+        .expect("PartFinal roundtrip");
+
+    assert_eq!(
+        resp.local_mk_backup.len(),
+        LOCAL_MK_BACKUP_LEN,
+        "local_mk_backup must be the masked-envelope length",
+    );
+}
+
+/// Restore path: a `local_mk_backup` minted on one (fresh) device is
+/// accepted on a second device that re-initializes with the same machine
+/// seed/owner.  The PTA key is derived deterministically from the seed +
+/// policy, so the same chain re-validates on the second device.
+#[test]
+fn part_final_restore_prev_backup_emu() {
+    let pota = CaKey::generate();
+    let policy = part_policy_with_pota(&pota.raw_pub());
+    let seed = mach_seed();
+    let thumb = pota_thumbprint();
+
+    // First device: mint a backup, then release the device (drops the
+    // process-global test lock so a second device can be opened).
+    let (backup, chain) = {
+        let ctx1 = TestCtx::new();
+        let session1 = bootstrap_rotated_co(&ctx1, &ROTATED_CO_PSK);
+        let chain = issue_pta_chain(&ctx1, &session1, &pota, &seed, &policy, &thumb);
+        let backup = ctx1
+            .part_final(&session1, &policy, &[], &chain.der_items())
+            .expect("PartFinal roundtrip")
+            .local_mk_backup;
+        (backup, chain)
+    };
+    assert_eq!(backup.len(), LOCAL_MK_BACKUP_LEN);
+
+    // Second device, same seed/owner: restore from the prior backup.
+    let ctx2 = TestCtx::new();
+    let session2 = bootstrap_rotated_co(&ctx2, &ROTATED_CO_PSK);
+    ctx2.part_init(&session2, &seed, &policy, &thumb)
+        .expect("PartInit roundtrip");
+    let resp = ctx2
+        .part_final(&session2, &policy, &backup, &chain.der_items())
+        .expect("PartFinal must restore PartLocalMK from a valid prior backup");
+    assert_eq!(
+        resp.local_mk_backup.len(),
+        LOCAL_MK_BACKUP_LEN,
+        "restored backup must be re-masked to the envelope length",
+    );
+}
+
+/// A tampered `prev_local_mk_backup` must be rejected: flipping a byte in
+/// the tag-bound metadata makes the re-derived `PartLocalBMK` unmask fail
+/// the AEAD tag check, so restore must error rather than mint blindly.
+#[test]
+fn part_final_reject_tampered_backup_emu() {
+    let pota = CaKey::generate();
+    let policy = part_policy_with_pota(&pota.raw_pub());
+    let seed = mach_seed();
+    let thumb = pota_thumbprint();
+
+    // First device: mint a backup, then release the test lock.
+    let (mut backup, chain) = {
+        let ctx1 = TestCtx::new();
+        let session1 = bootstrap_rotated_co(&ctx1, &ROTATED_CO_PSK);
+        let chain = issue_pta_chain(&ctx1, &session1, &pota, &seed, &policy, &thumb);
+        let backup = ctx1
+            .part_final(&session1, &policy, &[], &chain.der_items())
+            .expect("PartFinal roundtrip")
+            .local_mk_backup;
+        (backup, chain)
+    };
+
+    // Corrupt the ciphertext/tag region; AEAD verification must fail.
+    let last = backup.len() - 1;
+    backup[last] ^= 0x01;
+
+    let ctx2 = TestCtx::new();
+    let session2 = bootstrap_rotated_co(&ctx2, &ROTATED_CO_PSK);
+    ctx2.part_init(&session2, &seed, &policy, &thumb)
+        .expect("PartInit roundtrip");
+    ctx2.part_final(&session2, &policy, &backup, &chain.der_items())
+        .expect_err("PartFinal with a tampered backup must fail the AEAD tag check");
+}
+
+/// A PTA chain that is not anchored to the policy `POTAPubKey` must be
+/// rejected: here the chain is rooted at a different CA than the policy's
+/// POTA key, so the anchor requirement is never met.
+#[test]
+fn part_final_reject_unanchored_chain_emu() {
+    let ctx = TestCtx::new();
+    let session = bootstrap_rotated_co(&ctx, &ROTATED_CO_PSK);
+
+    let pota = CaKey::generate();
+    let policy = part_policy_with_pota(&pota.raw_pub());
+    let init = ctx
+        .part_init(&session, &mach_seed(), &policy, &pota_thumbprint())
+        .expect("PartInit roundtrip");
+
+    // Certify the (correct) PTA key under a rogue CA that is not the
+    // policy POTA anchor.
+    let rogue = CaKey::generate();
+    let chain = make_pta_chain(&rogue, &pta_pub_from_csr(&init.pta_csr));
+
+    ctx.part_final(&session, &policy, &[], &chain.der_items())
+        .expect_err("a chain not anchored to the policy POTA must be rejected");
+}
+
+/// A POTA-anchored chain whose terminal (PTA) certificate carries a key
+/// other than the partition PTA key must be rejected
+/// (`PartFinalPtaMismatch`).
+#[test]
+fn part_final_reject_pta_mismatch_emu() {
+    let ctx = TestCtx::new();
+    let session = bootstrap_rotated_co(&ctx, &ROTATED_CO_PSK);
+
+    let pota = CaKey::generate();
+    let policy = part_policy_with_pota(&pota.raw_pub());
+    ctx.part_init(&session, &mach_seed(), &policy, &pota_thumbprint())
+        .expect("PartInit roundtrip");
+
+    // Correctly anchored to POTA, but the PTA cert certifies the wrong
+    // public key (not the partition's PTA).
+    let wrong_pta = CaKey::generate();
+    let chain = make_pta_chain(&pota, &wrong_pta.sec1_pub());
+
+    ctx.part_final(&session, &policy, &[], &chain.der_items())
+        .expect_err("a PTA cert carrying a non-partition key must be rejected");
+}
+
+/// Regression: after `PartFinal` the partition is `Initialized`, and an
+/// `Initialized` partition must continue to serve host IO (the dispatch
+/// enable gate includes `Initialized`).  Before that fix any
+/// post-finalize command — here `PartInfo` — was silently dropped as a
+/// "disabled partition".
+#[test]
+fn part_final_partition_serves_io_when_initialized_emu() {
+    use azihsm_ddi_tbor_types::TborPartInfoReq;
+
+    /// `PartState::Initialized` wire discriminant.
+    const PART_STATE_INITIALIZED: u8 = 5;
+
+    let ctx = TestCtx::new();
+    let session = bootstrap_rotated_co(&ctx, &ROTATED_CO_PSK);
+    let pota = CaKey::generate();
+    let policy = part_policy_with_pota(&pota.raw_pub());
+    let chain = issue_pta_chain(
+        &ctx,
+        &session,
+        &pota,
+        &mach_seed(),
+        &policy,
+        &pota_thumbprint(),
+    );
+
+    ctx.part_final(&session, &policy, &[], &chain.der_items())
+        .expect("PartFinal");
+
+    // The partition is now Initialized; a follow-up command must still be
+    // served rather than dropped as a disabled partition.
+    let info = ctx
+        .tbor(&TborPartInfoReq::new())
+        .expect("PartInfo after PartFinal must be served");
+    assert_eq!(
+        info.part_state, PART_STATE_INITIALIZED,
+        "PartInfo must report Initialized after PartFinal",
+    );
+}

--- a/ddi/tbor/types/tests/commands/part_final/chain_path.rs
+++ b/ddi/tbor/types/tests/commands/part_final/chain_path.rs
@@ -3,19 +3,19 @@
 
 //! `PartFinal` tests that supply a real PTA certificate chain.
 //!
-//! Every test here carries certificates **out of band** as SGL Data
-//! Blocks, which only the emulator transport implements
-//! (`ddi/emu/src/dev.rs`); `ddi/nix` rejects non-empty `oob_items`, so
-//! these cannot run on hardware until the driver grows an OOB path. The
-//! gates that fire *before* the chain walk live in [`super::fw_rejects`]
-//! and do run on hardware.
+//! Every test here carries certificates **out of band**. Both transports
+//! now implement that: `ddi/emu` writes the Metadata Page directly, and
+//! `ddi/nix` hands the items to the driver's data-transfer ioctl, which
+//! DMA-maps them and builds the page in the kernel. So these run on
+//! `emu` **and hardware**. The gates that fire *before* the chain walk
+//! live in [`super::fw_rejects`].
 
-#![cfg(feature = "emu")]
-
+use azihsm_ddi_tbor_types::TborStatus;
 use azihsm_ddi_tbor_types::LOCAL_MK_BACKUP_LEN;
 
 use super::*;
 use crate::commands::part_init::part_policy_with_pota;
+use crate::harness::assertions::assert_fw_rejects;
 use crate::harness::x509_fixture::make_pta_chain;
 use crate::harness::x509_fixture::pta_pub_from_csr;
 use crate::harness::x509_fixture::CaKey;
@@ -43,7 +43,7 @@ fn issue_pta_chain(
 /// (no prior backup) with a valid POTA-anchored PTA chain returns a
 /// `local_mk_backup` of the pinned length.
 #[test]
-fn part_final_smoke_roundtrip_emu() {
+fn part_final_smoke_roundtrip() {
     let ctx = TestCtx::new();
     let session = bootstrap_rotated_co(&ctx, &ROTATED_CO_PSK);
 
@@ -76,7 +76,7 @@ fn part_final_smoke_roundtrip_emu() {
 /// seed/owner.  The PTA key is derived deterministically from the seed +
 /// policy, so the same chain re-validates on the second device.
 #[test]
-fn part_final_restore_prev_backup_emu() {
+fn part_final_restore_prev_backup() {
     let pota = CaKey::generate();
     let policy = part_policy_with_pota(&pota.raw_pub());
     let seed = mach_seed();
@@ -115,7 +115,7 @@ fn part_final_restore_prev_backup_emu() {
 /// the tag-bound metadata makes the re-derived `PartLocalBMK` unmask fail
 /// the AEAD tag check, so restore must error rather than mint blindly.
 #[test]
-fn part_final_reject_tampered_backup_emu() {
+fn part_final_reject_tampered_backup() {
     let pota = CaKey::generate();
     let policy = part_policy_with_pota(&pota.raw_pub());
     let seed = mach_seed();
@@ -149,7 +149,7 @@ fn part_final_reject_tampered_backup_emu() {
 /// rejected: here the chain is rooted at a different CA than the policy's
 /// POTA key, so the anchor requirement is never met.
 #[test]
-fn part_final_reject_unanchored_chain_emu() {
+fn part_final_reject_unanchored_chain() {
     let ctx = TestCtx::new();
     let session = bootstrap_rotated_co(&ctx, &ROTATED_CO_PSK);
 
@@ -164,15 +164,19 @@ fn part_final_reject_unanchored_chain_emu() {
     let rogue = CaKey::generate();
     let chain = make_pta_chain(&rogue, &pta_pub_from_csr(&init.pta_csr));
 
-    ctx.part_final(&session, &policy, &[], &chain.der_items())
+    let err = ctx
+        .part_final(&session, &policy, &[], &chain.der_items())
         .expect_err("a chain not anchored to the policy POTA must be rejected");
+    // Assert the specific status: a bare `expect_err` would also accept
+    // a transport/DMA failure and pass for the wrong reason.
+    assert_fw_rejects(&err, TborStatus::InvalidArg);
 }
 
 /// A POTA-anchored chain whose terminal (PTA) certificate carries a key
 /// other than the partition PTA key must be rejected
 /// (`PartFinalPtaMismatch`).
 #[test]
-fn part_final_reject_pta_mismatch_emu() {
+fn part_final_reject_pta_mismatch() {
     let ctx = TestCtx::new();
     let session = bootstrap_rotated_co(&ctx, &ROTATED_CO_PSK);
 
@@ -186,8 +190,10 @@ fn part_final_reject_pta_mismatch_emu() {
     let wrong_pta = CaKey::generate();
     let chain = make_pta_chain(&pota, &wrong_pta.sec1_pub());
 
-    ctx.part_final(&session, &policy, &[], &chain.der_items())
+    let err = ctx
+        .part_final(&session, &policy, &[], &chain.der_items())
         .expect_err("a PTA cert carrying a non-partition key must be rejected");
+    assert_fw_rejects(&err, TborStatus::PartFinalPtaMismatch);
 }
 
 /// Regression: after `PartFinal` the partition is `Initialized`, and an
@@ -196,7 +202,7 @@ fn part_final_reject_pta_mismatch_emu() {
 /// post-finalize command — here `PartInfo` — was silently dropped as a
 /// "disabled partition".
 #[test]
-fn part_final_partition_serves_io_when_initialized_emu() {
+fn part_final_partition_serves_io_when_initialized() {
     use azihsm_ddi_tbor_types::TborPartInfoReq;
 
     /// `PartState::Initialized` wire discriminant.

--- a/ddi/tbor/types/tests/commands/part_final/fw_rejects.rs
+++ b/ddi/tbor/types/tests/commands/part_final/fw_rejects.rs
@@ -1,0 +1,51 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! `PartFinal` handler gates that reject **before** the PTA cert-chain
+//! walk.
+//!
+//! These tests supply an empty `certs` slice, so nothing is carried out
+//! of band and no SGL Data Block is referenced. That makes them the only
+//! part of the `PartFinal` surface that runs on real hardware today: the
+//! host-side OOB path is implemented for the emulator only (`ddi/emu`),
+//! while `ddi/nix` still rejects non-empty `oob_items`. Everything that
+//! needs a real chain lives in [`super::chain_path`] and stays emu-gated.
+
+use super::*;
+
+/// `PartFinal` before `PartInit` must be rejected: the partition is not
+/// in the `Initializing` lifecycle state.  This gate fires before the
+/// cert-chain walk, so no chain is supplied.
+#[test]
+fn part_final_reject_wrong_state() {
+    let ctx = TestCtx::new();
+
+    let session = bootstrap_rotated_co(&ctx, &ROTATED_CO_PSK);
+    let policy = known_good_part_policy();
+
+    ctx.part_final(&session, &policy, &[], &[])
+        .expect_err("PartFinal without PartInit must be rejected by the state gate");
+}
+
+/// `PartFinal` re-supplying a policy that does not match the one bound at
+/// `PartInit` must be rejected (`SHA-384(part_policy) != policy_hash`).
+/// This gate fires before the cert-chain walk, so no chain is supplied.
+#[test]
+fn part_final_reject_policy_mismatch() {
+    let ctx = TestCtx::new();
+
+    let session = bootstrap_rotated_co(&ctx, &ROTATED_CO_PSK);
+    let policy = known_good_part_policy();
+
+    ctx.part_init(&session, &mach_seed(), &policy, &pota_thumbprint())
+        .expect("PartInit roundtrip");
+
+    // Flip a byte in the `info` tail (still a structurally valid policy,
+    // but a different SHA-384 digest).
+    let mut wrong = policy;
+    let last = wrong.len() - 2;
+    wrong[last] ^= 0x01;
+
+    ctx.part_final(&session, &wrong, &[], &[])
+        .expect_err("PartFinal with a mismatched policy must be rejected");
+}

--- a/ddi/tbor/types/tests/commands/part_final/fw_rejects.rs
+++ b/ddi/tbor/types/tests/commands/part_final/fw_rejects.rs
@@ -5,11 +5,10 @@
 //! walk.
 //!
 //! These tests supply an empty `certs` slice, so nothing is carried out
-//! of band and no SGL Data Block is referenced. That makes them the only
-//! part of the `PartFinal` surface that runs on real hardware today: the
-//! host-side OOB path is implemented for the emulator only (`ddi/emu`),
-//! while `ddi/nix` still rejects non-empty `oob_items`. Everything that
-//! needs a real chain lives in [`super::chain_path`] and stays emu-gated.
+//! of band and no SGL Data Block is referenced. They therefore exercise
+//! the handler gates in isolation from the OOB transport. The tests that
+//! supply a real chain live in [`super::chain_path`] and now run on
+//! hardware too, via the driver's data-transfer ioctl.
 //!
 //! The reachable gates, in the order the firmware applies them
 //! (`fw/core/lib/src/ddi/tbor/part_final.rs`):
@@ -122,8 +121,10 @@ fn part_final_reject_wrong_state() {
     let session = bootstrap_rotated_co(&ctx, &ROTATED_CO_PSK);
     let policy = known_good_part_policy();
 
-    ctx.part_final(&session, &policy, &[], &[])
+    let err = ctx
+        .part_final(&session, &policy, &[], &[])
         .expect_err("PartFinal without PartInit must be rejected by the state gate");
+    assert_fw_rejects(&err, TborStatus::InvalidArg);
 }
 
 /// `PartFinal` re-supplying a policy that does not match the one bound at
@@ -145,6 +146,8 @@ fn part_final_reject_policy_mismatch() {
     let last = wrong.len() - 2;
     wrong[last] ^= 0x01;
 
-    ctx.part_final(&session, &wrong, &[], &[])
+    let err = ctx
+        .part_final(&session, &wrong, &[], &[])
         .expect_err("PartFinal with a mismatched policy must be rejected");
+    assert_fw_rejects(&err, TborStatus::InvalidArg);
 }

--- a/ddi/tbor/types/tests/commands/part_final/fw_rejects.rs
+++ b/ddi/tbor/types/tests/commands/part_final/fw_rejects.rs
@@ -10,8 +10,107 @@
 //! host-side OOB path is implemented for the emulator only (`ddi/emu`),
 //! while `ddi/nix` still rejects non-empty `oob_items`. Everything that
 //! needs a real chain lives in [`super::chain_path`] and stays emu-gated.
+//!
+//! The reachable gates, in the order the firmware applies them
+//! (`fw/core/lib/src/ddi/tbor/part_final.rs`):
+//!
+//! 1. `parse_request` — CO-only role gate, then the
+//!    `prev_local_mk_backup` length check.
+//! 2. `handle` — the `Initializing` lifecycle gate, then
+//!    `SHA-384(part_policy) == policy_hash`.
+//!
+//! Only after those does `validate_pta_chain` touch the OOB page, so
+//! everything above is testable on silicon.
+
+use azihsm_ddi_tbor_types::SessionType;
+use azihsm_ddi_tbor_types::TborStatus;
+use azihsm_ddi_tbor_types::LOCAL_MK_BACKUP_LEN;
+use azihsm_ddi_tbor_types::PSK_LEN;
 
 use super::*;
+use crate::commands::part_init::CU;
+use crate::commands::part_init::ROTATED_CU_PSK;
+use crate::harness::assertions::assert_fw_rejects;
+use crate::harness::session_guard::SessionGuard;
+use crate::harness::SessionOpenInitOptions;
+
+/// Rotates the PSK for `role`, closes the bootstrap session, and opens a
+/// new guarded session under the rotated credential.
+///
+/// `PartFinal` sits behind the dispatcher's default-PSK gate, so a
+/// session opened on the factory PSK would be rejected there rather than
+/// by the handler gate under test. Rotating first makes the request reach
+/// the handler. Mirrors the helper in `part_init::fw_rejects`.
+fn rotate_psk_and_open_role<'a>(
+    ctx: &'a TestCtx,
+    role: u8,
+    sty: SessionType,
+    rotated_psk: &[u8; PSK_LEN],
+) -> SessionGuard<'a> {
+    let bootstrap = ctx.open_session(role, sty).expect("open bootstrap session");
+
+    ctx.psk_change(bootstrap.handshake(), rotated_psk)
+        .expect("rotate role PSK");
+
+    bootstrap
+        .close()
+        .expect("close bootstrap session after PSK rotation");
+
+    let opts = SessionOpenInitOptions::new(role, sty).with_psk(rotated_psk);
+    let pending = ctx
+        .session_open_init_with_options(opts)
+        .expect("session_open_init under rotated PSK");
+    let handshake = ctx
+        .session_open_finish(pending)
+        .expect("session_open_finish under rotated PSK");
+    SessionGuard::new(ctx, handshake)
+}
+
+/// `PartFinal` is CO-only: a CU session must be rejected by the handler's
+/// role gate with [`TborStatus::InvalidPermissions`].
+///
+/// The CU PSK is rotated first so the request clears the default-PSK
+/// dispatcher gate and actually reaches the role check.  This is the
+/// first gate in `parse_request`, so it fires before the cert-chain walk
+/// and needs no out-of-band data.
+#[test]
+fn part_final_reject_cu_session() {
+    let ctx = TestCtx::new();
+
+    let session = rotate_psk_and_open_role(&ctx, CU, SessionType::PlainText, &ROTATED_CU_PSK);
+    let policy = known_good_part_policy();
+
+    let err = ctx
+        .part_final(session.handshake(), &policy, &[], &[])
+        .expect_err("PartFinal on a CU session must be rejected");
+    assert_fw_rejects(&err, TborStatus::InvalidPermissions);
+}
+
+/// A present-but-wrong-length `prev_local_mk_backup` must be rejected.
+///
+/// The field is variable (empty = absent); when present it must be
+/// exactly [`LOCAL_MK_BACKUP_LEN`].  `PartInit` runs first so the
+/// partition is `Initializing` — that way the rejection comes from the
+/// length check in `parse_request` rather than the lifecycle gate, which
+/// also surfaces `InvalidArg`.
+#[test]
+fn part_final_reject_bad_prev_backup_len() {
+    let ctx = TestCtx::new();
+
+    let session = bootstrap_rotated_co(&ctx, &ROTATED_CO_PSK);
+    let policy = known_good_part_policy();
+
+    ctx.part_init(&session, &mach_seed(), &policy, &pota_thumbprint())
+        .expect("PartInit roundtrip");
+
+    // Non-empty (so "absent" does not apply) but not the envelope length.
+    let short_backup = [0u8; LOCAL_MK_BACKUP_LEN - 1];
+
+    let err = ctx
+        .part_final(&session, &policy, &short_backup, &[])
+        .expect_err("PartFinal with a wrong-length prev backup must be rejected");
+    assert_fw_rejects(&err, TborStatus::InvalidArg);
+}
 
 /// `PartFinal` before `PartInit` must be rejected: the partition is not
 /// in the `Initializing` lifecycle state.  This gate fires before the

--- a/ddi/tbor/types/tests/commands/part_final/mod.rs
+++ b/ddi/tbor/types/tests/commands/part_final/mod.rs
@@ -12,12 +12,12 @@
 //! certificate transport, because that is what decides where it can run:
 //!
 //! * [`fw_rejects`] — handler gates that fire *before* the cert-chain
-//!   walk, so they pass an empty `certs` slice and reference no SGL Data
-//!   Block. These run on `emu` **and hardware**.
-//! * [`chain_path`] — everything that supplies a real chain. The
-//!   certificates travel out of band, which only `ddi/emu` implements
-//!   (`ddi/nix` rejects non-empty `oob_items`), so these stay
-//!   `#[cfg(feature = "emu")]` until the driver grows an OOB path.
+//!   walk, so they pass an empty `certs` slice and reference no
+//!   out-of-band page.
+//! * [`chain_path`] — everything that supplies a real chain, carried
+//!   out of band. Both transports implement this (`ddi/emu` writes the
+//!   Metadata Page itself; `ddi/nix` goes through the driver's
+//!   data-transfer ioctl), so these run on emu and hardware alike.
 //!
 //! Cross-test isolation comes from [`TestCtx::new`] (factory-reset +
 //! process-global lock held for the ctx's lifetime), so each test starts

--- a/ddi/tbor/types/tests/commands/part_final/mod.rs
+++ b/ddi/tbor/types/tests/commands/part_final/mod.rs
@@ -1,275 +1,39 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-//! End-to-end `PartFinal` tests against the std-PAL emulator.
+//! Integration tests for the TBOR `PartFinal` command.
 //!
 //! `PartFinal` runs after `PartInit` and finalizes the partition: it
 //! validates the supplied PTA certificate chain (POTA-anchored, terminal
 //! cert == partition PTA key), derives the partition-local masking keys,
-//! and returns the current `local_mk` backup.  These tests drive the full
-//! `OpenSession → PskChange → PartInit → PartFinal` flow, generating a
-//! real POTA-anchored PTA chain on the host (see
-//! [`crate::harness::x509_fixture`]) and feeding its certificates out of
-//! band so the firmware `x509-chain` validator runs for real.
+//! and returns the current `local_mk` backup.
+//!
+//! Submodules are split by whether the test needs the **out-of-band**
+//! certificate transport, because that is what decides where it can run:
+//!
+//! * [`fw_rejects`] — handler gates that fire *before* the cert-chain
+//!   walk, so they pass an empty `certs` slice and reference no SGL Data
+//!   Block. These run on `emu` **and hardware**.
+//! * [`chain_path`] — everything that supplies a real chain. The
+//!   certificates travel out of band, which only `ddi/emu` implements
+//!   (`ddi/nix` rejects non-empty `oob_items`), so these stay
+//!   `#[cfg(feature = "emu")]` until the driver grows an OOB path.
+//!
+//! Cross-test isolation comes from [`TestCtx::new`] (factory-reset +
+//! process-global lock held for the ctx's lifetime), so each test starts
+//! from a pristine `Enabled` partition with the canonical default PSKs.
+//!
+//! Bootstrap helpers and the wire-correct policy/seed/thumbprint
+//! fixtures are shared with `PartInit` and re-exported here via
+//! `use super::part_init::*`-style imports so each submodule can reach
+//! them through `super::*`.
 
-#![cfg(feature = "emu")]
+pub(super) use crate::commands::part_init::bootstrap_rotated_co;
+pub(super) use crate::commands::part_init::known_good_part_policy;
+pub(super) use crate::commands::part_init::mach_seed;
+pub(super) use crate::commands::part_init::pota_thumbprint;
+pub(super) use crate::commands::part_init::ROTATED_CO_PSK;
+pub(super) use crate::harness::TestCtx;
 
-use azihsm_ddi_tbor_types::LOCAL_MK_BACKUP_LEN;
-
-use crate::commands::part_init::bootstrap_rotated_co;
-use crate::commands::part_init::known_good_part_policy;
-use crate::commands::part_init::mach_seed;
-use crate::commands::part_init::part_policy_with_pota;
-use crate::commands::part_init::pota_thumbprint;
-use crate::commands::part_init::ROTATED_CO_PSK;
-use crate::harness::x509_fixture::make_pta_chain;
-use crate::harness::x509_fixture::pta_pub_from_csr;
-use crate::harness::x509_fixture::CaKey;
-use crate::harness::x509_fixture::PtaChain;
-use crate::harness::SessionHandshake;
-use crate::harness::TestCtx;
-
-/// Run `PartInit` on `session` and issue the resulting PTA chain: read
-/// the PTA public key from the returned CSR and certify it under `pota`
-/// (a POTA root → PTA-intermediate chain).
-fn issue_pta_chain(
-    ctx: &TestCtx,
-    session: &SessionHandshake,
-    pota: &CaKey,
-    seed: &[u8],
-    policy: &[u8],
-    thumb: &[u8],
-) -> PtaChain {
-    let init = ctx
-        .part_init(session, seed, policy, thumb)
-        .expect("PartInit roundtrip");
-    make_pta_chain(pota, &pta_pub_from_csr(&init.pta_csr))
-}
-
-/// Happy path: `PartInit` then a first-instantiation `PartFinal`
-/// (no prior backup) with a valid POTA-anchored PTA chain returns a
-/// `local_mk_backup` of the pinned length.
-#[test]
-fn part_final_smoke_roundtrip_emu() {
-    let ctx = TestCtx::new();
-    let session = bootstrap_rotated_co(&ctx, &ROTATED_CO_PSK);
-
-    // The partition owner's POTA trust anchor: its public key is bound
-    // into the policy so the chain can be validated against it.
-    let pota = CaKey::generate();
-    let policy = part_policy_with_pota(&pota.raw_pub());
-    let chain = issue_pta_chain(
-        &ctx,
-        &session,
-        &pota,
-        &mach_seed(),
-        &policy,
-        &pota_thumbprint(),
-    );
-
-    let resp = ctx
-        .part_final(&session, &policy, &[], &chain.der_items())
-        .expect("PartFinal roundtrip");
-
-    assert_eq!(
-        resp.local_mk_backup.len(),
-        LOCAL_MK_BACKUP_LEN,
-        "local_mk_backup must be the masked-envelope length",
-    );
-}
-
-/// Restore path: a `local_mk_backup` minted on one (fresh) device is
-/// accepted on a second device that re-initializes with the same machine
-/// seed/owner.  The PTA key is derived deterministically from the seed +
-/// policy, so the same chain re-validates on the second device.
-#[test]
-fn part_final_restore_prev_backup_emu() {
-    let pota = CaKey::generate();
-    let policy = part_policy_with_pota(&pota.raw_pub());
-    let seed = mach_seed();
-    let thumb = pota_thumbprint();
-
-    // First device: mint a backup, then release the device (drops the
-    // process-global test lock so a second device can be opened).
-    let (backup, chain) = {
-        let ctx1 = TestCtx::new();
-        let session1 = bootstrap_rotated_co(&ctx1, &ROTATED_CO_PSK);
-        let chain = issue_pta_chain(&ctx1, &session1, &pota, &seed, &policy, &thumb);
-        let backup = ctx1
-            .part_final(&session1, &policy, &[], &chain.der_items())
-            .expect("PartFinal roundtrip")
-            .local_mk_backup;
-        (backup, chain)
-    };
-    assert_eq!(backup.len(), LOCAL_MK_BACKUP_LEN);
-
-    // Second device, same seed/owner: restore from the prior backup.
-    let ctx2 = TestCtx::new();
-    let session2 = bootstrap_rotated_co(&ctx2, &ROTATED_CO_PSK);
-    ctx2.part_init(&session2, &seed, &policy, &thumb)
-        .expect("PartInit roundtrip");
-    let resp = ctx2
-        .part_final(&session2, &policy, &backup, &chain.der_items())
-        .expect("PartFinal must restore PartLocalMK from a valid prior backup");
-    assert_eq!(
-        resp.local_mk_backup.len(),
-        LOCAL_MK_BACKUP_LEN,
-        "restored backup must be re-masked to the envelope length",
-    );
-}
-
-/// A tampered `prev_local_mk_backup` must be rejected: flipping a byte in
-/// the tag-bound metadata makes the re-derived `PartLocalBMK` unmask fail
-/// the AEAD tag check, so restore must error rather than mint blindly.
-#[test]
-fn part_final_reject_tampered_backup_emu() {
-    let pota = CaKey::generate();
-    let policy = part_policy_with_pota(&pota.raw_pub());
-    let seed = mach_seed();
-    let thumb = pota_thumbprint();
-
-    // First device: mint a backup, then release the test lock.
-    let (mut backup, chain) = {
-        let ctx1 = TestCtx::new();
-        let session1 = bootstrap_rotated_co(&ctx1, &ROTATED_CO_PSK);
-        let chain = issue_pta_chain(&ctx1, &session1, &pota, &seed, &policy, &thumb);
-        let backup = ctx1
-            .part_final(&session1, &policy, &[], &chain.der_items())
-            .expect("PartFinal roundtrip")
-            .local_mk_backup;
-        (backup, chain)
-    };
-
-    // Corrupt the ciphertext/tag region; AEAD verification must fail.
-    let last = backup.len() - 1;
-    backup[last] ^= 0x01;
-
-    let ctx2 = TestCtx::new();
-    let session2 = bootstrap_rotated_co(&ctx2, &ROTATED_CO_PSK);
-    ctx2.part_init(&session2, &seed, &policy, &thumb)
-        .expect("PartInit roundtrip");
-    ctx2.part_final(&session2, &policy, &backup, &chain.der_items())
-        .expect_err("PartFinal with a tampered backup must fail the AEAD tag check");
-}
-
-/// `PartFinal` before `PartInit` must be rejected: the partition is not
-/// in the `Initializing` lifecycle state.  This gate fires before the
-/// cert-chain walk, so no chain is supplied.
-#[test]
-fn part_final_reject_wrong_state_emu() {
-    let ctx = TestCtx::new();
-
-    let session = bootstrap_rotated_co(&ctx, &ROTATED_CO_PSK);
-    let policy = known_good_part_policy();
-
-    ctx.part_final(&session, &policy, &[], &[])
-        .expect_err("PartFinal without PartInit must be rejected by the state gate");
-}
-
-/// `PartFinal` re-supplying a policy that does not match the one bound at
-/// `PartInit` must be rejected (`SHA-384(part_policy) != policy_hash`).
-/// This gate fires before the cert-chain walk, so no chain is supplied.
-#[test]
-fn part_final_reject_policy_mismatch_emu() {
-    let ctx = TestCtx::new();
-
-    let session = bootstrap_rotated_co(&ctx, &ROTATED_CO_PSK);
-    let pota = CaKey::generate();
-    let policy = part_policy_with_pota(&pota.raw_pub());
-
-    ctx.part_init(&session, &mach_seed(), &policy, &pota_thumbprint())
-        .expect("PartInit roundtrip");
-
-    // Flip a byte in the `info` tail (still a structurally valid policy,
-    // but a different SHA-384 digest).
-    let mut wrong = policy;
-    let last = wrong.len() - 2;
-    wrong[last] ^= 0x01;
-
-    ctx.part_final(&session, &wrong, &[], &[])
-        .expect_err("PartFinal with a mismatched policy must be rejected");
-}
-
-/// A PTA chain that is not anchored to the policy `POTAPubKey` must be
-/// rejected: here the chain is rooted at a different CA than the policy's
-/// POTA key, so the anchor requirement is never met.
-#[test]
-fn part_final_reject_unanchored_chain_emu() {
-    let ctx = TestCtx::new();
-    let session = bootstrap_rotated_co(&ctx, &ROTATED_CO_PSK);
-
-    let pota = CaKey::generate();
-    let policy = part_policy_with_pota(&pota.raw_pub());
-    let init = ctx
-        .part_init(&session, &mach_seed(), &policy, &pota_thumbprint())
-        .expect("PartInit roundtrip");
-
-    // Certify the (correct) PTA key under a rogue CA that is not the
-    // policy POTA anchor.
-    let rogue = CaKey::generate();
-    let chain = make_pta_chain(&rogue, &pta_pub_from_csr(&init.pta_csr));
-
-    ctx.part_final(&session, &policy, &[], &chain.der_items())
-        .expect_err("a chain not anchored to the policy POTA must be rejected");
-}
-
-/// A POTA-anchored chain whose terminal (PTA) certificate carries a key
-/// other than the partition PTA key must be rejected
-/// (`PartFinalPtaMismatch`).
-#[test]
-fn part_final_reject_pta_mismatch_emu() {
-    let ctx = TestCtx::new();
-    let session = bootstrap_rotated_co(&ctx, &ROTATED_CO_PSK);
-
-    let pota = CaKey::generate();
-    let policy = part_policy_with_pota(&pota.raw_pub());
-    ctx.part_init(&session, &mach_seed(), &policy, &pota_thumbprint())
-        .expect("PartInit roundtrip");
-
-    // Correctly anchored to POTA, but the PTA cert certifies the wrong
-    // public key (not the partition's PTA).
-    let wrong_pta = CaKey::generate();
-    let chain = make_pta_chain(&pota, &wrong_pta.sec1_pub());
-
-    ctx.part_final(&session, &policy, &[], &chain.der_items())
-        .expect_err("a PTA cert carrying a non-partition key must be rejected");
-}
-
-/// Regression: after `PartFinal` the partition is `Initialized`, and an
-/// `Initialized` partition must continue to serve host IO (the dispatch
-/// enable gate includes `Initialized`).  Before that fix any
-/// post-finalize command — here `PartInfo` — was silently dropped as a
-/// "disabled partition".
-#[test]
-fn part_final_partition_serves_io_when_initialized_emu() {
-    use azihsm_ddi_tbor_types::TborPartInfoReq;
-
-    /// `PartState::Initialized` wire discriminant.
-    const PART_STATE_INITIALIZED: u8 = 5;
-
-    let ctx = TestCtx::new();
-    let session = bootstrap_rotated_co(&ctx, &ROTATED_CO_PSK);
-    let pota = CaKey::generate();
-    let policy = part_policy_with_pota(&pota.raw_pub());
-    let chain = issue_pta_chain(
-        &ctx,
-        &session,
-        &pota,
-        &mach_seed(),
-        &policy,
-        &pota_thumbprint(),
-    );
-
-    ctx.part_final(&session, &policy, &[], &chain.der_items())
-        .expect("PartFinal");
-
-    // The partition is now Initialized; a follow-up command must still be
-    // served rather than dropped as a disabled partition.
-    let info = ctx
-        .tbor(&TborPartInfoReq::new())
-        .expect("PartInfo after PartFinal must be served");
-    assert_eq!(
-        info.part_state, PART_STATE_INITIALIZED,
-        "PartInfo must report Initialized after PartFinal",
-    );
-}
+mod chain_path;
+mod fw_rejects;

--- a/ddi/tbor/types/tests/commands/part_init/mod.rs
+++ b/ddi/tbor/types/tests/commands/part_init/mod.rs
@@ -103,12 +103,6 @@ pub(crate) fn known_good_part_policy() -> [u8; PART_POLICY_LEN] {
 /// Like [`known_good_part_policy`] but with a caller-supplied **real**
 /// `POTAPubKey` (raw P-384 `X ‖ Y`, 96 bytes), so `PartFinal` can validate
 /// a PTA certificate chain anchored to it.
-///
-/// TODO(hw): gated to `feature = "emu"` because the only consumers
-/// (`part_final`, `sd_sealing_key_gen`, `sd_create_remote_backup`)
-/// are not yet supported on hw. Remove this gate once those commands
-/// land on hw.
-#[cfg(feature = "emu")]
 pub(crate) fn part_policy_with_pota(pota_raw: &[u8; 96]) -> [u8; PART_POLICY_LEN] {
     const OFF_POTA: usize = 2;
     let mut bytes = known_good_part_policy();

--- a/ddi/tbor/types/tests/harness/mod.rs
+++ b/ddi/tbor/types/tests/harness/mod.rs
@@ -40,7 +40,6 @@ pub mod ctx;
 pub mod fixture;
 pub mod session;
 pub mod session_guard;
-#[cfg(feature = "emu")]
 pub mod x509_fixture;
 
 // Re-export commonly-used schema items so test code doesn't have to

--- a/fw/core/lib/src/io.rs
+++ b/fw/core/lib/src/io.rs
@@ -443,25 +443,16 @@ impl<P: HsmPal> Hsm<P> {
     fn decode_io_sqe(io: &P::Io) -> Result<IoSqeParams, OpError> {
         let sqe = Sqe::from(io.sqe());
         sqe.validate_io_op()?;
-        // Out-of-band SGL descriptor array (side-band bulk transfers such
-        // as PartFinal's PTA cert chain); `None` when the SQE carries no
-        // OOB region.  A non-zero `oob_len` with a null `oob_prp` is
-        // rejected up front: `validate_io_op` only bounds the OOB length,
-        // so without this a later OOB read would DMA from a null address.
-        let oob_len = sqe.oob_len();
+        // Out-of-band Metadata Page (side-band bulk transfers such as
+        // PartFinal's PTA cert chain); `None` when the SQE carries no OOB
+        // region.  Presence is signalled by a non-null `oob_prp`: the
+        // driver leaves `oob_len` (DW15) reserved, and the Metadata Page
+        // is self-describing via its `buffer_count` header.
         let oob_prp = sqe.oob_prp();
-        let oob = match (oob_len != 0, oob_prp.is_null()) {
-            (false, _) => None,
-            (true, false) => Some(OobPtr {
-                prp: oob_prp,
-                len: oob_len,
-            }),
-            (true, true) => {
-                return Err(OpError::new(
-                    HsmError::InvalidArg,
-                    HostStatus::INVALID_FIELD_IN_COMMAND,
-                ));
-            }
+        let oob = if oob_prp.is_null() {
+            None
+        } else {
+            Some(OobPtr { prp: oob_prp })
         };
         Ok(IoSqeParams {
             src_len: sqe.src_len() as usize,

--- a/fw/core/lib/src/op.rs
+++ b/fw/core/lib/src/op.rs
@@ -43,13 +43,6 @@ const MAX_SRC_LEN: u32 = PAGE_4K;
 /// the GDMA path to plumb a second PRP page (`dst_prp2`).
 const MAX_DST_LEN: u32 = 2 * PAGE_4K;
 
-/// Size of one NVMe SGL Data Block descriptor in the OOB array.
-const OOB_ENTRY_LEN: u32 = 16;
-
-/// Maximum out-of-band descriptor-array length: one 4K descriptor page
-/// (→ up to 256 SGL Data Block descriptors).
-const MAX_OOB_LEN: u32 = PAGE_4K;
-
 /// Returns true if the 64-bit DMA address is 4K-page-aligned.
 #[inline]
 fn is_aligned_4k(addr: HsmDmaAddr) -> bool {
@@ -154,37 +147,26 @@ impl SqeValidateExt for Sqe<'_> {
             ));
         }
 
-        // Optional out-of-band SGL descriptor array (`oob_prp`/`oob_len`).
-        // When present it must be a whole number of 16-byte SGL Data
-        // Block descriptors, no larger than a single descriptor page, and
-        // 4K-page-aligned so the array cannot straddle a page boundary.
-        let oob_len = self.oob_len();
-        if oob_len != 0 {
-            if !oob_len.is_multiple_of(OOB_ENTRY_LEN) || oob_len > MAX_OOB_LEN {
-                error!(
-                    "core",
-                    HsmError::IoChannelInvalidOobLen,
-                    "Invalid OOB descriptor-array length: {}",
-                    oob_len
-                );
-                return Err(OpError::new(
-                    HsmError::IoChannelInvalidOobLen,
-                    HostStatus::INVALID_OOB_LEN,
-                ));
-            }
-
-            if !is_aligned_4k(self.oob_prp()) {
-                error!(
-                    "core",
-                    HsmError::IoChannelInvalidOobAlignment,
-                    "Invalid OOB PRP alignment: {:?}",
-                    self.oob_prp()
-                );
-                return Err(OpError::new(
-                    HsmError::IoChannelInvalidOobAlignment,
-                    HostStatus::INVALID_OOB_PRP,
-                ));
-            }
+        // Optional out-of-band Metadata Page (`oob_prp`).  When present it
+        // must be 4K-page-aligned: the driver allocates it from a
+        // PAGE_SIZE `dma_pool`, and the page is a fixed 4 KiB structure
+        // that must not straddle a page boundary.
+        //
+        // `oob_len` (DW15) is deliberately not validated: the driver
+        // leaves it reserved and the Metadata Page carries its own
+        // `buffer_count` header, so length lives in the page rather than
+        // the SQE.
+        if !self.oob_prp().is_null() && !is_aligned_4k(self.oob_prp()) {
+            error!(
+                "core",
+                HsmError::IoChannelInvalidOobAlignment,
+                "Invalid OOB PRP alignment: {:?}",
+                self.oob_prp()
+            );
+            return Err(OpError::new(
+                HsmError::IoChannelInvalidOobAlignment,
+                HostStatus::INVALID_OOB_PRP,
+            ));
         }
 
         Ok(())

--- a/fw/core/oob/src/lib.rs
+++ b/fw/core/oob/src/lib.rs
@@ -62,12 +62,15 @@ pub const METADATA_ENTRY_OFF: usize = 4;
 /// `AZIHSM_MAX_DATA_XFER_DEVICE_BUFFERS`.
 pub const MAX_OOB_ITEMS: usize = 16;
 
-/// Bytes fetched from a per-item SGL segment in one read, and the
-/// resulting descriptor budget. The driver rejects items needing more
-/// than one segment, and a cert-chain item is a handful of descriptors
-/// at most, so this is ample.
-const SEG_READ_LEN: usize = 256;
-const MAX_SEG_DESCRIPTORS: usize = SEG_READ_LEN / SGL_ENTRY_LEN;
+/// A per-item SGL segment is read in chunks of this size rather than in
+/// one 4 KiB read, to keep the scratch allocation small. The driver
+/// allocates each segment as `seg_cnt * PAGE_SIZE` (so at least one full
+/// page) and rejects items needing more than one segment, hence the
+/// walk is bounded by the page rather than by a fixed descriptor count.
+const SEG_CHUNK_LEN: usize = 256;
+const SEG_CHUNK_DESCRIPTORS: usize = SEG_CHUNK_LEN / SGL_ENTRY_LEN;
+const SEG_PAGE_LEN: usize = 4096;
+const SEG_CHUNKS: usize = SEG_PAGE_LEN / SEG_CHUNK_LEN;
 
 /// Size of the Metadata Page (`METADATA_SIZE` in the driver UAPI).
 const METADATA_PAGE_LEN: usize = 4096;
@@ -205,41 +208,48 @@ where
 
         // ── Walk the item's SGL segment, chunk by chunk ──────────────
         //
-        // The whole segment is fetched once: per-descriptor 16-byte
-        // reads would hit the same GDMA small-transfer fault as the
-        // header, and one read is cheaper. The driver allocates the
-        // segment as a coherent page, so reading `SEG_READ_LEN` from
-        // its (page-aligned) base stays in bounds.
-        let seg = scoped.dma_alloc(SEG_READ_LEN)?;
-        // Also a plain contiguous host buffer — read via PRP, as above.
-        pal.copy_mem_from_host(io, seg_addr, seg, true).await?;
-
+        // The segment is read in `SEG_CHUNK_LEN` slices rather than one
+        // descriptor at a time: 16-byte reads hit the same GDMA
+        // small-transfer fault as the header. The walk spans the whole
+        // segment page, so an item split across many descriptors is
+        // handled; the driver allocates at least one full page per
+        // segment and rejects items needing more than one segment.
+        let seg = scoped.dma_alloc(SEG_CHUNK_LEN)?;
         let mut copied = 0usize;
         let mut tail: &mut DmaBuf = dst;
 
-        for i in 0..MAX_SEG_DESCRIPTORS {
+        'outer: for chunk_idx in 0..SEG_CHUNKS {
             if copied == xfer_length {
                 break;
             }
-            let off = i * SGL_ENTRY_LEN;
+            let chunk_addr = addr_offset(seg_addr, (chunk_idx * SEG_CHUNK_LEN) as u64)?;
+            // Plain contiguous host memory — read via PRP, as above.
+            pal.copy_mem_from_host(io, chunk_addr, seg, true).await?;
 
-            // NVMe SGL Data Block: `addr(8) ‖ length(4) ‖ rsvd(3) ‖ type(1)`.
-            let chunk = le_u32(seg, off + 8)? as usize;
-            if chunk == 0 || copied + chunk > xfer_length {
-                return Err(HsmError::InvalidArg);
+            for i in 0..SEG_CHUNK_DESCRIPTORS {
+                if copied == xfer_length {
+                    break 'outer;
+                }
+                let off = i * SGL_ENTRY_LEN;
+
+                // NVMe SGL Data Block: `addr(8) ‖ length(4) ‖ rsvd(3) ‖ type(1)`.
+                let chunk = le_u32(seg, off + 8)? as usize;
+                if chunk == 0 || copied + chunk > xfer_length {
+                    return Err(HsmError::InvalidArg);
+                }
+
+                // Hand the GDMA exactly this chunk's destination window;
+                // it validates the descriptor length against the slice.
+                let (head, rest) = tail.split_at_mut(chunk);
+                let raw: &[u8; SGL_ENTRY_LEN] = seg
+                    .get(off..off + SGL_ENTRY_LEN)
+                    .and_then(|s| s.try_into().ok())
+                    .ok_or(HsmError::InternalError)?;
+                pal.copy_mem_from_host_raw(io, raw, head, false).await?;
+
+                copied += chunk;
+                tail = rest;
             }
-
-            // Hand the GDMA exactly this chunk's destination window; it
-            // validates the descriptor length against the slice length.
-            let (head, rest) = tail.split_at_mut(chunk);
-            let raw: &[u8; SGL_ENTRY_LEN] = seg
-                .get(off..off + SGL_ENTRY_LEN)
-                .and_then(|s| s.try_into().ok())
-                .ok_or(HsmError::InternalError)?;
-            pal.copy_mem_from_host_raw(io, raw, head, false).await?;
-
-            copied += chunk;
-            tail = rest;
         }
 
         // A segment that never reached `xfer_length` is malformed.

--- a/fw/core/oob/src/lib.rs
+++ b/fw/core/oob/src/lib.rs
@@ -1,22 +1,42 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-//! Out-of-band (OOB) side-band item transfer over NVMe SGL descriptors.
+//! Out-of-band (OOB) side-band item transfer via the host **Metadata
+//! Page**.
 //!
 //! Some TBOR commands carry bulk evidence — DER certificate chains and
 //! COSE_Sign1 attestation reports — **out of band** rather than inside
-//! the 4 KiB request buffer. The SQE's `oob_prp` points at a host page
-//! of 16-byte **NVMe SGL Data Block descriptors**; a TBOR message
-//! references an item by its **index** into that array. [`copy_oob`]
-//! locates the indexed descriptor and forwards it **verbatim** to the
-//! GDMA ([`HsmGdmaController::copy_mem_from_host_raw`]), which interprets
-//! the descriptor and copies the item into a caller-allocated
-//! [`DmaBuf`]. This layer does **no** SGL parsing itself — it only
-//! bounds the index and computes the descriptor's address.
+//! the 4 KiB request buffer. The SQE's `oob_prp` (DW13-14) points at a
+//! single 4 KiB host page, the *Metadata Page*, and a TBOR message
+//! references an item by its **index** into that page.
 //!
-//! The Uno GDMA does not walk PRP lists; each transfer is a single SGL
-//! Data Block (arbitrary address, no page-alignment constraint), so OOB
-//! items are copied one at a time by index.
+//! Layout (mirrors `azihsm_hsm_data_xfer_metadata` in the Linux driver,
+//! `drivers/linux/drvsrc/azihsm_hsm_cmd.h`):
+//!
+//! ```text
+//! offset 0            buffer_count : u32          (1 ..= MAX_OOB_ITEMS)
+//! offset 4 + 16*i     xfer_length      : u32      bytes of item i
+//!                     rsvd             : u32
+//!                     hw_sgl_mem_paddr : u64      -> item i's SGL segment
+//! offset 260..4095    rsvd
+//! ```
+//!
+//! Each `hw_sgl_mem_paddr` is **not** the data: it points at a per-item
+//! **NVMe SGL segment**, a page of 16-byte SGL Data Block descriptors
+//! (`addr(8) ‖ length(4) ‖ rsvd(3) ‖ type(1)`), one per physically
+//! contiguous chunk of the host buffer. [`copy_oob`] walks that segment
+//! and forwards each descriptor **verbatim** to the GDMA
+//! ([`HsmGdmaController::copy_mem_from_host_raw`]), which interprets it
+//! and copies the chunk into the matching sub-range of a caller-allocated
+//! [`DmaBuf`].
+//!
+//! The Uno GDMA does not walk PRP lists or SGL chains itself; each
+//! transfer is a single SGL Data Block, so this layer drives the walk one
+//! descriptor at a time.
+//!
+//! Note the SQE's `oob_len` (DW15) is **not** used: the driver leaves it
+//! reserved, and the Metadata Page is self-describing via `buffer_count`.
+//! Presence of OOB data is signalled by a non-null `oob_prp`.
 
 #![no_std]
 
@@ -32,22 +52,36 @@ use azihsm_fw_hsm_pal_traits::HsmScopedAlloc;
 /// Size of one NVMe SGL Data Block descriptor on the wire.
 pub const SGL_ENTRY_LEN: usize = 16;
 
-/// Reference to the OOB SGL descriptor array carried by the SQE
-/// (`oob_prp` + `oob_len`).
+/// Size of one Metadata Page entry (`xfer_length ‖ rsvd ‖ paddr`).
+pub const METADATA_ENTRY_LEN: usize = 16;
+
+/// Byte offset of the first entry, past the `buffer_count` header.
+pub const METADATA_ENTRY_OFF: usize = 4;
+
+/// Maximum number of OOB items the device accepts, matching the driver's
+/// `AZIHSM_MAX_DATA_XFER_DEVICE_BUFFERS`.
+pub const MAX_OOB_ITEMS: usize = 16;
+
+/// Bytes fetched from a per-item SGL segment in one read, and the
+/// resulting descriptor budget. The driver rejects items needing more
+/// than one segment, and a cert-chain item is a handful of descriptors
+/// at most, so this is ample.
+const SEG_READ_LEN: usize = 256;
+const MAX_SEG_DESCRIPTORS: usize = SEG_READ_LEN / SGL_ENTRY_LEN;
+
+/// Size of the Metadata Page (`METADATA_SIZE` in the driver UAPI).
+const METADATA_PAGE_LEN: usize = 4096;
+
+/// Granularity that Metadata Page prefix reads are rounded up to. The
+/// GDMA faults on very small transfers, so the header/entry fetch is
+/// padded rather than issued as a 4- or 16-byte read.
+const PREFIX_GRAIN: usize = 32;
+
+/// Reference to the OOB Metadata Page carried by the SQE (`oob_prp`).
 #[derive(Debug, Clone, Copy)]
 pub struct OobPtr {
-    /// Host pointer to the 16-byte-per-entry SGL descriptor array.
+    /// Host pointer to the 4 KiB Metadata Page.
     pub prp: HsmDmaAddr,
-    /// Byte length of the descriptor array (`num_entries * 16`).
-    pub len: u32,
-}
-
-impl OobPtr {
-    /// Number of SGL descriptors in the array.
-    #[inline]
-    pub fn entry_count(&self) -> usize {
-        self.len as usize / SGL_ENTRY_LEN
-    }
 }
 
 /// Byte-offset an [`HsmDmaAddr`], rejecting 64-bit overflow.
@@ -61,45 +95,60 @@ fn addr_offset(base: HsmDmaAddr, off: u64) -> HsmResult<HsmDmaAddr> {
     })
 }
 
-/// Host address of the SGL Data Block descriptor at `index`, bounds-checked
-/// against the descriptor array length.
+/// Host address of the Metadata Page entry for `index`.
 ///
-/// This is the only interpretation the OOB layer does — locating the
-/// 16-byte descriptor.  The descriptor's contents (address / length /
-/// type) are consumed by the GDMA layer
-/// ([`HsmGdmaController::copy_mem_from_host_raw`]), not here.
+/// Entries start at [`METADATA_ENTRY_OFF`] (past the `buffer_count`
+/// header) and are [`METADATA_ENTRY_LEN`] bytes each. The index is
+/// bounded by [`MAX_OOB_ITEMS`] here; it is additionally checked against
+/// the page's own `buffer_count` in [`copy_oob`].
 ///
 /// # Errors
-/// * [`HsmError::InvalidArg`] — `index` is out of bounds for `oob.len`,
-///   or the descriptor address overflows.
+/// * [`HsmError::InvalidArg`] — `index` >= [`MAX_OOB_ITEMS`], or the
+///   address overflows.
 pub fn entry_addr(oob: &OobPtr, index: usize) -> HsmResult<HsmDmaAddr> {
-    let entry_off = index
-        .checked_mul(SGL_ENTRY_LEN)
-        .ok_or(HsmError::InvalidArg)?;
-    let entry_end = entry_off
-        .checked_add(SGL_ENTRY_LEN)
-        .ok_or(HsmError::InvalidArg)?;
-    if entry_end > oob.len as usize {
+    if index >= MAX_OOB_ITEMS {
         return Err(HsmError::InvalidArg);
     }
-    addr_offset(oob.prp, entry_off as u64)
+    let off = index
+        .checked_mul(METADATA_ENTRY_LEN)
+        .and_then(|v| v.checked_add(METADATA_ENTRY_OFF))
+        .ok_or(HsmError::InvalidArg)?;
+    addr_offset(oob.prp, off as u64)
+}
+
+/// Read a little-endian `u32` from `bytes[off..off + 4]`.
+fn le_u32(bytes: &[u8], off: usize) -> HsmResult<u32> {
+    let raw: [u8; 4] = bytes
+        .get(off..off + 4)
+        .and_then(|s| s.try_into().ok())
+        .ok_or(HsmError::InternalError)?;
+    Ok(u32::from_le_bytes(raw))
+}
+
+/// Read a little-endian `u64` from `bytes[off..off + 8]` as an
+/// [`HsmDmaAddr`].
+fn le_addr(bytes: &[u8], off: usize) -> HsmResult<HsmDmaAddr> {
+    Ok(HsmDmaAddr {
+        lo: le_u32(bytes, off)?,
+        hi: le_u32(bytes, off + 4)?,
+    })
 }
 
 /// Copy OOB item `index` into the caller-allocated `dst`.
 ///
-/// Locates the 16-byte SGL Data Block descriptor at `oob.prp + index*16`,
-/// reads it, and forwards it **verbatim** to the GDMA
-/// ([`HsmGdmaController::copy_mem_from_host_raw`]), which interprets the
-/// descriptor (address / length / type) and copies the item into `dst`.
-/// The OOB layer does no SGL parsing itself.
+/// Reads the Metadata Page header and the item's entry, then walks the
+/// item's NVMe SGL segment, forwarding each 16-byte Data Block descriptor
+/// to the GDMA so its chunk lands at the running offset in `dst`.
 ///
-/// The GDMA enforces that the descriptor's `length` equals `dst.len()`,
-/// so the caller must size `dst` to the item's length (from the TBOR
-/// descriptor, which must agree with the OOB descriptor).
+/// `dst.len()` must equal the entry's `xfer_length`, and the segment's
+/// descriptor lengths must sum to exactly that — a short or over-long
+/// segment is rejected rather than silently truncating.
 ///
 /// # Errors
-/// * [`HsmError::InvalidArg`] — `index` out of bounds, or the descriptor
-///   `length` does not equal `dst.len()` (from the GDMA).
+/// * [`HsmError::InvalidArg`] — `index` out of range for the page's
+///   `buffer_count`, a `buffer_count` above [`MAX_OOB_ITEMS`],
+///   `xfer_length != dst.len()`, or a segment whose chunks do not sum to
+///   `xfer_length`.
 /// * [`HsmError`] — propagated from the GDMA / allocator.
 pub async fn copy_oob<P>(
     pal: &P,
@@ -111,22 +160,92 @@ pub async fn copy_oob<P>(
 where
     P: HsmGdmaController + HsmAlloc,
 {
-    let entry_addr = entry_addr(oob, index)?;
+    // Bounds the index before any DMA; the page's own `buffer_count`
+    // is checked once the prefix has been read.
+    if index >= MAX_OOB_ITEMS {
+        return Err(HsmError::InvalidArg);
+    }
 
     pal.alloc_scoped_async(io, async |scoped| {
-        // Read the 16-byte SGL Data Block descriptor (unaligned address
-        // is fine for an SGL read).
-        let entry = scoped.dma_alloc(SGL_ENTRY_LEN)?;
-        pal.copy_mem_from_host(io, entry_addr, entry, false).await?;
+        // ── Metadata Page prefix: header + entries up to `index` ─────
+        //
+        // Read the header and the wanted entry in a single transfer.
+        // Two separate 4- and 16-byte reads are avoided deliberately:
+        // the GDMA faults on very small transfers, and one read is
+        // cheaper anyway. The prefix is rounded up to `PREFIX_GRAIN` and
+        // always stays inside the 4 KiB page.
+        let want = METADATA_ENTRY_OFF + METADATA_ENTRY_LEN * (index + 1);
+        let prefix_len = want.next_multiple_of(PREFIX_GRAIN).min(METADATA_PAGE_LEN);
+        let hdr = scoped.dma_alloc(prefix_len)?;
+        // `prp = true`: the Metadata Page is a plain contiguous host
+        // buffer, so the address goes in a PRP and the length is passed
+        // separately. The SGL form would put the length in the
+        // descriptor's second word, which this call site leaves zero —
+        // a zero-length SGL read that the GDMA rejects.
+        pal.copy_mem_from_host(io, oob.prp, hdr, true).await?;
 
-        // Borrow the descriptor bytes directly as a fixed array (no
-        // copy) — `entry` derefs to a 16-byte `[u8]`.
-        let bytes: &[u8] = entry;
-        let raw: &[u8; SGL_ENTRY_LEN] = bytes.try_into().map_err(|_| HsmError::InternalError)?;
+        let buffer_count = le_u32(hdr, 0)? as usize;
+        if buffer_count == 0 || buffer_count > MAX_OOB_ITEMS || index >= buffer_count {
+            return Err(HsmError::InvalidArg);
+        }
 
-        // Forward the raw descriptor to the GDMA, which interprets it and
-        // copies the item into `dst` (validating `length == dst.len()`).
-        pal.copy_mem_from_host_raw(io, raw, dst, false).await?;
+        // ── The item's entry: `xfer_length ‖ rsvd ‖ hw_sgl_mem_paddr` ──
+        let entry_off = METADATA_ENTRY_OFF + METADATA_ENTRY_LEN * index;
+        let xfer_length = le_u32(hdr, entry_off)? as usize;
+        let seg_addr = le_addr(hdr, entry_off + 8)?;
+
+        // The caller sizes `dst` from the TBOR descriptor; the two must
+        // agree or we would copy a different item than was requested.
+        if xfer_length != dst.len() {
+            return Err(HsmError::InvalidArg);
+        }
+        if seg_addr.is_null() {
+            return Err(HsmError::InvalidArg);
+        }
+
+        // ── Walk the item's SGL segment, chunk by chunk ──────────────
+        //
+        // The whole segment is fetched once: per-descriptor 16-byte
+        // reads would hit the same GDMA small-transfer fault as the
+        // header, and one read is cheaper. The driver allocates the
+        // segment as a coherent page, so reading `SEG_READ_LEN` from
+        // its (page-aligned) base stays in bounds.
+        let seg = scoped.dma_alloc(SEG_READ_LEN)?;
+        // Also a plain contiguous host buffer — read via PRP, as above.
+        pal.copy_mem_from_host(io, seg_addr, seg, true).await?;
+
+        let mut copied = 0usize;
+        let mut tail: &mut DmaBuf = dst;
+
+        for i in 0..MAX_SEG_DESCRIPTORS {
+            if copied == xfer_length {
+                break;
+            }
+            let off = i * SGL_ENTRY_LEN;
+
+            // NVMe SGL Data Block: `addr(8) ‖ length(4) ‖ rsvd(3) ‖ type(1)`.
+            let chunk = le_u32(seg, off + 8)? as usize;
+            if chunk == 0 || copied + chunk > xfer_length {
+                return Err(HsmError::InvalidArg);
+            }
+
+            // Hand the GDMA exactly this chunk's destination window; it
+            // validates the descriptor length against the slice length.
+            let (head, rest) = tail.split_at_mut(chunk);
+            let raw: &[u8; SGL_ENTRY_LEN] = seg
+                .get(off..off + SGL_ENTRY_LEN)
+                .and_then(|s| s.try_into().ok())
+                .ok_or(HsmError::InternalError)?;
+            pal.copy_mem_from_host_raw(io, raw, head, false).await?;
+
+            copied += chunk;
+            tail = rest;
+        }
+
+        // A segment that never reached `xfer_length` is malformed.
+        if copied != xfer_length {
+            return Err(HsmError::InvalidArg);
+        }
         Ok(())
     })
     .await
@@ -139,37 +258,28 @@ mod tests {
     use super::*;
 
     #[test]
-    fn entry_count_divides_by_16() {
+    fn entry_addr_skips_the_buffer_count_header() {
         let oob = OobPtr {
             prp: HsmDmaAddr { lo: 0x1000, hi: 0 },
-            len: 48,
         };
-        assert_eq!(oob.entry_count(), 3);
-    }
-
-    #[test]
-    fn entry_addr_computes_indexed_offset() {
-        let oob = OobPtr {
-            prp: HsmDmaAddr { lo: 0x1000, hi: 0 },
-            len: 48,
-        };
+        // Entry 0 sits immediately after the 4-byte header.
         assert_eq!(
             entry_addr(&oob, 0).unwrap(),
-            HsmDmaAddr { lo: 0x1000, hi: 0 }
+            HsmDmaAddr { lo: 0x1004, hi: 0 }
         );
+        // Entry 2 is at 4 + 2*16 = 0x24.
         assert_eq!(
             entry_addr(&oob, 2).unwrap(),
-            HsmDmaAddr { lo: 0x1020, hi: 0 }
+            HsmDmaAddr { lo: 0x1024, hi: 0 }
         );
     }
 
     #[test]
-    fn entry_addr_rejects_out_of_bounds_index() {
+    fn entry_addr_rejects_index_beyond_device_max() {
         let oob = OobPtr {
             prp: HsmDmaAddr { lo: 0x1000, hi: 0 },
-            len: 48, // 3 entries → valid indices 0..=2
         };
-        assert_eq!(entry_addr(&oob, 3), Err(HsmError::InvalidArg));
+        assert_eq!(entry_addr(&oob, MAX_OOB_ITEMS), Err(HsmError::InvalidArg));
         assert_eq!(entry_addr(&oob, usize::MAX), Err(HsmError::InvalidArg));
     }
 
@@ -177,26 +287,41 @@ mod tests {
     fn entry_addr_crosses_32bit_boundary() {
         let oob = OobPtr {
             prp: HsmDmaAddr {
-                lo: 0xFFFF_FFF0,
+                lo: 0xFFFF_FFFC,
                 hi: 0,
             },
-            len: 32,
         };
-        // Entry 1 at +16 wraps `lo` into `hi`.
-        assert_eq!(entry_addr(&oob, 1).unwrap(), HsmDmaAddr { lo: 0, hi: 1 });
+        // Entry 0 at +4 wraps `lo` into `hi`.
+        assert_eq!(entry_addr(&oob, 0).unwrap(), HsmDmaAddr { lo: 0, hi: 1 });
     }
 
     #[test]
     fn addr_offset_rejects_overflow() {
+        let base = HsmDmaAddr {
+            lo: 0xFFFF_FFFF,
+            hi: 0xFFFF_FFFF,
+        };
+        assert_eq!(addr_offset(base, 1), Err(HsmError::InvalidArg));
+    }
+
+    #[test]
+    fn le_readers_decode_little_endian() {
+        let bytes = [
+            0x78, 0x56, 0x34, 0x12, 0x01, 0x00, 0x00, 0x00, 0xEF, 0xBE, 0, 0, 1, 0, 0, 0,
+        ];
+        assert_eq!(le_u32(&bytes, 0).unwrap(), 0x1234_5678);
         assert_eq!(
-            addr_offset(
-                HsmDmaAddr {
-                    lo: 0xFFFF_FFFF,
-                    hi: 0xFFFF_FFFF
-                },
-                1
-            ),
-            Err(HsmError::InvalidArg)
+            le_addr(&bytes, 8).unwrap(),
+            HsmDmaAddr {
+                lo: 0x0000_BEEF,
+                hi: 1
+            }
         );
+    }
+
+    #[test]
+    fn le_readers_reject_short_input() {
+        let bytes = [0u8; 3];
+        assert_eq!(le_u32(&bytes, 0), Err(HsmError::InternalError));
     }
 }


### PR DESCRIPTION
## What

`PartFinal`'s PTA certificate chain travels **out of band**, and until now that path had zero hardware coverage:

- the firmware expected a flat array of SGL Data Block descriptors, which is not what the Linux driver builds, and
- `ddi/nix` rejected non-empty `oob_items` outright,

so the six chain tests were `#[cfg(feature = "emu")]` and only ever ran against the emulator.

This change moves both sides onto the driver's **Metadata Page** contract (ADO PR [16771989](https://msazure.visualstudio.com/One/_git/Martichoras/pullrequest/16771989)) and enables the full `part_final` suite on silicon.

## Firmware (`fw/core/oob`, `fw/core/lib`)

Parse the Metadata Page: a `buffer_count: u32` header followed by 16-byte
`xfer_length | rsvd | hw_sgl_mem_paddr` entries. Each entry points at a per-item NVMe SGL
*segment*, which is walked descriptor by descriptor, forwarding each Data Block to the GDMA
and requiring the chunks to sum to exactly `xfer_length`.

Presence is now signalled by a non-null `oob_prp` (DW13–14). DW15 stays reserved, matching
the driver, so the old `oob_len` validation is removed. Verified with `offsetof` that the
driver's `metadata_page_addr` lands in DW13–14 and that its entry struct is layout-identical
to what the firmware parses.

## Host (`ddi/nix`, `ddi/emu`)

`ddi/nix` now carries OOB items through the driver's data-transfer ioctl
(`_IOWR('B', 0x7, ...)`), which takes the generic command plus a buffer list and builds the
Metadata Page in the kernel — so the host never touches physical addresses. The driver
validates `in.cmdset` against the ioctl it was reached through, so the OOB path advertises
`DataXfer`; the firmware still routes purely on the opcode. The emulator writes the same page
shape directly.

## Two findings worth recording

**Reads of the Metadata Page and the SGL segment must use the PRP form.** Passing `prp = false`
builds `GdmaBuf::Sgl { sgl0: addr, sgl1: ZERO }`, and for the SGL form `sgl1.lo` *is* the
transfer length — so this was a zero-length read that the GDMA rejected with
`dma_error(1)` (`0x08f08101`). The emulator is in-process and never models the GDMA
descriptor, so **only hardware could catch this**; emu was green throughout.

**Very small transfers fault.** The header and its entry are fetched in a single read rather
than a 4-byte and a 16-byte read, and the segment likewise. This is also cheaper.

## Test-integrity fix

`part_final_reject_unanchored_chain` and `part_final_reject_pta_mismatch` asserted only
`expect_err`, so they passed *even while the OOB transport was completely broken* — they were
happily accepting the GDMA fault. They now assert the specific status via `assert_fw_rejects`,
which immediately showed the unanchored-chain case returns `InvalidArg`, not
`InvalidCertificate` as assumed.

## Results

| Suite | Before | After |
| --- | --- | --- |
| `part_final` (hardware) | 4/10 (6 emu-gated) | **10/10** |
| `part_final` (emu) | 10/10 | **10/10** |
| Full TBOR (hardware) | 187/187 | **193/193** |
| Full TBOR (emu) | 302/302 | **302/302** |

`part_init` 107/107 on hardware; MBOR core unaffected (`establish_credential`, `open_session`,
`reopen_session` all consistent with baseline). clippy clean on the workspace and the uno
firmware target with `-D warnings`; `cargo fmt --all --check` clean.

## Notes for reviewers

- **The hardware OOB path requires the LargeDataXfer driver, and that PR is still a draft.**
  With the stock driver the six `chain_path` tests fail, since it has no data-transfer ioctl.
  If that PR's shape changes, both the firmware parser and `ddi/nix` move with it.
- Still uncovered: `ConfigPartSD`/SDLocalMK, and the decode rejects that need a hand-built
  frame (the typed host API cannot express a non-multiple-of-3 `cert_descriptors` or a
  wrong-length `part_policy`).
- `MAX_OOB_ITEMS` (16) is deliberately equal to the driver's
  `AZIHSM_MAX_DATA_XFER_DEVICE_BUFFERS`, so anything the host accepts fits one Metadata Page.
